### PR TITLE
feat: Add Schema / Structured Data with JSON-LD output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,536 @@
+# StrataWP SEO
+
+**AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, and technical SEO — on autopilot.
+
+[![Version](https://img.shields.io/badge/version-2.1.0-blue.svg)]()
+[![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
+[![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
+[![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
+
+---
+
+## Screenshots
+
+<!-- Replace these placeholders with actual screenshots -->
+
+| Settings Page | Generate Content |
+|---|---|
+| ![Settings](screenshots/settings-page.png) | ![Generate](screenshots/generate-page.png) |
+
+| SEO Audit Dashboard | Schema JSON-LD Output |
+|---|---|
+| ![Audit](screenshots/audit-page.png) | ![Schema](screenshots/schema-output.png) |
+
+---
+
+## Features
+
+### AI Content Generation
+- **Multi-provider AI** — Anthropic (Claude), OpenAI (GPT), Google (Gemini), xAI (Grok)
+- **Site-aware generation** — analyzes your existing content, categories, and internal links before writing
+- **7 content templates** — Auto, Listicle, How-To Guide, Comparison, Case Study, News Analysis, Tutorial
+- **Voice profiles** — create reusable writing personas with tone, formality, vocabulary, and style preferences
+- **Internal linking** — automatically links to your existing posts (configurable min/max)
+- **FAQ sections** — generates FAQ with JSON-LD structured data for rich snippets
+- **Key Takeaways** — optional bullet-point summary with ItemList schema
+- **Table of Contents** — linked TOC at the top of each post
+- **Duplicate detection** — prevents generating content too similar to existing posts (85% threshold)
+- **Content scoring** — rates generated posts on SEO quality; optionally blocks low-scoring posts as drafts
+
+### Featured & In-Content Images
+- **4 image providers** — Unsplash, Pexels, Pixabay, DALL-E (AI-generated)
+- **Auto featured images** — fetches a relevant image for each generated post
+- **In-content images** — inserts contextual images within the post body (1-4 per post)
+
+### Automated Publishing
+- **Flexible scheduling** — daily, twice weekly, three times weekly, weekly, biweekly, or monthly
+- **Topic queue** — pre-load topics with scheduled dates and template preferences
+- **Content calendar** — visual overview of scheduled and generated content
+- **Bulk generation** — generate up to 5 posts in one click
+
+### Technical SEO Audit
+- **8 audit modules** — Canonical URLs, XML Sitemap, Open Graph, Twitter Cards, Robots.txt, Meta Robots, Image SEO, Page Speed Hints
+- **Auto-fix** — one-click fixes for canonical tags, OG/Twitter meta, sitemap generation
+- **Scheduled audits** — daily, weekly, or monthly automated checks
+- **Dashboard widget** — site health score at a glance
+- **CSV export** — download audit results for reporting
+
+### Schema / Structured Data
+- **Article schema** — automatic JSON-LD on all posts (Article, BlogPosting, or NewsArticle)
+- **Breadcrumb schema** — BreadcrumbList on posts, pages, archives, and author pages
+- **WebSite schema** — with optional SearchAction for Google sitelinks searchbox
+- **Organization/Person schema** — configurable entity type with logo and social profiles
+- **Conflict detection** — auto-disables when Yoast SEO, RankMath, or All in One SEO is active
+
+### Developer Features
+- **20+ filters and actions** — extend every part of the generation pipeline
+- **WP-CLI commands** — generate, analyze, manage queue, and check status from the terminal
+- **REST API** — programmatic access to generation and audit features
+- **Cost tracking** — monitor token usage and estimated API costs
+
+---
+
+## Installation
+
+### From WordPress Admin
+1. Download the plugin ZIP file
+2. Go to **Plugins > Add New > Upload Plugin**
+3. Upload the ZIP and click **Install Now**
+4. Click **Activate**
+
+### Manual Installation
+1. Upload the `stratawp-seo` folder to `/wp-content/plugins/`
+2. Activate through the **Plugins** menu in WordPress
+
+### Requirements
+- WordPress 6.0 or higher
+- PHP 8.0 or higher
+- An API key from at least one AI provider (Anthropic, OpenAI, Google, or xAI)
+
+---
+
+## Quick Start
+
+1. **Add your API key** — Go to **StrataWP SEO > Settings** and enter your AI provider API key (Anthropic recommended)
+2. **Describe your site** — Fill in your site niche and description so the AI understands your audience
+3. **Set your preferences** — Choose tone, word count range, and post status (draft recommended to start)
+4. **Generate your first post** — Go to **StrataWP SEO > Generate Content**, enter a topic, and click Generate
+5. **Review and publish** — Edit the generated draft in WordPress, then publish when ready
+
+---
+
+## Configuration Guide
+
+### AI Provider
+
+| Setting | Description |
+|---|---|
+| **AI Provider** | Choose between Anthropic (Claude), OpenAI (GPT), Google (Gemini), or xAI (Grok) |
+| **API Key** | Your provider's API key. Only the active provider's key is required |
+| **AI Model** | Model list updates automatically when you switch providers |
+
+### Featured Images
+
+| Setting | Description |
+|---|---|
+| **Auto Featured Images** | Automatically fetch a relevant featured image for each post |
+| **Image Provider** | Unsplash, Pexels, Pixabay (free stock photos), or DALL-E (AI-generated) |
+| **In-Content Images** | Insert contextual images within the post body |
+| **Images Per Post** | Number of in-content images (1-4) |
+| **Image Max Width** | Maximum width in pixels (600-2400) |
+
+### Site Details
+
+| Setting | Description |
+|---|---|
+| **Site Niche** | Your industry or topic area (e.g., "Home Renovation", "Digital Marketing") |
+| **Site Description** | Detailed description of your site, audience, and unique value proposition |
+
+The more detail you provide here, the more relevant and targeted your generated content will be.
+
+### Writing Preferences
+
+| Setting | Description |
+|---|---|
+| **Tone of Voice** | Professional, Conversational, Friendly, Authoritative, Casual, Formal, or Witty |
+| **Voice Profile** | Override tone with a reusable voice profile (create profiles under Voice Profiles) |
+| **Custom Style Notes** | Free-text instructions (e.g., "Use short paragraphs, avoid jargon") |
+| **Target Keywords** | Comma-separated keywords to weave into generated content |
+
+### Content Settings
+
+| Setting | Description |
+|---|---|
+| **Post Status** | Draft (recommended), Pending Review, or Published |
+| **Post Author** | WordPress user to assign as author |
+| **Default Category** | Fixed category, or let the AI choose the best fit |
+| **Word Count** | Minimum (300-5000) and maximum (500-8000) word targets |
+| **Internal Links** | Min and max number of links to your existing posts |
+| **FAQ Section** | Generate FAQ with JSON-LD schema for rich snippets |
+| **Table of Contents** | Linked TOC at the top of each post |
+| **Key Takeaways** | Bullet-point summary after the intro, with optional schema markup |
+
+### Auto-Publishing Schedule
+
+| Setting | Description |
+|---|---|
+| **Enable** | Turn on scheduled generation |
+| **Frequency** | Daily, twice weekly, three times weekly, weekly, biweekly, or monthly |
+| **Day of Week** | Starting day for the schedule |
+| **Time** | Time of day to run |
+| **Posts Per Run** | Number of posts per scheduled run (1-5) |
+
+### SEO Audit
+
+| Setting | Description |
+|---|---|
+| **Auto Canonical Tags** | Add canonical tags to posts/pages missing them |
+| **Auto OG/Twitter Tags** | Output Open Graph and Twitter Card meta tags |
+| **Sitemap Generation** | Generate XML sitemap (disabled if another sitemap plugin is active) |
+| **Audit Schedule** | How often to run automated audits (daily, weekly, monthly) |
+
+### Schema / Structured Data
+
+| Setting | Description |
+|---|---|
+| **Enable Schema Markup** | Output JSON-LD structured data (auto-disabled when Yoast/RankMath/AIOSEO is active) |
+| **Article Type** | Article, BlogPosting, or NewsArticle for blog posts |
+| **Sitelinks Searchbox** | Add SearchAction for Google sitelinks search box on your homepage |
+| **Site Represents** | Organization or Person |
+| **Name** | Organization or person name (defaults to site name) |
+| **Logo URL** | Full URL to logo image (min 112x112px) |
+| **Social Profiles** | One URL per line — populates the `sameAs` property |
+
+### Advanced Settings
+
+| Setting | Description |
+|---|---|
+| **Default Template** | Default content format for generation |
+| **Rate Limit** | Cooldown in seconds between generations (prevents double-clicks) |
+| **Duplicate Detection** | Block posts with titles too similar to existing content |
+| **Cost Tracking** | Track token usage and estimated costs per generation |
+| **Min Content Score** | Posts scoring below this are forced to draft status (0 to disable) |
+
+---
+
+## WP-CLI Commands
+
+StrataWP SEO registers the `wp swps` command namespace.
+
+### Generate a post
+
+```bash
+# Generate with AI-chosen topic
+wp swps generate
+
+# Generate with a specific topic
+wp swps generate "Best practices for WordPress security"
+
+# Generate with a specific template
+wp swps generate --template=listicle
+wp swps generate "How to speed up WordPress" --template=how-to
+```
+
+Available templates: `auto`, `listicle`, `how-to`, `comparison`, `case-study`, `news`, `tutorial`
+
+### Analyze site content
+
+```bash
+# JSON output (default)
+wp swps analyze
+
+# Table format
+wp swps analyze --format=table
+```
+
+### Check plugin status
+
+```bash
+wp swps status
+```
+
+Shows version, AI provider, model, schedule status, cost stats, and queue count.
+
+### Manage topic queue
+
+```bash
+# List queued topics
+wp swps queue list
+
+# Add a topic
+wp swps queue add "WordPress security best practices"
+
+# Add with scheduled date and template
+wp swps queue add "Top 10 SEO tools" --date="2026-04-01 09:00:00" --template=listicle
+
+# Remove a topic by ID
+wp swps queue remove 123
+
+# Clear all queued topics
+wp swps queue clear
+```
+
+---
+
+## Developer Reference
+
+StrataWP SEO provides filters and actions throughout the generation pipeline via the `SWPS_Hooks` class. All hooks use the `swps_` prefix.
+
+### Filters
+
+#### Content Generation
+
+**`swps_system_prompt`** — Modify the system prompt sent to the AI.
+
+```php
+add_filter( 'swps_system_prompt', function( string $prompt, string $tone, string $style ): string {
+    $prompt .= "\nAlways include a call-to-action at the end.";
+    return $prompt;
+}, 10, 3 );
+```
+
+**`swps_user_prompt`** — Modify the user prompt sent to the AI.
+
+```php
+add_filter( 'swps_user_prompt', function( string $prompt, string $topic, string $site_context ): string {
+    return $prompt;
+}, 10, 3 );
+```
+
+**`swps_ai_response`** — Modify the parsed AI response before post creation.
+
+```php
+add_filter( 'swps_ai_response', function( array $response, string $topic ): array {
+    return $response;
+}, 10, 2 );
+```
+
+**`swps_post_data`** — Modify WordPress post data before insertion.
+
+```php
+add_filter( 'swps_post_data', function( array $post_data, array $ai_result ): array {
+    $post_data['post_status'] = 'pending';
+    return $post_data;
+}, 10, 2 );
+```
+
+#### Images
+
+**`swps_image_query`** — Modify the image search query.
+
+```php
+add_filter( 'swps_image_query', function( string $query, int $post_id ): string {
+    return $query;
+}, 10, 2 );
+```
+
+**`swps_content_images_queries`** — Modify in-content image search queries.
+
+```php
+add_filter( 'swps_content_images_queries', function( array $queries, int $post_id ): array {
+    return $queries;
+}, 10, 2 );
+```
+
+**`swps_image_selection`** — Modify selected image data before insertion.
+
+```php
+add_filter( 'swps_image_selection', function( array $image_data, int $post_id, string $heading ): array {
+    return $image_data;
+}, 10, 3 );
+```
+
+#### Schema / Structured Data
+
+**`swps_schema_article`** — Modify Article JSON-LD before output.
+
+```php
+add_filter( 'swps_schema_article', function( array $schema, int $post_id ): array {
+    $schema['author']['sameAs'] = 'https://twitter.com/yourhandle';
+    return $schema;
+}, 10, 2 );
+```
+
+**`swps_schema_breadcrumb`** — Modify BreadcrumbList JSON-LD.
+
+```php
+add_filter( 'swps_schema_breadcrumb', function( array $schema ): array {
+    return $schema;
+} );
+```
+
+**`swps_schema_organization`** — Modify Organization/Person JSON-LD.
+
+```php
+add_filter( 'swps_schema_organization', function( array $schema ): array {
+    $schema['contactPoint'] = [
+        '@type'     => 'ContactPoint',
+        'telephone' => '+1-800-555-1234',
+    ];
+    return $schema;
+} );
+```
+
+**`swps_faq_schema`** — Modify FAQ JSON-LD.
+
+```php
+add_filter( 'swps_faq_schema', function( array $schema, string $title, array $faq_items ): array {
+    return $schema;
+}, 10, 3 );
+```
+
+**`swps_takeaways_schema`** — Modify Key Takeaways ItemList JSON-LD.
+
+```php
+add_filter( 'swps_takeaways_schema', function( array $schema, array $takeaways ): array {
+    return $schema;
+}, 10, 2 );
+```
+
+#### SEO Audit
+
+**`swps_audit_modules`** — Add or remove audit modules.
+
+```php
+add_filter( 'swps_audit_modules', function( array $modules ): array {
+    $modules['my_custom_check'] = new My_Custom_Audit_Module();
+    return $modules;
+} );
+```
+
+**`swps_audit_result`** — Modify an individual module's audit result.
+
+```php
+add_filter( 'swps_audit_result', function( array $result, string $module_id ): array {
+    return $result;
+}, 10, 2 );
+```
+
+#### Content Scoring
+
+**`swps_score_weights`** — Adjust content scoring weights.
+
+```php
+add_filter( 'swps_score_weights', function( array $weights, int $post_id, string $post_type ): array {
+    $weights['readability'] = 0.3;
+    return $weights;
+}, 10, 3 );
+```
+
+### Actions
+
+**`swps_before_generate`** — Fires before content generation starts.
+
+```php
+add_action( 'swps_before_generate', function( string $topic, string $template ): void {
+    // Log generation attempt
+}, 10, 2 );
+```
+
+**`swps_after_generate`** — Fires after successful generation.
+
+```php
+add_action( 'swps_after_generate', function( array $result, string $topic, string $template ): void {
+    // Notify Slack, send email, etc.
+}, 10, 3 );
+```
+
+**`swps_post_created`** — Fires after the WordPress post is inserted.
+
+```php
+add_action( 'swps_post_created', function( int $post_id, array $ai_result, array $post_data ): void {
+    // Add custom meta, trigger workflows
+}, 10, 3 );
+```
+
+**`swps_generation_failed`** — Fires when generation fails.
+
+```php
+add_action( 'swps_generation_failed', function( WP_Error $error, string $topic, string $template ): void {
+    error_log( 'SWPS generation failed: ' . $error->get_error_message() );
+}, 10, 3 );
+```
+
+**`swps_score_complete`** — Fires after content scoring completes.
+
+```php
+add_action( 'swps_score_complete', function( array $results, int $post_id ): void {
+    if ( $results['overall_score'] >= 90 ) {
+        wp_update_post( [ 'ID' => $post_id, 'post_status' => 'publish' ] );
+    }
+}, 10, 2 );
+```
+
+**`swps_image_inserted`** — Fires after an in-content image is inserted.
+
+```php
+add_action( 'swps_image_inserted', function( int $attachment_id, int $post_id, string $alt_text, int $position ): void {
+    // Track image insertions
+}, 10, 4 );
+```
+
+**`swps_audit_complete`** — Fires after a full audit run completes.
+
+```php
+add_action( 'swps_audit_complete', function( array $results, int $overall_score ): void {
+    if ( $overall_score < 50 ) {
+        wp_mail( get_option( 'admin_email' ), 'SEO Score Alert', 'Score dropped to ' . $overall_score );
+    }
+}, 10, 2 );
+```
+
+---
+
+## Frequently Asked Questions
+
+### Which AI provider should I use?
+
+Anthropic (Claude) is recommended for the best content quality. OpenAI and Google are also excellent alternatives. All providers produce SEO-optimized content — choose based on your preference and existing API keys.
+
+### Will this plugin conflict with Yoast SEO or RankMath?
+
+No. StrataWP SEO's schema output automatically disables itself when Yoast, RankMath, or All in One SEO is detected. The content generation and audit features work alongside any SEO plugin.
+
+### Does the AI generate unique content?
+
+Yes. Each generation produces original content based on your site context, niche, and preferences. The optional duplicate detection feature (85% similarity threshold) prevents generating content too similar to your existing posts.
+
+### Can I review posts before they go live?
+
+Yes — set the **Default Post Status** to "Draft" (recommended) or "Pending Review". You can also set a **Minimum Content Score** to automatically hold low-quality generations as drafts.
+
+### How much does it cost to run?
+
+The plugin itself is free/included. You pay only for AI API usage. A typical 1,500-word post costs approximately $0.01-0.05 depending on your provider and model. Enable **Cost Tracking** in Advanced Settings to monitor usage.
+
+### Can I extend the SEO audit with custom checks?
+
+Yes — use the `swps_audit_modules` filter to register your own audit module. Your module should extend the `SWPS_Audit_Module` abstract class.
+
+### Does the schema markup support custom post types?
+
+Currently, Article schema outputs on standard `post` type only. Breadcrumb schema works on all post types and taxonomies. You can extend schema output for custom post types using the `swps_schema_article` filter.
+
+---
+
+## Changelog
+
+### 2.1.0
+- Added Schema / Structured Data (Article, Breadcrumb, WebSite, Organization/Person JSON-LD)
+- Added conflict detection for Yoast, RankMath, and AIOSEO schema
+- Added 7 schema settings fields with developer filter hooks
+- Version bump for cache busting after SEO Audit release
+
+### 2.0.0
+- Added Technical SEO Audit with 8 modules (Canonical, Sitemap, OG, Twitter, Robots.txt, Meta Robots, Image SEO, Page Speed)
+- Added auto-fix for canonical tags, OG/Twitter meta, and sitemap generation
+- Added dashboard widget with site health score
+- Added voice profiles for reusable writing personas
+- Added in-content image insertion (1-4 images per post)
+- Added content scoring with quality gate
+- Added topic queue and content calendar
+- Added cost tracking and rate limiting
+- Added duplicate detection
+- Added bulk generation (up to 5 posts)
+- Added WP-CLI commands (`generate`, `analyze`, `status`, `queue`)
+- Added REST API
+- Added multi-provider support (Anthropic, OpenAI, Google, xAI)
+- Added multi-provider image support (Unsplash, Pexels, Pixabay, DALL-E)
+- Added 7 content templates
+- Added Key Takeaways with schema markup
+- Added background processing
+- Added 20+ developer hooks
+
+### 1.0.0
+- Initial release
+- AI content generation with Anthropic Claude
+- Featured images via Unsplash
+- FAQ schema generation
+- Internal linking
+- Scheduled publishing
+
+---
+
+## License
+
+StrataWP SEO is licensed under the [GPL v2 or later](https://www.gnu.org/licenses/gpl-2.0.html).

--- a/docs/plans/2026-03-05-schema-structured-data-design.md
+++ b/docs/plans/2026-03-05-schema-structured-data-design.md
@@ -1,0 +1,169 @@
+# Schema / Structured Data — Design Document
+
+**Date:** 2026-03-05
+**Scope:** Site-wide JSON-LD structured data output for Article, Breadcrumb, WebSite, and Organization/Person schema types.
+**Approach:** Single coordinator class (`SWPS_Schema`) hooked to `wp_head`, with auto-detection of competing SEO plugins.
+
+---
+
+## 1. Overview
+
+Add automatic JSON-LD structured data to every post and page. Four schema types target the rich results that matter most: Article (post content), Breadcrumb (navigation hierarchy), WebSite (sitelinks searchbox), and Organization/Person (site identity + publisher).
+
+Applies to **all posts and pages** — not limited to SWPS-generated content. Existing FAQ and Key Takeaways schema (post-meta based, AI-generated content only) remain unchanged.
+
+---
+
+## 2. New Class: `SWPS_Schema`
+
+**File:** `includes/class-schema.php`
+
+Single class, one public entry point hooked to `wp_head` at priority 1. Outputs up to 4 `<script type="application/ld+json">` blocks depending on page context.
+
+### Conflict Detection
+
+Constructor checks before registering the `wp_head` hook:
+
+1. `swps_schema_enabled` option — master toggle, default on
+2. `WPSEO_VERSION` constant (Yoast SEO)
+3. `RANK_MATH_VERSION` constant (RankMath)
+4. `AIOSEO_VERSION` constant (All in One SEO)
+
+If the master toggle is off or any competing plugin is active, the class does not hook into `wp_head`. No schema output.
+
+### Output Method
+
+The `wp_head` callback calls each schema method based on page context:
+
+| Schema Type | Condition | Method |
+|---|---|---|
+| Article | `is_singular('post')` | `article_schema()` |
+| Breadcrumb | All pages except `is_front_page()` | `breadcrumb_schema()` |
+| WebSite | `is_front_page()` | `website_schema()` |
+| Organization/Person | `is_front_page()` | `organization_schema()` |
+
+Each method builds an array, applies its filter, then outputs via `wp_json_encode()` with `JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT`.
+
+---
+
+## 3. Article Schema
+
+**Outputs on:** `is_singular('post')`
+
+Fields populated from standard WordPress data:
+
+| JSON-LD Field | Source |
+|---|---|
+| `@type` | Setting: `swps_schema_article_type` (default `Article`) |
+| `headline` | `get_the_title()` |
+| `description` | Excerpt, or auto-trimmed content (160 chars) |
+| `author` | `@type: Person`, author display name, author archive URL |
+| `datePublished` | Post date, ISO 8601 |
+| `dateModified` | Post modified date, ISO 8601 |
+| `image` | Featured image URL + width + height (omitted if none) |
+| `publisher` | References Organization from settings |
+| `mainEntityOfPage` | Canonical URL (`get_permalink()`) |
+| `wordCount` | `str_word_count( wp_strip_all_tags( $content ) )` |
+
+**Setting:** `swps_schema_article_type` — dropdown: `Article` (default), `BlogPosting`, `NewsArticle`.
+
+**Filter:** `swps_schema_article` — receives schema array and post ID.
+
+---
+
+## 4. Breadcrumb Schema
+
+**Outputs on:** All pages except homepage.
+
+Builds `BreadcrumbList` with `ListItem` entries automatically from WordPress hierarchy:
+
+**Posts:** Home → Primary Category → Post Title
+- Primary category: first assigned category, or Yoast primary category (`_yoast_wpseo_primary_category` meta) if set.
+
+**Pages:** Home → Parent Page → Child Page
+- Follows WP `post_parent` hierarchy.
+
+**Category/Tag archives:** Home → Archive Name
+
+Each `ListItem` includes `position`, `name`, and `item` (URL).
+
+**No settings needed.** Schema-only — no visible frontend breadcrumb trail.
+
+**Filter:** `swps_schema_breadcrumb` — receives schema array.
+
+---
+
+## 5. WebSite Schema
+
+**Outputs on:** `is_front_page()` only.
+
+| JSON-LD Field | Source |
+|---|---|
+| `@type` | `WebSite` |
+| `name` | `swps_schema_name` setting (falls back to `get_bloginfo('name')`) |
+| `url` | `home_url('/')` |
+| `potentialAction` | `SearchAction` with target `site_url('/?s={search_term_string}')` |
+
+**Setting:** `swps_schema_searchbox` — checkbox, default on. When off, the `potentialAction` is omitted.
+
+---
+
+## 6. Organization / Person Schema
+
+**Outputs on:** `is_front_page()` only.
+
+| JSON-LD Field | Source |
+|---|---|
+| `@type` | `swps_schema_entity_type` setting: `Organization` or `Person` |
+| `name` | `swps_schema_name` setting |
+| `logo` | `swps_schema_logo` setting (URL, min 112×112px) |
+| `url` | `home_url('/')` |
+| `sameAs` | `swps_schema_social_profiles` setting (one URL per line → array) |
+
+Also serves as the `publisher` reference in Article schema.
+
+**Filter:** `swps_schema_organization` — receives schema array.
+
+---
+
+## 7. Settings
+
+New section "Schema / Structured Data" on the StrataWP SEO settings page.
+
+| Option Key | Type | Default | Purpose |
+|---|---|---|---|
+| `swps_schema_enabled` | Checkbox | `1` (on) | Master toggle for all schema output |
+| `swps_schema_article_type` | Select | `Article` | Article, BlogPosting, or NewsArticle |
+| `swps_schema_searchbox` | Checkbox | `1` (on) | Enable sitelinks SearchAction |
+| `swps_schema_entity_type` | Select | `Organization` | Organization or Person |
+| `swps_schema_name` | Text | (empty, falls back to site name) | Entity name |
+| `swps_schema_logo` | Text (URL) | (empty) | Logo image URL |
+| `swps_schema_social_profiles` | Textarea | (empty) | Social profile URLs, one per line |
+
+Total: 7 fields in one section.
+
+---
+
+## 8. Developer Hooks
+
+| Filter | Parameters | Fires When |
+|---|---|---|
+| `swps_schema_article` | `$schema, $post_id` | Before Article JSON-LD output |
+| `swps_schema_breadcrumb` | `$schema` | Before BreadcrumbList JSON-LD output |
+| `swps_schema_organization` | `$schema` | Before Organization/Person JSON-LD output |
+
+---
+
+## 9. Files
+
+**Create (1):**
+- `includes/class-schema.php` — `SWPS_Schema` class (~250–300 lines)
+
+**Modify (2):**
+- `stratawp-seo.php` — `require_once`, instantiate `SWPS_Schema`, hook to `wp_head` priority 1
+- `includes/class-settings.php` — add Schema section with 7 fields
+
+**No changes to:**
+- Existing FAQ schema (`output_faq_schema()`)
+- Existing Takeaways schema (`output_takeaways_schema()`)
+- Audit modules, REST API, admin JS/CSS

--- a/docs/plans/2026-03-05-schema-structured-data-implementation.md
+++ b/docs/plans/2026-03-05-schema-structured-data-implementation.md
@@ -1,0 +1,642 @@
+# Schema / Structured Data — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add automatic JSON-LD structured data (Article, Breadcrumb, WebSite, Organization/Person) to all posts and pages, with conflict detection for Yoast/RankMath/AIOSEO.
+
+**Architecture:** Single `SWPS_Schema` class hooked to `wp_head` priority 1. Outputs up to 4 JSON-LD blocks based on page context. Settings stored as `swps_schema_*` options. Filters via `SWPS_Hooks` for developer extensibility.
+
+**Tech Stack:** PHP 8.0+, WordPress Settings API, JSON-LD via `wp_json_encode()`, no external dependencies.
+
+---
+
+### Task 1: Create `SWPS_Schema` Class — Skeleton + Conflict Detection + Output Helper
+
+**Files:**
+- Create: `includes/class-schema.php`
+
+**Context:** This is the core class. The constructor checks for competing plugins and registers the `wp_head` hook only when safe. A private `output_jsonld()` helper DRYs the JSON-LD script tag output.
+
+**Code:**
+
+```php
+<?php
+/**
+ * Schema / Structured Data output.
+ *
+ * Outputs JSON-LD structured data on the frontend for Article,
+ * Breadcrumb, WebSite, and Organization/Person schema types.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Class SWPS_Schema
+ *
+ * Hooked to wp_head at priority 1. Auto-detects Yoast, RankMath,
+ * and AIOSEO — defers entirely when any is active.
+ */
+class SWPS_Schema {
+
+    /**
+     * Constructor — bail if schema is disabled or another SEO plugin handles it.
+     */
+    public function __construct() {
+        if ( is_admin() ) {
+            return;
+        }
+
+        if ( ! get_option( 'swps_schema_enabled', 1 ) ) {
+            return;
+        }
+
+        // Defer to other SEO plugins that output their own schema.
+        if ( defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' ) ) {
+            return;
+        }
+
+        add_action( 'wp_head', [ $this, 'output_schema' ], 1 );
+    }
+
+    /**
+     * Main wp_head callback — dispatches to individual schema methods.
+     */
+    public function output_schema(): void {
+        if ( is_front_page() ) {
+            $this->website_schema();
+            $this->organization_schema();
+        }
+
+        if ( is_singular( 'post' ) ) {
+            $this->article_schema();
+        }
+
+        if ( ! is_front_page() ) {
+            $this->breadcrumb_schema();
+        }
+    }
+
+    /**
+     * Output a JSON-LD script tag from a schema array.
+     *
+     * @param array $schema Schema data array.
+     */
+    private function output_jsonld( array $schema ): void {
+        if ( empty( $schema ) ) {
+            return;
+        }
+
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON-LD script tag.
+        echo '<script type="application/ld+json">'
+           . wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT )
+           . '</script>' . "\n";
+    }
+
+    /**
+     * Article schema placeholder — implemented in Task 2.
+     */
+    private function article_schema(): void {}
+
+    /**
+     * Breadcrumb schema placeholder — implemented in Task 3.
+     */
+    private function breadcrumb_schema(): void {}
+
+    /**
+     * WebSite schema placeholder — implemented in Task 4.
+     */
+    private function website_schema(): void {}
+
+    /**
+     * Organization/Person schema placeholder — implemented in Task 4.
+     */
+    private function organization_schema(): void {}
+}
+```
+
+**Commit:** `feat: Add SWPS_Schema skeleton with conflict detection and JSON-LD helper`
+
+---
+
+### Task 2: Article Schema
+
+**Files:**
+- Modify: `includes/class-schema.php` — replace `article_schema()` placeholder
+
+**Context:** Outputs `Article` (or `BlogPosting`/`NewsArticle`) JSON-LD on single posts. Pulls data from WP post object, author, featured image. References the Organization from settings as publisher.
+
+**Code — replace the `article_schema()` method:**
+
+```php
+    /**
+     * Output Article schema on single posts.
+     */
+    private function article_schema(): void {
+        $post = get_post();
+
+        if ( ! $post ) {
+            return;
+        }
+
+        $article_type = get_option( 'swps_schema_article_type', 'Article' );
+        $author       = get_userdata( $post->post_author );
+        $excerpt      = get_the_excerpt( $post );
+
+        if ( empty( $excerpt ) ) {
+            $excerpt = wp_trim_words( wp_strip_all_tags( $post->post_content ), 25, '...' );
+        }
+
+        $schema = [
+            '@context'         => 'https://schema.org',
+            '@type'            => $article_type,
+            'headline'         => get_the_title( $post ),
+            'description'      => $excerpt,
+            'datePublished'    => get_the_date( 'c', $post ),
+            'dateModified'     => get_the_modified_date( 'c', $post ),
+            'mainEntityOfPage' => [
+                '@type' => 'WebPage',
+                '@id'   => get_permalink( $post ),
+            ],
+            'wordCount'        => str_word_count( wp_strip_all_tags( $post->post_content ) ),
+        ];
+
+        // Author.
+        if ( $author ) {
+            $schema['author'] = [
+                '@type' => 'Person',
+                'name'  => $author->display_name,
+                'url'   => get_author_posts_url( $author->ID ),
+            ];
+        }
+
+        // Featured image.
+        $thumb_id = get_post_thumbnail_id( $post );
+
+        if ( $thumb_id ) {
+            $img_data = wp_get_attachment_image_src( $thumb_id, 'full' );
+
+            if ( $img_data ) {
+                $schema['image'] = [
+                    '@type'  => 'ImageObject',
+                    'url'    => $img_data[0],
+                    'width'  => $img_data[1],
+                    'height' => $img_data[2],
+                ];
+            }
+        }
+
+        // Publisher — references Organization settings.
+        $org_name = get_option( 'swps_schema_name', '' );
+
+        if ( empty( $org_name ) ) {
+            $org_name = get_bloginfo( 'name' );
+        }
+
+        $publisher = [
+            '@type' => 'Organization',
+            'name'  => $org_name,
+        ];
+
+        $logo_url = get_option( 'swps_schema_logo', '' );
+
+        if ( ! empty( $logo_url ) ) {
+            $publisher['logo'] = [
+                '@type' => 'ImageObject',
+                'url'   => $logo_url,
+            ];
+        }
+
+        $schema['publisher'] = $publisher;
+
+        /**
+         * Filter the Article schema before output.
+         *
+         * @param array $schema  Article schema array.
+         * @param int   $post_id Post ID.
+         */
+        $schema = SWPS_Hooks::filter_schema_article( $schema, $post->ID );
+
+        $this->output_jsonld( $schema );
+    }
+```
+
+**Commit:** `feat: Add Article schema output on single posts`
+
+---
+
+### Task 3: Breadcrumb Schema
+
+**Files:**
+- Modify: `includes/class-schema.php` — replace `breadcrumb_schema()` placeholder
+
+**Context:** Outputs `BreadcrumbList` on all pages except homepage. Builds trail from WP hierarchy: Home → Category → Post (for posts), Home → Parent → Child (for pages), Home → Archive Name (for archives).
+
+**Code — replace the `breadcrumb_schema()` method:**
+
+```php
+    /**
+     * Output BreadcrumbList schema on all pages except homepage.
+     */
+    private function breadcrumb_schema(): void {
+        $items = [];
+
+        // Home is always first.
+        $items[] = [
+            'name' => get_bloginfo( 'name' ),
+            'url'  => home_url( '/' ),
+        ];
+
+        if ( is_singular( 'post' ) ) {
+            $post       = get_post();
+            $category   = $this->get_primary_category( $post );
+
+            if ( $category ) {
+                $items[] = [
+                    'name' => $category->name,
+                    'url'  => get_category_link( $category->term_id ),
+                ];
+            }
+
+            $items[] = [
+                'name' => get_the_title( $post ),
+                'url'  => get_permalink( $post ),
+            ];
+        } elseif ( is_page() ) {
+            $post      = get_post();
+            $ancestors = array_reverse( get_post_ancestors( $post ) );
+
+            foreach ( $ancestors as $ancestor_id ) {
+                $items[] = [
+                    'name' => get_the_title( $ancestor_id ),
+                    'url'  => get_permalink( $ancestor_id ),
+                ];
+            }
+
+            $items[] = [
+                'name' => get_the_title( $post ),
+                'url'  => get_permalink( $post ),
+            ];
+        } elseif ( is_category() || is_tag() || is_tax() ) {
+            $term = get_queried_object();
+
+            if ( $term ) {
+                $items[] = [
+                    'name' => $term->name,
+                    'url'  => get_term_link( $term ),
+                ];
+            }
+        } elseif ( is_author() ) {
+            $author = get_queried_object();
+
+            if ( $author ) {
+                $items[] = [
+                    'name' => $author->display_name,
+                    'url'  => get_author_posts_url( $author->ID ),
+                ];
+            }
+        }
+
+        // Need at least 2 items (Home + something) for a valid breadcrumb.
+        if ( count( $items ) < 2 ) {
+            return;
+        }
+
+        $list_items = [];
+
+        foreach ( $items as $position => $item ) {
+            $list_items[] = [
+                '@type'    => 'ListItem',
+                'position' => $position + 1,
+                'name'     => $item['name'],
+                'item'     => $item['url'],
+            ];
+        }
+
+        $schema = [
+            '@context'        => 'https://schema.org',
+            '@type'           => 'BreadcrumbList',
+            'itemListElement' => $list_items,
+        ];
+
+        /** Filter the Breadcrumb schema before output. */
+        $schema = SWPS_Hooks::filter_schema_breadcrumb( $schema );
+
+        $this->output_jsonld( $schema );
+    }
+
+    /**
+     * Get the primary category for a post.
+     *
+     * Uses Yoast primary category if set, otherwise falls back to first category.
+     *
+     * @param WP_Post $post Post object.
+     * @return WP_Term|null Category term or null.
+     */
+    private function get_primary_category( WP_Post $post ): ?WP_Term {
+        // Check Yoast primary category first.
+        $primary_id = get_post_meta( $post->ID, '_yoast_wpseo_primary_category', true );
+
+        if ( $primary_id ) {
+            $term = get_term( (int) $primary_id, 'category' );
+
+            if ( $term && ! is_wp_error( $term ) ) {
+                return $term;
+            }
+        }
+
+        // Fall back to first assigned category.
+        $categories = get_the_category( $post->ID );
+
+        if ( ! empty( $categories ) ) {
+            return $categories[0];
+        }
+
+        return null;
+    }
+```
+
+**Commit:** `feat: Add Breadcrumb schema with primary category detection`
+
+---
+
+### Task 4: WebSite + Organization Schema
+
+**Files:**
+- Modify: `includes/class-schema.php` — replace `website_schema()` and `organization_schema()` placeholders
+
+**Context:** Both output on homepage only. WebSite includes optional SearchAction for sitelinks searchbox. Organization/Person uses settings fields. The entity type dropdown controls `@type`.
+
+**Code — replace both methods:**
+
+```php
+    /**
+     * Output WebSite schema on the homepage.
+     */
+    private function website_schema(): void {
+        $name = get_option( 'swps_schema_name', '' );
+
+        if ( empty( $name ) ) {
+            $name = get_bloginfo( 'name' );
+        }
+
+        $schema = [
+            '@context' => 'https://schema.org',
+            '@type'    => 'WebSite',
+            'name'     => $name,
+            'url'      => home_url( '/' ),
+        ];
+
+        // Optional sitelinks searchbox.
+        if ( get_option( 'swps_schema_searchbox', 1 ) ) {
+            $schema['potentialAction'] = [
+                '@type'       => 'SearchAction',
+                'target'      => [
+                    '@type'       => 'EntryPoint',
+                    'urlTemplate' => home_url( '/?s={search_term_string}' ),
+                ],
+                'query-input' => 'required name=search_term_string',
+            ];
+        }
+
+        $this->output_jsonld( $schema );
+    }
+
+    /**
+     * Output Organization or Person schema on the homepage.
+     */
+    private function organization_schema(): void {
+        $entity_type = get_option( 'swps_schema_entity_type', 'Organization' );
+        $name        = get_option( 'swps_schema_name', '' );
+
+        if ( empty( $name ) ) {
+            $name = get_bloginfo( 'name' );
+        }
+
+        $schema = [
+            '@context' => 'https://schema.org',
+            '@type'    => $entity_type,
+            'name'     => $name,
+            'url'      => home_url( '/' ),
+        ];
+
+        // Logo (Organization only, per Google spec).
+        if ( 'Organization' === $entity_type ) {
+            $logo_url = get_option( 'swps_schema_logo', '' );
+
+            if ( ! empty( $logo_url ) ) {
+                $schema['logo'] = [
+                    '@type' => 'ImageObject',
+                    'url'   => $logo_url,
+                ];
+            }
+        }
+
+        // Social profiles.
+        $social_raw = get_option( 'swps_schema_social_profiles', '' );
+
+        if ( ! empty( $social_raw ) ) {
+            $urls = array_filter( array_map( 'trim', explode( "\n", $social_raw ) ) );
+
+            if ( ! empty( $urls ) ) {
+                $schema['sameAs'] = array_values( $urls );
+            }
+        }
+
+        /** Filter the Organization/Person schema before output. */
+        $schema = SWPS_Hooks::filter_schema_organization( $schema );
+
+        $this->output_jsonld( $schema );
+    }
+```
+
+**Commit:** `feat: Add WebSite and Organization/Person schema on homepage`
+
+---
+
+### Task 5: Settings — Schema Section
+
+**Files:**
+- Modify: `includes/class-settings.php` — add Schema section after Audit section (after line 317)
+
+**Context:** 7 fields in a new "Schema / Structured Data" section. Uses existing `add_field()` helper. All field types (checkbox, select, text, textarea) are already supported by `render_field()`.
+
+**Code — insert after the SEO Audit section (after `audit_cron_schedule` field):**
+
+```php
+        // --- Schema / Structured Data Section ---
+        add_settings_section( 'swps_schema_section', __( 'Schema / Structured Data', 'stratawp-seo' ), [ $this, 'render_schema_section' ], 'stratawp-seo' );
+
+        $this->add_field( 'schema_enabled', __( 'Enable Schema Markup', 'stratawp-seo' ), 'checkbox', 'swps_schema_section', [
+            'label' => __( 'Output JSON-LD structured data on all posts and pages (auto-disabled when Yoast, RankMath, or AIOSEO is active)', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'schema_article_type', __( 'Article Type', 'stratawp-seo' ), 'select', 'swps_schema_section', [
+            'options' => [
+                'Article'      => __( 'Article', 'stratawp-seo' ),
+                'BlogPosting'  => __( 'BlogPosting', 'stratawp-seo' ),
+                'NewsArticle'  => __( 'NewsArticle', 'stratawp-seo' ),
+            ],
+            'description' => __( 'Schema type for blog posts. Most sites should use Article.', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'schema_searchbox', __( 'Sitelinks Searchbox', 'stratawp-seo' ), 'checkbox', 'swps_schema_section', [
+            'label' => __( 'Add SearchAction to enable Google sitelinks search box on your homepage', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'schema_entity_type', __( 'Site Represents', 'stratawp-seo' ), 'select', 'swps_schema_section', [
+            'options' => [
+                'Organization' => __( 'Organization', 'stratawp-seo' ),
+                'Person'       => __( 'Person', 'stratawp-seo' ),
+            ],
+            'description' => __( 'Does this website represent an organization or an individual?', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'schema_name', __( 'Name', 'stratawp-seo' ), 'text', 'swps_schema_section', [
+            'placeholder' => get_bloginfo( 'name' ),
+            'description' => __( 'Organization or person name. Leave blank to use your site name.', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'schema_logo', __( 'Logo URL', 'stratawp-seo' ), 'text', 'swps_schema_section', [
+            'placeholder' => 'https://example.com/logo.png',
+            'description' => __( 'Full URL to your logo image (minimum 112×112px). Used for Organization schema and Article publisher.', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'schema_social_profiles', __( 'Social Profiles', 'stratawp-seo' ), 'textarea', 'swps_schema_section', [
+            'rows'        => 4,
+            'placeholder' => "https://facebook.com/yourpage\nhttps://twitter.com/yourhandle\nhttps://linkedin.com/company/yourcompany",
+            'description' => __( 'One social profile URL per line. Populates the sameAs property.', 'stratawp-seo' ),
+        ] );
+```
+
+**Also add the section render callback** (alongside existing `render_audit_section()`):
+
+```php
+    /**
+     * Render the Schema settings section description.
+     */
+    public function render_schema_section(): void {
+        echo '<p>' . esc_html__( 'Automatic JSON-LD structured data for rich results in Google. Disabled automatically when Yoast SEO, RankMath, or All in One SEO is active.', 'stratawp-seo' ) . '</p>';
+    }
+```
+
+**Commit:** `feat: Add Schema settings section with 7 configuration fields`
+
+---
+
+### Task 6: Plugin Integration — Require, Instantiate, Hook
+
+**Files:**
+- Modify: `stratawp-seo.php` — 3 changes:
+  1. Add `require_once` for `class-schema.php` (after line 78, with audit classes)
+  2. Add `public SWPS_Schema $schema;` property (after line 122)
+  3. Add `$this->schema = new SWPS_Schema();` instantiation (after line 147, after seo_audit)
+  4. Add activation defaults for schema options (in the `get_activation_defaults()` method)
+
+**Code for each change:**
+
+**1. Require (insert after the audit class requires, before "Core classes" comment):**
+
+```php
+// Schema structured data.
+require_once SWPS_PLUGIN_DIR . 'includes/class-schema.php';
+```
+
+**2. Property (insert after `public SWPS_SEO_Audit $seo_audit;`):**
+
+```php
+    public SWPS_Schema $schema;
+```
+
+**3. Instantiation (insert after `$this->seo_audit = new SWPS_SEO_Audit();`):**
+
+```php
+        $this->schema = new SWPS_Schema();
+```
+
+**4. Activation defaults — add to the defaults array (after `audit_cron_schedule`):**
+
+```php
+            'schema_enabled'         => 1,
+            'schema_article_type'    => 'Article',
+            'schema_searchbox'       => 1,
+            'schema_entity_type'     => 'Organization',
+            'schema_name'            => '',
+            'schema_logo'            => '',
+            'schema_social_profiles' => '',
+```
+
+**Commit:** `feat: Wire SWPS_Schema into plugin bootstrap and activation defaults`
+
+---
+
+### Task 7: Developer Hooks — Add Filter Helpers to `SWPS_Hooks`
+
+**Files:**
+- Modify: `includes/class-hooks.php` — add 3 static methods before the closing `}`
+
+**Code — append before the closing brace of the class:**
+
+```php
+    /**
+     * Apply the Article schema filter.
+     *
+     * @param array $schema  Article schema array.
+     * @param int   $post_id Post ID.
+     * @return array Filtered schema.
+     */
+    public static function filter_schema_article( array $schema, int $post_id ): array {
+        return apply_filters( 'swps_schema_article', $schema, $post_id );
+    }
+
+    /**
+     * Apply the Breadcrumb schema filter.
+     *
+     * @param array $schema BreadcrumbList schema array.
+     * @return array Filtered schema.
+     */
+    public static function filter_schema_breadcrumb( array $schema ): array {
+        return apply_filters( 'swps_schema_breadcrumb', $schema );
+    }
+
+    /**
+     * Apply the Organization/Person schema filter.
+     *
+     * @param array $schema Organization or Person schema array.
+     * @return array Filtered schema.
+     */
+    public static function filter_schema_organization( array $schema ): array {
+        return apply_filters( 'swps_schema_organization', $schema );
+    }
+```
+
+**Commit:** `feat: Add schema filter helpers to SWPS_Hooks`
+
+---
+
+### Task 8: PHP Lint + Final Review
+
+**Files:**
+- All modified files
+
+**Steps:**
+
+1. Run `php -l` on all 4 files:
+   ```bash
+   php -l includes/class-schema.php
+   php -l includes/class-settings.php
+   php -l includes/class-hooks.php
+   php -l stratawp-seo.php
+   ```
+   Expected: `No syntax errors detected` for all.
+
+2. Verify the complete `class-schema.php` reads cleanly as a single coherent file.
+
+3. Verify activation defaults are present and match the settings fields.
+
+4. Verify no duplicate option keys or conflicting hook names.
+
+**Commit:** No commit needed unless fixes are required.

--- a/includes/class-hooks.php
+++ b/includes/class-hooks.php
@@ -213,6 +213,37 @@ class SWPS_Hooks {
     }
 
     /**
+     * Apply the Article schema filter.
+     *
+     * @param array $schema  Article schema array.
+     * @param int   $post_id Post ID.
+     * @return array Filtered schema.
+     */
+    public static function filter_schema_article( array $schema, int $post_id ): array {
+        return apply_filters( 'swps_schema_article', $schema, $post_id );
+    }
+
+    /**
+     * Apply the Breadcrumb schema filter.
+     *
+     * @param array $schema BreadcrumbList schema array.
+     * @return array Filtered schema.
+     */
+    public static function filter_schema_breadcrumb( array $schema ): array {
+        return apply_filters( 'swps_schema_breadcrumb', $schema );
+    }
+
+    /**
+     * Apply the Organization/Person schema filter.
+     *
+     * @param array $schema Organization or Person schema array.
+     * @return array Filtered schema.
+     */
+    public static function filter_schema_organization( array $schema ): array {
+        return apply_filters( 'swps_schema_organization', $schema );
+    }
+
+    /**
      * Fire the audit_complete action.
      *
      * @param array $results All module results.

--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -1,0 +1,366 @@
+<?php
+/**
+ * Schema / Structured Data output.
+ *
+ * Outputs JSON-LD structured data on the frontend for Article,
+ * Breadcrumb, WebSite, and Organization/Person schema types.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Class SWPS_Schema
+ *
+ * Hooked to wp_head at priority 1. Auto-detects Yoast, RankMath,
+ * and AIOSEO — defers entirely when any is active.
+ */
+class SWPS_Schema {
+
+    /**
+     * Constructor — bail if schema is disabled or another SEO plugin handles it.
+     */
+    public function __construct() {
+        if ( is_admin() ) {
+            return;
+        }
+
+        if ( ! get_option( 'swps_schema_enabled', 1 ) ) {
+            return;
+        }
+
+        // Defer to other SEO plugins that output their own schema.
+        if ( defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' ) ) {
+            return;
+        }
+
+        add_action( 'wp_head', [ $this, 'output_schema' ], 1 );
+    }
+
+    /**
+     * Main wp_head callback — dispatches to individual schema methods.
+     */
+    public function output_schema(): void {
+        if ( is_front_page() ) {
+            $this->website_schema();
+            $this->organization_schema();
+        }
+
+        if ( is_singular( 'post' ) ) {
+            $this->article_schema();
+        }
+
+        if ( ! is_front_page() ) {
+            $this->breadcrumb_schema();
+        }
+    }
+
+    /**
+     * Output a JSON-LD script tag from a schema array.
+     *
+     * @param array $schema Schema data array.
+     */
+    private function output_jsonld( array $schema ): void {
+        if ( empty( $schema ) ) {
+            return;
+        }
+
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON-LD script tag.
+        echo '<script type="application/ld+json">'
+           . wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT )
+           . '</script>' . "\n";
+    }
+
+    /**
+     * Output Article schema on single posts.
+     */
+    private function article_schema(): void {
+        $post = get_post();
+
+        if ( ! $post ) {
+            return;
+        }
+
+        $article_type = get_option( 'swps_schema_article_type', 'Article' );
+        $author       = get_userdata( $post->post_author );
+        $excerpt      = get_the_excerpt( $post );
+
+        if ( empty( $excerpt ) ) {
+            $excerpt = wp_trim_words( wp_strip_all_tags( $post->post_content ), 25, '...' );
+        }
+
+        $schema = [
+            '@context'         => 'https://schema.org',
+            '@type'            => $article_type,
+            'headline'         => get_the_title( $post ),
+            'description'      => $excerpt,
+            'datePublished'    => get_the_date( 'c', $post ),
+            'dateModified'     => get_the_modified_date( 'c', $post ),
+            'mainEntityOfPage' => [
+                '@type' => 'WebPage',
+                '@id'   => get_permalink( $post ),
+            ],
+            'wordCount'        => str_word_count( wp_strip_all_tags( $post->post_content ) ),
+        ];
+
+        // Author.
+        if ( $author ) {
+            $schema['author'] = [
+                '@type' => 'Person',
+                'name'  => $author->display_name,
+                'url'   => get_author_posts_url( $author->ID ),
+            ];
+        }
+
+        // Featured image.
+        $thumb_id = get_post_thumbnail_id( $post );
+
+        if ( $thumb_id ) {
+            $img_data = wp_get_attachment_image_src( $thumb_id, 'full' );
+
+            if ( $img_data ) {
+                $schema['image'] = [
+                    '@type'  => 'ImageObject',
+                    'url'    => $img_data[0],
+                    'width'  => $img_data[1],
+                    'height' => $img_data[2],
+                ];
+            }
+        }
+
+        // Publisher — references Organization settings.
+        $org_name = get_option( 'swps_schema_name', '' );
+
+        if ( empty( $org_name ) ) {
+            $org_name = get_bloginfo( 'name' );
+        }
+
+        $publisher = [
+            '@type' => 'Organization',
+            'name'  => $org_name,
+        ];
+
+        $logo_url = get_option( 'swps_schema_logo', '' );
+
+        if ( ! empty( $logo_url ) ) {
+            $publisher['logo'] = [
+                '@type' => 'ImageObject',
+                'url'   => $logo_url,
+            ];
+        }
+
+        $schema['publisher'] = $publisher;
+
+        /**
+         * Filter the Article schema before output.
+         *
+         * @param array $schema  Article schema array.
+         * @param int   $post_id Post ID.
+         */
+        $schema = SWPS_Hooks::filter_schema_article( $schema, $post->ID );
+
+        $this->output_jsonld( $schema );
+    }
+
+    /**
+     * Output BreadcrumbList schema on all pages except homepage.
+     */
+    private function breadcrumb_schema(): void {
+        $items = [];
+
+        // Home is always first.
+        $items[] = [
+            'name' => get_bloginfo( 'name' ),
+            'url'  => home_url( '/' ),
+        ];
+
+        if ( is_singular( 'post' ) ) {
+            $post       = get_post();
+            $category   = $this->get_primary_category( $post );
+
+            if ( $category ) {
+                $items[] = [
+                    'name' => $category->name,
+                    'url'  => get_category_link( $category->term_id ),
+                ];
+            }
+
+            $items[] = [
+                'name' => get_the_title( $post ),
+                'url'  => get_permalink( $post ),
+            ];
+        } elseif ( is_page() ) {
+            $post      = get_post();
+            $ancestors = array_reverse( get_post_ancestors( $post ) );
+
+            foreach ( $ancestors as $ancestor_id ) {
+                $items[] = [
+                    'name' => get_the_title( $ancestor_id ),
+                    'url'  => get_permalink( $ancestor_id ),
+                ];
+            }
+
+            $items[] = [
+                'name' => get_the_title( $post ),
+                'url'  => get_permalink( $post ),
+            ];
+        } elseif ( is_category() || is_tag() || is_tax() ) {
+            $term = get_queried_object();
+
+            if ( $term ) {
+                $items[] = [
+                    'name' => $term->name,
+                    'url'  => get_term_link( $term ),
+                ];
+            }
+        } elseif ( is_author() ) {
+            $author = get_queried_object();
+
+            if ( $author ) {
+                $items[] = [
+                    'name' => $author->display_name,
+                    'url'  => get_author_posts_url( $author->ID ),
+                ];
+            }
+        }
+
+        // Need at least 2 items (Home + something) for a valid breadcrumb.
+        if ( count( $items ) < 2 ) {
+            return;
+        }
+
+        $list_items = [];
+
+        foreach ( $items as $position => $item ) {
+            $list_items[] = [
+                '@type'    => 'ListItem',
+                'position' => $position + 1,
+                'name'     => $item['name'],
+                'item'     => $item['url'],
+            ];
+        }
+
+        $schema = [
+            '@context'        => 'https://schema.org',
+            '@type'           => 'BreadcrumbList',
+            'itemListElement' => $list_items,
+        ];
+
+        /** Filter the Breadcrumb schema before output. */
+        $schema = SWPS_Hooks::filter_schema_breadcrumb( $schema );
+
+        $this->output_jsonld( $schema );
+    }
+
+    /**
+     * Get the primary category for a post.
+     *
+     * Uses Yoast primary category if set, otherwise falls back to first category.
+     *
+     * @param WP_Post $post Post object.
+     * @return WP_Term|null Category term or null.
+     */
+    private function get_primary_category( WP_Post $post ): ?WP_Term {
+        // Check Yoast primary category first.
+        $primary_id = get_post_meta( $post->ID, '_yoast_wpseo_primary_category', true );
+
+        if ( $primary_id ) {
+            $term = get_term( (int) $primary_id, 'category' );
+
+            if ( $term && ! is_wp_error( $term ) ) {
+                return $term;
+            }
+        }
+
+        // Fall back to first assigned category.
+        $categories = get_the_category( $post->ID );
+
+        if ( ! empty( $categories ) ) {
+            return $categories[0];
+        }
+
+        return null;
+    }
+
+    /**
+     * Output WebSite schema on the homepage.
+     */
+    private function website_schema(): void {
+        $name = get_option( 'swps_schema_name', '' );
+
+        if ( empty( $name ) ) {
+            $name = get_bloginfo( 'name' );
+        }
+
+        $schema = [
+            '@context' => 'https://schema.org',
+            '@type'    => 'WebSite',
+            'name'     => $name,
+            'url'      => home_url( '/' ),
+        ];
+
+        // Optional sitelinks searchbox.
+        if ( get_option( 'swps_schema_searchbox', 1 ) ) {
+            $schema['potentialAction'] = [
+                '@type'       => 'SearchAction',
+                'target'      => [
+                    '@type'       => 'EntryPoint',
+                    'urlTemplate' => home_url( '/?s={search_term_string}' ),
+                ],
+                'query-input' => 'required name=search_term_string',
+            ];
+        }
+
+        $this->output_jsonld( $schema );
+    }
+
+    /**
+     * Output Organization or Person schema on the homepage.
+     */
+    private function organization_schema(): void {
+        $entity_type = get_option( 'swps_schema_entity_type', 'Organization' );
+        $name        = get_option( 'swps_schema_name', '' );
+
+        if ( empty( $name ) ) {
+            $name = get_bloginfo( 'name' );
+        }
+
+        $schema = [
+            '@context' => 'https://schema.org',
+            '@type'    => $entity_type,
+            'name'     => $name,
+            'url'      => home_url( '/' ),
+        ];
+
+        // Logo (Organization only, per Google spec).
+        if ( 'Organization' === $entity_type ) {
+            $logo_url = get_option( 'swps_schema_logo', '' );
+
+            if ( ! empty( $logo_url ) ) {
+                $schema['logo'] = [
+                    '@type' => 'ImageObject',
+                    'url'   => $logo_url,
+                ];
+            }
+        }
+
+        // Social profiles.
+        $social_raw = get_option( 'swps_schema_social_profiles', '' );
+
+        if ( ! empty( $social_raw ) ) {
+            $urls = array_filter( array_map( 'trim', explode( "\n", $social_raw ) ) );
+
+            if ( ! empty( $urls ) ) {
+                $schema['sameAs'] = array_values( $urls );
+            }
+        }
+
+        /** Filter the Organization/Person schema before output. */
+        $schema = SWPS_Hooks::filter_schema_organization( $schema );
+
+        $this->output_jsonld( $schema );
+    }
+}

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -316,6 +316,50 @@ class SWPS_Settings {
             'description' => __( 'How often to run the automated SEO audit.', 'stratawp-seo' ),
         ] );
 
+        // --- Schema / Structured Data Section ---
+        add_settings_section( 'swps_schema_section', __( 'Schema / Structured Data', 'stratawp-seo' ), [ $this, 'render_schema_section' ], 'stratawp-seo' );
+
+        $this->add_field( 'schema_enabled', __( 'Enable Schema Markup', 'stratawp-seo' ), 'checkbox', 'swps_schema_section', [
+            'label' => __( 'Output JSON-LD structured data on all posts and pages (auto-disabled when Yoast, RankMath, or AIOSEO is active)', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'schema_article_type', __( 'Article Type', 'stratawp-seo' ), 'select', 'swps_schema_section', [
+            'options' => [
+                'Article'      => __( 'Article', 'stratawp-seo' ),
+                'BlogPosting'  => __( 'BlogPosting', 'stratawp-seo' ),
+                'NewsArticle'  => __( 'NewsArticle', 'stratawp-seo' ),
+            ],
+            'description' => __( 'Schema type for blog posts. Most sites should use Article.', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'schema_searchbox', __( 'Sitelinks Searchbox', 'stratawp-seo' ), 'checkbox', 'swps_schema_section', [
+            'label' => __( 'Add SearchAction to enable Google sitelinks search box on your homepage', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'schema_entity_type', __( 'Site Represents', 'stratawp-seo' ), 'select', 'swps_schema_section', [
+            'options' => [
+                'Organization' => __( 'Organization', 'stratawp-seo' ),
+                'Person'       => __( 'Person', 'stratawp-seo' ),
+            ],
+            'description' => __( 'Does this website represent an organization or an individual?', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'schema_name', __( 'Name', 'stratawp-seo' ), 'text', 'swps_schema_section', [
+            'placeholder' => get_bloginfo( 'name' ),
+            'description' => __( 'Organization or person name. Leave blank to use your site name.', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'schema_logo', __( 'Logo URL', 'stratawp-seo' ), 'text', 'swps_schema_section', [
+            'placeholder' => 'https://example.com/logo.png',
+            'description' => __( 'Full URL to your logo image (minimum 112×112px). Used for Organization schema and Article publisher.', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'schema_social_profiles', __( 'Social Profiles', 'stratawp-seo' ), 'textarea', 'swps_schema_section', [
+            'rows'        => 4,
+            'placeholder' => "https://facebook.com/yourpage\nhttps://twitter.com/yourhandle\nhttps://linkedin.com/company/yourcompany",
+            'description' => __( 'One social profile URL per line. Populates the sameAs property.', 'stratawp-seo' ),
+        ] );
+
         // --- Advanced Section (v2.0) ---
         add_settings_section( 'swps_advanced_section', __( 'Advanced Settings', 'stratawp-seo' ), [ $this, 'render_advanced_section' ], 'stratawp-seo' );
 
@@ -649,6 +693,13 @@ class SWPS_Settings {
         } else {
             include SWPS_PLUGIN_DIR . 'templates/voice-profiles-page.php';
         }
+    }
+
+    /**
+     * Render the Schema settings section description.
+     */
+    public function render_schema_section(): void {
+        echo '<p>' . esc_html__( 'Automatic JSON-LD structured data for rich results in Google. Disabled automatically when Yoast SEO, RankMath, or All in One SEO is active.', 'stratawp-seo' ) . '</p>';
     }
 
     public function render_audit_section(): void {

--- a/readme.txt
+++ b/readme.txt
@@ -1,52 +1,152 @@
 === StrataWP SEO ===
 Contributors: jonimms
-Tags: seo, ai, content-generator, blog, internal-linking
+Tags: seo, ai, content generator, structured data, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 1.0.0
+Stable tag: 2.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with smart internal linking, on autopilot.
+AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, structured data, and technical SEO.
 
 == Description ==
 
-StrataWP SEO uses Claude AI to generate SEO-optimized blog posts that are aware of your existing site content. Unlike generic AI writing tools, StrataWP SEO reads your published posts, understands your niche, and creates content with natural internal links to your existing pages.
+StrataWP SEO is an AI-powered content generation and technical SEO plugin for WordPress. It analyzes your existing site content, then generates SEO-optimized blog posts with internal linking, FAQ schema, and featured images — on autopilot or on demand.
 
-**Features:**
+= AI Content Generation =
 
-* **Site-Aware Content Generation** — The AI reads your existing posts and creates content that fits your site
-* **Smart Internal Linking** — Every generated post includes natural internal links to your existing content
-* **SEO Optimization** — Proper heading hierarchy, meta descriptions, focus keywords, and FAQ schema
-* **Yoast & RankMath Compatible** — Automatically populates SEO plugin meta fields
-* **Scheduled Auto-Publishing** — Set it and forget it with WP-Cron powered scheduling
-* **Customizable Voice** — Configure tone, style, and writing preferences
-* **FAQ Schema** — Automatic FAQ structured data for rich snippets
+* **Multi-provider AI** — Anthropic (Claude), OpenAI (GPT), Google (Gemini), xAI (Grok)
+* **Site-aware generation** — analyzes your existing content, categories, and internal links before writing
+* **7 content templates** — Auto, Listicle, How-To Guide, Comparison, Case Study, News Analysis, Tutorial
+* **Voice profiles** — create reusable writing personas with tone, formality, vocabulary, and style preferences
+* **Internal linking** — automatically links to your existing posts
+* **FAQ sections** — generates FAQ with JSON-LD structured data for rich snippets
+* **Key Takeaways** — optional bullet-point summary with ItemList schema
+* **Table of Contents** — linked TOC at the top of each post
+* **Duplicate detection** — prevents generating content too similar to existing posts
+* **Content scoring** — rates generated posts on SEO quality
+
+= Featured & In-Content Images =
+
+* **4 image providers** — Unsplash, Pexels, Pixabay, DALL-E (AI-generated)
+* **Auto featured images** — fetches a relevant image for each generated post
+* **In-content images** — inserts contextual images within the post body (1-4 per post)
+
+= Automated Publishing =
+
+* **Flexible scheduling** — daily, twice weekly, three times weekly, weekly, biweekly, or monthly
+* **Topic queue** — pre-load topics with scheduled dates and template preferences
+* **Content calendar** — visual overview of scheduled and generated content
+* **Bulk generation** — generate up to 5 posts in one click
+
+= Technical SEO Audit =
+
+* **8 audit modules** — Canonical URLs, XML Sitemap, Open Graph, Twitter Cards, Robots.txt, Meta Robots, Image SEO, Page Speed Hints
+* **Auto-fix** — one-click fixes for canonical tags, OG/Twitter meta, sitemap generation
+* **Scheduled audits** — daily, weekly, or monthly automated checks
+* **Dashboard widget** — site health score at a glance
+* **CSV export** — download audit results for reporting
+
+= Schema / Structured Data =
+
+* **Article schema** — automatic JSON-LD on all posts (Article, BlogPosting, or NewsArticle)
+* **Breadcrumb schema** — BreadcrumbList on posts, pages, archives, and author pages
+* **WebSite schema** — with optional SearchAction for Google sitelinks searchbox
+* **Organization/Person schema** — configurable entity type with logo and social profiles
+* **Conflict detection** — auto-disables when Yoast SEO, RankMath, or All in One SEO is active
+
+= Developer Features =
+
+* **20+ filters and actions** — extend every part of the generation pipeline
+* **WP-CLI commands** — generate, analyze, manage queue, and check status from the terminal
+* **REST API** — programmatic access to generation and audit features
+* **Cost tracking** — monitor token usage and estimated API costs
 
 == Installation ==
 
 1. Upload the `stratawp-seo` folder to `/wp-content/plugins/`
-2. Activate the plugin through the 'Plugins' menu
-3. Go to StrataWP SEO → Settings and enter your Anthropic API key
-4. Configure your site details and writing preferences
-5. Go to StrataWP SEO → Generate Content to create your first post
+2. Activate the plugin through the **Plugins** menu in WordPress
+3. Go to **StrataWP SEO > Settings** and enter your AI provider API key
+4. Fill in your site niche and description
+5. Go to **StrataWP SEO > Generate Content** to create your first post
+
+= Requirements =
+
+* WordPress 6.0 or higher
+* PHP 8.0 or higher
+* An API key from at least one AI provider (Anthropic, OpenAI, Google, or xAI)
 
 == Frequently Asked Questions ==
 
-= Do I need an Anthropic API key? =
+= Which AI provider should I use? =
 
-Yes. StrataWP SEO uses the Claude AI API. You can get an API key at console.anthropic.com. Typical cost per generated post is $0.05-0.10.
+Anthropic (Claude) is recommended for the best content quality. OpenAI and Google are also excellent alternatives. All providers produce SEO-optimized content.
 
-= Will it publish posts automatically? =
+= Will this plugin conflict with Yoast SEO or RankMath? =
 
-By default, posts are saved as drafts for your review. You can change this to auto-publish in settings, or enable scheduled generation.
+No. StrataWP SEO's schema output automatically disables itself when Yoast, RankMath, or All in One SEO is detected. The content generation and audit features work alongside any SEO plugin.
 
-= Does it work with Yoast SEO / RankMath? =
+= Does the AI generate unique content? =
 
-Yes! Generated posts automatically populate meta descriptions and focus keywords for both Yoast SEO and RankMath.
+Yes. Each generation produces original content based on your site context, niche, and preferences. The optional duplicate detection feature prevents generating content too similar to your existing posts.
+
+= Can I review posts before they go live? =
+
+Yes. Set the Default Post Status to "Draft" (recommended) or "Pending Review". You can also set a Minimum Content Score to automatically hold low-quality generations as drafts.
+
+= How much does it cost to run? =
+
+The plugin itself is free/included. You pay only for AI API usage. A typical 1,500-word post costs approximately $0.01-0.05 depending on your provider and model. Enable Cost Tracking in Advanced Settings to monitor usage.
+
+= Can I extend the SEO audit with custom checks? =
+
+Yes. Use the `swps_audit_modules` filter to register your own audit module. Your module should extend the `SWPS_Audit_Module` abstract class.
+
+== Screenshots ==
+
+1. Settings page — configure AI provider, site details, and writing preferences
+2. Generate Content — create posts on demand with topic and template selection
+3. SEO Audit — 8-module technical audit with scores and one-click fixes
+4. Schema JSON-LD — automatic structured data output in page source
 
 == Changelog ==
 
+= 2.1.0 =
+* Added Schema / Structured Data (Article, Breadcrumb, WebSite, Organization/Person JSON-LD)
+* Added conflict detection for Yoast, RankMath, and AIOSEO schema
+* Added 7 schema settings fields with developer filter hooks
+* Version bump for cache busting after SEO Audit release
+
+= 2.0.0 =
+* Added Technical SEO Audit with 8 modules (Canonical, Sitemap, OG, Twitter, Robots.txt, Meta Robots, Image SEO, Page Speed)
+* Added auto-fix for canonical tags, OG/Twitter meta, and sitemap generation
+* Added dashboard widget with site health score
+* Added voice profiles for reusable writing personas
+* Added in-content image insertion (1-4 images per post)
+* Added content scoring with quality gate
+* Added topic queue and content calendar
+* Added cost tracking and rate limiting
+* Added duplicate detection
+* Added bulk generation (up to 5 posts)
+* Added WP-CLI commands (generate, analyze, status, queue)
+* Added REST API
+* Added multi-provider support (Anthropic, OpenAI, Google, xAI)
+* Added multi-provider image support (Unsplash, Pexels, Pixabay, DALL-E)
+* Added 7 content templates
+* Added Key Takeaways with schema markup
+* Added background processing
+* Added 20+ developer hooks
+
 = 1.0.0 =
 * Initial release
+* AI content generation with Anthropic Claude
+* Featured images via Unsplash
+* FAQ schema generation
+* Internal linking
+* Scheduled publishing
+
+== Upgrade Notice ==
+
+= 2.1.0 =
+Adds automatic JSON-LD structured data for Article, Breadcrumb, WebSite, and Organization/Person schema types. No breaking changes.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 2.0.0
+ * Version: 2.1.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'SWPS_VERSION', '2.0.0' );
+define( 'SWPS_VERSION', '2.1.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -77,6 +77,9 @@ require_once SWPS_PLUGIN_DIR . 'includes/audit/class-meta-robots-module.php';
 require_once SWPS_PLUGIN_DIR . 'includes/audit/class-image-seo-module.php';
 require_once SWPS_PLUGIN_DIR . 'includes/audit/class-pagespeed-module.php';
 
+// Schema structured data.
+require_once SWPS_PLUGIN_DIR . 'includes/class-schema.php';
+
 // Core classes.
 require_once SWPS_PLUGIN_DIR . 'includes/class-settings.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-analyzer.php';
@@ -120,6 +123,7 @@ final class StrataWP_SEO {
     public SWPS_Voice_Profile $voice_profile;
     public SWPS_Image_Inserter $image_inserter;
     public SWPS_SEO_Audit $seo_audit;
+    public SWPS_Schema $schema;
 
     public static function instance(): self {
         if ( null === self::$instance ) {
@@ -145,6 +149,7 @@ final class StrataWP_SEO {
         $this->images    = SWPS_Provider_Factory::create_image_provider();
         $this->image_inserter = new SWPS_Image_Inserter( $this->images );
         $this->seo_audit = new SWPS_SEO_Audit();
+        $this->schema    = new SWPS_Schema();
         $this->settings  = new SWPS_Settings();
         $this->analyzer  = new SWPS_Analyzer( $this->cache_manager );
         $this->generator = new SWPS_Generator(
@@ -810,6 +815,14 @@ function swps_activate(): void {
         'audit_auto_og'         => 1,
         'audit_auto_sitemap'    => 1,
         'audit_cron_schedule'   => 'weekly',
+        // Schema defaults.
+        'schema_enabled'         => 1,
+        'schema_article_type'    => 'Article',
+        'schema_searchbox'       => 1,
+        'schema_entity_type'     => 'Organization',
+        'schema_name'            => '',
+        'schema_logo'            => '',
+        'schema_social_profiles' => '',
     ];
 
     foreach ( $defaults as $key => $value ) {


### PR DESCRIPTION
## Summary
- Add automatic JSON-LD structured data output (Article, Breadcrumb, WebSite, Organization/Person) via new `SWPS_Schema` class hooked to `wp_head` at priority 1
- Conflict detection auto-disables schema when Yoast, RankMath, or AIOSEO is active
- 7 new settings fields in a "Schema / Structured Data" section (enable, article type, searchbox, entity type, name, logo, social profiles)
- 3 developer filter hooks (`swps_schema_article`, `swps_schema_breadcrumb`, `swps_schema_organization`) via `SWPS_Hooks`

## Test Plan
- [ ] Verify JSON-LD Article schema appears in `<head>` on single posts
- [ ] Verify BreadcrumbList schema appears on posts, pages, categories, and author archives (not homepage)
- [ ] Verify WebSite + Organization schema appears on homepage only
- [ ] Verify schema output is suppressed when Yoast/RankMath/AIOSEO is active
- [ ] Verify all 7 settings fields render and save correctly
- [ ] Validate JSON-LD output with Google's Rich Results Test
- [ ] Verify activation defaults are set on fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)