### PR TITLE
feat: Technical SEO Audit Tools — 8 module strategy-based architecture

### DIFF
--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -405,3 +405,128 @@
     font-weight: 600;
     margin-top: 4px;
 }
+
+/* ===================== SEO Audit ===================== */
+
+.swps-audit-header {
+    display: flex;
+    align-items: center;
+    gap: 30px;
+    margin: 20px 0;
+    padding: 24px;
+    background: #fff;
+    border: 1px solid #c3c4c7;
+    border-radius: 4px;
+}
+
+.swps-audit-score-circle {
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: #fff;
+}
+
+.swps-audit-score--excellent { background: #00a32a; }
+.swps-audit-score--good { background: #dba617; color: #1d2327; }
+.swps-audit-score--poor { background: #d63638; }
+
+.swps-audit-score-number {
+    font-size: 32px;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.swps-audit-score-label {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-top: 4px;
+}
+
+.swps-audit-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.swps-audit-last-run {
+    color: #646970;
+    font-size: 13px;
+}
+
+.swps-audit-modules {
+    display: grid;
+    gap: 16px;
+}
+
+.swps-audit-module-card {
+    padding: 16px 24px;
+}
+
+.swps-audit-module-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.swps-audit-module-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.swps-audit-module-info .dashicons {
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+}
+
+.swps-audit-module-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.swps-audit-module-summary {
+    color: #646970;
+    margin: 8px 0 0;
+    font-size: 13px;
+}
+
+.swps-audit-issues {
+    margin-top: 12px;
+}
+
+.swps-audit-issues .widefat td {
+    font-size: 13px;
+}
+
+.swps-issue-link {
+    margin-left: 8px;
+    font-size: 12px;
+}
+
+.swps-issue-fixable {
+    width: 30px;
+    text-align: center;
+}
+
+.swps-issue-fixable .dashicons {
+    color: #2271b1;
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+}
+
+@media (max-width: 782px) {
+    .swps-audit-header {
+        flex-direction: column;
+        text-align: center;
+    }
+}

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -735,7 +735,7 @@
             url: swpsAdmin.ajax_url,
             type: 'POST',
             data: {
-                action: 'swps_run_audit',
+                action: 'swps_get_audit_results',
                 nonce: swpsAdmin.nonce,
             },
             success: function(response) {

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -619,4 +619,148 @@
         $('#vp-formality-label').text(this.value + '/10');
     });
 
+    // =====================================================================
+    // SEO Audit page
+    // =====================================================================
+
+    var $auditProgress = $('#swps-audit-progress');
+
+    // Toggle issues.
+    $(document).on('click', '.swps-toggle-issues', function() {
+        var moduleId = $(this).data('module');
+        var $issues = $('#swps-issues-' + moduleId);
+        $issues.slideToggle(200);
+        var $icon = $(this).find('.dashicons');
+        $icon.toggleClass('dashicons-arrow-down-alt2 dashicons-arrow-up-alt2');
+    });
+
+    // Run Audit.
+    $('#swps-run-audit').on('click', function() {
+        var $btn = $(this);
+        $btn.prop('disabled', true);
+        $auditProgress.slideDown(200);
+
+        $.ajax({
+            url: swpsAdmin.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'swps_run_audit',
+                nonce: swpsAdmin.nonce,
+            },
+            timeout: 120000,
+            success: function(response) {
+                if (response.success) {
+                    location.reload();
+                } else {
+                    alert(response.data.message || 'Audit failed.');
+                }
+            },
+            error: function() {
+                alert('Audit request failed.');
+            },
+            complete: function() {
+                $btn.prop('disabled', false);
+                $auditProgress.slideUp(200);
+            }
+        });
+    });
+
+    // Fix single module.
+    $(document).on('click', '.swps-fix-module', function() {
+        var $btn = $(this);
+        var moduleId = $btn.data('module');
+        $btn.prop('disabled', true).text('Fixing...');
+
+        $.ajax({
+            url: swpsAdmin.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'swps_fix_module',
+                nonce: swpsAdmin.nonce,
+                module_id: moduleId,
+            },
+            timeout: 60000,
+            success: function(response) {
+                if (response.success) {
+                    location.reload();
+                } else {
+                    alert(response.data.message || 'Fix failed.');
+                    $btn.prop('disabled', false).text('Fix');
+                }
+            },
+            error: function() {
+                alert('Fix request failed.');
+                $btn.prop('disabled', false).text('Fix');
+            }
+        });
+    });
+
+    // Fix All.
+    $('#swps-fix-all').on('click', function() {
+        if (!confirm('Run auto-fix for all fixable modules?')) return;
+
+        var $btn = $(this);
+        $btn.prop('disabled', true).text('Fixing all...');
+        $auditProgress.slideDown(200);
+
+        $.ajax({
+            url: swpsAdmin.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'swps_fix_all',
+                nonce: swpsAdmin.nonce,
+            },
+            timeout: 120000,
+            success: function(response) {
+                if (response.success) {
+                    location.reload();
+                } else {
+                    alert('Fix all failed.');
+                }
+            },
+            error: function() {
+                alert('Fix all request failed.');
+            },
+            complete: function() {
+                $btn.prop('disabled', false).text('Fix All');
+                $auditProgress.slideUp(200);
+            }
+        });
+    });
+
+    // Export CSV.
+    $('#swps-export-csv').on('click', function() {
+        // Fetch current cached results via AJAX to build CSV.
+        $.ajax({
+            url: swpsAdmin.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'swps_run_audit',
+                nonce: swpsAdmin.nonce,
+            },
+            success: function(response) {
+                if (!response.success) return;
+
+                var csv = 'Module,Score,Status,Issues\n';
+                var modules = response.data.modules || {};
+
+                for (var id in modules) {
+                    var mod = modules[id];
+                    var issueMessages = (mod.issues || []).map(function(i) { return i.message; }).join('; ');
+                    csv += '"' + id + '",' + mod.score + ',"' + mod.status + '","' + issueMessages.replace(/"/g, '""') + '"\n';
+                }
+
+                csv += '\nOverall Score,' + response.data.overall_score + '\n';
+
+                var blob = new Blob([csv], { type: 'text/csv' });
+                var url = URL.createObjectURL(blob);
+                var a = document.createElement('a');
+                a.href = url;
+                a.download = 'swps-seo-audit-' + new Date().toISOString().slice(0, 10) + '.csv';
+                a.click();
+                URL.revokeObjectURL(url);
+            }
+        });
+    });
+
 })(jQuery);

--- a/includes/audit/class-canonical-module.php
+++ b/includes/audit/class-canonical-module.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Canonical URLs audit module.
+ *
+ * Checks for missing canonical tags on public posts/pages.
+ * Auto-fix: Injects self-referencing canonical via wp_head.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_Canonical_Module extends SWPS_Audit_Module {
+
+	public function get_id(): string {
+		return 'canonical';
+	}
+
+	public function get_label(): string {
+		return __( 'Canonical URLs', 'stratawp-seo' );
+	}
+
+	public function can_auto_fix(): bool {
+		return true;
+	}
+
+	public function run(): array {
+		$posts  = $this->get_public_posts();
+		$issues = [];
+
+		foreach ( $posts as $post ) {
+			// Check if Yoast or RankMath provides a canonical.
+			$yoast_canonical     = get_post_meta( $post->ID, '_yoast_wpseo_canonical', true );
+			$rankmath_canonical  = get_post_meta( $post->ID, 'rank_math_canonical_url', true );
+			$has_seo_canonical   = ! empty( $yoast_canonical ) || ! empty( $rankmath_canonical );
+
+			// Check if our auto-canonical is enabled.
+			$our_canonical = (bool) get_option( 'swps_audit_auto_canonical', 1 );
+
+			if ( ! $has_seo_canonical && ! $our_canonical ) {
+				$issues[] = [
+					'post_id' => $post->ID,
+					'message' => sprintf(
+						__( '"%s" has no canonical tag.', 'stratawp-seo' ),
+						$post->post_title
+					),
+					'fixable' => true,
+				];
+			}
+		}
+
+		$total   = count( $posts );
+		$failing = count( $issues );
+		$score   = $total > 0 ? (int) round( ( ( $total - $failing ) / $total ) * 100 ) : 100;
+
+		return [
+			'score'   => $score,
+			'status'  => $this->status_from_score( $score ),
+			'issues'  => $issues,
+			'summary' => 0 === $failing
+				? __( 'All posts have canonical tags.', 'stratawp-seo' )
+				: sprintf( __( '%d posts missing canonical tags.', 'stratawp-seo' ), $failing ),
+		];
+	}
+
+	public function auto_fix( array $issues ): array {
+		// Enable the auto-canonical option.
+		update_option( 'swps_audit_auto_canonical', 1 );
+
+		return [
+			'fixed'    => count( $issues ),
+			'messages' => [ __( 'Auto-canonical injection enabled. Canonical tags will be output via wp_head.', 'stratawp-seo' ) ],
+		];
+	}
+
+	/**
+	 * Output canonical tag on singular pages when enabled.
+	 * Hooked to wp_head at priority 1 from the main plugin class.
+	 */
+	public static function output_canonical(): void {
+		if ( ! is_singular() ) {
+			return;
+		}
+
+		if ( ! get_option( 'swps_audit_auto_canonical', 1 ) ) {
+			return;
+		}
+
+		// Skip if Yoast or RankMath is handling canonicals.
+		if ( defined( 'WPSEO_VERSION' ) || class_exists( 'RankMath' ) ) {
+			return;
+		}
+
+		$url = wp_get_canonical_url();
+		if ( $url ) {
+			printf( '<link rel="canonical" href="%s" />' . "\n", esc_url( $url ) );
+		}
+	}
+}

--- a/includes/audit/class-image-seo-module.php
+++ b/includes/audit/class-image-seo-module.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Image SEO audit module.
+ *
+ * Checks for missing alt text, poor file names, and missing dimensions.
+ * Auto-fix: Generates alt text for images missing it (batched, max 20).
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_Image_SEO_Module extends SWPS_Audit_Module {
+
+	private const MAX_BATCH = 20;
+
+	public function get_id(): string {
+		return 'image_seo';
+	}
+
+	public function get_label(): string {
+		return __( 'Image SEO', 'stratawp-seo' );
+	}
+
+	public function can_auto_fix(): bool {
+		return true;
+	}
+
+	public function run(): array {
+		$issues = [];
+
+		// Query recent attachments (images).
+		$attachments = get_posts( [
+			'post_type'      => 'attachment',
+			'post_mime_type' => 'image',
+			'post_status'    => 'inherit',
+			'posts_per_page' => 200,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+			'no_found_rows'  => true,
+		] );
+
+		$missing_alt    = 0;
+		$bad_filenames  = 0;
+		$fixable_ids    = [];
+
+		foreach ( $attachments as $attachment ) {
+			$alt = get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true );
+
+			if ( empty( trim( $alt ) ) ) {
+				$missing_alt++;
+				$fixable_ids[] = $attachment->ID;
+
+				$issues[] = [
+					'post_id' => $attachment->ID,
+					'message' => sprintf(
+						__( 'Image "%s" is missing alt text.', 'stratawp-seo' ),
+						basename( get_attached_file( $attachment->ID ) )
+					),
+					'fixable' => true,
+				];
+			}
+
+			// Check filename quality.
+			$filename = basename( get_attached_file( $attachment->ID ) );
+			if ( preg_match( '/^(IMG_|DSC_|Screenshot|image|photo)\d*/i', $filename ) ) {
+				$bad_filenames++;
+
+				$issues[] = [
+					'post_id' => $attachment->ID,
+					'message' => sprintf(
+						__( 'Image "%s" has a non-descriptive filename.', 'stratawp-seo' ),
+						$filename
+					),
+					'fixable' => false,
+				];
+			}
+		}
+
+		$total   = count( $attachments );
+		$failing = $missing_alt + $bad_filenames;
+		$score   = $total > 0 ? (int) round( ( ( $total - $failing ) / $total ) * 100 ) : 100;
+
+		return [
+			'score'   => $score,
+			'status'  => $this->status_from_score( $score ),
+			'issues'  => $issues,
+			'summary' => 0 === $failing
+				? __( 'All images have alt text and descriptive filenames.', 'stratawp-seo' )
+				: sprintf(
+					__( '%d missing alt text, %d non-descriptive filenames.', 'stratawp-seo' ),
+					$missing_alt,
+					$bad_filenames
+				),
+		];
+	}
+
+	public function auto_fix( array $issues ): array {
+		$fixable = array_filter( $issues, fn( $i ) => $i['fixable'] && $i['post_id'] );
+		$fixable = array_slice( $fixable, 0, self::MAX_BATCH );
+
+		$fixed    = 0;
+		$messages = [];
+
+		foreach ( $fixable as $issue ) {
+			$attachment = get_post( $issue['post_id'] );
+			if ( ! $attachment ) {
+				continue;
+			}
+
+			// Generate alt text from parent post context + filename.
+			$alt = $this->generate_alt_text( $attachment );
+
+			if ( ! empty( $alt ) ) {
+				update_post_meta( $attachment->ID, '_wp_attachment_image_alt', sanitize_text_field( $alt ) );
+				$fixed++;
+				$messages[] = sprintf(
+					__( 'Set alt text for "%s": "%s"', 'stratawp-seo' ),
+					basename( get_attached_file( $attachment->ID ) ),
+					$alt
+				);
+			}
+		}
+
+		return [
+			'fixed'    => $fixed,
+			'messages' => $messages,
+		];
+	}
+
+	/**
+	 * Generate alt text for an image attachment.
+	 * Uses the parent post title + image caption/title as context.
+	 * Falls back to a cleaned-up filename if no context available.
+	 */
+	private function generate_alt_text( WP_Post $attachment ): string {
+		// Try caption or title from attachment.
+		if ( ! empty( $attachment->post_excerpt ) ) {
+			return $attachment->post_excerpt;
+		}
+
+		if ( ! empty( $attachment->post_title ) && 'attachment' !== $attachment->post_title ) {
+			// Clean up auto-generated titles (which are often just the filename).
+			$title = $attachment->post_title;
+			// If it looks like a cleaned filename, use parent context instead.
+			if ( ! preg_match( '/^(IMG|DSC|Screenshot|image|photo)/i', $title ) ) {
+				return $title;
+			}
+		}
+
+		// Use parent post context.
+		if ( $attachment->post_parent ) {
+			$parent = get_post( $attachment->post_parent );
+			if ( $parent ) {
+				return sprintf(
+					__( 'Image from "%s"', 'stratawp-seo' ),
+					$parent->post_title
+				);
+			}
+		}
+
+		// Last resort: clean up filename.
+		$filename = pathinfo( basename( get_attached_file( $attachment->ID ) ), PATHINFO_FILENAME );
+		return ucfirst( str_replace( [ '-', '_' ], ' ', $filename ) );
+	}
+}

--- a/includes/audit/class-image-seo-module.php
+++ b/includes/audit/class-image-seo-module.php
@@ -49,7 +49,7 @@ class SWPS_Image_SEO_Module extends SWPS_Audit_Module {
 		foreach ( $attachments as $attachment ) {
 			$alt = get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true );
 
-			if ( empty( trim( $alt ) ) ) {
+			if ( '' === trim( (string) $alt ) ) {
 				$missing_alt++;
 				$fixable_ids[] = $attachment->ID;
 
@@ -81,7 +81,7 @@ class SWPS_Image_SEO_Module extends SWPS_Audit_Module {
 
 		$total   = count( $attachments );
 		$failing = $missing_alt + $bad_filenames;
-		$score   = $total > 0 ? (int) round( ( ( $total - $failing ) / $total ) * 100 ) : 100;
+		$score   = $total > 0 ? max( 0, (int) round( ( ( $total - $failing ) / $total ) * 100 ) ) : 100;
 
 		return [
 			'score'   => $score,

--- a/includes/audit/class-meta-robots-module.php
+++ b/includes/audit/class-meta-robots-module.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Meta Robots audit module.
+ *
+ * Checks for conflicting noindex/nofollow on published posts.
+ * No auto-fix — flags only (too dangerous to auto-change indexing).
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_Meta_Robots_Module extends SWPS_Audit_Module {
+
+	public function get_id(): string {
+		return 'meta_robots';
+	}
+
+	public function get_label(): string {
+		return __( 'Meta Robots', 'stratawp-seo' );
+	}
+
+	public function can_auto_fix(): bool {
+		return false;
+	}
+
+	public function run(): array {
+		$posts  = $this->get_public_posts();
+		$issues = [];
+
+		foreach ( $posts as $post ) {
+			$problems = [];
+
+			// Yoast noindex check.
+			$yoast_noindex = get_post_meta( $post->ID, '_yoast_wpseo_meta-robots-noindex', true );
+			if ( '1' === $yoast_noindex ) {
+				$problems[] = 'Yoast noindex';
+			}
+
+			// RankMath robots check.
+			$rm_robots = get_post_meta( $post->ID, 'rank_math_robots', true );
+			if ( is_array( $rm_robots ) ) {
+				if ( in_array( 'noindex', $rm_robots, true ) ) {
+					$problems[] = 'RankMath noindex';
+				}
+				if ( in_array( 'nofollow', $rm_robots, true ) ) {
+					$problems[] = 'RankMath nofollow';
+				}
+			}
+
+			// WordPress core noindex (WP 5.7+).
+			$wp_noindex = get_post_meta( $post->ID, '_wp_page_template_noindex', true );
+			if ( $wp_noindex ) {
+				$problems[] = 'WP noindex';
+			}
+
+			if ( ! empty( $problems ) ) {
+				$issues[] = [
+					'post_id' => $post->ID,
+					'message' => sprintf(
+						__( '"%s" has restrictive meta robots: %s.', 'stratawp-seo' ),
+						$post->post_title,
+						implode( ', ', $problems )
+					),
+					'fixable' => false,
+				];
+			}
+		}
+
+		$total   = count( $posts );
+		$failing = count( $issues );
+		$score   = $total > 0 ? (int) round( ( ( $total - $failing ) / $total ) * 100 ) : 100;
+
+		return [
+			'score'   => $score,
+			'status'  => $this->status_from_score( $score ),
+			'issues'  => $issues,
+			'summary' => 0 === $failing
+				? __( 'No conflicting meta robots directives found.', 'stratawp-seo' )
+				: sprintf( __( '%d published posts have restrictive robots settings.', 'stratawp-seo' ), $failing ),
+		];
+	}
+}

--- a/includes/audit/class-opengraph-module.php
+++ b/includes/audit/class-opengraph-module.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Open Graph audit module.
+ *
+ * Checks for OG title, description, and image on public posts.
+ * Auto-fix: Outputs OG meta tags via wp_head.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_OpenGraph_Module extends SWPS_Audit_Module {
+
+	public function get_id(): string {
+		return 'opengraph';
+	}
+
+	public function get_label(): string {
+		return __( 'Open Graph', 'stratawp-seo' );
+	}
+
+	public function can_auto_fix(): bool {
+		return true;
+	}
+
+	public function run(): array {
+		$posts  = $this->get_public_posts();
+		$issues = [];
+
+		// If another SEO plugin handles OG or we handle it, skip post-level checks.
+		if ( defined( 'WPSEO_VERSION' ) || class_exists( 'RankMath' ) ) {
+			return [
+				'score'   => 100,
+				'status'  => 'pass',
+				'issues'  => [],
+				'summary' => __( 'Open Graph tags managed by SEO plugin.', 'stratawp-seo' ),
+			];
+		}
+
+		$our_og = (bool) get_option( 'swps_audit_auto_og', 1 );
+
+		if ( ! $our_og ) {
+			// Check posts for missing OG signals (no featured image = no OG image).
+			foreach ( $posts as $post ) {
+				if ( ! has_post_thumbnail( $post->ID ) ) {
+					$issues[] = [
+						'post_id' => $post->ID,
+						'message' => sprintf(
+							__( '"%s" has no featured image for og:image.', 'stratawp-seo' ),
+							$post->post_title
+						),
+						'fixable' => false,
+					];
+				}
+			}
+		} else {
+			// OG enabled — just check for missing images.
+			foreach ( $posts as $post ) {
+				if ( ! has_post_thumbnail( $post->ID ) ) {
+					$issues[] = [
+						'post_id' => $post->ID,
+						'message' => sprintf(
+							__( '"%s" will use fallback og:image (no featured image).', 'stratawp-seo' ),
+							$post->post_title
+						),
+						'fixable' => false,
+					];
+				}
+			}
+		}
+
+		$total   = count( $posts );
+		$failing = count( $issues );
+		$score   = $total > 0 ? (int) round( ( ( $total - $failing ) / $total ) * 100 ) : 100;
+		// Minimum 50 if our OG output is enabled (tags exist, just image issues).
+		if ( $our_og && $score < 50 ) {
+			$score = 50;
+		}
+
+		return [
+			'score'   => $score,
+			'status'  => $this->status_from_score( $score ),
+			'issues'  => $issues,
+			'summary' => 0 === $failing
+				? __( 'All posts have Open Graph tags.', 'stratawp-seo' )
+				: sprintf( __( '%d posts with OG image issues.', 'stratawp-seo' ), $failing ),
+		];
+	}
+
+	public function auto_fix( array $issues ): array {
+		update_option( 'swps_audit_auto_og', 1 );
+
+		return [
+			'fixed'    => 1,
+			'messages' => [ __( 'Auto Open Graph tag output enabled.', 'stratawp-seo' ) ],
+		];
+	}
+
+	/**
+	 * Output OG and Twitter meta tags on singular pages.
+	 * Hooked to wp_head at priority 5.
+	 */
+	public static function output_meta_tags(): void {
+		if ( ! is_singular() ) {
+			return;
+		}
+
+		// Skip if Yoast or RankMath handles OG.
+		if ( defined( 'WPSEO_VERSION' ) || class_exists( 'RankMath' ) ) {
+			return;
+		}
+
+		if ( ! get_option( 'swps_audit_auto_og', 1 ) ) {
+			return;
+		}
+
+		$post = get_queried_object();
+		if ( ! $post || ! ( $post instanceof WP_Post ) ) {
+			return;
+		}
+
+		$title       = get_the_title( $post );
+		$description = self::get_description( $post );
+		$url         = get_permalink( $post );
+		$site_name   = get_bloginfo( 'name' );
+		$image       = self::get_og_image( $post );
+
+		// OG tags.
+		printf( '<meta property="og:type" content="article" />' . "\n" );
+		printf( '<meta property="og:title" content="%s" />' . "\n", esc_attr( $title ) );
+		printf( '<meta property="og:description" content="%s" />' . "\n", esc_attr( $description ) );
+		printf( '<meta property="og:url" content="%s" />' . "\n", esc_url( $url ) );
+		printf( '<meta property="og:site_name" content="%s" />' . "\n", esc_attr( $site_name ) );
+
+		if ( $image ) {
+			printf( '<meta property="og:image" content="%s" />' . "\n", esc_url( $image ) );
+		}
+
+		// Twitter Card tags.
+		printf( '<meta name="twitter:card" content="summary_large_image" />' . "\n" );
+		printf( '<meta name="twitter:title" content="%s" />' . "\n", esc_attr( $title ) );
+		printf( '<meta name="twitter:description" content="%s" />' . "\n", esc_attr( $description ) );
+
+		if ( $image ) {
+			printf( '<meta name="twitter:image" content="%s" />' . "\n", esc_url( $image ) );
+		}
+	}
+
+	/**
+	 * Get OG description from post.
+	 * Priority: Yoast meta desc → RankMath desc → excerpt → first 160 chars.
+	 */
+	private static function get_description( WP_Post $post ): string {
+		$desc = get_post_meta( $post->ID, '_yoast_wpseo_metadesc', true );
+		if ( ! empty( $desc ) ) {
+			return $desc;
+		}
+
+		$desc = get_post_meta( $post->ID, 'rank_math_description', true );
+		if ( ! empty( $desc ) ) {
+			return $desc;
+		}
+
+		if ( ! empty( $post->post_excerpt ) ) {
+			return wp_trim_words( $post->post_excerpt, 30, '...' );
+		}
+
+		return wp_trim_words( wp_strip_all_tags( $post->post_content ), 30, '...' );
+	}
+
+	/**
+	 * Get OG image URL.
+	 * Priority: featured image → first content image → site icon.
+	 */
+	private static function get_og_image( WP_Post $post ): string {
+		// Featured image.
+		$thumb_id = get_post_thumbnail_id( $post->ID );
+		if ( $thumb_id ) {
+			$img = wp_get_attachment_image_src( $thumb_id, 'large' );
+			if ( $img ) {
+				return $img[0];
+			}
+		}
+
+		// First content image.
+		if ( preg_match( '/<img[^>]+src=["\']([^"\']+)/i', $post->post_content, $matches ) ) {
+			return $matches[1];
+		}
+
+		// Site icon.
+		$icon_id = get_option( 'site_icon' );
+		if ( $icon_id ) {
+			$icon_url = wp_get_attachment_url( $icon_id );
+			if ( $icon_url ) {
+				return $icon_url;
+			}
+		}
+
+		return '';
+	}
+}

--- a/includes/audit/class-pagespeed-module.php
+++ b/includes/audit/class-pagespeed-module.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Page Speed Hints audit module.
+ *
+ * Checks for common performance issues: missing lazy loading,
+ * missing image dimensions, render-blocking resources.
+ * Advisory only -- no auto-fix.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_PageSpeed_Module extends SWPS_Audit_Module {
+
+	public function get_id(): string {
+		return 'pagespeed';
+	}
+
+	public function get_label(): string {
+		return __( 'Page Speed Hints', 'stratawp-seo' );
+	}
+
+	public function can_auto_fix(): bool {
+		return false;
+	}
+
+	public function run(): array {
+		$issues = [];
+
+		// Check recent posts for image issues in content.
+		$posts = $this->get_public_posts( 50 );
+
+		$missing_dimensions = 0;
+		$missing_lazy       = 0;
+
+		foreach ( $posts as $post ) {
+			$content = $post->post_content;
+
+			// Find all img tags.
+			if ( preg_match_all( '/<img[^>]*>/i', $content, $matches ) ) {
+				foreach ( $matches[0] as $img_tag ) {
+					// Check for width/height attributes.
+					if ( ! preg_match( '/\bwidth\s*=/', $img_tag ) || ! preg_match( '/\bheight\s*=/', $img_tag ) ) {
+						$missing_dimensions++;
+					}
+
+					// Check for lazy loading.
+					if ( false === stripos( $img_tag, 'loading=' ) ) {
+						$missing_lazy++;
+					}
+				}
+			}
+		}
+
+		if ( $missing_dimensions > 0 ) {
+			$issues[] = [
+				'post_id' => null,
+				'message' => sprintf(
+					__( '%d images across recent posts are missing width/height attributes (causes layout shift).', 'stratawp-seo' ),
+					$missing_dimensions
+				),
+				'fixable' => false,
+			];
+		}
+
+		if ( $missing_lazy > 0 ) {
+			$issues[] = [
+				'post_id' => null,
+				'message' => sprintf(
+					__( '%d images are missing loading="lazy" attribute.', 'stratawp-seo' ),
+					$missing_lazy
+				),
+				'fixable' => false,
+			];
+		}
+
+		// Note: WordPress 5.5+ adds lazy loading and 5.9+ adds dimensions automatically
+		// for images processed through wp_get_attachment_image(). Flag is still useful
+		// for manually inserted images.
+
+		$score = 100;
+		if ( $missing_dimensions > 10 ) {
+			$score -= 30;
+		} elseif ( $missing_dimensions > 0 ) {
+			$score -= 15;
+		}
+
+		if ( $missing_lazy > 10 ) {
+			$score -= 20;
+		} elseif ( $missing_lazy > 0 ) {
+			$score -= 10;
+		}
+
+		$score = max( 0, $score );
+
+		return [
+			'score'   => $score,
+			'status'  => $this->status_from_score( $score ),
+			'issues'  => $issues,
+			'summary' => empty( $issues )
+				? __( 'No page speed issues detected in recent content.', 'stratawp-seo' )
+				: sprintf( __( '%d performance issue(s) found.', 'stratawp-seo' ), count( $issues ) ),
+		];
+	}
+}

--- a/includes/audit/class-robots-module.php
+++ b/includes/audit/class-robots-module.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Robots.txt audit module.
+ *
+ * Checks that robots.txt exists, doesn't block important paths, includes sitemap.
+ * Auto-fix: Creates default robots.txt via do_robots filter.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_Robots_Module extends SWPS_Audit_Module {
+
+	public function get_id(): string {
+		return 'robots';
+	}
+
+	public function get_label(): string {
+		return __( 'Robots.txt', 'stratawp-seo' );
+	}
+
+	public function can_auto_fix(): bool {
+		return true;
+	}
+
+	public function run(): array {
+		$issues = [];
+
+		// Check for a physical robots.txt.
+		$has_physical = file_exists( ABSPATH . 'robots.txt' );
+
+		if ( $has_physical ) {
+			$content = file_get_contents( ABSPATH . 'robots.txt' );
+
+			// Check for blocking /wp-content/.
+			if ( false !== stripos( $content, 'disallow: /wp-content/' ) ) {
+				$issues[] = [
+					'post_id' => null,
+					'message' => __( 'robots.txt blocks /wp-content/ which may prevent image indexing.', 'stratawp-seo' ),
+					'fixable' => false, // Don't auto-modify a physical file.
+				];
+			}
+
+			// Check for sitemap line.
+			if ( false === stripos( $content, 'sitemap:' ) ) {
+				$issues[] = [
+					'post_id' => null,
+					'message' => __( 'robots.txt does not include a Sitemap directive.', 'stratawp-seo' ),
+					'fixable' => false,
+				];
+			}
+		}
+		// WordPress virtual robots.txt is always present if no physical file exists.
+		// We enhance it via filter if needed.
+
+		$failing = count( $issues );
+		$score   = 0 === $failing ? 100 : ( 1 === $failing ? 60 : 30 );
+
+		return [
+			'score'   => $score,
+			'status'  => $this->status_from_score( $score ),
+			'issues'  => $issues,
+			'summary' => 0 === $failing
+				? __( 'robots.txt is properly configured.', 'stratawp-seo' )
+				: sprintf( __( '%d robots.txt issue(s) found.', 'stratawp-seo' ), $failing ),
+		];
+	}
+
+	public function auto_fix( array $issues ): array {
+		// We can't modify a physical file, but we can ensure our filter is active.
+		return [
+			'fixed'    => 0,
+			'messages' => [ __( 'SWPS enhances the virtual robots.txt with sitemap directives automatically.', 'stratawp-seo' ) ],
+		];
+	}
+
+	/**
+	 * Enhance the virtual robots.txt output.
+	 * Hooked to robots_txt filter.
+	 */
+	public static function filter_robots_txt( string $output, bool $public ): string {
+		if ( ! $public ) {
+			return $output;
+		}
+
+		// Add sitemap URL if not already present.
+		if ( false === stripos( $output, 'sitemap:' ) ) {
+			// Prefer our sitemap if active, otherwise WP core.
+			if ( get_option( 'swps_audit_auto_sitemap', 1 ) ) {
+				$sitemap_url = home_url( '/swps-sitemap.xml' );
+			} else {
+				$sitemap_url = home_url( '/wp-sitemap.xml' );
+			}
+
+			$output .= "\nSitemap: " . esc_url( $sitemap_url ) . "\n";
+		}
+
+		return $output;
+	}
+}

--- a/includes/audit/class-robots-module.php
+++ b/includes/audit/class-robots-module.php
@@ -33,7 +33,10 @@ class SWPS_Robots_Module extends SWPS_Audit_Module {
 		$has_physical = file_exists( ABSPATH . 'robots.txt' );
 
 		if ( $has_physical ) {
-			$content = file_get_contents( ABSPATH . 'robots.txt' );
+			$content = file_get_contents( ABSPATH . 'robots.txt' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			if ( false === $content ) {
+				$content = '';
+			}
 
 			// Check for blocking /wp-content/.
 			if ( false !== stripos( $content, 'disallow: /wp-content/' ) ) {

--- a/includes/audit/class-sitemap-module.php
+++ b/includes/audit/class-sitemap-module.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * XML Sitemap audit module.
+ *
+ * Checks if a sitemap exists and covers all public posts.
+ * Auto-fix: Generates /swps-sitemap.xml via rewrite rule.
+ * Skips generation if Yoast, RankMath, or WordPress core sitemaps are active.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_Sitemap_Module extends SWPS_Audit_Module {
+
+	public function get_id(): string {
+		return 'sitemap';
+	}
+
+	public function get_label(): string {
+		return __( 'XML Sitemap', 'stratawp-seo' );
+	}
+
+	public function can_auto_fix(): bool {
+		return true;
+	}
+
+	public function run(): array {
+		$issues = [];
+
+		$has_other_sitemap = $this->detect_other_sitemap();
+
+		if ( $has_other_sitemap ) {
+			return [
+				'score'   => 100,
+				'status'  => 'pass',
+				'issues'  => [],
+				'summary' => __( 'Sitemap provided by another plugin.', 'stratawp-seo' ),
+			];
+		}
+
+		$our_sitemap_enabled = (bool) get_option( 'swps_audit_auto_sitemap', 1 );
+
+		if ( ! $our_sitemap_enabled ) {
+			$issues[] = [
+				'post_id' => null,
+				'message' => __( 'No sitemap detected and SWPS sitemap generation is disabled.', 'stratawp-seo' ),
+				'fixable' => true,
+			];
+
+			return [
+				'score'   => 0,
+				'status'  => 'fail',
+				'issues'  => $issues,
+				'summary' => __( 'No sitemap found.', 'stratawp-seo' ),
+			];
+		}
+
+		// Sitemap is enabled — check that posts are covered.
+		$posts = $this->get_public_posts();
+		$noindex_count = 0;
+
+		foreach ( $posts as $post ) {
+			$noindex = get_post_meta( $post->ID, '_yoast_wpseo_meta-robots-noindex', true );
+			$rm_robots = get_post_meta( $post->ID, 'rank_math_robots', true );
+
+			if ( '1' === $noindex || ( is_array( $rm_robots ) && in_array( 'noindex', $rm_robots, true ) ) ) {
+				$noindex_count++;
+			}
+		}
+
+		$indexed = count( $posts ) - $noindex_count;
+
+		return [
+			'score'   => 100,
+			'status'  => 'pass',
+			'issues'  => [],
+			'summary' => sprintf( __( 'SWPS sitemap active with %d URLs.', 'stratawp-seo' ), $indexed ),
+		];
+	}
+
+	public function auto_fix( array $issues ): array {
+		update_option( 'swps_audit_auto_sitemap', 1 );
+		flush_rewrite_rules();
+
+		return [
+			'fixed'    => 1,
+			'messages' => [ __( 'SWPS sitemap generation enabled at /swps-sitemap.xml.', 'stratawp-seo' ) ],
+		];
+	}
+
+	/**
+	 * Detect if another sitemap provider is active.
+	 */
+	private function detect_other_sitemap(): bool {
+		// Yoast SEO.
+		if ( defined( 'WPSEO_VERSION' ) && class_exists( 'WPSEO_Sitemaps' ) ) {
+			return true;
+		}
+
+		// RankMath.
+		if ( class_exists( 'RankMath' ) ) {
+			return true;
+		}
+
+		// WordPress core sitemaps (WP 5.5+).
+		if ( function_exists( 'wp_sitemaps_get_server' ) ) {
+			$server = wp_sitemaps_get_server();
+			if ( $server && method_exists( $server, 'sitemaps_enabled' ) && $server->sitemaps_enabled() ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Register sitemap rewrite rules.
+	 * Called from main plugin on init.
+	 */
+	public static function register_rewrite_rules(): void {
+		if ( ! get_option( 'swps_audit_auto_sitemap', 1 ) ) {
+			return;
+		}
+
+		add_rewrite_rule( 'swps-sitemap\.xml$', 'index.php?swps_sitemap=1', 'top' );
+		add_filter( 'query_vars', function ( array $vars ): array {
+			$vars[] = 'swps_sitemap';
+			return $vars;
+		} );
+	}
+
+	/**
+	 * Handle the sitemap request.
+	 * Hooked to template_redirect from the main plugin class.
+	 */
+	public static function serve_sitemap(): void {
+		if ( ! get_query_var( 'swps_sitemap' ) ) {
+			return;
+		}
+
+		// Skip if another provider is active.
+		$module = new self();
+		if ( $module->detect_other_sitemap() ) {
+			return;
+		}
+
+		if ( ! get_option( 'swps_audit_auto_sitemap', 1 ) ) {
+			return;
+		}
+
+		header( 'Content-Type: application/xml; charset=UTF-8' );
+		header( 'X-Robots-Tag: noindex' );
+
+		echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
+		echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"' . "\n";
+		echo '        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">' . "\n";
+
+		// Homepage.
+		printf(
+			"<url>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n  <priority>1.0</priority>\n</url>\n",
+			esc_url( home_url( '/' ) ),
+			gmdate( 'Y-m-d\TH:i:s+00:00' )
+		);
+
+		$posts = get_posts( [
+			'post_type'      => get_post_types( [ 'public' => true ] ),
+			'post_status'    => 'publish',
+			'posts_per_page' => 2000,
+			'orderby'        => 'modified',
+			'order'          => 'DESC',
+			'no_found_rows'  => true,
+		] );
+
+		$now = time();
+
+		foreach ( $posts as $post ) {
+			// Skip noindex posts.
+			$noindex = get_post_meta( $post->ID, '_yoast_wpseo_meta-robots-noindex', true );
+			$rm_robots = get_post_meta( $post->ID, 'rank_math_robots', true );
+			if ( '1' === $noindex || ( is_array( $rm_robots ) && in_array( 'noindex', $rm_robots, true ) ) ) {
+				continue;
+			}
+
+			$modified = get_post_modified_time( 'U', true, $post );
+			$age_days = ( $now - $modified ) / DAY_IN_SECONDS;
+			$priority = $age_days < 30 ? '0.8' : '0.6';
+
+			echo "<url>\n";
+			printf( "  <loc>%s</loc>\n", esc_url( get_permalink( $post ) ) );
+			printf( "  <lastmod>%s</lastmod>\n", gmdate( 'Y-m-d\TH:i:s+00:00', $modified ) );
+			printf( "  <priority>%s</priority>\n", $priority );
+
+			// Image entry for featured image.
+			$thumb_id = get_post_thumbnail_id( $post->ID );
+			if ( $thumb_id ) {
+				$img_url = wp_get_attachment_url( $thumb_id );
+				if ( $img_url ) {
+					echo "  <image:image>\n";
+					printf( "    <image:loc>%s</image:loc>\n", esc_url( $img_url ) );
+					$alt = get_post_meta( $thumb_id, '_wp_attachment_image_alt', true );
+					if ( $alt ) {
+						printf( "    <image:title>%s</image:title>\n", esc_xml( $alt ) );
+					}
+					echo "  </image:image>\n";
+				}
+			}
+
+			echo "</url>\n";
+		}
+
+		echo '</urlset>';
+		exit;
+	}
+
+	/**
+	 * Ping search engines after a post is published.
+	 */
+	public static function ping_search_engines(): void {
+		if ( ! get_option( 'swps_audit_auto_sitemap', 1 ) ) {
+			return;
+		}
+
+		$sitemap_url = home_url( '/swps-sitemap.xml' );
+
+		wp_remote_get( 'https://www.google.com/ping?sitemap=' . urlencode( $sitemap_url ), [
+			'timeout'   => 5,
+			'blocking'  => false,
+			'sslverify' => false,
+		] );
+
+		wp_remote_get( 'https://www.bing.com/ping?sitemap=' . urlencode( $sitemap_url ), [
+			'timeout'   => 5,
+			'blocking'  => false,
+			'sslverify' => false,
+		] );
+	}
+}

--- a/includes/audit/class-twitter-module.php
+++ b/includes/audit/class-twitter-module.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Twitter Cards audit module.
+ *
+ * Checks for twitter:card meta tags on public posts.
+ * Auto-fix is handled by the OpenGraph module (both output together).
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_Twitter_Module extends SWPS_Audit_Module {
+
+	public function get_id(): string {
+		return 'twitter';
+	}
+
+	public function get_label(): string {
+		return __( 'Twitter Cards', 'stratawp-seo' );
+	}
+
+	public function can_auto_fix(): bool {
+		return true;
+	}
+
+	public function run(): array {
+		// Twitter cards are output by the OpenGraph module.
+		// This module just checks the same conditions.
+		if ( defined( 'WPSEO_VERSION' ) || class_exists( 'RankMath' ) ) {
+			return [
+				'score'   => 100,
+				'status'  => 'pass',
+				'issues'  => [],
+				'summary' => __( 'Twitter Cards managed by SEO plugin.', 'stratawp-seo' ),
+			];
+		}
+
+		$our_og = (bool) get_option( 'swps_audit_auto_og', 1 );
+
+		if ( $our_og ) {
+			return [
+				'score'   => 100,
+				'status'  => 'pass',
+				'issues'  => [],
+				'summary' => __( 'Twitter Cards output via SWPS OG auto-tags.', 'stratawp-seo' ),
+			];
+		}
+
+		return [
+			'score'   => 0,
+			'status'  => 'fail',
+			'issues'  => [
+				[
+					'post_id' => null,
+					'message' => __( 'No Twitter Card tags detected. Enable OG auto-tags to fix.', 'stratawp-seo' ),
+					'fixable' => true,
+				],
+			],
+			'summary' => __( 'No Twitter Card tags found.', 'stratawp-seo' ),
+		];
+	}
+
+	public function auto_fix( array $issues ): array {
+		// Enable OG (which includes Twitter tags).
+		update_option( 'swps_audit_auto_og', 1 );
+
+		return [
+			'fixed'    => 1,
+			'messages' => [ __( 'OG auto-tags enabled (includes Twitter Cards).', 'stratawp-seo' ) ],
+		];
+	}
+}

--- a/includes/class-audit-module.php
+++ b/includes/class-audit-module.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Abstract base class for SEO audit modules.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+abstract class SWPS_Audit_Module {
+
+	/**
+	 * Unique module identifier (e.g. 'canonical', 'sitemap').
+	 */
+	abstract public function get_id(): string;
+
+	/**
+	 * Human-readable module name.
+	 */
+	abstract public function get_label(): string;
+
+	/**
+	 * Run the audit check.
+	 *
+	 * @return array {
+	 *     @type int    $score   0-100 score.
+	 *     @type string $status  'pass' | 'warning' | 'fail'.
+	 *     @type array  $issues  Array of issue arrays with 'post_id', 'message', 'fixable'.
+	 *     @type string $summary One-line human summary.
+	 * }
+	 */
+	abstract public function run(): array;
+
+	/**
+	 * Whether this module supports auto-fix.
+	 */
+	abstract public function can_auto_fix(): bool;
+
+	/**
+	 * Run auto-fix for the given issues.
+	 *
+	 * @param array $issues Issues from a prior run().
+	 * @return array { @type int $fixed Count of fixed issues. @type string[] $messages Log messages. }
+	 */
+	public function auto_fix( array $issues ): array {
+		return [ 'fixed' => 0, 'messages' => [] ];
+	}
+
+	/**
+	 * Determine status string from a score.
+	 *
+	 * @param int $score 0-100 score.
+	 * @return string 'pass' | 'warning' | 'fail'.
+	 */
+	protected function status_from_score( int $score ): string {
+		if ( $score >= 80 ) {
+			return 'pass';
+		}
+		if ( $score >= 50 ) {
+			return 'warning';
+		}
+		return 'fail';
+	}
+
+	/**
+	 * Helper: Get all published public posts/pages.
+	 *
+	 * @param int $limit Max posts to query. Default 500.
+	 * @return WP_Post[]
+	 */
+	protected function get_public_posts( int $limit = 500 ): array {
+		return get_posts( [
+			'post_type'      => get_post_types( [ 'public' => true ] ),
+			'post_status'    => 'publish',
+			'posts_per_page' => $limit,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+			'no_found_rows'  => true,
+		] );
+	}
+}

--- a/includes/class-hooks.php
+++ b/includes/class-hooks.php
@@ -190,4 +190,35 @@ class SWPS_Hooks {
     public static function do_image_inserted( int $attachment_id, int $post_id, string $alt_text, int $position ): void {
         do_action( 'swps_image_inserted', $attachment_id, $post_id, $alt_text, $position );
     }
+
+    /**
+     * Apply the audit modules filter.
+     *
+     * @param SWPS_Audit_Module[] $modules Registered modules.
+     * @return SWPS_Audit_Module[]
+     */
+    public static function filter_audit_modules( array $modules ): array {
+        return apply_filters( 'swps_audit_modules', $modules );
+    }
+
+    /**
+     * Apply the audit result filter.
+     *
+     * @param array  $result    Module result array.
+     * @param string $module_id Module ID.
+     * @return array
+     */
+    public static function filter_audit_result( array $result, string $module_id ): array {
+        return apply_filters( 'swps_audit_result', $result, $module_id );
+    }
+
+    /**
+     * Fire the audit_complete action.
+     *
+     * @param array $results All module results.
+     * @param int   $overall Overall score.
+     */
+    public static function do_audit_complete( array $results, int $overall ): void {
+        do_action( 'swps_audit_complete', $results, $overall );
+    }
 }

--- a/includes/class-rest-api.php
+++ b/includes/class-rest-api.php
@@ -157,6 +157,29 @@ class SWPS_REST_API {
                 ],
             ],
         ] );
+
+        // Audit endpoints.
+        register_rest_route( self::NAMESPACE, '/audit', [
+            [
+                'methods'             => 'GET',
+                'callback'            => [ $this, 'get_audit' ],
+                'permission_callback' => [ $this, 'check_permissions' ],
+            ],
+            [
+                'methods'             => 'POST',
+                'callback'            => [ $this, 'run_audit' ],
+                'permission_callback' => [ $this, 'check_permissions' ],
+            ],
+        ] );
+
+        register_rest_route( self::NAMESPACE, '/audit/fix/(?P<module_id>[a-z_]+)', [
+            'methods'             => 'POST',
+            'callback'            => [ $this, 'fix_audit_module' ],
+            'permission_callback' => [ $this, 'check_permissions' ],
+            'args'                => [
+                'module_id' => [ 'type' => 'string', 'required' => true, 'sanitize_callback' => 'sanitize_text_field' ],
+            ],
+        ] );
     }
 
     /**
@@ -434,6 +457,58 @@ class SWPS_REST_API {
 
         return new WP_REST_Response( [
             'success' => $success,
+        ] );
+    }
+
+    /**
+     * GET /audit - Get cached audit results.
+     */
+    public function get_audit(): WP_REST_Response {
+        $audit = stratawp_seo()->seo_audit;
+
+        return new WP_REST_Response( [
+            'success' => true,
+            'data'    => $audit->get_cached_results(),
+            'last_run' => $audit->get_last_run(),
+        ] );
+    }
+
+    /**
+     * POST /audit - Run a fresh audit.
+     */
+    public function run_audit(): WP_REST_Response {
+        $audit   = stratawp_seo()->seo_audit;
+        $results = $audit->run_all();
+
+        return new WP_REST_Response( [
+            'success'  => true,
+            'data'     => $results,
+            'last_run' => $audit->get_last_run(),
+        ] );
+    }
+
+    /**
+     * POST /audit/fix/{module_id} - Auto-fix a specific module.
+     */
+    public function fix_audit_module( WP_REST_Request $request ): WP_REST_Response {
+        $audit     = stratawp_seo()->seo_audit;
+        $module_id = $request->get_param( 'module_id' );
+
+        $fix_result = $audit->fix_module( $module_id );
+
+        if ( null === $fix_result ) {
+            return new WP_REST_Response( [
+                'success' => false,
+                'message' => 'Module not found or does not support auto-fix.',
+            ], 404 );
+        }
+
+        return new WP_REST_Response( [
+            'success' => true,
+            'data'    => [
+                'fix'     => $fix_result,
+                'results' => $audit->get_cached_results(),
+            ],
         ] );
     }
 }

--- a/includes/class-seo-audit.php
+++ b/includes/class-seo-audit.php
@@ -35,6 +35,20 @@ class SWPS_SEO_Audit {
 	public function __construct() {
 		add_action( 'init', [ $this, 'register_default_modules' ], 20 );
 		add_action( self::CRON_HOOK, [ $this, 'run_all' ] );
+		add_filter( 'cron_schedules', [ $this, 'register_custom_schedules' ] );
+	}
+
+	/**
+	 * Register custom cron schedules needed by the audit.
+	 */
+	public function register_custom_schedules( array $schedules ): array {
+		if ( ! isset( $schedules['swps_monthly'] ) ) {
+			$schedules['swps_monthly'] = [
+				'interval' => 30 * DAY_IN_SECONDS,
+				'display'  => __( 'Monthly', 'stratawp-seo' ),
+			];
+		}
+		return $schedules;
 	}
 
 	/**

--- a/includes/class-seo-audit.php
+++ b/includes/class-seo-audit.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * SEO Audit coordinator -- registers modules, runs audits, caches results.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_SEO_Audit {
+
+	private const RESULTS_OPTION  = 'swps_audit_results';
+	private const LAST_RUN_OPTION = 'swps_audit_last_run';
+	private const CRON_HOOK       = 'swps_audit_cron';
+
+	/**
+	 * Default weights per module ID for overall score.
+	 */
+	private const WEIGHTS = [
+		'canonical'   => 15,
+		'sitemap'     => 15,
+		'opengraph'   => 12,
+		'twitter'     => 8,
+		'robots'      => 10,
+		'meta_robots' => 15,
+		'image_seo'   => 15,
+		'pagespeed'   => 10,
+	];
+
+	/** @var SWPS_Audit_Module[] */
+	private array $modules = [];
+
+	public function __construct() {
+		add_action( 'init', [ $this, 'register_default_modules' ], 20 );
+		add_action( self::CRON_HOOK, [ $this, 'run_all' ] );
+	}
+
+	/**
+	 * Register the 8 built-in audit modules.
+	 */
+	public function register_default_modules(): void {
+		$defaults = [
+			new SWPS_Canonical_Module(),
+			new SWPS_Sitemap_Module(),
+			new SWPS_OpenGraph_Module(),
+			new SWPS_Twitter_Module(),
+			new SWPS_Robots_Module(),
+			new SWPS_Meta_Robots_Module(),
+			new SWPS_Image_SEO_Module(),
+			new SWPS_PageSpeed_Module(),
+		];
+
+		foreach ( $defaults as $module ) {
+			$this->modules[ $module->get_id() ] = $module;
+		}
+
+		/**
+		 * Filter the registered audit modules.
+		 *
+		 * @param SWPS_Audit_Module[] $modules Keyed by module ID.
+		 */
+		$this->modules = apply_filters( 'swps_audit_modules', $this->modules );
+	}
+
+	/**
+	 * Run all registered modules and cache results.
+	 *
+	 * @return array { @type int $overall_score, @type array $modules keyed by ID }
+	 */
+	public function run_all(): array {
+		$results = [];
+
+		foreach ( $this->modules as $id => $module ) {
+			$result          = $module->run();
+			$results[ $id ]  = apply_filters( 'swps_audit_result', $result, $id );
+		}
+
+		$overall = $this->calculate_overall_score( $results );
+
+		$data = [
+			'overall_score' => $overall,
+			'modules'       => $results,
+		];
+
+		update_option( self::RESULTS_OPTION, $data, false );
+		update_option( self::LAST_RUN_OPTION, current_time( 'mysql' ), false );
+
+		do_action( 'swps_audit_complete', $data, $overall );
+
+		return $data;
+	}
+
+	/**
+	 * Run a single module by ID.
+	 *
+	 * @param string $id Module identifier.
+	 * @return array|null Module result or null if not found.
+	 */
+	public function run_module( string $id ): ?array {
+		if ( ! isset( $this->modules[ $id ] ) ) {
+			return null;
+		}
+
+		$result = $this->modules[ $id ]->run();
+		$result = apply_filters( 'swps_audit_result', $result, $id );
+
+		// Update the cached results for this module.
+		$cached                    = $this->get_cached_results();
+		$cached['modules'][ $id ] = $result;
+		$cached['overall_score']  = $this->calculate_overall_score( $cached['modules'] );
+
+		update_option( self::RESULTS_OPTION, $cached, false );
+
+		return $result;
+	}
+
+	/**
+	 * Run auto-fix for a specific module.
+	 *
+	 * @param string $id Module identifier.
+	 * @return array|null Fix result or null if module not found or not fixable.
+	 */
+	public function fix_module( string $id ): ?array {
+		if ( ! isset( $this->modules[ $id ] ) || ! $this->modules[ $id ]->can_auto_fix() ) {
+			return null;
+		}
+
+		$cached = $this->get_cached_results();
+		$issues = $cached['modules'][ $id ]['issues'] ?? [];
+
+		$fix_result = $this->modules[ $id ]->auto_fix( $issues );
+
+		// Re-run the module to get updated results.
+		$this->run_module( $id );
+
+		return $fix_result;
+	}
+
+	/**
+	 * Get cached audit results.
+	 *
+	 * @return array { @type int $overall_score, @type array $modules }
+	 */
+	public function get_cached_results(): array {
+		return get_option( self::RESULTS_OPTION, [
+			'overall_score' => 0,
+			'modules'       => [],
+		] );
+	}
+
+	/**
+	 * Get last run timestamp.
+	 *
+	 * @return string MySQL datetime string or empty.
+	 */
+	public function get_last_run(): string {
+		return get_option( self::LAST_RUN_OPTION, '' );
+	}
+
+	/**
+	 * Get all registered modules.
+	 *
+	 * @return SWPS_Audit_Module[]
+	 */
+	public function get_modules(): array {
+		return $this->modules;
+	}
+
+	/**
+	 * Calculate weighted overall score from module results.
+	 *
+	 * @param array $module_results Module results keyed by ID.
+	 * @return int Weighted overall score 0-100.
+	 */
+	private function calculate_overall_score( array $module_results ): int {
+		$total_weight = 0;
+		$weighted_sum = 0;
+
+		foreach ( $module_results as $id => $result ) {
+			$weight        = self::WEIGHTS[ $id ] ?? 10;
+			$weighted_sum += ( $result['score'] ?? 0 ) * $weight;
+			$total_weight += $weight;
+		}
+
+		if ( 0 === $total_weight ) {
+			return 0;
+		}
+
+		return (int) round( $weighted_sum / $total_weight );
+	}
+
+	/**
+	 * Schedule the audit cron.
+	 */
+	public static function schedule_cron(): void {
+		self::unschedule_cron();
+
+		$schedule = get_option( 'swps_audit_cron_schedule', 'weekly' );
+
+		$recurrence_map = [
+			'daily'   => 'daily',
+			'weekly'  => 'weekly',
+			'monthly' => 'swps_monthly',
+		];
+
+		$recurrence = $recurrence_map[ $schedule ] ?? 'weekly';
+		$next_run   = time() + DAY_IN_SECONDS; // Start tomorrow.
+
+		wp_schedule_event( $next_run, $recurrence, self::CRON_HOOK );
+	}
+
+	/**
+	 * Unschedule the audit cron.
+	 */
+	public static function unschedule_cron(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+		wp_unschedule_hook( self::CRON_HOOK );
+	}
+}

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -57,6 +57,15 @@ class SWPS_Settings {
             'swps-voice-profiles',
             [ $this, 'render_voice_profiles_page' ]
         );
+
+        add_submenu_page(
+            'stratawp-seo',
+            __( 'SEO Audit', 'stratawp-seo' ),
+            __( 'SEO Audit', 'stratawp-seo' ),
+            'manage_options',
+            'swps-seo-audit',
+            [ $this, 'render_audit_page' ]
+        );
     }
 
     /**
@@ -281,6 +290,30 @@ class SWPS_Settings {
             'min'         => 1,
             'max'         => 5,
             'description' => __( 'Number of posts to generate each time (max 5).', 'stratawp-seo' ),
+        ] );
+
+        // --- SEO Audit Section ---
+        add_settings_section( 'swps_audit_section', __( 'SEO Audit', 'stratawp-seo' ), [ $this, 'render_audit_section' ], 'stratawp-seo' );
+
+        $this->add_field( 'audit_auto_canonical', __( 'Auto Canonical Tags', 'stratawp-seo' ), 'checkbox', 'swps_audit_section', [
+            'label' => __( 'Automatically add canonical tags to posts/pages missing them', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'audit_auto_og', __( 'Auto OG/Twitter Tags', 'stratawp-seo' ), 'checkbox', 'swps_audit_section', [
+            'label' => __( 'Automatically output Open Graph and Twitter Card meta tags', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'audit_auto_sitemap', __( 'Sitemap Generation', 'stratawp-seo' ), 'checkbox', 'swps_audit_section', [
+            'label' => __( 'Generate XML sitemap (only when no other sitemap plugin is active)', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'audit_cron_schedule', __( 'Audit Schedule', 'stratawp-seo' ), 'select', 'swps_audit_section', [
+            'options' => [
+                'daily'   => __( 'Daily', 'stratawp-seo' ),
+                'weekly'  => __( 'Weekly', 'stratawp-seo' ),
+                'monthly' => __( 'Monthly', 'stratawp-seo' ),
+            ],
+            'description' => __( 'How often to run the automated SEO audit.', 'stratawp-seo' ),
         ] );
 
         // --- Advanced Section (v2.0) ---
@@ -616,5 +649,17 @@ class SWPS_Settings {
         } else {
             include SWPS_PLUGIN_DIR . 'templates/voice-profiles-page.php';
         }
+    }
+
+    public function render_audit_section(): void {
+        echo '<p>' . esc_html__( 'Configure automatic SEO audit checks and fixes.', 'stratawp-seo' ) . '</p>';
+    }
+
+    public function render_audit_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        include SWPS_PLUGIN_DIR . 'templates/audit-page.php';
     }
 }

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -205,6 +205,7 @@ final class StrataWP_SEO {
 
         // SEO Audit AJAX handlers.
         add_action( 'wp_ajax_swps_run_audit', [ $this, 'ajax_run_audit' ] );
+        add_action( 'wp_ajax_swps_get_audit_results', [ $this, 'ajax_get_audit_results' ] );
         add_action( 'wp_ajax_swps_fix_module', [ $this, 'ajax_fix_module' ] );
         add_action( 'wp_ajax_swps_fix_all', [ $this, 'ajax_fix_all' ] );
 
@@ -247,6 +248,12 @@ final class StrataWP_SEO {
      * Enqueue admin CSS and JS on our pages only.
      */
     public function enqueue_admin_assets( string $hook ): void {
+        // Load only CSS on the Dashboard (for the audit widget).
+        if ( 'index.php' === $hook ) {
+            wp_enqueue_style( 'swps-admin', SWPS_PLUGIN_URL . 'admin/css/admin.css', [], SWPS_VERSION );
+            return;
+        }
+
         if ( ! str_contains( $hook, 'stratawp-seo' ) && ! str_contains( $hook, 'swps-generate' ) && ! str_contains( $hook, 'swps-voice-profiles' ) && ! str_contains( $hook, 'swps-seo-audit' ) ) {
             return;
         }
@@ -661,7 +668,7 @@ final class StrataWP_SEO {
             printf(
                 '<p class="description">%s %s</p>',
                 esc_html__( 'Last audited:', 'stratawp-seo' ),
-                esc_html( human_time_diff( strtotime( $last_run ), current_time( 'timestamp' ) ) . ' ago' )
+                esc_html( human_time_diff( strtotime( $last_run ), time() ) . ' ago' )
             );
         }
     }
@@ -679,6 +686,19 @@ final class StrataWP_SEO {
         $results = $this->seo_audit->run_all();
 
         wp_send_json_success( $results );
+    }
+
+    /**
+     * AJAX: Get cached audit results without re-running.
+     */
+    public function ajax_get_audit_results(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        wp_send_json_success( $this->seo_audit->get_cached_results() );
     }
 
     /**

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -65,6 +65,18 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-content-scorer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-voice-profile.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-image-inserter.php';
 
+// SEO Audit classes.
+require_once SWPS_PLUGIN_DIR . 'includes/class-audit-module.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-seo-audit.php';
+require_once SWPS_PLUGIN_DIR . 'includes/audit/class-canonical-module.php';
+require_once SWPS_PLUGIN_DIR . 'includes/audit/class-sitemap-module.php';
+require_once SWPS_PLUGIN_DIR . 'includes/audit/class-opengraph-module.php';
+require_once SWPS_PLUGIN_DIR . 'includes/audit/class-twitter-module.php';
+require_once SWPS_PLUGIN_DIR . 'includes/audit/class-robots-module.php';
+require_once SWPS_PLUGIN_DIR . 'includes/audit/class-meta-robots-module.php';
+require_once SWPS_PLUGIN_DIR . 'includes/audit/class-image-seo-module.php';
+require_once SWPS_PLUGIN_DIR . 'includes/audit/class-pagespeed-module.php';
+
 // Core classes.
 require_once SWPS_PLUGIN_DIR . 'includes/class-settings.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-analyzer.php';
@@ -107,6 +119,7 @@ final class StrataWP_SEO {
     public SWPS_Content_Scorer $content_scorer;
     public SWPS_Voice_Profile $voice_profile;
     public SWPS_Image_Inserter $image_inserter;
+    public SWPS_SEO_Audit $seo_audit;
 
     public static function instance(): self {
         if ( null === self::$instance ) {
@@ -131,6 +144,7 @@ final class StrataWP_SEO {
         $this->api       = SWPS_Provider_Factory::create_ai_provider();
         $this->images    = SWPS_Provider_Factory::create_image_provider();
         $this->image_inserter = new SWPS_Image_Inserter( $this->images );
+        $this->seo_audit = new SWPS_SEO_Audit();
         $this->settings  = new SWPS_Settings();
         $this->analyzer  = new SWPS_Analyzer( $this->cache_manager );
         $this->generator = new SWPS_Generator(
@@ -181,6 +195,22 @@ final class StrataWP_SEO {
         // In-content image insertion on post creation.
         add_action( 'swps_post_created', [ $this, 'insert_content_images' ], 20, 3 );
 
+        // SEO Audit frontend hooks.
+        add_action( 'wp_head', [ SWPS_Canonical_Module::class, 'output_canonical' ], 1 );
+        add_action( 'wp_head', [ SWPS_OpenGraph_Module::class, 'output_meta_tags' ], 5 );
+        add_action( 'init', [ SWPS_Sitemap_Module::class, 'register_rewrite_rules' ] );
+        add_action( 'template_redirect', [ SWPS_Sitemap_Module::class, 'serve_sitemap' ] );
+        add_action( 'publish_post', [ SWPS_Sitemap_Module::class, 'ping_search_engines' ] );
+        add_filter( 'robots_txt', [ SWPS_Robots_Module::class, 'filter_robots_txt' ], 10, 2 );
+
+        // SEO Audit AJAX handlers.
+        add_action( 'wp_ajax_swps_run_audit', [ $this, 'ajax_run_audit' ] );
+        add_action( 'wp_ajax_swps_fix_module', [ $this, 'ajax_fix_module' ] );
+        add_action( 'wp_ajax_swps_fix_all', [ $this, 'ajax_fix_all' ] );
+
+        // Dashboard widget.
+        add_action( 'wp_dashboard_setup', [ $this, 'register_dashboard_widget' ] );
+
         // Plugins page link.
         add_filter( 'plugin_action_links_' . SWPS_PLUGIN_BASENAME, [ $this, 'add_settings_link' ] );
 
@@ -217,7 +247,7 @@ final class StrataWP_SEO {
      * Enqueue admin CSS and JS on our pages only.
      */
     public function enqueue_admin_assets( string $hook ): void {
-        if ( ! str_contains( $hook, 'stratawp-seo' ) && ! str_contains( $hook, 'swps-generate' ) && ! str_contains( $hook, 'swps-voice-profiles' ) ) {
+        if ( ! str_contains( $hook, 'stratawp-seo' ) && ! str_contains( $hook, 'swps-generate' ) && ! str_contains( $hook, 'swps-voice-profiles' ) && ! str_contains( $hook, 'swps-seo-audit' ) ) {
             return;
         }
 
@@ -555,6 +585,153 @@ final class StrataWP_SEO {
 
         wp_send_json_success();
     }
+
+    /**
+     * Register the SEO Audit dashboard widget.
+     */
+    public function register_dashboard_widget(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        wp_add_dashboard_widget(
+            'swps_audit_widget',
+            __( 'StrataWP SEO — Site Health', 'stratawp-seo' ),
+            [ $this, 'render_dashboard_widget' ]
+        );
+    }
+
+    /**
+     * Render the SEO Audit dashboard widget.
+     */
+    public function render_dashboard_widget(): void {
+        $results  = $this->seo_audit->get_cached_results();
+        $last_run = $this->seo_audit->get_last_run();
+        $modules  = $this->seo_audit->get_modules();
+        $overall  = $results['overall_score'] ?? 0;
+
+        $score_class = $overall >= 80 ? 'excellent' : ( $overall >= 50 ? 'good' : 'poor' );
+
+        if ( empty( $results['modules'] ) ) {
+            echo '<p>' . esc_html__( 'No audit results yet. Run your first audit.', 'stratawp-seo' ) . '</p>';
+            echo '<p><a href="' . esc_url( admin_url( 'admin.php?page=swps-seo-audit' ) ) . '" class="button button-primary">' . esc_html__( 'Run Audit', 'stratawp-seo' ) . '</a></p>';
+            return;
+        }
+
+        printf(
+            '<div class="swps-widget-score swps-score-badge swps-score-badge--%s" style="font-size:16px;padding:8px 16px;margin-bottom:12px;">%s: %d/100</div>',
+            esc_attr( $score_class ),
+            esc_html__( 'Site Health', 'stratawp-seo' ),
+            (int) $overall
+        );
+
+        echo '<table class="widefat striped" style="margin-bottom:12px;">';
+        echo '<tbody>';
+
+        foreach ( $modules as $id => $module ) {
+            $mod_result = $results['modules'][ $id ] ?? null;
+            $mod_status = $mod_result['status'] ?? 'fail';
+            $mod_score  = $mod_result['score'] ?? 0;
+            $issue_count = count( $mod_result['issues'] ?? [] );
+
+            $icon = match ( $mod_status ) {
+                'pass'    => '<span style="color:#00a32a;">&#10003;</span>',
+                'warning' => '<span style="color:#dba617;">&#9888;</span>',
+                default   => '<span style="color:#d63638;">&#10007;</span>',
+            };
+
+            printf(
+                '<tr><td>%s %s</td><td style="text-align:right;">%d/100</td><td style="text-align:right;color:#646970;">%d issues</td></tr>',
+                $icon, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                esc_html( $module->get_label() ),
+                (int) $mod_score,
+                $issue_count
+            );
+        }
+
+        echo '</tbody></table>';
+
+        printf(
+            '<p><a href="%s" class="button">%s</a></p>',
+            esc_url( admin_url( 'admin.php?page=swps-seo-audit' ) ),
+            esc_html__( 'View Details', 'stratawp-seo' )
+        );
+
+        if ( $last_run ) {
+            printf(
+                '<p class="description">%s %s</p>',
+                esc_html__( 'Last audited:', 'stratawp-seo' ),
+                esc_html( human_time_diff( strtotime( $last_run ), current_time( 'timestamp' ) ) . ' ago' )
+            );
+        }
+    }
+
+    /**
+     * AJAX: Run full SEO audit.
+     */
+    public function ajax_run_audit(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $results = $this->seo_audit->run_all();
+
+        wp_send_json_success( $results );
+    }
+
+    /**
+     * AJAX: Fix a single audit module.
+     */
+    public function ajax_fix_module(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $module_id  = sanitize_text_field( $_POST['module_id'] ?? '' );
+        $fix_result = $this->seo_audit->fix_module( $module_id );
+
+        if ( null === $fix_result ) {
+            wp_send_json_error( [ 'message' => 'Module not found or does not support auto-fix.' ] );
+        }
+
+        wp_send_json_success( [
+            'fix'     => $fix_result,
+            'results' => $this->seo_audit->get_cached_results(),
+        ] );
+    }
+
+    /**
+     * AJAX: Fix all fixable audit modules.
+     */
+    public function ajax_fix_all(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $all_fixes = [];
+
+        foreach ( $this->seo_audit->get_modules() as $id => $module ) {
+            if ( $module->can_auto_fix() ) {
+                $cached = $this->seo_audit->get_cached_results();
+                $issues = $cached['modules'][ $id ]['issues'] ?? [];
+
+                if ( ! empty( $issues ) ) {
+                    $all_fixes[ $id ] = $this->seo_audit->fix_module( $id );
+                }
+            }
+        }
+
+        wp_send_json_success( [
+            'fixes'   => $all_fixes,
+            'results' => $this->seo_audit->get_cached_results(),
+        ] );
+    }
 }
 
 /**
@@ -608,6 +785,11 @@ function swps_activate(): void {
         'image_max_width'       => 1200,
         'jon_ai_endpoint'    => '',
         'jon_ai_secret'      => '',
+        // SEO Audit defaults.
+        'audit_auto_canonical'  => 1,
+        'audit_auto_og'         => 1,
+        'audit_auto_sitemap'    => 1,
+        'audit_cron_schedule'   => 'weekly',
     ];
 
     foreach ( $defaults as $key => $value ) {
@@ -619,6 +801,7 @@ function swps_activate(): void {
     // Register CPTs for flush_rewrite_rules.
     SWPS_Topic_Queue::register_post_type();
     SWPS_Voice_Profile::register_post_type();
+    SWPS_SEO_Audit::schedule_cron();
     flush_rewrite_rules();
 
     if ( get_option( 'swps_cron_enabled' ) ) {
@@ -632,6 +815,7 @@ register_activation_hook( __FILE__, 'swps_activate' );
  */
 function swps_deactivate(): void {
     SWPS_Cron::unschedule();
+    SWPS_SEO_Audit::unschedule_cron();
     flush_rewrite_rules();
 }
 register_deactivation_hook( __FILE__, 'swps_deactivate' );

--- a/templates/audit-page.php
+++ b/templates/audit-page.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * SEO Audit admin page template.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$audit    = stratawp_seo()->seo_audit;
+$results  = $audit->get_cached_results();
+$last_run = $audit->get_last_run();
+$modules  = $audit->get_modules();
+$overall  = $results['overall_score'] ?? 0;
+
+$score_class = $overall >= 80 ? 'excellent' : ( $overall >= 50 ? 'good' : 'poor' );
+?>
+<div class="wrap swps-wrap">
+	<h1><?php esc_html_e( 'SEO Audit', 'stratawp-seo' ); ?></h1>
+
+	<div class="swps-audit-header">
+		<div class="swps-audit-score-circle swps-audit-score--<?php echo esc_attr( $score_class ); ?>">
+			<span class="swps-audit-score-number"><?php echo (int) $overall; ?></span>
+			<span class="swps-audit-score-label"><?php esc_html_e( 'Site Health', 'stratawp-seo' ); ?></span>
+		</div>
+
+		<div class="swps-audit-actions">
+			<button id="swps-run-audit" class="button button-primary button-hero">
+				<span class="dashicons dashicons-search" style="margin-top: 4px;"></span>
+				<?php esc_html_e( 'Run Audit', 'stratawp-seo' ); ?>
+			</button>
+
+			<button id="swps-fix-all" class="button button-hero">
+				<span class="dashicons dashicons-admin-tools" style="margin-top: 4px;"></span>
+				<?php esc_html_e( 'Fix All', 'stratawp-seo' ); ?>
+			</button>
+
+			<button id="swps-export-csv" class="button">
+				<?php esc_html_e( 'Export CSV', 'stratawp-seo' ); ?>
+			</button>
+
+			<?php if ( $last_run ) : ?>
+				<span class="swps-audit-last-run">
+					<?php
+					printf(
+						esc_html__( 'Last audited: %s', 'stratawp-seo' ),
+						esc_html( human_time_diff( strtotime( $last_run ), current_time( 'timestamp' ) ) . ' ago' )
+					);
+					?>
+				</span>
+			<?php endif; ?>
+		</div>
+	</div>
+
+	<div id="swps-audit-progress" class="swps-progress" style="display: none;">
+		<div class="swps-spinner"></div>
+		<div class="swps-progress-text">
+			<strong id="swps-audit-progress-title"><?php esc_html_e( 'Running audit...', 'stratawp-seo' ); ?></strong>
+		</div>
+	</div>
+
+	<div class="swps-audit-modules">
+		<?php foreach ( $modules as $id => $module ) :
+			$mod_result = $results['modules'][ $id ] ?? null;
+			$mod_score  = $mod_result['score'] ?? 0;
+			$mod_status = $mod_result['status'] ?? 'fail';
+			$issues     = $mod_result['issues'] ?? [];
+			$summary    = $mod_result['summary'] ?? __( 'Not yet audited.', 'stratawp-seo' );
+			$can_fix    = $module->can_auto_fix();
+
+			$status_icon = match ( $mod_status ) {
+				'pass'    => '<span class="dashicons dashicons-yes-alt" style="color:#00a32a;"></span>',
+				'warning' => '<span class="dashicons dashicons-warning" style="color:#dba617;"></span>',
+				default   => '<span class="dashicons dashicons-dismiss" style="color:#d63638;"></span>',
+			};
+		?>
+		<div class="swps-audit-module-card swps-card" data-module-id="<?php echo esc_attr( $id ); ?>">
+			<div class="swps-audit-module-header">
+				<div class="swps-audit-module-info">
+					<?php echo $status_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<strong><?php echo esc_html( $module->get_label() ); ?></strong>
+					<span class="swps-score-badge swps-score-badge--<?php echo $mod_score >= 80 ? 'excellent' : ( $mod_score >= 50 ? 'good' : 'poor' ); ?>">
+						<?php echo (int) $mod_score; ?>/100
+					</span>
+				</div>
+				<div class="swps-audit-module-actions">
+					<?php if ( $can_fix && ! empty( $issues ) ) : ?>
+						<button class="button swps-fix-module" data-module="<?php echo esc_attr( $id ); ?>">
+							<?php esc_html_e( 'Fix', 'stratawp-seo' ); ?>
+						</button>
+					<?php endif; ?>
+					<button class="button swps-toggle-issues" data-module="<?php echo esc_attr( $id ); ?>">
+						<?php echo count( $issues ); ?> <?php esc_html_e( 'issues', 'stratawp-seo' ); ?>
+						<span class="dashicons dashicons-arrow-down-alt2"></span>
+					</button>
+				</div>
+			</div>
+			<p class="swps-audit-module-summary"><?php echo esc_html( $summary ); ?></p>
+
+			<?php if ( ! empty( $issues ) ) : ?>
+			<div class="swps-audit-issues" id="swps-issues-<?php echo esc_attr( $id ); ?>" style="display: none;">
+				<table class="widefat striped">
+					<tbody>
+					<?php foreach ( $issues as $issue ) : ?>
+						<tr>
+							<td>
+								<?php echo esc_html( $issue['message'] ); ?>
+								<?php if ( $issue['post_id'] ) : ?>
+									<a href="<?php echo esc_url( get_edit_post_link( $issue['post_id'] ) ); ?>" target="_blank" class="swps-issue-link">
+										<?php esc_html_e( 'Edit', 'stratawp-seo' ); ?> &rarr;
+									</a>
+								<?php endif; ?>
+							</td>
+							<td class="swps-issue-fixable">
+								<?php if ( $issue['fixable'] ) : ?>
+									<span class="dashicons dashicons-admin-tools" title="<?php esc_attr_e( 'Auto-fixable', 'stratawp-seo' ); ?>"></span>
+								<?php endif; ?>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+					</tbody>
+				</table>
+			</div>
+			<?php endif; ?>
+		</div>
+		<?php endforeach; ?>
+	</div>
+</div>

--- a/templates/audit-page.php
+++ b/templates/audit-page.php
@@ -46,7 +46,7 @@ $score_class = $overall >= 80 ? 'excellent' : ( $overall >= 50 ? 'good' : 'poor'
 					<?php
 					printf(
 						esc_html__( 'Last audited: %s', 'stratawp-seo' ),
-						esc_html( human_time_diff( strtotime( $last_run ), current_time( 'timestamp' ) ) . ' ago' )
+						esc_html( human_time_diff( strtotime( $last_run ), time() ) . ' ago' )
 					);
 					?>
 				</span>


### PR DESCRIPTION
## Summary

- **8 audit modules** with strategy-based architecture: Canonical URLs, XML Sitemap, Open Graph, Twitter Cards, Robots.txt, Meta Robots, Image SEO, and Page Speed Hints
- **Auto-fix capabilities** for canonicals, OG/Twitter tags, sitemap generation, robots.txt enhancement, and image alt text — with Yoast/RankMath conflict avoidance
- **Admin audit page** with weighted score circle, expandable module cards, one-click Fix All, and CSV export
- **Full plugin integration**: Settings API (4 audit config fields), REST API (3 endpoints), Dashboard Widget, WP-Cron scheduling (daily/weekly/monthly), and developer hooks via `SWPS_Hooks`

## Architecture

Abstract `SWPS_Audit_Module` base class defines the contract (`run()`, `can_auto_fix()`, `auto_fix()`). `SWPS_SEO_Audit` coordinator registers all 8 modules and orchestrates audits with weighted scoring. Each module is self-contained in `includes/audit/`.

**New files (11):** Base class, coordinator, 8 module classes, admin template  
**Modified files (6):** Main plugin file, settings, hooks, REST API, admin CSS, admin JS  
**Total:** 17 files, +2,163 lines

## Test plan

- [ ] Activate plugin — verify no PHP errors, audit settings appear under StrataWP SEO menu
- [ ] Navigate to SEO Audit page — verify score circle renders, all 8 modules display
- [ ] Click "Run Audit" — verify AJAX spinner, results populate with scores and issues
- [ ] Click "Fix All" — verify auto-fixable modules apply fixes, re-audit shows improvement
- [ ] Expand module cards — verify issue tables show details (URL, current value, recommendation)
- [ ] Click "Export CSV" — verify download with correct audit data (no re-run)
- [ ] Check Dashboard — verify SEO Health widget appears with score and module breakdown
- [ ] Test with Yoast active — verify canonical/OG modules detect and defer to Yoast
- [ ] Visit `/swps-sitemap.xml` after enabling auto-sitemap — verify valid XML output
- [ ] Verify WP-Cron: set schedule to daily, confirm `swps_audit_cron` event registered
- [ ] Test REST endpoints: `GET /wp-json/swps/v1/audit`, `POST .../audit`, `POST .../audit/fix/{id}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)