### PR TITLE
feat: Keywords Research & Meta Editor (v2.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, and technical SEO — on autopilot.
 
-[![Version](https://img.shields.io/badge/version-2.2.0-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-2.3.0-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -66,6 +66,23 @@
 - **Organization/Person schema** — configurable entity type with logo and social profiles
 - **Conflict detection** — auto-disables when Yoast SEO, RankMath, or All in One SEO is active
 
+### Keyword Research & Tracking
+- **AI-powered keyword suggestions** — generate keyword ideas from seed topics using your configured AI provider
+- **GSC-powered rank tracking** — sync keyword rankings from Google Search Console automatically
+- **Striking distance opportunities** — identify keywords ranking in positions 8-20 with the best potential for quick wins
+
+### SEO Meta Editor
+- **Per-post meta title/description** — set custom SEO titles and descriptions on every post and page
+- **Live SERP preview** — real-time Google search result preview as you type
+- **Character counters** — visual indicators for optimal meta title and description length
+- **SEO checklist** — focus keyword analysis with actionable recommendations in the post editor
+- **Social previews** — Open Graph and Twitter Card meta with per-post overrides
+- **Canonical URL** — set a custom canonical URL per post
+- **Robots meta** — per-post noindex/nofollow controls
+- **Breadcrumb title override** — customize the breadcrumb label per post
+- **AI Generate button** — one-click AI-powered meta title and description generation
+- **Conflict detection** — auto-disables meta tag output when Yoast SEO, RankMath, or All in One SEO is active
+
 ### Analytics & Search Console
 - **On-site analytics** — cookie-free, GDPR-friendly page view tracking (no external services)
 - **Time on page** — tracks how long visitors spend on each page
@@ -79,7 +96,7 @@
 - **Configurable retention** — keep data for 30, 90, 180, or 365 days with automatic pruning
 
 ### Developer Features
-- **20+ filters and actions** — extend every part of the generation pipeline
+- **25+ filters and actions** — extend every part of the generation pipeline
 - **WP-CLI commands** — generate, analyze, manage queue, and check status from the terminal
 - **REST API** — programmatic access to generation and audit features
 - **Cost tracking** — monitor token usage and estimated API costs
@@ -196,6 +213,20 @@ The more detail you provide here, the more relevant and targeted your generated 
 | **Name** | Organization or person name (defaults to site name) |
 | **Logo URL** | Full URL to logo image (min 112x112px) |
 | **Social Profiles** | One URL per line — populates the `sameAs` property |
+
+### SEO Meta Editor
+
+| Setting | Description |
+|---|---|
+| **Meta Editor Enabled** (`swps_meta_editor_enabled`) | Enable/disable the meta editor metabox on post edit screens |
+| **Meta Editor Post Types** (`swps_meta_editor_post_types`) | Comma-separated list of post types that show the meta editor (default: `post,page`) |
+| **Auto-Generate Meta** (`swps_meta_auto_generate`) | Automatically generate meta title and description when a post is published |
+
+### Keyword Tracking
+
+| Setting | Description |
+|---|---|
+| **Keyword Sync Frequency** (`swps_keyword_tracking_frequency`) | How often to sync keyword data from Google Search Console (daily, weekly, or monthly) |
 
 ### Analytics
 
@@ -444,6 +475,58 @@ add_filter( 'swps_gsc_data', function( array $data, string $property ): array {
 }, 10, 2 );
 ```
 
+#### SEO Meta Editor
+
+**`swps_meta_title`** — Filter the meta title output for a post.
+
+```php
+add_filter( 'swps_meta_title', function( string $title, int $post_id ): string {
+    return $title . ' | My Brand';
+}, 10, 2 );
+```
+
+**`swps_meta_description`** — Filter the meta description output for a post.
+
+```php
+add_filter( 'swps_meta_description', function( string $description, int $post_id ): string {
+    return $description;
+}, 10, 2 );
+```
+
+**`swps_meta_robots`** — Filter the robots meta directives for a post.
+
+```php
+add_filter( 'swps_meta_robots', function( string $robots, int $post_id ): string {
+    if ( get_post_type( $post_id ) === 'landing_page' ) {
+        return 'noindex, nofollow';
+    }
+    return $robots;
+}, 10, 2 );
+```
+
+**`swps_seo_checklist`** — Filter or add SEO checklist items in the meta editor metabox.
+
+```php
+add_filter( 'swps_seo_checklist', function( array $items, int $post_id ): array {
+    $items[] = [
+        'label'  => 'Has a CTA in the first paragraph',
+        'status' => 'pass',
+    ];
+    return $items;
+}, 10, 2 );
+```
+
+#### Keyword Research
+
+**`swps_keyword_suggestions`** — Filter AI-generated keyword suggestions.
+
+```php
+add_filter( 'swps_keyword_suggestions', function( array $keywords, string $seed_topic ): array {
+    // Remove branded terms
+    return array_filter( $keywords, fn( $kw ) => stripos( $kw, 'brand' ) === false );
+}, 10, 2 );
+```
+
 #### Content Scoring
 
 **`swps_score_weights`** — Adjust content scoring weights.
@@ -545,6 +628,10 @@ The plugin itself is free/included. You pay only for AI API usage. A typical 1,5
 
 Yes — use the `swps_audit_modules` filter to register your own audit module. Your module should extend the `SWPS_Audit_Module` abstract class.
 
+### Can I use the meta editor alongside Yoast/RankMath?
+
+Yes! StrataWP SEO automatically detects these plugins and disables its own meta tag output to prevent conflicts. The meta editor fields are still available for reference, but frontend output is deferred to the other plugin.
+
 ### Does the schema markup support custom post types?
 
 Currently, Article schema outputs on standard `post` type only. Breadcrumb schema works on all post types and taxonomies. You can extend schema output for custom post types using the `swps_schema_article` filter.
@@ -560,6 +647,16 @@ No — GSC integration is optional. The on-site analytics (page views, time on p
 ---
 
 ## Changelog
+
+### 2.3.0
+- Added: Keyword Research & Tracking — AI-powered keyword suggestions and GSC rank tracking
+- Added: SEO Meta Editor — per-post meta title, description, social previews, and robots controls
+- Added: Live SERP preview with character counters in post editor
+- Added: SEO checklist with focus keyword analysis
+- Added: Striking distance keyword opportunities (position 8-20)
+- Added: AI-powered meta title/description generation
+- Added: Conflict detection — auto-disables meta output when Yoast/RankMath/AIOSEO is active
+- Added: 5 new developer hooks for meta/keyword extensibility
 
 ### 2.2.0
 - Added on-site analytics tracking (page views, time on page, scroll depth, bounce rate)

--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -652,3 +652,59 @@
 .swps-metabox-stats td:last-child {
     text-align: right;
 }
+
+/* === Keywords Page === */
+.swps-keywords-section { margin-bottom: 30px; }
+.swps-suggest-form { display: flex; gap: 8px; align-items: center; margin-bottom: 16px; }
+.swps-suggest-form .regular-text { flex: 1; }
+.swps-intent-badge { display: inline-block; padding: 2px 8px; border-radius: 3px; font-size: 12px; }
+.swps-intent-informational { background: #e7f5ff; color: #1971c2; }
+.swps-intent-transactional { background: #e6fcf5; color: #087f5b; }
+.swps-intent-navigational { background: #fff3e0; color: #e65100; }
+
+/* Keywords modal */
+.swps-modal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.5); z-index: 100000; display: flex; align-items: center; justify-content: center; }
+.swps-modal-content { background: #fff; border-radius: 8px; padding: 24px; max-width: 700px; width: 90%; position: relative; }
+.swps-modal-close { position: absolute; top: 12px; right: 16px; font-size: 24px; cursor: pointer; color: #646970; }
+
+/* === Meta Editor Metabox === */
+.swps-meta-editor { max-width: 100%; }
+.swps-meta-row { margin-bottom: 12px; }
+.swps-meta-row label { display: block; margin-bottom: 4px; font-weight: 600; }
+.swps-meta-row .widefat { width: 100%; }
+
+/* SERP Preview */
+.swps-serp-preview { margin-bottom: 16px; }
+.swps-serp-mock { background: #fff; border: 1px solid #dcdcde; border-radius: 8px; padding: 16px; max-width: 600px; }
+.swps-serp-title { color: #1a0dab; font-size: 18px; line-height: 1.3; margin-bottom: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.swps-serp-url { color: #006621; font-size: 13px; margin-bottom: 2px; }
+.swps-serp-desc { color: #545454; font-size: 13px; line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+
+/* Character counters */
+.swps-char-count { font-weight: normal; font-size: 12px; margin-left: 8px; }
+.swps-count-green { color: #00a32a; }
+.swps-count-yellow { color: #dba617; }
+.swps-count-red { color: #d63638; }
+
+/* SEO Checklist */
+.swps-seo-checklist { background: #f6f7f7; border: 1px solid #dcdcde; border-radius: 4px; padding: 12px 16px; margin: 16px 0; }
+.swps-seo-checklist h4 { margin: 0 0 8px; }
+.swps-seo-checklist ul { margin: 0; padding: 0; list-style: none; }
+.swps-seo-checklist li { padding: 4px 0; font-size: 13px; }
+.swps-check-icon { display: inline-block; width: 16px; text-align: center; margin-right: 4px; }
+.swps-check-pass { color: #00a32a; }
+.swps-check-fail { color: #d63638; }
+.swps-check-neutral { color: #646970; }
+
+/* Advanced & Social collapsible */
+.swps-meta-advanced, .swps-meta-social { margin-top: 12px; }
+.swps-meta-advanced summary, .swps-meta-social summary { cursor: pointer; font-weight: 600; padding: 8px 0; }
+
+/* Social Preview */
+.swps-social-preview { margin-top: 12px; }
+.swps-social-card { border: 1px solid #dcdcde; border-radius: 4px; overflow: hidden; max-width: 500px; }
+.swps-social-image { height: 150px; background-size: cover; background-position: center; background-color: #f0f0f0; }
+.swps-social-text { padding: 10px 12px; }
+.swps-social-domain { font-size: 11px; color: #646970; text-transform: uppercase; }
+.swps-social-title { font-size: 14px; font-weight: 600; margin: 2px 0; }
+.swps-social-desc { font-size: 12px; color: #646970; }

--- a/admin/js/keywords.js
+++ b/admin/js/keywords.js
@@ -23,7 +23,7 @@
 
             res.data.forEach(function (kw) {
                 var postLink = kw.post_title
-                    ? '<a href="' + kw.post_url + '">' + escHtml(kw.post_title) + '</a>'
+                    ? '<a href="' + escAttr(kw.post_url) + '">' + escHtml(kw.post_title) + '</a>'
                     : '<em>None</em>';
                 var pos = kw.position !== null ? parseFloat(kw.position).toFixed(1) : '—';
                 var row = '<tr>';

--- a/admin/js/keywords.js
+++ b/admin/js/keywords.js
@@ -1,0 +1,226 @@
+/**
+ * StrataWP SEO — Keywords Page JS
+ */
+(function ($) {
+    'use strict';
+
+    if (typeof swpsAdmin === 'undefined') return;
+
+    // --- Load tracked keywords ---
+    function loadTracked() {
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_get_keywords',
+            nonce: swpsAdmin.nonce
+        }, function (res) {
+            if (!res.success) return;
+            var tbody = $('#swps-tracked-table tbody');
+            tbody.empty();
+
+            if (!res.data.length) {
+                tbody.html('<tr><td colspan="7">No tracked keywords yet. Use AI suggestions above to discover and track keywords.</td></tr>');
+                return;
+            }
+
+            res.data.forEach(function (kw) {
+                var postLink = kw.post_title
+                    ? '<a href="' + kw.post_url + '">' + escHtml(kw.post_title) + '</a>'
+                    : '<em>None</em>';
+                var pos = kw.position !== null ? parseFloat(kw.position).toFixed(1) : '—';
+                var row = '<tr>';
+                row += '<td><a href="#" class="swps-kw-history" data-keyword="' + escAttr(kw.keyword) + '">' + escHtml(kw.keyword) + '</a></td>';
+                row += '<td>' + pos + '</td>';
+                row += '<td>' + parseInt(kw.clicks).toLocaleString() + '</td>';
+                row += '<td>' + parseInt(kw.impressions).toLocaleString() + '</td>';
+                row += '<td>' + parseFloat(kw.ctr).toFixed(1) + '%</td>';
+                row += '<td>' + postLink + '</td>';
+                row += '<td><button class="button button-small swps-untrack-btn" data-keyword="' + escAttr(kw.keyword) + '">Untrack</button></td>';
+                row += '</tr>';
+                tbody.append(row);
+            });
+        });
+    }
+
+    // --- Load opportunities ---
+    function loadOpportunities() {
+        if (!$('#swps-opportunities-table').length) return;
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_get_opportunities',
+            nonce: swpsAdmin.nonce
+        }, function (res) {
+            if (!res.success) return;
+            var tbody = $('#swps-opportunities-table tbody');
+            tbody.empty();
+
+            if (!res.data.length) {
+                tbody.html('<tr><td colspan="5">No striking distance keywords found yet. Track keywords and sync with GSC.</td></tr>');
+                return;
+            }
+
+            res.data.forEach(function (opp) {
+                var row = '<tr>';
+                row += '<td>' + escHtml(opp.keyword) + '</td>';
+                row += '<td>' + parseFloat(opp.position).toFixed(1) + '</td>';
+                row += '<td>' + parseInt(opp.impressions).toLocaleString() + '</td>';
+                row += '<td>' + parseFloat(opp.ctr).toFixed(1) + '%</td>';
+                row += '<td>';
+                row += '<a href="' + swpsAdmin.generate_url + '&topic=' + encodeURIComponent(opp.keyword) + '" class="button button-small">Generate Post</a>';
+                row += '</td>';
+                row += '</tr>';
+                tbody.append(row);
+            });
+        });
+    }
+
+    // --- AI Suggestions ---
+    $('#swps-suggest-btn').on('click', function () {
+        var seed = $('#swps-seed-topic').val().trim();
+        if (!seed) return;
+
+        var btn = $(this);
+        var spinner = $('#swps-suggest-spinner');
+        btn.prop('disabled', true);
+        spinner.addClass('is-active');
+
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_suggest_keywords',
+            nonce: swpsAdmin.nonce,
+            seed_topic: seed
+        }, function (res) {
+            btn.prop('disabled', false);
+            spinner.removeClass('is-active');
+
+            if (!res.success) {
+                alert(res.data.message || 'Failed to get suggestions.');
+                return;
+            }
+
+            var table = $('#swps-suggestions-table');
+            var tbody = table.find('tbody');
+            tbody.empty();
+            table.show();
+
+            res.data.forEach(function (s) {
+                var row = '<tr>';
+                row += '<td><strong>' + escHtml(s.keyword) + '</strong></td>';
+                row += '<td><span class="swps-intent-badge swps-intent-' + escAttr(s.intent) + '">' + escHtml(s.intent) + '</span></td>';
+                row += '<td>' + escHtml(s.difficulty) + '</td>';
+                row += '<td>' + escHtml(s.suggested_title) + '</td>';
+                row += '<td><button class="button button-small swps-track-btn" data-keyword="' + escAttr(s.keyword) + '">Track</button></td>';
+                row += '</tr>';
+                tbody.append(row);
+            });
+        });
+    });
+
+    // --- Track keyword ---
+    $(document).on('click', '.swps-track-btn', function () {
+        var btn = $(this);
+        var keyword = btn.data('keyword');
+        btn.prop('disabled', true).text('Tracking...');
+
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_track_keyword',
+            nonce: swpsAdmin.nonce,
+            keyword: keyword
+        }, function () {
+            btn.text('Tracked').addClass('disabled');
+            loadTracked();
+        });
+    });
+
+    // --- Untrack keyword ---
+    $(document).on('click', '.swps-untrack-btn', function () {
+        var keyword = $(this).data('keyword');
+        if (!confirm('Stop tracking "' + keyword + '"?')) return;
+
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_untrack_keyword',
+            nonce: swpsAdmin.nonce,
+            keyword: keyword
+        }, function () { loadTracked(); });
+    });
+
+    // --- Keyword history modal ---
+    $(document).on('click', '.swps-kw-history', function (e) {
+        e.preventDefault();
+        var keyword = $(this).data('keyword');
+        $('#swps-history-title').text(keyword);
+        $('#swps-keyword-history-modal').show();
+
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_keyword_history',
+            nonce: swpsAdmin.nonce,
+            keyword: keyword,
+            days: 90
+        }, function (res) {
+            if (!res.success || !res.data.length) {
+                $('#swps-history-chart').html('<p>No history data yet.</p>');
+                return;
+            }
+            renderPositionChart(res.data);
+        });
+    });
+
+    $('.swps-modal-close').on('click', function () {
+        $(this).closest('.swps-modal').hide();
+    });
+
+    // --- Position chart (SVG) ---
+    function renderPositionChart(data) {
+        var container = document.getElementById('swps-history-chart');
+        if (!container) return;
+
+        var width = container.offsetWidth || 600;
+        var height = 200;
+        var pad = { top: 20, right: 20, bottom: 30, left: 50 };
+        var cW = width - pad.left - pad.right;
+        var cH = height - pad.top - pad.bottom;
+
+        // Position is inverted — lower is better.
+        var positions = data.map(function (d) { return parseFloat(d.position) || 100; });
+        var maxPos = Math.max.apply(null, positions);
+        var minPos = Math.min.apply(null, positions);
+        if (maxPos === minPos) maxPos = minPos + 10;
+
+        var points = data.map(function (d, i) {
+            var x = pad.left + (i / Math.max(data.length - 1, 1)) * cW;
+            var pos = parseFloat(d.position) || 100;
+            var y = pad.top + ((pos - minPos) / (maxPos - minPos)) * cH;
+            return x + ',' + y;
+        });
+
+        var svg = '<svg width="' + width + '" height="' + height + '" xmlns="http://www.w3.org/2000/svg">';
+        svg += '<polyline points="' + points.join(' ') + '" fill="none" stroke="#2271b1" stroke-width="2" />';
+
+        // Y-axis: position labels (inverted).
+        for (var i = 0; i <= 4; i++) {
+            var yVal = Math.round(minPos + ((maxPos - minPos) / 4) * i);
+            var yPos = pad.top + (i / 4) * cH;
+            svg += '<text x="' + (pad.left - 8) + '" y="' + (yPos + 4) + '" text-anchor="end" fill="#646970" font-size="11">#' + yVal + '</text>';
+            svg += '<line x1="' + pad.left + '" y1="' + yPos + '" x2="' + (width - pad.right) + '" y2="' + yPos + '" stroke="#e0e0e0" />';
+        }
+
+        svg += '</svg>';
+        container.innerHTML = svg;
+    }
+
+    // --- Helpers ---
+    function escHtml(str) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str || ''));
+        return div.innerHTML;
+    }
+
+    function escAttr(str) {
+        return (str || '').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    // --- Init ---
+    $(document).ready(function () {
+        if ($('.swps-keywords-wrap').length) {
+            loadTracked();
+            loadOpportunities();
+        }
+    });
+
+})(jQuery);

--- a/admin/js/meta-editor.js
+++ b/admin/js/meta-editor.js
@@ -1,0 +1,173 @@
+/**
+ * StrataWP SEO — Meta Editor JS
+ *
+ * Live SERP preview, character counters, SEO checklist, AI generate.
+ */
+(function ($) {
+    'use strict';
+
+    if (typeof swpsAdmin === 'undefined') return;
+
+    var $metaTitle, $metaDesc, $focusKw, $serpTitle, $serpDesc;
+    var $titleCount, $descCount;
+
+    function init() {
+        $metaTitle  = $('#_swps_meta_title');
+        $metaDesc   = $('#_swps_meta_description');
+        $focusKw    = $('#_swps_focus_keyword');
+        $serpTitle   = $('#swps-serp-title');
+        $serpDesc    = $('#swps-serp-desc');
+        $titleCount  = $('#swps-title-count');
+        $descCount   = $('#swps-desc-count');
+
+        if (!$metaTitle.length) return;
+
+        // Live preview.
+        $metaTitle.on('input', updatePreview);
+        $metaDesc.on('input', updatePreview);
+        $focusKw.on('input', updateChecklist);
+
+        // Initial state.
+        updatePreview();
+        updateChecklist();
+
+        // AI Generate.
+        $('#swps-ai-generate-meta').on('click', aiGenerate);
+
+        // Social preview updates.
+        $('#_swps_social_title, #_swps_social_description, #_swps_social_image').on('input', updateSocialPreview);
+        updateSocialPreview();
+    }
+
+    function updatePreview() {
+        var title = $metaTitle.val() || $metaTitle.attr('placeholder') || '';
+        var desc  = $metaDesc.val() || $metaDesc.attr('placeholder') || '';
+
+        // Truncate for display.
+        $serpTitle.text(title.length > 60 ? title.substring(0, 57) + '...' : title);
+        $serpDesc.text(desc.length > 160 ? desc.substring(0, 157) + '...' : desc);
+
+        // Character counters.
+        updateCounter($titleCount, $metaTitle.val().length, 50, 60);
+        updateCounter($descCount, $metaDesc.val().length, 140, 160);
+
+        updateChecklist();
+    }
+
+    function updateCounter($el, len, min, max) {
+        $el.text(len + '/' + max);
+        $el.removeClass('swps-count-green swps-count-yellow swps-count-red');
+        if (len === 0) return;
+        if (len >= min && len <= max) {
+            $el.addClass('swps-count-green');
+        } else if (len > max) {
+            $el.addClass('swps-count-red');
+        } else {
+            $el.addClass('swps-count-yellow');
+        }
+    }
+
+    function updateChecklist() {
+        var keyword = $focusKw.val().toLowerCase().trim();
+        if (!keyword) {
+            $('#swps-seo-checklist li .swps-check-icon').html('—').attr('class', 'swps-check-icon swps-check-neutral');
+            return;
+        }
+
+        var title     = $metaTitle.val().toLowerCase();
+        var desc      = $metaDesc.val().toLowerCase();
+        var titleLen  = $metaTitle.val().length;
+        var descLen   = $metaDesc.val().length;
+
+        // Get post content from editor.
+        var content = getEditorContent().toLowerCase();
+        var firstParagraph = content.split(/\n\n|\r\n\r\n/)[0] || '';
+
+        // Get H2 headings.
+        var h2s = content.match(/<h2[^>]*>(.*?)<\/h2>/gi) || [];
+        var h2Text = h2s.join(' ').toLowerCase();
+
+        setCheck('keyword-in-title', title.indexOf(keyword) !== -1);
+        setCheck('keyword-in-desc', desc.indexOf(keyword) !== -1);
+        setCheck('title-length', titleLen >= 50 && titleLen <= 60);
+        setCheck('desc-length', descLen >= 140 && descLen <= 160);
+        setCheck('keyword-in-content', firstParagraph.indexOf(keyword) !== -1);
+        setCheck('keyword-in-h2', h2Text.indexOf(keyword) !== -1);
+    }
+
+    function setCheck(name, pass) {
+        var $li = $('[data-check="' + name + '"]');
+        var $icon = $li.find('.swps-check-icon');
+        if (pass) {
+            $icon.html('&#10003;').attr('class', 'swps-check-icon swps-check-pass');
+        } else {
+            $icon.html('&#10007;').attr('class', 'swps-check-icon swps-check-fail');
+        }
+    }
+
+    function getEditorContent() {
+        // Block editor.
+        if (typeof wp !== 'undefined' && wp.data && wp.data.select('core/editor')) {
+            var content = wp.data.select('core/editor').getEditedPostContent();
+            if (content) return content;
+        }
+        // Classic editor.
+        if (typeof tinymce !== 'undefined') {
+            var editor = tinymce.get('content');
+            if (editor) return editor.getContent();
+        }
+        // Fallback: textarea.
+        var $textarea = $('#content');
+        return $textarea.length ? $textarea.val() : '';
+    }
+
+    function aiGenerate() {
+        var btn = $(this);
+        var postId = $('.swps-meta-editor').data('post-id');
+        var keyword = $focusKw.val();
+
+        btn.prop('disabled', true).text('Generating...');
+
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_generate_meta',
+            nonce: swpsAdmin.nonce,
+            post_id: postId,
+            focus_keyword: keyword
+        }, function (res) {
+            btn.prop('disabled', false).text('AI Generate');
+
+            if (!res.success) {
+                alert(res.data.message || 'Failed to generate meta.');
+                return;
+            }
+
+            if (res.data.meta_title) {
+                $metaTitle.val(res.data.meta_title);
+            }
+            if (res.data.meta_description) {
+                $metaDesc.val(res.data.meta_description);
+            }
+
+            updatePreview();
+        });
+    }
+
+    function updateSocialPreview() {
+        var title = $('#_swps_social_title').val() || $metaTitle.val() || $metaTitle.attr('placeholder') || '';
+        var desc  = $('#_swps_social_description').val() || $metaDesc.val() || '';
+        var image = $('#_swps_social_image').val() || '';
+
+        $('#swps-fb-title').text(title);
+        $('#swps-fb-desc').text(desc);
+
+        var $fbImage = $('#swps-fb-image');
+        if (image) {
+            $fbImage.css('background-image', 'url(' + image + ')').show();
+        } else {
+            $fbImage.hide();
+        }
+    }
+
+    $(document).ready(init);
+
+})(jQuery);

--- a/docs/plans/2026-03-06-keywords-meta-editor-design.md
+++ b/docs/plans/2026-03-06-keywords-meta-editor-design.md
@@ -1,0 +1,130 @@
+# Keywords & Meta Editor Design
+
+**Goal:** Add keyword research/tracking and per-post SEO meta editing to StrataWP SEO (v2.3.0).
+
+**Architecture:** Two integrated modules sharing a focus keyword concept. AI suggests keywords, GSC tracks rankings, and the meta editor targets keywords with optimized titles/descriptions. Conflict detection auto-disables meta output when Yoast/RankMath/AIOSEO is active.
+
+---
+
+## Data Model
+
+### Custom table: `swps_keyword_tracking`
+
+| Column      | Type          | Notes                                      |
+|-------------|---------------|--------------------------------------------|
+| id          | BIGINT PK     | Auto-increment                             |
+| keyword     | VARCHAR(255)  | The tracked keyword                        |
+| post_id     | BIGINT NULL    | Linked post (nullable for unlinked keywords)|
+| position    | FLOAT          | Average search position                    |
+| clicks      | INT UNSIGNED   | Click count                                |
+| impressions | INT UNSIGNED   | Impression count                           |
+| ctr         | FLOAT          | Click-through rate                         |
+| date        | DATE           | Data date                                  |
+
+- Composite index on `(keyword, date)`
+- Source: GSC pull on configurable schedule + AI-suggested keywords stored with null position until GSC data appears
+
+### Post meta (per-post SEO fields)
+
+| Meta key                    | Type    | Purpose                          |
+|-----------------------------|---------|----------------------------------|
+| `_swps_meta_title`          | string  | Custom meta title                |
+| `_swps_meta_description`    | string  | Custom meta description          |
+| `_swps_focus_keyword`       | string  | Primary target keyword           |
+| `_swps_secondary_keywords`  | string  | Comma-separated secondary keywords|
+| `_swps_canonical_url`       | string  | Canonical URL override           |
+| `_swps_robots`              | string  | noindex/nofollow per-post        |
+| `_swps_breadcrumb_title`    | string  | Breadcrumb title override        |
+| `_swps_social_title`        | string  | OG/Twitter title override        |
+| `_swps_social_description`  | string  | OG/Twitter description override  |
+| `_swps_social_image`        | string  | OG/Twitter image URL override    |
+
+---
+
+## Keyword Research & Tracking
+
+### AI Keyword Suggestions
+
+- New admin page: **StrataWP SEO > Keywords**
+- User enters a seed topic (or auto-suggests from site niche/existing content)
+- AI provider generates 10-20 keyword ideas with estimated search intent (informational, transactional, navigational)
+- User can "track" keywords — adds them to the tracking table
+- "Suggest for post" button on the post editor links keywords to specific posts
+
+### GSC-Powered Rank Tracking
+
+- WP-Cron job at configurable frequency (daily/weekly/monthly)
+- Pulls GSC Search Analytics data for all tracked keywords
+- Stores position, clicks, impressions, CTR per keyword per day in `swps_keyword_tracking`
+- Keywords page table: keyword, current position, change vs previous period, clicks, impressions, linked post
+- Click a keyword for position history chart (SVG, same pattern as analytics dashboard)
+
+### Topic Opportunities
+
+- "Opportunities" section on Keywords page
+- Shows keywords with high impressions but low CTR (position 8-20, "striking distance")
+- "Generate Post" button pre-fills content generator with that topic
+- Surfaces keywords ranking without a dedicated post (content gap detection)
+
+---
+
+## Meta Title & Description Editor
+
+### Post Editor Metabox
+
+- Appears below the post editor on posts, pages, and custom post types
+- Fields: focus keyword, secondary keywords, meta title, meta description, canonical URL, robots meta (index/noindex, follow/nofollow dropdowns), breadcrumb title
+- **Google Preview** — live SERP snippet: title (truncated 60 chars), URL, description (truncated 160 chars). Updates as you type.
+- **Social Preview tabs** — Facebook and Twitter card previews using OG/social overrides. Falls back to meta title/description if social fields empty.
+- **Character counters** — green/yellow/red for title (50-60 ideal) and description (140-160 ideal)
+- **AI Generate button** — sends post content + focus keyword to AI, returns suggested meta title and description. One click to accept.
+
+### SEO Checklist
+
+Shown in the metabox as actionable indicators (green check / red X):
+
+- Focus keyword in meta title
+- Focus keyword in meta description
+- Meta title length in range (50-60)
+- Meta description length in range (140-160)
+- Focus keyword in first paragraph
+- Focus keyword in at least one H2
+
+No overall score — just clear pass/fail per item.
+
+### Frontend Output
+
+- Outputs `<title>`, `<meta name="description">`, `<link rel="canonical">`, `<meta name="robots">`, OG tags, Twitter Card tags in `wp_head`
+- Auto-disable when Yoast/RankMath/AIOSEO detected (same pattern as SWPS_Schema)
+- Falls back to post title / auto-generated excerpt when custom fields empty
+
+---
+
+## Integration Points
+
+### Settings
+
+- Analytics section: `keyword_tracking_frequency` (select: daily/weekly/monthly)
+- New "SEO Meta" section: `meta_editor_enabled` (checkbox), `meta_editor_post_types` (multi-checkbox), `meta_auto_generate` (checkbox — auto-generate meta on publish if empty)
+
+### Conflict Detection
+
+- Check for `WPSEO_VERSION`, `RANK_MATH_VERSION`, `AIOSEO_VERSION` on plugin load
+- If detected: suppress all meta/OG/Twitter/canonical output, show admin notice
+- Reuse detection pattern from `SWPS_Schema`
+
+### Content Generator Integration
+
+- On post generation, also generate meta title + description, save to post meta
+- Focus keyword from keyword opportunities included in generation prompt
+- Existing `swps_post_data` filter still works for developer overrides
+
+### Developer Hooks
+
+| Hook                       | Type   | Purpose                              |
+|----------------------------|--------|--------------------------------------|
+| `swps_meta_title`          | filter | Filter meta title output             |
+| `swps_meta_description`    | filter | Filter meta description output       |
+| `swps_meta_robots`         | filter | Filter robots meta per post          |
+| `swps_keyword_suggestions` | filter | Filter AI keyword suggestions        |
+| `swps_seo_checklist`       | filter | Filter/add checklist items in metabox|

--- a/docs/plans/2026-03-06-keywords-meta-editor-implementation.md
+++ b/docs/plans/2026-03-06-keywords-meta-editor-implementation.md
@@ -1,0 +1,1929 @@
+# Keywords & Meta Editor Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add keyword research/tracking and per-post SEO meta editing with AI integration, conflict detection, and GSC-powered rank tracking (v2.3.0).
+
+**Architecture:** Two integrated modules — `SWPS_Keyword_Tracker` manages keyword discovery (AI) and rank tracking (GSC cron), `SWPS_Meta_Editor` handles per-post SEO fields, frontend meta output, and conflict detection. A shared focus keyword concept links them. Both integrate with the existing content generator.
+
+**Tech Stack:** PHP 8.0+, WordPress Settings API, WP-Cron, custom DB table via `$wpdb`/`dbDelta()`, jQuery AJAX, vanilla JS for live SERP preview, existing AI provider abstraction.
+
+---
+
+### Task 1: Keyword Tracker — Database & Core Class
+
+**Files:**
+- Create: `includes/class-keyword-tracker.php`
+
+**Context:** This class manages the `swps_keyword_tracking` custom table and provides CRUD + query methods for tracked keywords. Pattern follows `SWPS_Analytics_Tracker` — static `create_tables()` for activation, instance methods for queries. The existing `SWPS_Search_Console` class provides GSC data; this class stores processed keyword-level snapshots.
+
+**Implementation:**
+
+```php
+<?php
+/**
+ * Keyword tracking — DB table, CRUD, GSC sync, AI suggestions.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SWPS_Keyword_Tracker {
+
+    private const TABLE     = 'swps_keyword_tracking';
+    private const CRON_HOOK = 'swps_keyword_sync';
+
+    private SWPS_Search_Console $search_console;
+
+    public function __construct( SWPS_Search_Console $search_console ) {
+        $this->search_console = $search_console;
+        add_action( self::CRON_HOOK, [ $this, 'sync_from_gsc' ] );
+    }
+
+    /**
+     * Create the keyword tracking table. Called on activation.
+     */
+    public static function create_tables(): void {
+        global $wpdb;
+
+        $charset = $wpdb->get_charset_collate();
+        $table   = $wpdb->prefix . self::TABLE;
+
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            keyword VARCHAR(255) NOT NULL,
+            post_id BIGINT UNSIGNED DEFAULT NULL,
+            position FLOAT DEFAULT NULL,
+            clicks INT UNSIGNED NOT NULL DEFAULT 0,
+            impressions INT UNSIGNED NOT NULL DEFAULT 0,
+            ctr FLOAT NOT NULL DEFAULT 0,
+            date DATE NOT NULL,
+            PRIMARY KEY (id),
+            KEY idx_keyword_date (keyword, date),
+            KEY idx_post_id (post_id)
+        ) {$charset};";
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta( $sql );
+    }
+
+    /**
+     * Schedule the keyword sync cron.
+     */
+    public static function schedule_cron(): void {
+        if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+            $frequency = get_option( 'swps_keyword_tracking_frequency', 'weekly' );
+            wp_schedule_event( time(), $frequency, self::CRON_HOOK );
+        }
+    }
+
+    /**
+     * Unschedule the keyword sync cron.
+     */
+    public static function unschedule_cron(): void {
+        $timestamp = wp_next_scheduled( self::CRON_HOOK );
+        if ( $timestamp ) {
+            wp_unschedule_event( $timestamp, self::CRON_HOOK );
+        }
+    }
+
+    /**
+     * Reschedule cron with new frequency (called when settings change).
+     */
+    public static function reschedule_cron(): void {
+        self::unschedule_cron();
+        self::schedule_cron();
+    }
+
+    /**
+     * Track a keyword (add to tracking list).
+     *
+     * @param string $keyword Keyword text.
+     * @param int    $post_id Optional linked post ID.
+     * @return bool
+     */
+    public function track_keyword( string $keyword, int $post_id = 0 ): bool {
+        global $wpdb;
+
+        $keyword = sanitize_text_field( strtolower( trim( $keyword ) ) );
+        if ( empty( $keyword ) ) {
+            return false;
+        }
+
+        // Check if already tracked.
+        $exists = $wpdb->get_var( $wpdb->prepare(
+            "SELECT COUNT(*) FROM {$wpdb->prefix}" . self::TABLE . " WHERE keyword = %s LIMIT 1",
+            $keyword
+        ) );
+
+        if ( $exists ) {
+            return true; // Already tracking.
+        }
+
+        return (bool) $wpdb->insert(
+            $wpdb->prefix . self::TABLE,
+            [
+                'keyword'     => $keyword,
+                'post_id'     => $post_id ?: null,
+                'position'    => null,
+                'clicks'      => 0,
+                'impressions' => 0,
+                'ctr'         => 0,
+                'date'        => gmdate( 'Y-m-d' ),
+            ],
+            [ '%s', '%d', '%f', '%d', '%d', '%f', '%s' ]
+        );
+    }
+
+    /**
+     * Untrack a keyword (remove all history).
+     *
+     * @param string $keyword Keyword text.
+     * @return bool
+     */
+    public function untrack_keyword( string $keyword ): bool {
+        global $wpdb;
+        return (bool) $wpdb->delete(
+            $wpdb->prefix . self::TABLE,
+            [ 'keyword' => strtolower( trim( $keyword ) ) ],
+            [ '%s' ]
+        );
+    }
+
+    /**
+     * Link a keyword to a post.
+     *
+     * @param string $keyword Keyword text.
+     * @param int    $post_id Post ID.
+     * @return bool
+     */
+    public function link_to_post( string $keyword, int $post_id ): bool {
+        global $wpdb;
+        return (bool) $wpdb->update(
+            $wpdb->prefix . self::TABLE,
+            [ 'post_id' => $post_id ],
+            [ 'keyword' => strtolower( trim( $keyword ) ) ],
+            [ '%d' ],
+            [ '%s' ]
+        );
+    }
+
+    /**
+     * Get all tracked keywords with latest data.
+     *
+     * @param int $limit Max results.
+     * @return array
+     */
+    public function get_tracked_keywords( int $limit = 100 ): array {
+        global $wpdb;
+
+        $table = $wpdb->prefix . self::TABLE;
+
+        // Get the most recent row per keyword.
+        $results = $wpdb->get_results( $wpdb->prepare(
+            "SELECT t1.*
+             FROM {$table} t1
+             INNER JOIN (
+                 SELECT keyword, MAX(date) as max_date
+                 FROM {$table}
+                 GROUP BY keyword
+             ) t2 ON t1.keyword = t2.keyword AND t1.date = t2.max_date
+             ORDER BY t1.impressions DESC
+             LIMIT %d",
+            $limit
+        ), ARRAY_A );
+
+        return $results ?: [];
+    }
+
+    /**
+     * Get position history for a specific keyword.
+     *
+     * @param string $keyword Keyword text.
+     * @param int    $days    Days of history.
+     * @return array
+     */
+    public function get_keyword_history( string $keyword, int $days = 90 ): array {
+        global $wpdb;
+
+        $table = $wpdb->prefix . self::TABLE;
+        $since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+        $results = $wpdb->get_results( $wpdb->prepare(
+            "SELECT date, position, clicks, impressions, ctr
+             FROM {$table}
+             WHERE keyword = %s AND date >= %s
+             ORDER BY date ASC",
+            strtolower( trim( $keyword ) ),
+            $since
+        ), ARRAY_A );
+
+        return $results ?: [];
+    }
+
+    /**
+     * Get "striking distance" keyword opportunities (position 8-20, high impressions).
+     *
+     * @param int $limit Max results.
+     * @return array
+     */
+    public function get_opportunities( int $limit = 20 ): array {
+        global $wpdb;
+
+        $table = $wpdb->prefix . self::TABLE;
+
+        $results = $wpdb->get_results( $wpdb->prepare(
+            "SELECT t1.*
+             FROM {$table} t1
+             INNER JOIN (
+                 SELECT keyword, MAX(date) as max_date
+                 FROM {$table}
+                 GROUP BY keyword
+             ) t2 ON t1.keyword = t2.keyword AND t1.date = t2.max_date
+             WHERE t1.position BETWEEN 8 AND 20
+             AND t1.impressions > 0
+             ORDER BY t1.impressions DESC
+             LIMIT %d",
+            $limit
+        ), ARRAY_A );
+
+        return $results ?: [];
+    }
+
+    /**
+     * Sync tracked keywords with GSC data.
+     * Called by WP-Cron on configured schedule.
+     */
+    public function sync_from_gsc(): void {
+        if ( ! $this->search_console->is_connected() ) {
+            return;
+        }
+
+        $tracked = $this->get_tracked_keywords( 500 );
+        if ( empty( $tracked ) ) {
+            return;
+        }
+
+        // Pull GSC query data for the last 7 days.
+        $gsc_data = $this->search_console->get_search_data( 7 );
+        $gsc_queries = [];
+
+        foreach ( $gsc_data['queries'] ?? [] as $row ) {
+            $query = strtolower( $row['keys'][0] ?? '' );
+            if ( $query ) {
+                $gsc_queries[ $query ] = $row;
+            }
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . self::TABLE;
+        $today = gmdate( 'Y-m-d' );
+
+        // Get unique tracked keywords.
+        $keywords = array_unique( array_column( $tracked, 'keyword' ) );
+
+        foreach ( $keywords as $keyword ) {
+            $gsc_row = $gsc_queries[ $keyword ] ?? null;
+
+            $wpdb->insert(
+                $table,
+                [
+                    'keyword'     => $keyword,
+                    'post_id'     => $this->find_post_for_keyword( $keyword, $tracked ),
+                    'position'    => $gsc_row ? round( $gsc_row['position'] ?? 0, 1 ) : null,
+                    'clicks'      => $gsc_row['clicks'] ?? 0,
+                    'impressions' => $gsc_row['impressions'] ?? 0,
+                    'ctr'         => $gsc_row ? round( ( $gsc_row['ctr'] ?? 0 ) * 100, 1 ) : 0,
+                    'date'        => $today,
+                ],
+                [ '%s', '%d', '%f', '%d', '%d', '%f', '%s' ]
+            );
+        }
+    }
+
+    /**
+     * Generate keyword suggestions via AI.
+     *
+     * @param string $seed_topic Seed topic for suggestions.
+     * @return array|WP_Error Array of keyword suggestions or error.
+     */
+    public function suggest_keywords( string $seed_topic ): array|WP_Error {
+        $api   = SWPS_Provider_Factory::create_ai_provider();
+        $niche = get_option( 'swps_site_niche', '' );
+        $desc  = get_option( 'swps_site_description', '' );
+
+        $prompt = sprintf(
+            "You are an SEO keyword research expert. Generate 15 keyword suggestions for a website in the \"%s\" niche.\n\n"
+            . "Site description: %s\n\n"
+            . "Seed topic: %s\n\n"
+            . "For each keyword, provide:\n"
+            . "- keyword: the exact search phrase (lowercase)\n"
+            . "- intent: informational, transactional, or navigational\n"
+            . "- difficulty: low, medium, or high (estimate)\n"
+            . "- suggested_title: a blog post title targeting this keyword\n\n"
+            . "Return JSON array only. No markdown, no explanation.\n"
+            . "Example: [{\"keyword\":\"best running shoes\",\"intent\":\"transactional\",\"difficulty\":\"high\",\"suggested_title\":\"10 Best Running Shoes for Every Budget in 2026\"}]",
+            $niche,
+            $desc,
+            $seed_topic
+        );
+
+        $response = $api->generate( $prompt, 'You are an SEO keyword research expert. Return only valid JSON.' );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $text = $response['content'] ?? '';
+
+        // Extract JSON from response.
+        $json_match = [];
+        if ( preg_match( '/\[.*\]/s', $text, $json_match ) ) {
+            $suggestions = json_decode( $json_match[0], true );
+            if ( is_array( $suggestions ) ) {
+                return apply_filters( 'swps_keyword_suggestions', $suggestions, $seed_topic );
+            }
+        }
+
+        return new WP_Error( 'swps_keyword_parse', __( 'Failed to parse keyword suggestions from AI response.', 'stratawp-seo' ) );
+    }
+
+    /**
+     * Find the linked post_id for a keyword from tracked data.
+     */
+    private function find_post_for_keyword( string $keyword, array $tracked ): int {
+        foreach ( $tracked as $row ) {
+            if ( $row['keyword'] === $keyword && ! empty( $row['post_id'] ) ) {
+                return (int) $row['post_id'];
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Drop the keyword tracking table. Called on uninstall.
+     */
+    public static function drop_tables(): void {
+        global $wpdb;
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . self::TABLE );
+    }
+}
+```
+
+**Verify:** `php -l includes/class-keyword-tracker.php`
+
+**Commit:** `git add includes/class-keyword-tracker.php && git commit -m "feat: Add SWPS_Keyword_Tracker with DB table, CRUD, GSC sync, and AI suggestions"`
+
+---
+
+### Task 2: Keywords Admin Page — Template & AJAX
+
+**Files:**
+- Create: `templates/keywords-page.php`
+- Create: `includes/class-keywords-page.php`
+
+**Context:** Admin page registered under the StrataWP SEO menu. Shows: AI suggestion form, tracked keywords table with position/change/clicks/impressions, opportunities section. Uses AJAX to load data and manage keywords. Follows the same pattern as `SWPS_Analytics_Dashboard` — class registers menu + AJAX handlers, template renders the HTML.
+
+**Implementation for `includes/class-keywords-page.php`:**
+
+```php
+<?php
+/**
+ * Keywords admin page — AI suggestions, tracked keywords, opportunities.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SWPS_Keywords_Page {
+
+    private SWPS_Keyword_Tracker $tracker;
+
+    public function __construct( SWPS_Keyword_Tracker $tracker ) {
+        $this->tracker = $tracker;
+
+        // Register after parent menu (priority 20).
+        add_action( 'admin_menu', [ $this, 'register_menu' ], 20 );
+
+        // AJAX endpoints.
+        add_action( 'wp_ajax_swps_suggest_keywords', [ $this, 'ajax_suggest' ] );
+        add_action( 'wp_ajax_swps_track_keyword', [ $this, 'ajax_track' ] );
+        add_action( 'wp_ajax_swps_untrack_keyword', [ $this, 'ajax_untrack' ] );
+        add_action( 'wp_ajax_swps_link_keyword', [ $this, 'ajax_link' ] );
+        add_action( 'wp_ajax_swps_keyword_history', [ $this, 'ajax_history' ] );
+        add_action( 'wp_ajax_swps_get_keywords', [ $this, 'ajax_get_keywords' ] );
+        add_action( 'wp_ajax_swps_get_opportunities', [ $this, 'ajax_get_opportunities' ] );
+    }
+
+    public function register_menu(): void {
+        add_submenu_page(
+            'stratawp-seo',
+            __( 'Keywords', 'stratawp-seo' ),
+            __( 'Keywords', 'stratawp-seo' ),
+            'manage_options',
+            'swps-keywords',
+            [ $this, 'render_page' ]
+        );
+    }
+
+    public function render_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        $gsc_connected = stratawp_seo()->search_console->is_connected();
+        include SWPS_PLUGIN_DIR . 'templates/keywords-page.php';
+    }
+
+    public function ajax_suggest(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $seed = sanitize_text_field( $_POST['seed_topic'] ?? '' );
+        if ( empty( $seed ) ) {
+            wp_send_json_error( [ 'message' => 'Please enter a seed topic.' ] );
+        }
+
+        $suggestions = $this->tracker->suggest_keywords( $seed );
+        if ( is_wp_error( $suggestions ) ) {
+            wp_send_json_error( [ 'message' => $suggestions->get_error_message() ] );
+        }
+
+        wp_send_json_success( $suggestions );
+    }
+
+    public function ajax_track(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
+        $post_id = absint( $_POST['post_id'] ?? 0 );
+
+        if ( empty( $keyword ) ) {
+            wp_send_json_error( [ 'message' => 'Keyword is required.' ] );
+        }
+
+        $this->tracker->track_keyword( $keyword, $post_id );
+        wp_send_json_success();
+    }
+
+    public function ajax_untrack(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
+        $this->tracker->untrack_keyword( $keyword );
+        wp_send_json_success();
+    }
+
+    public function ajax_link(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
+        $post_id = absint( $_POST['post_id'] ?? 0 );
+        $this->tracker->link_to_post( $keyword, $post_id );
+        wp_send_json_success();
+    }
+
+    public function ajax_history(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
+        $days    = absint( $_POST['days'] ?? 90 );
+        $history = $this->tracker->get_keyword_history( $keyword, $days );
+        wp_send_json_success( $history );
+    }
+
+    public function ajax_get_keywords(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $keywords = $this->tracker->get_tracked_keywords();
+
+        // Enrich with post titles.
+        foreach ( $keywords as &$kw ) {
+            if ( ! empty( $kw['post_id'] ) ) {
+                $post = get_post( (int) $kw['post_id'] );
+                $kw['post_title'] = $post ? $post->post_title : '';
+                $kw['post_url']   = $post ? get_edit_post_link( $post->ID, 'raw' ) : '';
+            }
+        }
+
+        wp_send_json_success( $keywords );
+    }
+
+    public function ajax_get_opportunities(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $opportunities = $this->tracker->get_opportunities();
+
+        foreach ( $opportunities as &$opp ) {
+            if ( ! empty( $opp['post_id'] ) ) {
+                $post = get_post( (int) $opp['post_id'] );
+                $opp['post_title'] = $post ? $post->post_title : '';
+            }
+        }
+
+        wp_send_json_success( $opportunities );
+    }
+}
+```
+
+**Implementation for `templates/keywords-page.php`:**
+
+```php
+<?php
+/**
+ * Keywords page template.
+ *
+ * @var bool $gsc_connected Whether GSC is connected.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div class="wrap swps-keywords-wrap">
+    <h1><?php esc_html_e( 'Keyword Research & Tracking', 'stratawp-seo' ); ?></h1>
+
+    <!-- AI Suggestion Panel -->
+    <div class="swps-keywords-section swps-suggest-panel">
+        <h2><?php esc_html_e( 'Discover Keywords', 'stratawp-seo' ); ?></h2>
+        <div class="swps-suggest-form">
+            <input type="text" id="swps-seed-topic" class="regular-text"
+                   placeholder="<?php esc_attr_e( 'Enter a seed topic (e.g., home renovation tips)', 'stratawp-seo' ); ?>" />
+            <button class="button button-primary" id="swps-suggest-btn">
+                <?php esc_html_e( 'Get AI Suggestions', 'stratawp-seo' ); ?>
+            </button>
+            <span class="spinner" id="swps-suggest-spinner"></span>
+        </div>
+        <table class="widefat striped" id="swps-suggestions-table" style="display:none;">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e( 'Keyword', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Intent', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Difficulty', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Suggested Title', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+
+    <!-- Tracked Keywords -->
+    <div class="swps-keywords-section">
+        <h2><?php esc_html_e( 'Tracked Keywords', 'stratawp-seo' ); ?></h2>
+        <table class="widefat striped" id="swps-tracked-table">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e( 'Keyword', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Position', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Clicks', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'CTR', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Linked Post', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr><td colspan="7" class="swps-loading"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+            </tbody>
+        </table>
+    </div>
+
+    <?php if ( $gsc_connected ) : ?>
+    <!-- Opportunities -->
+    <div class="swps-keywords-section">
+        <h2><?php esc_html_e( 'Opportunities (Striking Distance)', 'stratawp-seo' ); ?></h2>
+        <p class="description"><?php esc_html_e( 'Keywords ranking position 8-20 with high impressions — optimize these for quick wins.', 'stratawp-seo' ); ?></p>
+        <table class="widefat striped" id="swps-opportunities-table">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e( 'Keyword', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Position', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'CTR', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr><td colspan="5" class="swps-loading"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+            </tbody>
+        </table>
+    </div>
+    <?php endif; ?>
+
+    <!-- Keyword History Modal -->
+    <div id="swps-keyword-history-modal" class="swps-modal" style="display:none;">
+        <div class="swps-modal-content">
+            <span class="swps-modal-close">&times;</span>
+            <h3 id="swps-history-title"></h3>
+            <div id="swps-history-chart" class="swps-chart"></div>
+        </div>
+    </div>
+</div>
+```
+
+**Verify:** `php -l includes/class-keywords-page.php && php -l templates/keywords-page.php`
+
+**Commit:** `git add includes/class-keywords-page.php templates/keywords-page.php && git commit -m "feat: Add Keywords admin page with AJAX endpoints and template"`
+
+---
+
+### Task 3: Keywords Page JavaScript
+
+**Files:**
+- Create: `admin/js/keywords.js`
+
+**Context:** jQuery-based JS for the keywords admin page. Loads tracked keywords and opportunities via AJAX on page ready, handles AI suggestion form, track/untrack/link buttons, and keyword history chart modal. Reuses SVG chart pattern from `admin/js/analytics.js`. Depends on `swpsAdmin` localized data (ajax_url, nonce) from `swps-admin` script.
+
+**Implementation:**
+
+```js
+/**
+ * StrataWP SEO — Keywords Page JS
+ */
+(function ($) {
+    'use strict';
+
+    if (typeof swpsAdmin === 'undefined') return;
+
+    // --- Load tracked keywords ---
+    function loadTracked() {
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_get_keywords',
+            nonce: swpsAdmin.nonce
+        }, function (res) {
+            if (!res.success) return;
+            var tbody = $('#swps-tracked-table tbody');
+            tbody.empty();
+
+            if (!res.data.length) {
+                tbody.html('<tr><td colspan="7">No tracked keywords yet. Use AI suggestions above to discover and track keywords.</td></tr>');
+                return;
+            }
+
+            res.data.forEach(function (kw) {
+                var postLink = kw.post_title
+                    ? '<a href="' + kw.post_url + '">' + escHtml(kw.post_title) + '</a>'
+                    : '<em>None</em>';
+                var pos = kw.position !== null ? parseFloat(kw.position).toFixed(1) : '—';
+                var row = '<tr>';
+                row += '<td><a href="#" class="swps-kw-history" data-keyword="' + escAttr(kw.keyword) + '">' + escHtml(kw.keyword) + '</a></td>';
+                row += '<td>' + pos + '</td>';
+                row += '<td>' + parseInt(kw.clicks).toLocaleString() + '</td>';
+                row += '<td>' + parseInt(kw.impressions).toLocaleString() + '</td>';
+                row += '<td>' + parseFloat(kw.ctr).toFixed(1) + '%</td>';
+                row += '<td>' + postLink + '</td>';
+                row += '<td><button class="button button-small swps-untrack-btn" data-keyword="' + escAttr(kw.keyword) + '">Untrack</button></td>';
+                row += '</tr>';
+                tbody.append(row);
+            });
+        });
+    }
+
+    // --- Load opportunities ---
+    function loadOpportunities() {
+        if (!$('#swps-opportunities-table').length) return;
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_get_opportunities',
+            nonce: swpsAdmin.nonce
+        }, function (res) {
+            if (!res.success) return;
+            var tbody = $('#swps-opportunities-table tbody');
+            tbody.empty();
+
+            if (!res.data.length) {
+                tbody.html('<tr><td colspan="5">No striking distance keywords found yet. Track keywords and sync with GSC.</td></tr>');
+                return;
+            }
+
+            res.data.forEach(function (opp) {
+                var row = '<tr>';
+                row += '<td>' + escHtml(opp.keyword) + '</td>';
+                row += '<td>' + parseFloat(opp.position).toFixed(1) + '</td>';
+                row += '<td>' + parseInt(opp.impressions).toLocaleString() + '</td>';
+                row += '<td>' + parseFloat(opp.ctr).toFixed(1) + '%</td>';
+                row += '<td>';
+                row += '<a href="' + swpsAdmin.generate_url + '&topic=' + encodeURIComponent(opp.keyword) + '" class="button button-small">Generate Post</a>';
+                row += '</td>';
+                row += '</tr>';
+                tbody.append(row);
+            });
+        });
+    }
+
+    // --- AI Suggestions ---
+    $('#swps-suggest-btn').on('click', function () {
+        var seed = $('#swps-seed-topic').val().trim();
+        if (!seed) return;
+
+        var btn = $(this);
+        var spinner = $('#swps-suggest-spinner');
+        btn.prop('disabled', true);
+        spinner.addClass('is-active');
+
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_suggest_keywords',
+            nonce: swpsAdmin.nonce,
+            seed_topic: seed
+        }, function (res) {
+            btn.prop('disabled', false);
+            spinner.removeClass('is-active');
+
+            if (!res.success) {
+                alert(res.data.message || 'Failed to get suggestions.');
+                return;
+            }
+
+            var table = $('#swps-suggestions-table');
+            var tbody = table.find('tbody');
+            tbody.empty();
+            table.show();
+
+            res.data.forEach(function (s) {
+                var row = '<tr>';
+                row += '<td><strong>' + escHtml(s.keyword) + '</strong></td>';
+                row += '<td><span class="swps-intent-badge swps-intent-' + escAttr(s.intent) + '">' + escHtml(s.intent) + '</span></td>';
+                row += '<td>' + escHtml(s.difficulty) + '</td>';
+                row += '<td>' + escHtml(s.suggested_title) + '</td>';
+                row += '<td><button class="button button-small swps-track-btn" data-keyword="' + escAttr(s.keyword) + '">Track</button></td>';
+                row += '</tr>';
+                tbody.append(row);
+            });
+        });
+    });
+
+    // --- Track keyword ---
+    $(document).on('click', '.swps-track-btn', function () {
+        var btn = $(this);
+        var keyword = btn.data('keyword');
+        btn.prop('disabled', true).text('Tracking...');
+
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_track_keyword',
+            nonce: swpsAdmin.nonce,
+            keyword: keyword
+        }, function () {
+            btn.text('Tracked').addClass('disabled');
+            loadTracked();
+        });
+    });
+
+    // --- Untrack keyword ---
+    $(document).on('click', '.swps-untrack-btn', function () {
+        var keyword = $(this).data('keyword');
+        if (!confirm('Stop tracking "' + keyword + '"?')) return;
+
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_untrack_keyword',
+            nonce: swpsAdmin.nonce,
+            keyword: keyword
+        }, function () { loadTracked(); });
+    });
+
+    // --- Keyword history modal ---
+    $(document).on('click', '.swps-kw-history', function (e) {
+        e.preventDefault();
+        var keyword = $(this).data('keyword');
+        $('#swps-history-title').text(keyword);
+        $('#swps-keyword-history-modal').show();
+
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_keyword_history',
+            nonce: swpsAdmin.nonce,
+            keyword: keyword,
+            days: 90
+        }, function (res) {
+            if (!res.success || !res.data.length) {
+                $('#swps-history-chart').html('<p>No history data yet.</p>');
+                return;
+            }
+            renderPositionChart(res.data);
+        });
+    });
+
+    $('.swps-modal-close').on('click', function () {
+        $(this).closest('.swps-modal').hide();
+    });
+
+    // --- Position chart (SVG) ---
+    function renderPositionChart(data) {
+        var container = document.getElementById('swps-history-chart');
+        if (!container) return;
+
+        var width = container.offsetWidth || 600;
+        var height = 200;
+        var pad = { top: 20, right: 20, bottom: 30, left: 50 };
+        var cW = width - pad.left - pad.right;
+        var cH = height - pad.top - pad.bottom;
+
+        // Position is inverted — lower is better.
+        var positions = data.map(function (d) { return parseFloat(d.position) || 100; });
+        var maxPos = Math.max.apply(null, positions);
+        var minPos = Math.min.apply(null, positions);
+        if (maxPos === minPos) maxPos = minPos + 10;
+
+        var points = data.map(function (d, i) {
+            var x = pad.left + (i / Math.max(data.length - 1, 1)) * cW;
+            var pos = parseFloat(d.position) || 100;
+            var y = pad.top + ((pos - minPos) / (maxPos - minPos)) * cH;
+            return x + ',' + y;
+        });
+
+        var svg = '<svg width="' + width + '" height="' + height + '" xmlns="http://www.w3.org/2000/svg">';
+        svg += '<polyline points="' + points.join(' ') + '" fill="none" stroke="#2271b1" stroke-width="2" />';
+
+        // Y-axis: position labels (inverted).
+        for (var i = 0; i <= 4; i++) {
+            var yVal = Math.round(minPos + ((maxPos - minPos) / 4) * i);
+            var yPos = pad.top + (i / 4) * cH;
+            svg += '<text x="' + (pad.left - 8) + '" y="' + (yPos + 4) + '" text-anchor="end" fill="#646970" font-size="11">#' + yVal + '</text>';
+            svg += '<line x1="' + pad.left + '" y1="' + yPos + '" x2="' + (width - pad.right) + '" y2="' + yPos + '" stroke="#e0e0e0" />';
+        }
+
+        svg += '</svg>';
+        container.innerHTML = svg;
+    }
+
+    // --- Helpers ---
+    function escHtml(str) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str || ''));
+        return div.innerHTML;
+    }
+
+    function escAttr(str) {
+        return (str || '').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    // --- Init ---
+    $(document).ready(function () {
+        if ($('.swps-keywords-wrap').length) {
+            loadTracked();
+            loadOpportunities();
+        }
+    });
+
+})(jQuery);
+```
+
+**Verify:** File created, no PHP syntax to check (JS file).
+
+**Commit:** `git add admin/js/keywords.js && git commit -m "feat: Add keywords page JavaScript (AI suggestions, tracking, history chart)"`
+
+---
+
+### Task 4: Meta Editor — Core Class with Frontend Output
+
+**Files:**
+- Create: `includes/class-meta-editor.php`
+
+**Context:** Handles saving/retrieving per-post SEO meta fields, outputs `<title>`, `<meta>`, OG, Twitter Card, canonical, and robots tags in `wp_head`. Auto-disables when Yoast/RankMath/AIOSEO detected (same pattern as `SWPS_Schema` line 36). The existing `SWPS_OpenGraph_Module::output_meta_tags()` handles OG output for the audit — the meta editor should take precedence when its fields are populated, and coordinate with the OG module to avoid duplicates.
+
+**Implementation:**
+
+```php
+<?php
+/**
+ * SEO Meta Editor — per-post meta fields and frontend output.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SWPS_Meta_Editor {
+
+    private bool $conflict = false;
+
+    public function __construct() {
+        // Detect conflicting SEO plugins.
+        if ( defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' ) ) {
+            $this->conflict = true;
+        }
+
+        if ( ! get_option( 'swps_meta_editor_enabled', 1 ) ) {
+            return;
+        }
+
+        // Admin: register metabox and save hook.
+        add_action( 'add_meta_boxes', [ $this, 'register_metabox' ] );
+        add_action( 'save_post', [ $this, 'save_meta' ], 10, 2 );
+
+        // AJAX: AI-generate meta.
+        add_action( 'wp_ajax_swps_generate_meta', [ $this, 'ajax_generate_meta' ] );
+
+        // Frontend output — only when no conflict.
+        if ( ! $this->conflict && ! is_admin() ) {
+            add_action( 'wp_head', [ $this, 'output_meta_tags' ], 2 );
+            add_filter( 'pre_get_document_title', [ $this, 'filter_document_title' ], 20 );
+            add_filter( 'document_title_parts', [ $this, 'filter_title_parts' ], 20 );
+        }
+
+        // Admin notice if conflict detected.
+        if ( $this->conflict ) {
+            add_action( 'admin_notices', [ $this, 'conflict_notice' ] );
+        }
+    }
+
+    /**
+     * Check if there's an SEO plugin conflict.
+     */
+    public function has_conflict(): bool {
+        return $this->conflict;
+    }
+
+    /**
+     * Register the SEO metabox on configured post types.
+     */
+    public function register_metabox(): void {
+        $post_types = $this->get_enabled_post_types();
+
+        foreach ( $post_types as $post_type ) {
+            add_meta_box(
+                'swps_meta_editor',
+                __( 'StrataWP SEO', 'stratawp-seo' ),
+                [ $this, 'render_metabox' ],
+                $post_type,
+                'normal',
+                'high'
+            );
+        }
+    }
+
+    /**
+     * Render the SEO metabox.
+     */
+    public function render_metabox( WP_Post $post ): void {
+        wp_nonce_field( 'swps_meta_editor', 'swps_meta_editor_nonce' );
+
+        $meta_title        = get_post_meta( $post->ID, '_swps_meta_title', true );
+        $meta_description  = get_post_meta( $post->ID, '_swps_meta_description', true );
+        $focus_keyword     = get_post_meta( $post->ID, '_swps_focus_keyword', true );
+        $secondary_kws     = get_post_meta( $post->ID, '_swps_secondary_keywords', true );
+        $canonical_url     = get_post_meta( $post->ID, '_swps_canonical_url', true );
+        $robots            = get_post_meta( $post->ID, '_swps_robots', true );
+        $breadcrumb_title  = get_post_meta( $post->ID, '_swps_breadcrumb_title', true );
+        $social_title      = get_post_meta( $post->ID, '_swps_social_title', true );
+        $social_desc       = get_post_meta( $post->ID, '_swps_social_description', true );
+        $social_image      = get_post_meta( $post->ID, '_swps_social_image', true );
+
+        if ( $this->conflict ) {
+            echo '<div class="notice notice-warning inline"><p>';
+            esc_html_e( 'Meta output is disabled because another SEO plugin is active. Fields are saved but not output on the frontend.', 'stratawp-seo' );
+            echo '</p></div>';
+        }
+
+        include SWPS_PLUGIN_DIR . 'templates/meta-editor-metabox.php';
+    }
+
+    /**
+     * Save meta fields on post save.
+     */
+    public function save_meta( int $post_id, WP_Post $post ): void {
+        if ( ! isset( $_POST['swps_meta_editor_nonce'] ) ) {
+            return;
+        }
+        if ( ! wp_verify_nonce( $_POST['swps_meta_editor_nonce'], 'swps_meta_editor' ) ) {
+            return;
+        }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) {
+            return;
+        }
+
+        $fields = [
+            '_swps_meta_title'          => 'sanitize_text_field',
+            '_swps_meta_description'    => 'sanitize_textarea_field',
+            '_swps_focus_keyword'       => 'sanitize_text_field',
+            '_swps_secondary_keywords'  => 'sanitize_text_field',
+            '_swps_canonical_url'       => 'esc_url_raw',
+            '_swps_robots'              => 'sanitize_text_field',
+            '_swps_breadcrumb_title'    => 'sanitize_text_field',
+            '_swps_social_title'        => 'sanitize_text_field',
+            '_swps_social_description'  => 'sanitize_textarea_field',
+            '_swps_social_image'        => 'esc_url_raw',
+        ];
+
+        foreach ( $fields as $key => $sanitizer ) {
+            if ( isset( $_POST[ $key ] ) ) {
+                $value = call_user_func( $sanitizer, $_POST[ $key ] );
+                if ( ! empty( $value ) ) {
+                    update_post_meta( $post_id, $key, $value );
+                } else {
+                    delete_post_meta( $post_id, $key );
+                }
+            }
+        }
+    }
+
+    /**
+     * Output meta tags in wp_head.
+     */
+    public function output_meta_tags(): void {
+        if ( ! is_singular() ) {
+            return;
+        }
+
+        $post_id = get_the_ID();
+        if ( ! $post_id ) {
+            return;
+        }
+
+        $meta_desc  = get_post_meta( $post_id, '_swps_meta_description', true );
+        $canonical  = get_post_meta( $post_id, '_swps_canonical_url', true );
+        $robots     = get_post_meta( $post_id, '_swps_robots', true );
+
+        // Meta description.
+        $meta_desc = apply_filters( 'swps_meta_description', $meta_desc, $post_id );
+        if ( ! empty( $meta_desc ) ) {
+            printf( '<meta name="description" content="%s" />' . "\n", esc_attr( $meta_desc ) );
+        }
+
+        // Canonical.
+        if ( ! empty( $canonical ) ) {
+            printf( '<link rel="canonical" href="%s" />' . "\n", esc_url( $canonical ) );
+            // Remove WP default canonical.
+            remove_action( 'wp_head', 'rel_canonical' );
+        }
+
+        // Robots.
+        $robots = apply_filters( 'swps_meta_robots', $robots, $post_id );
+        if ( ! empty( $robots ) && 'index, follow' !== $robots ) {
+            printf( '<meta name="robots" content="%s" />' . "\n", esc_attr( $robots ) );
+        }
+
+        // Open Graph.
+        $this->output_og_tags( $post_id );
+
+        // Twitter Card.
+        $this->output_twitter_tags( $post_id );
+    }
+
+    /**
+     * Filter the document title for our custom meta title.
+     */
+    public function filter_document_title( string $title ): string {
+        if ( ! is_singular() ) {
+            return $title;
+        }
+
+        $custom = get_post_meta( get_the_ID(), '_swps_meta_title', true );
+        $custom = apply_filters( 'swps_meta_title', $custom, get_the_ID() );
+
+        return ! empty( $custom ) ? $custom : $title;
+    }
+
+    /**
+     * Filter document title parts.
+     */
+    public function filter_title_parts( array $parts ): array {
+        if ( ! is_singular() ) {
+            return $parts;
+        }
+
+        $custom = get_post_meta( get_the_ID(), '_swps_meta_title', true );
+        $custom = apply_filters( 'swps_meta_title', $custom, get_the_ID() );
+
+        if ( ! empty( $custom ) ) {
+            $parts['title'] = $custom;
+            // Remove site name suffix if custom title is set.
+            unset( $parts['site'] );
+        }
+
+        return $parts;
+    }
+
+    /**
+     * AJAX: Generate meta title and description using AI.
+     */
+    public function ajax_generate_meta(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+
+        if ( ! current_user_can( 'edit_posts' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $post_id       = absint( $_POST['post_id'] ?? 0 );
+        $focus_keyword = sanitize_text_field( $_POST['focus_keyword'] ?? '' );
+
+        if ( ! $post_id ) {
+            wp_send_json_error( [ 'message' => 'Invalid post ID.' ] );
+        }
+
+        $post = get_post( $post_id );
+        if ( ! $post ) {
+            wp_send_json_error( [ 'message' => 'Post not found.' ] );
+        }
+
+        $content = wp_strip_all_tags( $post->post_content );
+        $content = mb_substr( $content, 0, 2000 ); // Limit to keep prompt short.
+
+        $prompt = sprintf(
+            "Generate an SEO-optimized meta title (50-60 chars) and meta description (140-160 chars) for this blog post.\n\n"
+            . "Post title: %s\n"
+            . "Focus keyword: %s\n"
+            . "Content excerpt: %s\n\n"
+            . "Requirements:\n"
+            . "- Include the focus keyword naturally in both title and description\n"
+            . "- Meta title: compelling, under 60 characters\n"
+            . "- Meta description: actionable, includes a call to read, under 160 characters\n\n"
+            . "Return JSON only: {\"meta_title\":\"...\",\"meta_description\":\"...\"}",
+            $post->post_title,
+            $focus_keyword ?: '(none specified)',
+            $content
+        );
+
+        $api      = SWPS_Provider_Factory::create_ai_provider();
+        $response = $api->generate( $prompt, 'You are an SEO copywriting expert. Return only valid JSON.' );
+
+        if ( is_wp_error( $response ) ) {
+            wp_send_json_error( [ 'message' => $response->get_error_message() ] );
+        }
+
+        $text = $response['content'] ?? '';
+        $json_match = [];
+        if ( preg_match( '/\{.*\}/s', $text, $json_match ) ) {
+            $result = json_decode( $json_match[0], true );
+            if ( is_array( $result ) ) {
+                wp_send_json_success( $result );
+            }
+        }
+
+        wp_send_json_error( [ 'message' => 'Failed to parse AI response.' ] );
+    }
+
+    /**
+     * Show admin notice when SEO plugin conflict detected.
+     */
+    public function conflict_notice(): void {
+        $screen = get_current_screen();
+        if ( ! $screen || strpos( $screen->id, 'stratawp-seo' ) === false ) {
+            return;
+        }
+
+        echo '<div class="notice notice-info"><p>';
+        esc_html_e( 'StrataWP SEO: Meta tag output is disabled because another SEO plugin (Yoast, RankMath, or AIOSEO) is active. The meta editor fields are still saved for reference.', 'stratawp-seo' );
+        echo '</p></div>';
+    }
+
+    /**
+     * Get post types where the meta editor is enabled.
+     */
+    private function get_enabled_post_types(): array {
+        $saved = get_option( 'swps_meta_editor_post_types', '' );
+        if ( ! empty( $saved ) ) {
+            return array_map( 'sanitize_text_field', explode( ',', $saved ) );
+        }
+        return [ 'post', 'page' ];
+    }
+
+    /**
+     * Output Open Graph tags.
+     */
+    private function output_og_tags( int $post_id ): void {
+        $title = get_post_meta( $post_id, '_swps_social_title', true )
+              ?: get_post_meta( $post_id, '_swps_meta_title', true )
+              ?: get_the_title( $post_id );
+
+        $desc = get_post_meta( $post_id, '_swps_social_description', true )
+             ?: get_post_meta( $post_id, '_swps_meta_description', true )
+             ?: get_the_excerpt( $post_id );
+
+        $image = get_post_meta( $post_id, '_swps_social_image', true )
+              ?: get_the_post_thumbnail_url( $post_id, 'large' );
+
+        printf( '<meta property="og:type" content="article" />' . "\n" );
+        printf( '<meta property="og:title" content="%s" />' . "\n", esc_attr( $title ) );
+        printf( '<meta property="og:description" content="%s" />' . "\n", esc_attr( $desc ) );
+        printf( '<meta property="og:url" content="%s" />' . "\n", esc_url( get_permalink( $post_id ) ) );
+        if ( $image ) {
+            printf( '<meta property="og:image" content="%s" />' . "\n", esc_url( $image ) );
+        }
+        printf( '<meta property="og:site_name" content="%s" />' . "\n", esc_attr( get_bloginfo( 'name' ) ) );
+    }
+
+    /**
+     * Output Twitter Card tags.
+     */
+    private function output_twitter_tags( int $post_id ): void {
+        $title = get_post_meta( $post_id, '_swps_social_title', true )
+              ?: get_post_meta( $post_id, '_swps_meta_title', true )
+              ?: get_the_title( $post_id );
+
+        $desc = get_post_meta( $post_id, '_swps_social_description', true )
+             ?: get_post_meta( $post_id, '_swps_meta_description', true )
+             ?: get_the_excerpt( $post_id );
+
+        $image = get_post_meta( $post_id, '_swps_social_image', true )
+              ?: get_the_post_thumbnail_url( $post_id, 'large' );
+
+        printf( '<meta name="twitter:card" content="%s" />' . "\n", $image ? 'summary_large_image' : 'summary' );
+        printf( '<meta name="twitter:title" content="%s" />' . "\n", esc_attr( $title ) );
+        printf( '<meta name="twitter:description" content="%s" />' . "\n", esc_attr( $desc ) );
+        if ( $image ) {
+            printf( '<meta name="twitter:image" content="%s" />' . "\n", esc_url( $image ) );
+        }
+    }
+}
+```
+
+**Verify:** `php -l includes/class-meta-editor.php`
+
+**Commit:** `git add includes/class-meta-editor.php && git commit -m "feat: Add SWPS_Meta_Editor with per-post fields, frontend output, and conflict detection"`
+
+---
+
+### Task 5: Meta Editor Metabox Template
+
+**Files:**
+- Create: `templates/meta-editor-metabox.php`
+
+**Context:** Renders the SEO metabox inside the post editor. Variables `$meta_title`, `$meta_description`, `$focus_keyword`, etc. are set by `SWPS_Meta_Editor::render_metabox()` before this template is included. Includes: Google SERP preview (live-updating), character counters, social preview tabs, SEO checklist, and AI Generate button.
+
+**Implementation:**
+
+```php
+<?php
+/**
+ * Meta editor metabox template.
+ *
+ * Variables are set by SWPS_Meta_Editor::render_metabox().
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div class="swps-meta-editor" data-post-id="<?php echo esc_attr( $post->ID ); ?>">
+
+    <!-- Google Preview -->
+    <div class="swps-serp-preview">
+        <h4><?php esc_html_e( 'Google Preview', 'stratawp-seo' ); ?></h4>
+        <div class="swps-serp-mock">
+            <div class="swps-serp-title" id="swps-serp-title"><?php echo esc_html( $meta_title ?: $post->post_title ); ?></div>
+            <div class="swps-serp-url"><?php echo esc_url( get_permalink( $post->ID ) ); ?></div>
+            <div class="swps-serp-desc" id="swps-serp-desc"><?php echo esc_html( $meta_description ?: wp_trim_words( $post->post_content, 25, '...' ) ); ?></div>
+        </div>
+    </div>
+
+    <!-- Focus Keyword -->
+    <div class="swps-meta-row">
+        <label for="_swps_focus_keyword"><strong><?php esc_html_e( 'Focus Keyword', 'stratawp-seo' ); ?></strong></label>
+        <input type="text" name="_swps_focus_keyword" id="_swps_focus_keyword"
+               value="<?php echo esc_attr( $focus_keyword ); ?>" class="widefat"
+               placeholder="<?php esc_attr_e( 'e.g., best running shoes', 'stratawp-seo' ); ?>" />
+    </div>
+
+    <div class="swps-meta-row">
+        <label for="_swps_secondary_keywords"><?php esc_html_e( 'Secondary Keywords', 'stratawp-seo' ); ?></label>
+        <input type="text" name="_swps_secondary_keywords" id="_swps_secondary_keywords"
+               value="<?php echo esc_attr( $secondary_kws ); ?>" class="widefat"
+               placeholder="<?php esc_attr_e( 'Comma-separated: running gear, marathon training', 'stratawp-seo' ); ?>" />
+    </div>
+
+    <!-- Meta Title -->
+    <div class="swps-meta-row">
+        <label for="_swps_meta_title">
+            <?php esc_html_e( 'Meta Title', 'stratawp-seo' ); ?>
+            <span class="swps-char-count" id="swps-title-count">0</span>
+        </label>
+        <input type="text" name="_swps_meta_title" id="_swps_meta_title"
+               value="<?php echo esc_attr( $meta_title ); ?>" class="widefat"
+               placeholder="<?php echo esc_attr( $post->post_title ); ?>" />
+        <button type="button" class="button button-small" id="swps-ai-generate-meta">
+            <?php esc_html_e( 'AI Generate', 'stratawp-seo' ); ?>
+        </button>
+    </div>
+
+    <!-- Meta Description -->
+    <div class="swps-meta-row">
+        <label for="_swps_meta_description">
+            <?php esc_html_e( 'Meta Description', 'stratawp-seo' ); ?>
+            <span class="swps-char-count" id="swps-desc-count">0</span>
+        </label>
+        <textarea name="_swps_meta_description" id="_swps_meta_description" class="widefat" rows="3"
+                  placeholder="<?php esc_attr_e( 'Compelling description for search results...', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $meta_description ); ?></textarea>
+    </div>
+
+    <!-- SEO Checklist -->
+    <div class="swps-seo-checklist" id="swps-seo-checklist">
+        <h4><?php esc_html_e( 'SEO Checklist', 'stratawp-seo' ); ?></h4>
+        <ul>
+            <li data-check="keyword-in-title"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in meta title', 'stratawp-seo' ); ?></li>
+            <li data-check="keyword-in-desc"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in meta description', 'stratawp-seo' ); ?></li>
+            <li data-check="title-length"><span class="swps-check-icon"></span> <?php esc_html_e( 'Meta title length (50-60 chars)', 'stratawp-seo' ); ?></li>
+            <li data-check="desc-length"><span class="swps-check-icon"></span> <?php esc_html_e( 'Meta description length (140-160 chars)', 'stratawp-seo' ); ?></li>
+            <li data-check="keyword-in-content"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in first paragraph', 'stratawp-seo' ); ?></li>
+            <li data-check="keyword-in-h2"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in at least one H2', 'stratawp-seo' ); ?></li>
+        </ul>
+    </div>
+
+    <!-- Advanced: Canonical, Robots, Breadcrumb -->
+    <details class="swps-meta-advanced">
+        <summary><?php esc_html_e( 'Advanced', 'stratawp-seo' ); ?></summary>
+
+        <div class="swps-meta-row">
+            <label for="_swps_canonical_url"><?php esc_html_e( 'Canonical URL', 'stratawp-seo' ); ?></label>
+            <input type="url" name="_swps_canonical_url" id="_swps_canonical_url"
+                   value="<?php echo esc_url( $canonical_url ); ?>" class="widefat"
+                   placeholder="<?php echo esc_url( get_permalink( $post->ID ) ); ?>" />
+        </div>
+
+        <div class="swps-meta-row">
+            <label for="_swps_robots"><?php esc_html_e( 'Robots Meta', 'stratawp-seo' ); ?></label>
+            <select name="_swps_robots" id="_swps_robots">
+                <option value="" <?php selected( $robots, '' ); ?>><?php esc_html_e( 'Default (index, follow)', 'stratawp-seo' ); ?></option>
+                <option value="noindex, follow" <?php selected( $robots, 'noindex, follow' ); ?>><?php esc_html_e( 'noindex, follow', 'stratawp-seo' ); ?></option>
+                <option value="index, nofollow" <?php selected( $robots, 'index, nofollow' ); ?>><?php esc_html_e( 'index, nofollow', 'stratawp-seo' ); ?></option>
+                <option value="noindex, nofollow" <?php selected( $robots, 'noindex, nofollow' ); ?>><?php esc_html_e( 'noindex, nofollow', 'stratawp-seo' ); ?></option>
+            </select>
+        </div>
+
+        <div class="swps-meta-row">
+            <label for="_swps_breadcrumb_title"><?php esc_html_e( 'Breadcrumb Title', 'stratawp-seo' ); ?></label>
+            <input type="text" name="_swps_breadcrumb_title" id="_swps_breadcrumb_title"
+                   value="<?php echo esc_attr( $breadcrumb_title ); ?>" class="widefat"
+                   placeholder="<?php echo esc_attr( $post->post_title ); ?>" />
+        </div>
+    </details>
+
+    <!-- Social Preview -->
+    <details class="swps-meta-social">
+        <summary><?php esc_html_e( 'Social Previews', 'stratawp-seo' ); ?></summary>
+
+        <div class="swps-meta-row">
+            <label for="_swps_social_title"><?php esc_html_e( 'Social Title', 'stratawp-seo' ); ?></label>
+            <input type="text" name="_swps_social_title" id="_swps_social_title"
+                   value="<?php echo esc_attr( $social_title ); ?>" class="widefat"
+                   placeholder="<?php esc_attr_e( 'Falls back to meta title', 'stratawp-seo' ); ?>" />
+        </div>
+
+        <div class="swps-meta-row">
+            <label for="_swps_social_description"><?php esc_html_e( 'Social Description', 'stratawp-seo' ); ?></label>
+            <textarea name="_swps_social_description" id="_swps_social_description" class="widefat" rows="2"
+                      placeholder="<?php esc_attr_e( 'Falls back to meta description', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $social_desc ); ?></textarea>
+        </div>
+
+        <div class="swps-meta-row">
+            <label for="_swps_social_image"><?php esc_html_e( 'Social Image URL', 'stratawp-seo' ); ?></label>
+            <input type="url" name="_swps_social_image" id="_swps_social_image"
+                   value="<?php echo esc_url( $social_image ); ?>" class="widefat"
+                   placeholder="<?php esc_attr_e( 'Falls back to featured image', 'stratawp-seo' ); ?>" />
+        </div>
+
+        <!-- Facebook Preview Mock -->
+        <div class="swps-social-preview swps-fb-preview">
+            <h5><?php esc_html_e( 'Facebook Preview', 'stratawp-seo' ); ?></h5>
+            <div class="swps-social-card">
+                <div class="swps-social-image" id="swps-fb-image"></div>
+                <div class="swps-social-text">
+                    <div class="swps-social-domain"><?php echo esc_html( wp_parse_url( home_url(), PHP_URL_HOST ) ); ?></div>
+                    <div class="swps-social-title" id="swps-fb-title"></div>
+                    <div class="swps-social-desc" id="swps-fb-desc"></div>
+                </div>
+            </div>
+        </div>
+    </details>
+</div>
+```
+
+**Verify:** `php -l templates/meta-editor-metabox.php`
+
+**Commit:** `git add templates/meta-editor-metabox.php && git commit -m "feat: Add meta editor metabox template with SERP preview, checklist, and social previews"`
+
+---
+
+### Task 6: Meta Editor JavaScript
+
+**Files:**
+- Create: `admin/js/meta-editor.js`
+
+**Context:** Runs on post edit screens. Handles: live SERP preview (updates as user types), character counter colors (green 50-60 / 140-160, yellow near, red over), SEO checklist evaluation, AI generate button, and social preview updates. Depends on `swpsAdmin` localized data. Reads post content from the WordPress editor (classic or block).
+
+**Implementation:**
+
+```js
+/**
+ * StrataWP SEO — Meta Editor JS
+ *
+ * Live SERP preview, character counters, SEO checklist, AI generate.
+ */
+(function ($) {
+    'use strict';
+
+    if (typeof swpsAdmin === 'undefined') return;
+
+    var $metaTitle, $metaDesc, $focusKw, $serpTitle, $serpDesc;
+    var $titleCount, $descCount;
+
+    function init() {
+        $metaTitle  = $('#_swps_meta_title');
+        $metaDesc   = $('#_swps_meta_description');
+        $focusKw    = $('#_swps_focus_keyword');
+        $serpTitle   = $('#swps-serp-title');
+        $serpDesc    = $('#swps-serp-desc');
+        $titleCount  = $('#swps-title-count');
+        $descCount   = $('#swps-desc-count');
+
+        if (!$metaTitle.length) return;
+
+        // Live preview.
+        $metaTitle.on('input', updatePreview);
+        $metaDesc.on('input', updatePreview);
+        $focusKw.on('input', updateChecklist);
+
+        // Initial state.
+        updatePreview();
+        updateChecklist();
+
+        // AI Generate.
+        $('#swps-ai-generate-meta').on('click', aiGenerate);
+
+        // Social preview updates.
+        $('#_swps_social_title, #_swps_social_description, #_swps_social_image').on('input', updateSocialPreview);
+        updateSocialPreview();
+    }
+
+    function updatePreview() {
+        var title = $metaTitle.val() || $metaTitle.attr('placeholder') || '';
+        var desc  = $metaDesc.val() || $metaDesc.attr('placeholder') || '';
+
+        // Truncate for display.
+        $serpTitle.text(title.length > 60 ? title.substring(0, 57) + '...' : title);
+        $serpDesc.text(desc.length > 160 ? desc.substring(0, 157) + '...' : desc);
+
+        // Character counters.
+        updateCounter($titleCount, $metaTitle.val().length, 50, 60);
+        updateCounter($descCount, $metaDesc.val().length, 140, 160);
+
+        updateChecklist();
+    }
+
+    function updateCounter($el, len, min, max) {
+        $el.text(len + '/' + max);
+        $el.removeClass('swps-count-green swps-count-yellow swps-count-red');
+        if (len === 0) return;
+        if (len >= min && len <= max) {
+            $el.addClass('swps-count-green');
+        } else if (len > max) {
+            $el.addClass('swps-count-red');
+        } else {
+            $el.addClass('swps-count-yellow');
+        }
+    }
+
+    function updateChecklist() {
+        var keyword = $focusKw.val().toLowerCase().trim();
+        if (!keyword) {
+            $('#swps-seo-checklist li .swps-check-icon').html('—').attr('class', 'swps-check-icon swps-check-neutral');
+            return;
+        }
+
+        var title     = $metaTitle.val().toLowerCase();
+        var desc      = $metaDesc.val().toLowerCase();
+        var titleLen  = $metaTitle.val().length;
+        var descLen   = $metaDesc.val().length;
+
+        // Get post content from editor.
+        var content = getEditorContent().toLowerCase();
+        var firstParagraph = content.split(/\n\n|\r\n\r\n/)[0] || '';
+
+        // Get H2 headings.
+        var h2s = content.match(/<h2[^>]*>(.*?)<\/h2>/gi) || [];
+        var h2Text = h2s.join(' ').toLowerCase();
+
+        setCheck('keyword-in-title', title.indexOf(keyword) !== -1);
+        setCheck('keyword-in-desc', desc.indexOf(keyword) !== -1);
+        setCheck('title-length', titleLen >= 50 && titleLen <= 60);
+        setCheck('desc-length', descLen >= 140 && descLen <= 160);
+        setCheck('keyword-in-content', firstParagraph.indexOf(keyword) !== -1);
+        setCheck('keyword-in-h2', h2Text.indexOf(keyword) !== -1);
+    }
+
+    function setCheck(name, pass) {
+        var $li = $('[data-check="' + name + '"]');
+        var $icon = $li.find('.swps-check-icon');
+        if (pass) {
+            $icon.html('&#10003;').attr('class', 'swps-check-icon swps-check-pass');
+        } else {
+            $icon.html('&#10007;').attr('class', 'swps-check-icon swps-check-fail');
+        }
+    }
+
+    function getEditorContent() {
+        // Block editor.
+        if (typeof wp !== 'undefined' && wp.data && wp.data.select('core/editor')) {
+            var content = wp.data.select('core/editor').getEditedPostContent();
+            if (content) return content;
+        }
+        // Classic editor.
+        if (typeof tinymce !== 'undefined') {
+            var editor = tinymce.get('content');
+            if (editor) return editor.getContent();
+        }
+        // Fallback: textarea.
+        var $textarea = $('#content');
+        return $textarea.length ? $textarea.val() : '';
+    }
+
+    function aiGenerate() {
+        var btn = $(this);
+        var postId = $('.swps-meta-editor').data('post-id');
+        var keyword = $focusKw.val();
+
+        btn.prop('disabled', true).text('Generating...');
+
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_generate_meta',
+            nonce: swpsAdmin.nonce,
+            post_id: postId,
+            focus_keyword: keyword
+        }, function (res) {
+            btn.prop('disabled', false).text('AI Generate');
+
+            if (!res.success) {
+                alert(res.data.message || 'Failed to generate meta.');
+                return;
+            }
+
+            if (res.data.meta_title) {
+                $metaTitle.val(res.data.meta_title);
+            }
+            if (res.data.meta_description) {
+                $metaDesc.val(res.data.meta_description);
+            }
+
+            updatePreview();
+        });
+    }
+
+    function updateSocialPreview() {
+        var title = $('#_swps_social_title').val() || $metaTitle.val() || $metaTitle.attr('placeholder') || '';
+        var desc  = $('#_swps_social_description').val() || $metaDesc.val() || '';
+        var image = $('#_swps_social_image').val() || '';
+
+        $('#swps-fb-title').text(title);
+        $('#swps-fb-desc').text(desc);
+
+        var $fbImage = $('#swps-fb-image');
+        if (image) {
+            $fbImage.css('background-image', 'url(' + image + ')').show();
+        } else {
+            $fbImage.hide();
+        }
+    }
+
+    $(document).ready(init);
+
+})(jQuery);
+```
+
+**Verify:** JS file, no syntax check needed.
+
+**Commit:** `git add admin/js/meta-editor.js && git commit -m "feat: Add meta editor JavaScript (SERP preview, char counters, checklist, AI generate)"`
+
+---
+
+### Task 7: Settings, Hooks & Bootstrap Integration
+
+**Files:**
+- Modify: `includes/class-settings.php` — add SEO Meta and Keyword Tracking settings sections
+- Modify: `includes/class-hooks.php` — add 5 new hook methods
+- Modify: `stratawp-seo.php` — require new files, instantiate classes, enqueue scripts, add activation/deactivation hooks, bump version to 2.3.0
+
+**Context for settings:** Add new settings fields between the Schema section and Advanced section. New "SEO Meta" section with: `meta_editor_enabled` (checkbox), `meta_editor_post_types` (text, comma-separated), `meta_auto_generate` (checkbox). Under existing Analytics section add: `keyword_tracking_frequency` (select: daily/weekly/monthly).
+
+**Settings additions (add after Schema section, before Analytics section in `register_settings()`):**
+
+```php
+// --- SEO Meta Section ---
+add_settings_section( 'swps_meta_section', __( 'SEO Meta', 'stratawp-seo' ), [ $this, 'render_meta_section' ], 'stratawp-seo' );
+
+$this->add_field( 'meta_editor_enabled', __( 'Enable Meta Editor', 'stratawp-seo' ), 'checkbox', 'swps_meta_section', [
+    'label' => __( 'Show SEO meta fields (title, description, social, robots) on post and page editors', 'stratawp-seo' ),
+] );
+
+$this->add_field( 'meta_editor_post_types', __( 'Post Types', 'stratawp-seo' ), 'text', 'swps_meta_section', [
+    'placeholder' => 'post,page',
+    'description' => __( 'Comma-separated post types to show the meta editor on. Default: post,page', 'stratawp-seo' ),
+] );
+
+$this->add_field( 'meta_auto_generate', __( 'Auto-Generate Meta', 'stratawp-seo' ), 'checkbox', 'swps_meta_section', [
+    'label' => __( 'Automatically generate meta title and description via AI when publishing a post without them', 'stratawp-seo' ),
+] );
+```
+
+Add `keyword_tracking_frequency` field to the Analytics section:
+
+```php
+$this->add_field( 'keyword_tracking_frequency', __( 'Keyword Sync Frequency', 'stratawp-seo' ), 'select', 'swps_analytics_section', [
+    'options' => [
+        'daily'   => __( 'Daily', 'stratawp-seo' ),
+        'weekly'  => __( 'Weekly', 'stratawp-seo' ),
+        'monthly' => __( 'Monthly', 'stratawp-seo' ),
+    ],
+    'description' => __( 'How often to sync tracked keyword positions from Google Search Console.', 'stratawp-seo' ),
+] );
+```
+
+Add section description method:
+
+```php
+public function render_meta_section(): void {
+    echo '<p>' . esc_html__( 'Per-post SEO meta fields for titles, descriptions, social previews, and robots directives. Auto-disabled when Yoast, RankMath, or AIOSEO is active.', 'stratawp-seo' ) . '</p>';
+}
+```
+
+**Hooks additions (add before closing `}` of `SWPS_Hooks` class):**
+
+```php
+/**
+ * Apply the meta title filter.
+ */
+public static function filter_meta_title( string $title, int $post_id ): string {
+    return apply_filters( 'swps_meta_title', $title, $post_id );
+}
+
+/**
+ * Apply the meta description filter.
+ */
+public static function filter_meta_description( string $description, int $post_id ): string {
+    return apply_filters( 'swps_meta_description', $description, $post_id );
+}
+
+/**
+ * Apply the meta robots filter.
+ */
+public static function filter_meta_robots( string $robots, int $post_id ): string {
+    return apply_filters( 'swps_meta_robots', $robots, $post_id );
+}
+
+/**
+ * Apply the keyword suggestions filter.
+ */
+public static function filter_keyword_suggestions( array $suggestions, string $seed ): array {
+    return apply_filters( 'swps_keyword_suggestions', $suggestions, $seed );
+}
+
+/**
+ * Apply the SEO checklist filter.
+ */
+public static function filter_seo_checklist( array $items, int $post_id ): array {
+    return apply_filters( 'swps_seo_checklist', $items, $post_id );
+}
+```
+
+**Main plugin file changes (`stratawp-seo.php`):**
+
+1. Add require_once after Analytics section (~line 86):
+```php
+// Keywords & Meta Editor.
+require_once SWPS_PLUGIN_DIR . 'includes/class-keyword-tracker.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-keywords-page.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-meta-editor.php';
+```
+
+2. Add public properties after `$analytics_dashboard` (~line 134):
+```php
+public SWPS_Keyword_Tracker $keyword_tracker;
+public SWPS_Keywords_Page $keywords_page;
+public SWPS_Meta_Editor $meta_editor;
+```
+
+3. Add instantiation after `$this->analytics_dashboard` (~line 163):
+```php
+$this->keyword_tracker = new SWPS_Keyword_Tracker( $this->search_console );
+$this->keywords_page   = new SWPS_Keywords_Page( $this->keyword_tracker );
+$this->meta_editor     = new SWPS_Meta_Editor();
+```
+
+4. Update `enqueue_admin_assets()` — add `swps-keywords` to the hook check (~line 273):
+```php
+&& ! str_contains( $hook, 'swps-keywords' )
+```
+
+5. Add keywords JS enqueue (after analytics JS block, ~line 311):
+```php
+// Keywords page JS.
+if ( str_contains( $hook, 'swps-keywords' ) ) {
+    wp_enqueue_script(
+        'swps-keywords',
+        SWPS_PLUGIN_URL . 'admin/js/keywords.js',
+        [ 'jquery', 'swps-admin' ],
+        SWPS_VERSION,
+        true
+    );
+
+    wp_localize_script( 'swps-keywords', 'swpsKeywords', [
+        'generate_url' => admin_url( 'admin.php?page=swps-generate' ),
+    ] );
+}
+
+// Meta editor JS on post edit screens.
+if ( in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
+    wp_enqueue_script(
+        'swps-meta-editor',
+        SWPS_PLUGIN_URL . 'admin/js/meta-editor.js',
+        [ 'jquery', 'swps-admin' ],
+        SWPS_VERSION,
+        true
+    );
+}
+```
+
+6. Update `swpsAdmin` localize to include `generate_url`:
+Add to the `wp_localize_script` array:
+```php
+'generate_url' => admin_url( 'admin.php?page=swps-generate' ),
+```
+
+7. Add activation defaults (in `swps_activate()` defaults array):
+```php
+// Keywords & Meta defaults.
+'meta_editor_enabled'          => 1,
+'meta_editor_post_types'       => 'post,page',
+'meta_auto_generate'           => 0,
+'keyword_tracking_frequency'   => 'weekly',
+```
+
+8. Add to activation function (after `SWPS_Search_Console::schedule_cron()`):
+```php
+SWPS_Keyword_Tracker::create_tables();
+SWPS_Keyword_Tracker::schedule_cron();
+```
+
+9. Add to deactivation function:
+```php
+SWPS_Keyword_Tracker::unschedule_cron();
+```
+
+10. Bump version: Change `SWPS_VERSION` from `'2.2.0'` to `'2.3.0'` and update the plugin header Version to `2.3.0`.
+
+11. Coordinate OG output: When meta editor is active and not in conflict, disable the audit module's OG output to prevent duplicates. Add after the existing `SWPS_OpenGraph_Module::output_meta_tags` hook registration (~line 216):
+```php
+// Disable audit OG output when meta editor handles it.
+if ( get_option( 'swps_meta_editor_enabled', 1 ) && ! defined( 'WPSEO_VERSION' ) && ! defined( 'RANK_MATH_VERSION' ) && ! defined( 'AIOSEO_VERSION' ) ) {
+    remove_action( 'wp_head', [ SWPS_OpenGraph_Module::class, 'output_meta_tags' ], 5 );
+}
+```
+
+**Verify:** `php -l includes/class-settings.php && php -l includes/class-hooks.php && php -l stratawp-seo.php`
+
+**Commit:** `git add includes/class-settings.php includes/class-hooks.php stratawp-seo.php && git commit -m "feat: Wire keywords & meta editor into plugin — settings, hooks, bootstrap, v2.3.0"`
+
+---
+
+### Task 8: Generator Integration — Save Meta on Post Creation
+
+**Files:**
+- Modify: `includes/class-generator.php` — save `_swps_meta_title`, `_swps_meta_description`, `_swps_focus_keyword` when generating posts
+
+**Context:** The generator already saves `meta_description` and `focus_keyword` to Yoast/RankMath meta keys (lines 386-392). Add our own `_swps_*` keys alongside them. Also generate a meta title from the AI response.
+
+**Add after line 394 (`update_post_meta( $post_id, '_swps_generated', true );`):**
+
+```php
+// Store StrataWP SEO meta fields.
+update_post_meta( $post_id, '_swps_meta_description', $meta_desc );
+update_post_meta( $post_id, '_swps_focus_keyword', $focus_keyword );
+
+// Generate meta title (shortened post title if AI didn't provide one).
+$meta_title = sanitize_text_field( $ai_result['meta_title'] ?? '' );
+if ( empty( $meta_title ) ) {
+    $meta_title = mb_substr( $ai_result['title'], 0, 60 );
+}
+update_post_meta( $post_id, '_swps_meta_title', $meta_title );
+```
+
+**Verify:** `php -l includes/class-generator.php`
+
+**Commit:** `git add includes/class-generator.php && git commit -m "feat: Save _swps_ meta fields on post generation"`
+
+---
+
+### Task 9: CSS — Keywords Page & Meta Editor Styles
+
+**Files:**
+- Modify: `admin/css/admin.css` — append styles for keywords page and meta editor metabox
+
+**Append these styles:**
+
+```css
+/* === Keywords Page === */
+.swps-keywords-section { margin-bottom: 30px; }
+.swps-suggest-form { display: flex; gap: 8px; align-items: center; margin-bottom: 16px; }
+.swps-suggest-form .regular-text { flex: 1; }
+.swps-intent-badge { display: inline-block; padding: 2px 8px; border-radius: 3px; font-size: 12px; }
+.swps-intent-informational { background: #e7f5ff; color: #1971c2; }
+.swps-intent-transactional { background: #e6fcf5; color: #087f5b; }
+.swps-intent-navigational { background: #fff3e0; color: #e65100; }
+
+/* Keywords modal */
+.swps-modal { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.5); z-index: 100000; display: flex; align-items: center; justify-content: center; }
+.swps-modal-content { background: #fff; border-radius: 8px; padding: 24px; max-width: 700px; width: 90%; position: relative; }
+.swps-modal-close { position: absolute; top: 12px; right: 16px; font-size: 24px; cursor: pointer; color: #646970; }
+
+/* === Meta Editor Metabox === */
+.swps-meta-editor { max-width: 100%; }
+.swps-meta-row { margin-bottom: 12px; }
+.swps-meta-row label { display: block; margin-bottom: 4px; font-weight: 600; }
+.swps-meta-row .widefat { width: 100%; }
+
+/* SERP Preview */
+.swps-serp-preview { margin-bottom: 16px; }
+.swps-serp-mock { background: #fff; border: 1px solid #dcdcde; border-radius: 8px; padding: 16px; max-width: 600px; }
+.swps-serp-title { color: #1a0dab; font-size: 18px; line-height: 1.3; margin-bottom: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.swps-serp-url { color: #006621; font-size: 13px; margin-bottom: 2px; }
+.swps-serp-desc { color: #545454; font-size: 13px; line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+
+/* Character counters */
+.swps-char-count { font-weight: normal; font-size: 12px; margin-left: 8px; }
+.swps-count-green { color: #00a32a; }
+.swps-count-yellow { color: #dba617; }
+.swps-count-red { color: #d63638; }
+
+/* SEO Checklist */
+.swps-seo-checklist { background: #f6f7f7; border: 1px solid #dcdcde; border-radius: 4px; padding: 12px 16px; margin: 16px 0; }
+.swps-seo-checklist h4 { margin: 0 0 8px; }
+.swps-seo-checklist ul { margin: 0; padding: 0; list-style: none; }
+.swps-seo-checklist li { padding: 4px 0; font-size: 13px; }
+.swps-check-icon { display: inline-block; width: 16px; text-align: center; margin-right: 4px; }
+.swps-check-pass { color: #00a32a; }
+.swps-check-fail { color: #d63638; }
+.swps-check-neutral { color: #646970; }
+
+/* Advanced & Social collapsible */
+.swps-meta-advanced, .swps-meta-social { margin-top: 12px; }
+.swps-meta-advanced summary, .swps-meta-social summary { cursor: pointer; font-weight: 600; padding: 8px 0; }
+
+/* Social Preview */
+.swps-social-preview { margin-top: 12px; }
+.swps-social-card { border: 1px solid #dcdcde; border-radius: 4px; overflow: hidden; max-width: 500px; }
+.swps-social-image { height: 150px; background-size: cover; background-position: center; background-color: #f0f0f0; }
+.swps-social-text { padding: 10px 12px; }
+.swps-social-domain { font-size: 11px; color: #646970; text-transform: uppercase; }
+.swps-social-title { font-size: 14px; font-weight: 600; margin: 2px 0; }
+.swps-social-desc { font-size: 12px; color: #646970; }
+```
+
+**Verify:** Visual check (CSS file).
+
+**Commit:** `git add admin/css/admin.css && git commit -m "feat: Add keywords page and meta editor CSS styles"`
+
+---
+
+### Task 10: Documentation — Update README and readme.txt
+
+**Files:**
+- Modify: `README.md` — add Keywords & Meta Editor feature sections, settings, hooks, FAQ, changelog
+- Modify: `readme.txt` — add feature sections, FAQ, changelog, stable tag bump to 2.3.0
+
+**Key additions:**
+- Feature section: "Keyword Research & Tracking" and "SEO Meta Editor"
+- Settings table entries for new fields
+- Developer hooks table entries for 5 new hooks
+- FAQ: "Can I use the meta editor alongside Yoast/RankMath?" (auto-disables output, fields still saved)
+- Changelog for v2.3.0
+- Bump stable tag to 2.3.0
+
+**Commit:** `git add README.md readme.txt && git commit -m "docs: Update README, readme.txt, and version to 2.3.0 for Keywords & Meta Editor release"`
+
+---
+
+Plan complete and saved to `docs/plans/2026-03-06-keywords-meta-editor-implementation.md`. Two execution options:
+
+**1. Subagent-Driven (this session)** - I dispatch fresh subagent per task, review between tasks, fast iteration
+
+**2. Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/includes/class-generator.php
+++ b/includes/class-generator.php
@@ -394,7 +394,15 @@ PROMPT;
         // Store StrataWP SEO metadata.
         update_post_meta( $post_id, '_swps_generated', true );
         update_post_meta( $post_id, '_swps_generated_at', current_time( 'mysql' ) );
+        update_post_meta( $post_id, '_swps_meta_description', $meta_desc );
         update_post_meta( $post_id, '_swps_focus_keyword', $focus_keyword );
+
+        // Generate meta title (shortened post title if AI didn't provide one).
+        $meta_title = sanitize_text_field( $ai_result['meta_title'] ?? '' );
+        if ( empty( $meta_title ) ) {
+            $meta_title = mb_substr( $ai_result['title'], 0, 60 );
+        }
+        update_post_meta( $post_id, '_swps_meta_title', $meta_title );
         update_post_meta( $post_id, '_swps_secondary_keywords', $ai_result['secondary_keywords'] ?? [] );
         update_post_meta( $post_id, '_swps_internal_links', $ai_result['internal_links_used'] ?? [] );
         update_post_meta( $post_id, '_swps_external_links', $ai_result['external_links'] ?? [] );

--- a/includes/class-generator.php
+++ b/includes/class-generator.php
@@ -403,7 +403,9 @@ PROMPT;
             $meta_title = mb_substr( $ai_result['title'], 0, 60 );
         }
         update_post_meta( $post_id, '_swps_meta_title', $meta_title );
-        update_post_meta( $post_id, '_swps_secondary_keywords', $ai_result['secondary_keywords'] ?? [] );
+        $secondary = $ai_result['secondary_keywords'] ?? [];
+        $secondary_str = is_array( $secondary ) ? implode( ', ', array_map( 'sanitize_text_field', $secondary ) ) : sanitize_text_field( $secondary );
+        update_post_meta( $post_id, '_swps_secondary_keywords', $secondary_str );
         update_post_meta( $post_id, '_swps_internal_links', $ai_result['internal_links_used'] ?? [] );
         update_post_meta( $post_id, '_swps_external_links', $ai_result['external_links'] ?? [] );
         update_post_meta( $post_id, '_swps_template', $template );

--- a/includes/class-hooks.php
+++ b/includes/class-hooks.php
@@ -285,4 +285,39 @@ class SWPS_Hooks {
     public static function filter_gsc_data( array $data, string $property ): array {
         return apply_filters( 'swps_gsc_data', $data, $property );
     }
+
+    /**
+     * Apply the meta title filter.
+     */
+    public static function filter_meta_title( string $title, int $post_id ): string {
+        return apply_filters( 'swps_meta_title', $title, $post_id );
+    }
+
+    /**
+     * Apply the meta description filter.
+     */
+    public static function filter_meta_description( string $description, int $post_id ): string {
+        return apply_filters( 'swps_meta_description', $description, $post_id );
+    }
+
+    /**
+     * Apply the meta robots filter.
+     */
+    public static function filter_meta_robots( string $robots, int $post_id ): string {
+        return apply_filters( 'swps_meta_robots', $robots, $post_id );
+    }
+
+    /**
+     * Apply the keyword suggestions filter.
+     */
+    public static function filter_keyword_suggestions( array $suggestions, string $seed ): array {
+        return apply_filters( 'swps_keyword_suggestions', $suggestions, $seed );
+    }
+
+    /**
+     * Apply the SEO checklist filter.
+     */
+    public static function filter_seo_checklist( array $items, int $post_id ): array {
+        return apply_filters( 'swps_seo_checklist', $items, $post_id );
+    }
 }

--- a/includes/class-keyword-tracker.php
+++ b/includes/class-keyword-tracker.php
@@ -40,7 +40,7 @@ class SWPS_Keyword_Tracker {
 			ctr FLOAT NOT NULL DEFAULT 0,
 			date DATE NOT NULL,
 			PRIMARY KEY (id),
-			KEY idx_keyword_date (keyword, date),
+			UNIQUE KEY idx_keyword_date (keyword, date),
 			KEY idx_post_id (post_id)
 		) {$charset};";
 
@@ -101,19 +101,22 @@ class SWPS_Keyword_Tracker {
 			return true; // Already tracking.
 		}
 
-		return (bool) $wpdb->insert(
-			$wpdb->prefix . self::TABLE,
-			[
-				'keyword'     => $keyword,
-				'post_id'     => $post_id ?: null,
-				'position'    => null,
-				'clicks'      => 0,
-				'impressions' => 0,
-				'ctr'         => 0,
-				'date'        => gmdate( 'Y-m-d' ),
-			],
-			[ '%s', '%d', '%f', '%d', '%d', '%f', '%s' ]
-		);
+		$data = [
+			'keyword'     => $keyword,
+			'position'    => null,
+			'clicks'      => 0,
+			'impressions' => 0,
+			'ctr'         => 0,
+			'date'        => gmdate( 'Y-m-d' ),
+		];
+		$formats = [ '%s', '%f', '%d', '%d', '%f', '%s' ];
+
+		if ( $post_id ) {
+			$data['post_id'] = $post_id;
+			$formats[]       = '%d';
+		}
+
+		return (bool) $wpdb->insert( $wpdb->prefix . self::TABLE, $data, $formats );
 	}
 
 	/**
@@ -126,7 +129,7 @@ class SWPS_Keyword_Tracker {
 		global $wpdb;
 		return (bool) $wpdb->delete(
 			$wpdb->prefix . self::TABLE,
-			[ 'keyword' => strtolower( trim( $keyword ) ) ],
+			[ 'keyword' => sanitize_text_field( strtolower( trim( $keyword ) ) ) ],
 			[ '%s' ]
 		);
 	}
@@ -143,7 +146,7 @@ class SWPS_Keyword_Tracker {
 		return (bool) $wpdb->update(
 			$wpdb->prefix . self::TABLE,
 			[ 'post_id' => $post_id ],
-			[ 'keyword' => strtolower( trim( $keyword ) ) ],
+			[ 'keyword' => sanitize_text_field( strtolower( trim( $keyword ) ) ) ],
 			[ '%d' ],
 			[ '%s' ]
 		);
@@ -195,7 +198,7 @@ class SWPS_Keyword_Tracker {
 			 FROM {$table}
 			 WHERE keyword = %s AND date >= %s
 			 ORDER BY date ASC",
-			strtolower( trim( $keyword ) ),
+			sanitize_text_field( strtolower( trim( $keyword ) ) ),
 			$since
 		), ARRAY_A );
 
@@ -266,7 +269,7 @@ class SWPS_Keyword_Tracker {
 		foreach ( $keywords as $keyword ) {
 			$gsc_row = $gsc_queries[ $keyword ] ?? null;
 
-			$wpdb->insert(
+			$wpdb->replace(
 				$table,
 				[
 					'keyword'     => $keyword,

--- a/includes/class-keyword-tracker.php
+++ b/includes/class-keyword-tracker.php
@@ -103,18 +103,14 @@ class SWPS_Keyword_Tracker {
 
 		$data = [
 			'keyword'     => $keyword,
+			'post_id'     => $post_id ?: null,
 			'position'    => null,
 			'clicks'      => 0,
 			'impressions' => 0,
 			'ctr'         => 0,
 			'date'        => gmdate( 'Y-m-d' ),
 		];
-		$formats = [ '%s', '%f', '%d', '%d', '%f', '%s' ];
-
-		if ( $post_id ) {
-			$data['post_id'] = $post_id;
-			$formats[]       = '%d';
-		}
+		$formats = [ '%s', '%d', '%f', '%d', '%d', '%f', '%s' ];
 
 		return (bool) $wpdb->insert( $wpdb->prefix . self::TABLE, $data, $formats );
 	}
@@ -325,7 +321,7 @@ class SWPS_Keyword_Tracker {
 		if ( preg_match( '/\[.*\]/s', $text, $json_match ) ) {
 			$suggestions = json_decode( $json_match[0], true );
 			if ( is_array( $suggestions ) ) {
-				return apply_filters( 'swps_keyword_suggestions', $suggestions, $seed_topic );
+				return SWPS_Hooks::filter_keyword_suggestions( $suggestions, $seed_topic );
 			}
 		}
 

--- a/includes/class-keyword-tracker.php
+++ b/includes/class-keyword-tracker.php
@@ -1,0 +1,352 @@
+<?php
+/**
+ * Keyword tracking — DB table, CRUD, GSC sync, AI suggestions.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_Keyword_Tracker {
+
+	private const TABLE     = 'swps_keyword_tracking';
+	private const CRON_HOOK = 'swps_keyword_sync';
+
+	private SWPS_Search_Console $search_console;
+
+	public function __construct( SWPS_Search_Console $search_console ) {
+		$this->search_console = $search_console;
+		add_action( self::CRON_HOOK, [ $this, 'sync_from_gsc' ] );
+	}
+
+	/**
+	 * Create the keyword tracking table. Called on activation.
+	 */
+	public static function create_tables(): void {
+		global $wpdb;
+
+		$charset = $wpdb->get_charset_collate();
+		$table   = $wpdb->prefix . self::TABLE;
+
+		$sql = "CREATE TABLE {$table} (
+			id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			keyword VARCHAR(255) NOT NULL,
+			post_id BIGINT UNSIGNED DEFAULT NULL,
+			position FLOAT DEFAULT NULL,
+			clicks INT UNSIGNED NOT NULL DEFAULT 0,
+			impressions INT UNSIGNED NOT NULL DEFAULT 0,
+			ctr FLOAT NOT NULL DEFAULT 0,
+			date DATE NOT NULL,
+			PRIMARY KEY (id),
+			KEY idx_keyword_date (keyword, date),
+			KEY idx_post_id (post_id)
+		) {$charset};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Schedule the keyword sync cron.
+	 */
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			$frequency = get_option( 'swps_keyword_tracking_frequency', 'weekly' );
+			wp_schedule_event( time(), $frequency, self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Unschedule the keyword sync cron.
+	 */
+	public static function unschedule_cron(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Reschedule cron with new frequency (called when settings change).
+	 */
+	public static function reschedule_cron(): void {
+		self::unschedule_cron();
+		self::schedule_cron();
+	}
+
+	/**
+	 * Track a keyword (add to tracking list).
+	 *
+	 * @param string $keyword Keyword text.
+	 * @param int    $post_id Optional linked post ID.
+	 * @return bool
+	 */
+	public function track_keyword( string $keyword, int $post_id = 0 ): bool {
+		global $wpdb;
+
+		$keyword = sanitize_text_field( strtolower( trim( $keyword ) ) );
+		if ( empty( $keyword ) ) {
+			return false;
+		}
+
+		// Check if already tracked.
+		$exists = $wpdb->get_var( $wpdb->prepare(
+			"SELECT COUNT(*) FROM {$wpdb->prefix}" . self::TABLE . " WHERE keyword = %s LIMIT 1",
+			$keyword
+		) );
+
+		if ( $exists ) {
+			return true; // Already tracking.
+		}
+
+		return (bool) $wpdb->insert(
+			$wpdb->prefix . self::TABLE,
+			[
+				'keyword'     => $keyword,
+				'post_id'     => $post_id ?: null,
+				'position'    => null,
+				'clicks'      => 0,
+				'impressions' => 0,
+				'ctr'         => 0,
+				'date'        => gmdate( 'Y-m-d' ),
+			],
+			[ '%s', '%d', '%f', '%d', '%d', '%f', '%s' ]
+		);
+	}
+
+	/**
+	 * Untrack a keyword (remove all history).
+	 *
+	 * @param string $keyword Keyword text.
+	 * @return bool
+	 */
+	public function untrack_keyword( string $keyword ): bool {
+		global $wpdb;
+		return (bool) $wpdb->delete(
+			$wpdb->prefix . self::TABLE,
+			[ 'keyword' => strtolower( trim( $keyword ) ) ],
+			[ '%s' ]
+		);
+	}
+
+	/**
+	 * Link a keyword to a post.
+	 *
+	 * @param string $keyword Keyword text.
+	 * @param int    $post_id Post ID.
+	 * @return bool
+	 */
+	public function link_to_post( string $keyword, int $post_id ): bool {
+		global $wpdb;
+		return (bool) $wpdb->update(
+			$wpdb->prefix . self::TABLE,
+			[ 'post_id' => $post_id ],
+			[ 'keyword' => strtolower( trim( $keyword ) ) ],
+			[ '%d' ],
+			[ '%s' ]
+		);
+	}
+
+	/**
+	 * Get all tracked keywords with latest data.
+	 *
+	 * @param int $limit Max results.
+	 * @return array
+	 */
+	public function get_tracked_keywords( int $limit = 100 ): array {
+		global $wpdb;
+
+		$table = $wpdb->prefix . self::TABLE;
+
+		// Get the most recent row per keyword.
+		$results = $wpdb->get_results( $wpdb->prepare(
+			"SELECT t1.*
+			 FROM {$table} t1
+			 INNER JOIN (
+				 SELECT keyword, MAX(date) as max_date
+				 FROM {$table}
+				 GROUP BY keyword
+			 ) t2 ON t1.keyword = t2.keyword AND t1.date = t2.max_date
+			 ORDER BY t1.impressions DESC
+			 LIMIT %d",
+			$limit
+		), ARRAY_A );
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Get position history for a specific keyword.
+	 *
+	 * @param string $keyword Keyword text.
+	 * @param int    $days    Days of history.
+	 * @return array
+	 */
+	public function get_keyword_history( string $keyword, int $days = 90 ): array {
+		global $wpdb;
+
+		$table = $wpdb->prefix . self::TABLE;
+		$since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+		$results = $wpdb->get_results( $wpdb->prepare(
+			"SELECT date, position, clicks, impressions, ctr
+			 FROM {$table}
+			 WHERE keyword = %s AND date >= %s
+			 ORDER BY date ASC",
+			strtolower( trim( $keyword ) ),
+			$since
+		), ARRAY_A );
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Get "striking distance" keyword opportunities (position 8-20, high impressions).
+	 *
+	 * @param int $limit Max results.
+	 * @return array
+	 */
+	public function get_opportunities( int $limit = 20 ): array {
+		global $wpdb;
+
+		$table = $wpdb->prefix . self::TABLE;
+
+		$results = $wpdb->get_results( $wpdb->prepare(
+			"SELECT t1.*
+			 FROM {$table} t1
+			 INNER JOIN (
+				 SELECT keyword, MAX(date) as max_date
+				 FROM {$table}
+				 GROUP BY keyword
+			 ) t2 ON t1.keyword = t2.keyword AND t1.date = t2.max_date
+			 WHERE t1.position BETWEEN 8 AND 20
+			 AND t1.impressions > 0
+			 ORDER BY t1.impressions DESC
+			 LIMIT %d",
+			$limit
+		), ARRAY_A );
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Sync tracked keywords with GSC data.
+	 * Called by WP-Cron on configured schedule.
+	 */
+	public function sync_from_gsc(): void {
+		if ( ! $this->search_console->is_connected() ) {
+			return;
+		}
+
+		$tracked = $this->get_tracked_keywords( 500 );
+		if ( empty( $tracked ) ) {
+			return;
+		}
+
+		// Pull GSC query data for the last 7 days.
+		$gsc_data = $this->search_console->get_search_data( 7 );
+		$gsc_queries = [];
+
+		foreach ( $gsc_data['queries'] ?? [] as $row ) {
+			$query = strtolower( $row['keys'][0] ?? '' );
+			if ( $query ) {
+				$gsc_queries[ $query ] = $row;
+			}
+		}
+
+		global $wpdb;
+		$table = $wpdb->prefix . self::TABLE;
+		$today = gmdate( 'Y-m-d' );
+
+		// Get unique tracked keywords.
+		$keywords = array_unique( array_column( $tracked, 'keyword' ) );
+
+		foreach ( $keywords as $keyword ) {
+			$gsc_row = $gsc_queries[ $keyword ] ?? null;
+
+			$wpdb->insert(
+				$table,
+				[
+					'keyword'     => $keyword,
+					'post_id'     => $this->find_post_for_keyword( $keyword, $tracked ),
+					'position'    => $gsc_row ? round( $gsc_row['position'] ?? 0, 1 ) : null,
+					'clicks'      => $gsc_row['clicks'] ?? 0,
+					'impressions' => $gsc_row['impressions'] ?? 0,
+					'ctr'         => $gsc_row ? round( ( $gsc_row['ctr'] ?? 0 ) * 100, 1 ) : 0,
+					'date'        => $today,
+				],
+				[ '%s', '%d', '%f', '%d', '%d', '%f', '%s' ]
+			);
+		}
+	}
+
+	/**
+	 * Generate keyword suggestions via AI.
+	 *
+	 * @param string $seed_topic Seed topic for suggestions.
+	 * @return array|WP_Error Array of keyword suggestions or error.
+	 */
+	public function suggest_keywords( string $seed_topic ): array|WP_Error {
+		$api   = SWPS_Provider_Factory::create_ai_provider();
+		$niche = get_option( 'swps_site_niche', '' );
+		$desc  = get_option( 'swps_site_description', '' );
+
+		$prompt = sprintf(
+			"You are an SEO keyword research expert. Generate 15 keyword suggestions for a website in the \"%s\" niche.\n\n"
+			. "Site description: %s\n\n"
+			. "Seed topic: %s\n\n"
+			. "For each keyword, provide:\n"
+			. "- keyword: the exact search phrase (lowercase)\n"
+			. "- intent: informational, transactional, or navigational\n"
+			. "- difficulty: low, medium, or high (estimate)\n"
+			. "- suggested_title: a blog post title targeting this keyword\n\n"
+			. "Return JSON array only. No markdown, no explanation.\n"
+			. "Example: [{\"keyword\":\"best running shoes\",\"intent\":\"transactional\",\"difficulty\":\"high\",\"suggested_title\":\"10 Best Running Shoes for Every Budget in 2026\"}]",
+			$niche,
+			$desc,
+			$seed_topic
+		);
+
+		$response = $api->generate( $prompt, 'You are an SEO keyword research expert. Return only valid JSON.' );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$text = $response['content'] ?? '';
+
+		// Extract JSON from response.
+		$json_match = [];
+		if ( preg_match( '/\[.*\]/s', $text, $json_match ) ) {
+			$suggestions = json_decode( $json_match[0], true );
+			if ( is_array( $suggestions ) ) {
+				return apply_filters( 'swps_keyword_suggestions', $suggestions, $seed_topic );
+			}
+		}
+
+		return new WP_Error( 'swps_keyword_parse', __( 'Failed to parse keyword suggestions from AI response.', 'stratawp-seo' ) );
+	}
+
+	/**
+	 * Find the linked post_id for a keyword from tracked data.
+	 */
+	private function find_post_for_keyword( string $keyword, array $tracked ): int {
+		foreach ( $tracked as $row ) {
+			if ( $row['keyword'] === $keyword && ! empty( $row['post_id'] ) ) {
+				return (int) $row['post_id'];
+			}
+		}
+		return 0;
+	}
+
+	/**
+	 * Drop the keyword tracking table. Called on uninstall.
+	 */
+	public static function drop_tables(): void {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . self::TABLE );
+	}
+}

--- a/includes/class-keywords-page.php
+++ b/includes/class-keywords-page.php
@@ -91,6 +91,9 @@ class SWPS_Keywords_Page {
         }
 
         $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
+        if ( empty( $keyword ) ) {
+            wp_send_json_error( [ 'message' => 'Keyword is required.' ] );
+        }
         $this->tracker->untrack_keyword( $keyword );
         wp_send_json_success();
     }
@@ -103,6 +106,9 @@ class SWPS_Keywords_Page {
 
         $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
         $post_id = absint( $_POST['post_id'] ?? 0 );
+        if ( empty( $keyword ) || ! $post_id ) {
+            wp_send_json_error( [ 'message' => 'Keyword and post ID are required.' ] );
+        }
         $this->tracker->link_to_post( $keyword, $post_id );
         wp_send_json_success();
     }
@@ -114,7 +120,10 @@ class SWPS_Keywords_Page {
         }
 
         $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
-        $days    = absint( $_POST['days'] ?? 90 );
+        if ( empty( $keyword ) ) {
+            wp_send_json_error( [ 'message' => 'Keyword is required.' ] );
+        }
+        $days    = max( 7, absint( $_POST['days'] ?? 90 ) );
         $history = $this->tracker->get_keyword_history( $keyword, $days );
         wp_send_json_success( $history );
     }
@@ -129,12 +138,15 @@ class SWPS_Keywords_Page {
 
         // Enrich with post titles.
         foreach ( $keywords as &$kw ) {
+            $kw['post_title'] = '';
+            $kw['post_url']   = '';
             if ( ! empty( $kw['post_id'] ) ) {
                 $post = get_post( (int) $kw['post_id'] );
                 $kw['post_title'] = $post ? $post->post_title : '';
                 $kw['post_url']   = $post ? get_edit_post_link( $post->ID, 'raw' ) : '';
             }
         }
+        unset( $kw );
 
         wp_send_json_success( $keywords );
     }
@@ -148,11 +160,13 @@ class SWPS_Keywords_Page {
         $opportunities = $this->tracker->get_opportunities();
 
         foreach ( $opportunities as &$opp ) {
+            $opp['post_title'] = '';
             if ( ! empty( $opp['post_id'] ) ) {
                 $post = get_post( (int) $opp['post_id'] );
                 $opp['post_title'] = $post ? $post->post_title : '';
             }
         }
+        unset( $opp );
 
         wp_send_json_success( $opportunities );
     }

--- a/includes/class-keywords-page.php
+++ b/includes/class-keywords-page.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Keywords admin page — AI suggestions, tracked keywords, opportunities.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SWPS_Keywords_Page {
+
+    private SWPS_Keyword_Tracker $tracker;
+
+    public function __construct( SWPS_Keyword_Tracker $tracker ) {
+        $this->tracker = $tracker;
+
+        // Register after parent menu (priority 20).
+        add_action( 'admin_menu', [ $this, 'register_menu' ], 20 );
+
+        // AJAX endpoints.
+        add_action( 'wp_ajax_swps_suggest_keywords', [ $this, 'ajax_suggest' ] );
+        add_action( 'wp_ajax_swps_track_keyword', [ $this, 'ajax_track' ] );
+        add_action( 'wp_ajax_swps_untrack_keyword', [ $this, 'ajax_untrack' ] );
+        add_action( 'wp_ajax_swps_link_keyword', [ $this, 'ajax_link' ] );
+        add_action( 'wp_ajax_swps_keyword_history', [ $this, 'ajax_history' ] );
+        add_action( 'wp_ajax_swps_get_keywords', [ $this, 'ajax_get_keywords' ] );
+        add_action( 'wp_ajax_swps_get_opportunities', [ $this, 'ajax_get_opportunities' ] );
+    }
+
+    public function register_menu(): void {
+        add_submenu_page(
+            'stratawp-seo',
+            __( 'Keywords', 'stratawp-seo' ),
+            __( 'Keywords', 'stratawp-seo' ),
+            'manage_options',
+            'swps-keywords',
+            [ $this, 'render_page' ]
+        );
+    }
+
+    public function render_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+        $gsc_connected = stratawp_seo()->search_console->is_connected();
+        include SWPS_PLUGIN_DIR . 'templates/keywords-page.php';
+    }
+
+    public function ajax_suggest(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $seed = sanitize_text_field( $_POST['seed_topic'] ?? '' );
+        if ( empty( $seed ) ) {
+            wp_send_json_error( [ 'message' => 'Please enter a seed topic.' ] );
+        }
+
+        $suggestions = $this->tracker->suggest_keywords( $seed );
+        if ( is_wp_error( $suggestions ) ) {
+            wp_send_json_error( [ 'message' => $suggestions->get_error_message() ] );
+        }
+
+        wp_send_json_success( $suggestions );
+    }
+
+    public function ajax_track(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
+        $post_id = absint( $_POST['post_id'] ?? 0 );
+
+        if ( empty( $keyword ) ) {
+            wp_send_json_error( [ 'message' => 'Keyword is required.' ] );
+        }
+
+        $this->tracker->track_keyword( $keyword, $post_id );
+        wp_send_json_success();
+    }
+
+    public function ajax_untrack(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
+        $this->tracker->untrack_keyword( $keyword );
+        wp_send_json_success();
+    }
+
+    public function ajax_link(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
+        $post_id = absint( $_POST['post_id'] ?? 0 );
+        $this->tracker->link_to_post( $keyword, $post_id );
+        wp_send_json_success();
+    }
+
+    public function ajax_history(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
+        $days    = absint( $_POST['days'] ?? 90 );
+        $history = $this->tracker->get_keyword_history( $keyword, $days );
+        wp_send_json_success( $history );
+    }
+
+    public function ajax_get_keywords(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $keywords = $this->tracker->get_tracked_keywords();
+
+        // Enrich with post titles.
+        foreach ( $keywords as &$kw ) {
+            if ( ! empty( $kw['post_id'] ) ) {
+                $post = get_post( (int) $kw['post_id'] );
+                $kw['post_title'] = $post ? $post->post_title : '';
+                $kw['post_url']   = $post ? get_edit_post_link( $post->ID, 'raw' ) : '';
+            }
+        }
+
+        wp_send_json_success( $keywords );
+    }
+
+    public function ajax_get_opportunities(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $opportunities = $this->tracker->get_opportunities();
+
+        foreach ( $opportunities as &$opp ) {
+            if ( ! empty( $opp['post_id'] ) ) {
+                $post = get_post( (int) $opp['post_id'] );
+                $opp['post_title'] = $post ? $post->post_title : '';
+            }
+        }
+
+        wp_send_json_success( $opportunities );
+    }
+}

--- a/includes/class-meta-editor.php
+++ b/includes/class-meta-editor.php
@@ -37,6 +37,11 @@ class SWPS_Meta_Editor {
             add_filter( 'document_title_parts', [ $this, 'filter_title_parts' ], 20 );
         }
 
+        // Auto-generate meta on publish if setting is enabled.
+        if ( get_option( 'swps_meta_auto_generate', 0 ) ) {
+            add_action( 'transition_post_status', [ $this, 'maybe_auto_generate' ], 10, 3 );
+        }
+
         // Admin notice if conflict detected.
         if ( $this->conflict ) {
             add_action( 'admin_notices', [ $this, 'conflict_notice' ] );
@@ -117,7 +122,7 @@ class SWPS_Meta_Editor {
             '_swps_focus_keyword'       => 'sanitize_text_field',
             '_swps_secondary_keywords'  => 'sanitize_text_field',
             '_swps_canonical_url'       => 'esc_url_raw',
-            '_swps_robots'              => 'sanitize_text_field',
+            '_swps_robots'              => [ $this, 'sanitize_robots' ],
             '_swps_breadcrumb_title'    => 'sanitize_text_field',
             '_swps_social_title'        => 'sanitize_text_field',
             '_swps_social_description'  => 'sanitize_textarea_field',
@@ -154,7 +159,7 @@ class SWPS_Meta_Editor {
         $robots     = get_post_meta( $post_id, '_swps_robots', true );
 
         // Meta description.
-        $meta_desc = apply_filters( 'swps_meta_description', $meta_desc, $post_id );
+        $meta_desc = SWPS_Hooks::filter_meta_description( $meta_desc, $post_id );
         if ( ! empty( $meta_desc ) ) {
             printf( '<meta name="description" content="%s" />' . "\n", esc_attr( $meta_desc ) );
         }
@@ -167,7 +172,7 @@ class SWPS_Meta_Editor {
         }
 
         // Robots.
-        $robots = apply_filters( 'swps_meta_robots', $robots, $post_id );
+        $robots = SWPS_Hooks::filter_meta_robots( $robots, $post_id );
         if ( ! empty( $robots ) && 'index, follow' !== $robots ) {
             printf( '<meta name="robots" content="%s" />' . "\n", esc_attr( $robots ) );
         }
@@ -188,7 +193,7 @@ class SWPS_Meta_Editor {
         }
 
         $custom = get_post_meta( get_the_ID(), '_swps_meta_title', true );
-        $custom = apply_filters( 'swps_meta_title', $custom, get_the_ID() );
+        $custom = SWPS_Hooks::filter_meta_title( $custom, get_the_ID() );
 
         return ! empty( $custom ) ? $custom : $title;
     }
@@ -202,7 +207,7 @@ class SWPS_Meta_Editor {
         }
 
         $custom = get_post_meta( get_the_ID(), '_swps_meta_title', true );
-        $custom = apply_filters( 'swps_meta_title', $custom, get_the_ID() );
+        $custom = SWPS_Hooks::filter_meta_title( $custom, get_the_ID() );
 
         if ( ! empty( $custom ) ) {
             $parts['title'] = $custom;
@@ -284,6 +289,75 @@ class SWPS_Meta_Editor {
         echo '<div class="notice notice-info"><p>';
         esc_html_e( 'StrataWP SEO: Meta tag output is disabled because another SEO plugin (Yoast, RankMath, or AIOSEO) is active. The meta editor fields are still saved for reference.', 'stratawp-seo' );
         echo '</p></div>';
+    }
+
+    /**
+     * Sanitize robots meta value against allowed options.
+     */
+    public function sanitize_robots( string $value ): string {
+        $allowed = [ '', 'noindex, follow', 'index, nofollow', 'noindex, nofollow' ];
+        return in_array( $value, $allowed, true ) ? $value : '';
+    }
+
+    /**
+     * Auto-generate meta title/description when a post transitions to publish.
+     */
+    public function maybe_auto_generate( string $new_status, string $old_status, WP_Post $post ): void {
+        if ( 'publish' !== $new_status || 'publish' === $old_status ) {
+            return;
+        }
+
+        if ( ! in_array( $post->post_type, $this->get_enabled_post_types(), true ) ) {
+            return;
+        }
+
+        // Only generate if both fields are empty.
+        $existing_title = get_post_meta( $post->ID, '_swps_meta_title', true );
+        $existing_desc  = get_post_meta( $post->ID, '_swps_meta_description', true );
+        if ( ! empty( $existing_title ) || ! empty( $existing_desc ) ) {
+            return;
+        }
+
+        $content = wp_strip_all_tags( $post->post_content );
+        $content = mb_substr( $content, 0, 2000 );
+
+        $focus_keyword = get_post_meta( $post->ID, '_swps_focus_keyword', true );
+
+        $prompt = sprintf(
+            "Generate an SEO-optimized meta title (50-60 chars) and meta description (140-160 chars) for this blog post.\n\n"
+            . "Post title: %s\n"
+            . "Focus keyword: %s\n"
+            . "Content excerpt: %s\n\n"
+            . "Requirements:\n"
+            . "- Include the focus keyword naturally in both title and description\n"
+            . "- Meta title: compelling, under 60 characters\n"
+            . "- Meta description: actionable, includes a call to read, under 160 characters\n\n"
+            . "Return JSON only: {\"meta_title\":\"...\",\"meta_description\":\"...\"}",
+            $post->post_title,
+            $focus_keyword ?: '(none specified)',
+            $content
+        );
+
+        $api      = SWPS_Provider_Factory::create_ai_provider();
+        $response = $api->generate( $prompt, 'You are an SEO copywriting expert. Return only valid JSON.' );
+
+        if ( is_wp_error( $response ) ) {
+            return;
+        }
+
+        $text = $response['content'] ?? '';
+        $json_match = [];
+        if ( preg_match( '/\{.*\}/s', $text, $json_match ) ) {
+            $result = json_decode( $json_match[0], true );
+            if ( is_array( $result ) ) {
+                if ( ! empty( $result['meta_title'] ) ) {
+                    update_post_meta( $post->ID, '_swps_meta_title', sanitize_text_field( $result['meta_title'] ) );
+                }
+                if ( ! empty( $result['meta_description'] ) ) {
+                    update_post_meta( $post->ID, '_swps_meta_description', sanitize_textarea_field( $result['meta_description'] ) );
+                }
+            }
+        }
     }
 
     /**

--- a/includes/class-meta-editor.php
+++ b/includes/class-meta-editor.php
@@ -1,0 +1,347 @@
+<?php
+/**
+ * SEO Meta Editor — per-post meta fields and frontend output.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SWPS_Meta_Editor {
+
+    private bool $conflict = false;
+
+    public function __construct() {
+        // Detect conflicting SEO plugins.
+        if ( defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' ) ) {
+            $this->conflict = true;
+        }
+
+        if ( ! get_option( 'swps_meta_editor_enabled', 1 ) ) {
+            return;
+        }
+
+        // Admin: register metabox and save hook.
+        add_action( 'add_meta_boxes', [ $this, 'register_metabox' ] );
+        add_action( 'save_post', [ $this, 'save_meta' ], 10, 2 );
+
+        // AJAX: AI-generate meta.
+        add_action( 'wp_ajax_swps_generate_meta', [ $this, 'ajax_generate_meta' ] );
+
+        // Frontend output — only when no conflict.
+        if ( ! $this->conflict && ! is_admin() ) {
+            add_action( 'wp_head', [ $this, 'output_meta_tags' ], 2 );
+            add_filter( 'pre_get_document_title', [ $this, 'filter_document_title' ], 20 );
+            add_filter( 'document_title_parts', [ $this, 'filter_title_parts' ], 20 );
+        }
+
+        // Admin notice if conflict detected.
+        if ( $this->conflict ) {
+            add_action( 'admin_notices', [ $this, 'conflict_notice' ] );
+        }
+    }
+
+    /**
+     * Check if there's an SEO plugin conflict.
+     */
+    public function has_conflict(): bool {
+        return $this->conflict;
+    }
+
+    /**
+     * Register the SEO metabox on configured post types.
+     */
+    public function register_metabox(): void {
+        $post_types = $this->get_enabled_post_types();
+
+        foreach ( $post_types as $post_type ) {
+            add_meta_box(
+                'swps_meta_editor',
+                __( 'StrataWP SEO', 'stratawp-seo' ),
+                [ $this, 'render_metabox' ],
+                $post_type,
+                'normal',
+                'high'
+            );
+        }
+    }
+
+    /**
+     * Render the SEO metabox.
+     */
+    public function render_metabox( WP_Post $post ): void {
+        wp_nonce_field( 'swps_meta_editor', 'swps_meta_editor_nonce' );
+
+        $meta_title        = get_post_meta( $post->ID, '_swps_meta_title', true );
+        $meta_description  = get_post_meta( $post->ID, '_swps_meta_description', true );
+        $focus_keyword     = get_post_meta( $post->ID, '_swps_focus_keyword', true );
+        $secondary_kws     = get_post_meta( $post->ID, '_swps_secondary_keywords', true );
+        $canonical_url     = get_post_meta( $post->ID, '_swps_canonical_url', true );
+        $robots            = get_post_meta( $post->ID, '_swps_robots', true );
+        $breadcrumb_title  = get_post_meta( $post->ID, '_swps_breadcrumb_title', true );
+        $social_title      = get_post_meta( $post->ID, '_swps_social_title', true );
+        $social_desc       = get_post_meta( $post->ID, '_swps_social_description', true );
+        $social_image      = get_post_meta( $post->ID, '_swps_social_image', true );
+
+        if ( $this->conflict ) {
+            echo '<div class="notice notice-warning inline"><p>';
+            esc_html_e( 'Meta output is disabled because another SEO plugin is active. Fields are saved but not output on the frontend.', 'stratawp-seo' );
+            echo '</p></div>';
+        }
+
+        include SWPS_PLUGIN_DIR . 'templates/meta-editor-metabox.php';
+    }
+
+    /**
+     * Save meta fields on post save.
+     */
+    public function save_meta( int $post_id, WP_Post $post ): void {
+        if ( ! isset( $_POST['swps_meta_editor_nonce'] ) ) {
+            return;
+        }
+        if ( ! wp_verify_nonce( $_POST['swps_meta_editor_nonce'], 'swps_meta_editor' ) ) {
+            return;
+        }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) {
+            return;
+        }
+
+        $fields = [
+            '_swps_meta_title'          => 'sanitize_text_field',
+            '_swps_meta_description'    => 'sanitize_textarea_field',
+            '_swps_focus_keyword'       => 'sanitize_text_field',
+            '_swps_secondary_keywords'  => 'sanitize_text_field',
+            '_swps_canonical_url'       => 'esc_url_raw',
+            '_swps_robots'              => 'sanitize_text_field',
+            '_swps_breadcrumb_title'    => 'sanitize_text_field',
+            '_swps_social_title'        => 'sanitize_text_field',
+            '_swps_social_description'  => 'sanitize_textarea_field',
+            '_swps_social_image'        => 'esc_url_raw',
+        ];
+
+        foreach ( $fields as $key => $sanitizer ) {
+            if ( isset( $_POST[ $key ] ) ) {
+                $value = call_user_func( $sanitizer, $_POST[ $key ] );
+                if ( ! empty( $value ) ) {
+                    update_post_meta( $post_id, $key, $value );
+                } else {
+                    delete_post_meta( $post_id, $key );
+                }
+            }
+        }
+    }
+
+    /**
+     * Output meta tags in wp_head.
+     */
+    public function output_meta_tags(): void {
+        if ( ! is_singular() ) {
+            return;
+        }
+
+        $post_id = get_the_ID();
+        if ( ! $post_id ) {
+            return;
+        }
+
+        $meta_desc  = get_post_meta( $post_id, '_swps_meta_description', true );
+        $canonical  = get_post_meta( $post_id, '_swps_canonical_url', true );
+        $robots     = get_post_meta( $post_id, '_swps_robots', true );
+
+        // Meta description.
+        $meta_desc = apply_filters( 'swps_meta_description', $meta_desc, $post_id );
+        if ( ! empty( $meta_desc ) ) {
+            printf( '<meta name="description" content="%s" />' . "\n", esc_attr( $meta_desc ) );
+        }
+
+        // Canonical.
+        if ( ! empty( $canonical ) ) {
+            printf( '<link rel="canonical" href="%s" />' . "\n", esc_url( $canonical ) );
+            // Remove WP default canonical.
+            remove_action( 'wp_head', 'rel_canonical' );
+        }
+
+        // Robots.
+        $robots = apply_filters( 'swps_meta_robots', $robots, $post_id );
+        if ( ! empty( $robots ) && 'index, follow' !== $robots ) {
+            printf( '<meta name="robots" content="%s" />' . "\n", esc_attr( $robots ) );
+        }
+
+        // Open Graph.
+        $this->output_og_tags( $post_id );
+
+        // Twitter Card.
+        $this->output_twitter_tags( $post_id );
+    }
+
+    /**
+     * Filter the document title for our custom meta title.
+     */
+    public function filter_document_title( string $title ): string {
+        if ( ! is_singular() ) {
+            return $title;
+        }
+
+        $custom = get_post_meta( get_the_ID(), '_swps_meta_title', true );
+        $custom = apply_filters( 'swps_meta_title', $custom, get_the_ID() );
+
+        return ! empty( $custom ) ? $custom : $title;
+    }
+
+    /**
+     * Filter document title parts.
+     */
+    public function filter_title_parts( array $parts ): array {
+        if ( ! is_singular() ) {
+            return $parts;
+        }
+
+        $custom = get_post_meta( get_the_ID(), '_swps_meta_title', true );
+        $custom = apply_filters( 'swps_meta_title', $custom, get_the_ID() );
+
+        if ( ! empty( $custom ) ) {
+            $parts['title'] = $custom;
+            // Remove site name suffix if custom title is set.
+            unset( $parts['site'] );
+        }
+
+        return $parts;
+    }
+
+    /**
+     * AJAX: Generate meta title and description using AI.
+     */
+    public function ajax_generate_meta(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+
+        if ( ! current_user_can( 'edit_posts' ) ) {
+            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+        }
+
+        $post_id       = absint( $_POST['post_id'] ?? 0 );
+        $focus_keyword = sanitize_text_field( $_POST['focus_keyword'] ?? '' );
+
+        if ( ! $post_id ) {
+            wp_send_json_error( [ 'message' => 'Invalid post ID.' ] );
+        }
+
+        $post = get_post( $post_id );
+        if ( ! $post ) {
+            wp_send_json_error( [ 'message' => 'Post not found.' ] );
+        }
+
+        $content = wp_strip_all_tags( $post->post_content );
+        $content = mb_substr( $content, 0, 2000 ); // Limit to keep prompt short.
+
+        $prompt = sprintf(
+            "Generate an SEO-optimized meta title (50-60 chars) and meta description (140-160 chars) for this blog post.\n\n"
+            . "Post title: %s\n"
+            . "Focus keyword: %s\n"
+            . "Content excerpt: %s\n\n"
+            . "Requirements:\n"
+            . "- Include the focus keyword naturally in both title and description\n"
+            . "- Meta title: compelling, under 60 characters\n"
+            . "- Meta description: actionable, includes a call to read, under 160 characters\n\n"
+            . "Return JSON only: {\"meta_title\":\"...\",\"meta_description\":\"...\"}",
+            $post->post_title,
+            $focus_keyword ?: '(none specified)',
+            $content
+        );
+
+        $api      = SWPS_Provider_Factory::create_ai_provider();
+        $response = $api->generate( $prompt, 'You are an SEO copywriting expert. Return only valid JSON.' );
+
+        if ( is_wp_error( $response ) ) {
+            wp_send_json_error( [ 'message' => $response->get_error_message() ] );
+        }
+
+        $text = $response['content'] ?? '';
+        $json_match = [];
+        if ( preg_match( '/\{.*\}/s', $text, $json_match ) ) {
+            $result = json_decode( $json_match[0], true );
+            if ( is_array( $result ) ) {
+                wp_send_json_success( $result );
+            }
+        }
+
+        wp_send_json_error( [ 'message' => 'Failed to parse AI response.' ] );
+    }
+
+    /**
+     * Show admin notice when SEO plugin conflict detected.
+     */
+    public function conflict_notice(): void {
+        $screen = get_current_screen();
+        if ( ! $screen || strpos( $screen->id, 'stratawp-seo' ) === false ) {
+            return;
+        }
+
+        echo '<div class="notice notice-info"><p>';
+        esc_html_e( 'StrataWP SEO: Meta tag output is disabled because another SEO plugin (Yoast, RankMath, or AIOSEO) is active. The meta editor fields are still saved for reference.', 'stratawp-seo' );
+        echo '</p></div>';
+    }
+
+    /**
+     * Get post types where the meta editor is enabled.
+     */
+    private function get_enabled_post_types(): array {
+        $saved = get_option( 'swps_meta_editor_post_types', '' );
+        if ( ! empty( $saved ) ) {
+            return array_map( 'sanitize_text_field', explode( ',', $saved ) );
+        }
+        return [ 'post', 'page' ];
+    }
+
+    /**
+     * Output Open Graph tags.
+     */
+    private function output_og_tags( int $post_id ): void {
+        $title = get_post_meta( $post_id, '_swps_social_title', true )
+              ?: get_post_meta( $post_id, '_swps_meta_title', true )
+              ?: get_the_title( $post_id );
+
+        $desc = get_post_meta( $post_id, '_swps_social_description', true )
+             ?: get_post_meta( $post_id, '_swps_meta_description', true )
+             ?: get_the_excerpt( $post_id );
+
+        $image = get_post_meta( $post_id, '_swps_social_image', true )
+              ?: get_the_post_thumbnail_url( $post_id, 'large' );
+
+        printf( '<meta property="og:type" content="article" />' . "\n" );
+        printf( '<meta property="og:title" content="%s" />' . "\n", esc_attr( $title ) );
+        printf( '<meta property="og:description" content="%s" />' . "\n", esc_attr( $desc ) );
+        printf( '<meta property="og:url" content="%s" />' . "\n", esc_url( get_permalink( $post_id ) ) );
+        if ( $image ) {
+            printf( '<meta property="og:image" content="%s" />' . "\n", esc_url( $image ) );
+        }
+        printf( '<meta property="og:site_name" content="%s" />' . "\n", esc_attr( get_bloginfo( 'name' ) ) );
+    }
+
+    /**
+     * Output Twitter Card tags.
+     */
+    private function output_twitter_tags( int $post_id ): void {
+        $title = get_post_meta( $post_id, '_swps_social_title', true )
+              ?: get_post_meta( $post_id, '_swps_meta_title', true )
+              ?: get_the_title( $post_id );
+
+        $desc = get_post_meta( $post_id, '_swps_social_description', true )
+             ?: get_post_meta( $post_id, '_swps_meta_description', true )
+             ?: get_the_excerpt( $post_id );
+
+        $image = get_post_meta( $post_id, '_swps_social_image', true )
+              ?: get_the_post_thumbnail_url( $post_id, 'large' );
+
+        printf( '<meta name="twitter:card" content="%s" />' . "\n", $image ? 'summary_large_image' : 'summary' );
+        printf( '<meta name="twitter:title" content="%s" />' . "\n", esc_attr( $title ) );
+        printf( '<meta name="twitter:description" content="%s" />' . "\n", esc_attr( $desc ) );
+        if ( $image ) {
+            printf( '<meta name="twitter:image" content="%s" />' . "\n", esc_url( $image ) );
+        }
+    }
+}

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -360,6 +360,22 @@ class SWPS_Settings {
             'description' => __( 'One social profile URL per line. Populates the sameAs property.', 'stratawp-seo' ),
         ] );
 
+        // --- SEO Meta Section ---
+        add_settings_section( 'swps_meta_section', __( 'SEO Meta', 'stratawp-seo' ), [ $this, 'render_meta_section' ], 'stratawp-seo' );
+
+        $this->add_field( 'meta_editor_enabled', __( 'Enable Meta Editor', 'stratawp-seo' ), 'checkbox', 'swps_meta_section', [
+            'label' => __( 'Show SEO meta fields (title, description, social, robots) on post and page editors', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'meta_editor_post_types', __( 'Post Types', 'stratawp-seo' ), 'text', 'swps_meta_section', [
+            'placeholder' => 'post,page',
+            'description' => __( 'Comma-separated post types to show the meta editor on. Default: post,page', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'meta_auto_generate', __( 'Auto-Generate Meta', 'stratawp-seo' ), 'checkbox', 'swps_meta_section', [
+            'label' => __( 'Automatically generate meta title and description via AI when publishing a post without them', 'stratawp-seo' ),
+        ] );
+
         // --- Analytics Section ---
         add_settings_section( 'swps_analytics_section', __( 'Analytics', 'stratawp-seo' ), [ $this, 'render_analytics_section' ], 'stratawp-seo' );
 
@@ -388,6 +404,15 @@ class SWPS_Settings {
 
         $this->add_field( 'gsc_client_secret', __( 'Google OAuth Client Secret', 'stratawp-seo' ), 'password', 'swps_analytics_section', [
             'description' => __( 'Stored encrypted. After saving, connect via the Analytics page.', 'stratawp-seo' ),
+        ] );
+
+        $this->add_field( 'keyword_tracking_frequency', __( 'Keyword Sync Frequency', 'stratawp-seo' ), 'select', 'swps_analytics_section', [
+            'options' => [
+                'daily'   => __( 'Daily', 'stratawp-seo' ),
+                'weekly'  => __( 'Weekly', 'stratawp-seo' ),
+                'monthly' => __( 'Monthly', 'stratawp-seo' ),
+            ],
+            'description' => __( 'How often to sync tracked keyword positions from Google Search Console.', 'stratawp-seo' ),
         ] );
 
         // --- Advanced Section (v2.0) ---
@@ -647,6 +672,10 @@ class SWPS_Settings {
      */
     public function render_schema_section(): void {
         echo '<p>' . esc_html__( 'Automatic JSON-LD structured data for rich results in Google. Disabled automatically when Yoast SEO, RankMath, or All in One SEO is active.', 'stratawp-seo' ) . '</p>';
+    }
+
+    public function render_meta_section(): void {
+        echo '<p>' . esc_html__( 'Per-post SEO meta fields for titles, descriptions, social previews, and robots directives. Auto-disabled when Yoast, RankMath, or AIOSEO is active.', 'stratawp-seo' ) . '</p>';
     }
 
     public function render_analytics_section(): void {

--- a/readme.txt
+++ b/readme.txt
@@ -4,11 +4,11 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 2.2.0
+Stable tag: 2.3.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, structured data, analytics, and technical SEO.
+AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, structured data, analytics, keyword tracking, meta editing, and technical SEO.
 
 == Description ==
 
@@ -56,6 +56,24 @@ StrataWP SEO is an AI-powered content generation and technical SEO plugin for Wo
 * **Organization/Person schema** — configurable entity type with logo and social profiles
 * **Conflict detection** — auto-disables when Yoast SEO, RankMath, or All in One SEO is active
 
+= Keyword Research & Tracking =
+
+* **AI-powered keyword suggestions** — generate keyword ideas from seed topics using your configured AI provider
+* **GSC-powered rank tracking** — sync keyword rankings from Google Search Console automatically
+* **Striking distance opportunities** — identify keywords ranking in positions 8-20 with the best potential for quick wins
+
+= SEO Meta Editor =
+
+* **Per-post meta title/description** — set custom SEO titles and descriptions on every post and page
+* **Live SERP preview** — real-time Google search result preview as you type
+* **Character counters** — visual indicators for optimal meta title and description length
+* **SEO checklist** — focus keyword analysis with actionable recommendations in the post editor
+* **Social previews** — Open Graph and Twitter Card meta with per-post overrides
+* **Canonical URL & robots meta** — per-post canonical URL and noindex/nofollow controls
+* **Breadcrumb title override** — customize the breadcrumb label per post
+* **AI Generate button** — one-click AI-powered meta title and description generation
+* **Conflict detection** — auto-disables meta tag output when Yoast SEO, RankMath, or All in One SEO is active
+
 = Analytics & Search Console =
 
 * **On-site analytics** — cookie-free, GDPR-friendly page view tracking (no external services)
@@ -69,7 +87,7 @@ StrataWP SEO is an AI-powered content generation and technical SEO plugin for Wo
 
 = Developer Features =
 
-* **20+ filters and actions** — extend every part of the generation pipeline
+* **25+ filters and actions** — extend every part of the generation pipeline
 * **WP-CLI commands** — generate, analyze, manage queue, and check status from the terminal
 * **REST API** — programmatic access to generation and audit features
 * **Cost tracking** — monitor token usage and estimated API costs
@@ -114,6 +132,10 @@ The plugin itself is free/included. You pay only for AI API usage. A typical 1,5
 
 Yes. Use the `swps_audit_modules` filter to register your own audit module. Your module should extend the `SWPS_Audit_Module` abstract class.
 
+= Can I use the meta editor alongside Yoast/RankMath? =
+
+Yes! StrataWP SEO automatically detects these plugins and disables its own meta tag output to prevent conflicts. The meta editor fields are still available for reference, but frontend output is deferred to the other plugin.
+
 = Is the on-site analytics GDPR compliant? =
 
 Yes. The built-in analytics tracker is cookie-free and does not use any external tracking services. No personal data is stored. No consent banner is required.
@@ -130,8 +152,20 @@ No. GSC integration is optional. The on-site analytics works entirely without an
 4. Schema JSON-LD — automatic structured data output in page source
 5. Analytics Dashboard — page views, time on page, scroll depth, bounce rate, and GSC data
 6. Post Analytics — per-post metabox with views, engagement metrics, and top search queries
+7. Keyword Research — AI-powered suggestions and GSC rank tracking with striking distance opportunities
+8. SEO Meta Editor — per-post meta title, description, SERP preview, and SEO checklist
 
 == Changelog ==
+
+= 2.3.0 =
+* Added: Keyword Research & Tracking — AI-powered keyword suggestions and GSC rank tracking
+* Added: SEO Meta Editor — per-post meta title, description, social previews, and robots controls
+* Added: Live SERP preview with character counters in post editor
+* Added: SEO checklist with focus keyword analysis
+* Added: Striking distance keyword opportunities (position 8-20)
+* Added: AI-powered meta title/description generation
+* Added: Conflict detection — auto-disables meta output when Yoast/RankMath/AIOSEO is active
+* Added: 5 new developer hooks for meta/keyword extensibility
 
 = 2.2.0 =
 * Added on-site analytics tracking (page views, time on page, scroll depth, bounce rate)
@@ -177,6 +211,9 @@ No. GSC integration is optional. The on-site analytics works entirely without an
 * Scheduled publishing
 
 == Upgrade Notice ==
+
+= 2.3.0 =
+Adds Keyword Research & Tracking with AI-powered suggestions and GSC rank tracking, plus a full SEO Meta Editor with SERP preview, social previews, and conflict detection. No breaking changes.
 
 = 2.2.0 =
 Adds on-site analytics tracking and Google Search Console integration with a unified dashboard. Cookie-free, GDPR-friendly. No breaking changes.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 2.2.0
+ * Version: 2.3.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'SWPS_VERSION', '2.2.0' );
+define( 'SWPS_VERSION', '2.3.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -85,6 +85,11 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-analytics-tracker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-search-console.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-analytics-dashboard.php';
 
+// Keywords & Meta Editor.
+require_once SWPS_PLUGIN_DIR . 'includes/class-keyword-tracker.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-keywords-page.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-meta-editor.php';
+
 // Core classes.
 require_once SWPS_PLUGIN_DIR . 'includes/class-settings.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-analyzer.php';
@@ -132,6 +137,9 @@ final class StrataWP_SEO {
     public SWPS_Analytics_Tracker $analytics_tracker;
     public SWPS_Search_Console $search_console;
     public SWPS_Analytics_Dashboard $analytics_dashboard;
+    public SWPS_Keyword_Tracker $keyword_tracker;
+    public SWPS_Keywords_Page $keywords_page;
+    public SWPS_Meta_Editor $meta_editor;
 
     public static function instance(): self {
         if ( null === self::$instance ) {
@@ -161,6 +169,9 @@ final class StrataWP_SEO {
         $this->analytics_tracker   = new SWPS_Analytics_Tracker();
         $this->search_console      = new SWPS_Search_Console();
         $this->analytics_dashboard = new SWPS_Analytics_Dashboard( $this->analytics_tracker, $this->search_console );
+        $this->keyword_tracker = new SWPS_Keyword_Tracker( $this->search_console );
+        $this->keywords_page   = new SWPS_Keywords_Page( $this->keyword_tracker );
+        $this->meta_editor     = new SWPS_Meta_Editor();
         $this->settings  = new SWPS_Settings();
         $this->analyzer  = new SWPS_Analyzer( $this->cache_manager );
         $this->generator = new SWPS_Generator(
@@ -214,6 +225,10 @@ final class StrataWP_SEO {
         // SEO Audit frontend hooks.
         add_action( 'wp_head', [ SWPS_Canonical_Module::class, 'output_canonical' ], 1 );
         add_action( 'wp_head', [ SWPS_OpenGraph_Module::class, 'output_meta_tags' ], 5 );
+        // Disable audit OG output when meta editor handles it.
+        if ( get_option( 'swps_meta_editor_enabled', 1 ) && ! defined( 'WPSEO_VERSION' ) && ! defined( 'RANK_MATH_VERSION' ) && ! defined( 'AIOSEO_VERSION' ) ) {
+            remove_action( 'wp_head', [ SWPS_OpenGraph_Module::class, 'output_meta_tags' ], 5 );
+        }
         add_action( 'init', [ SWPS_Sitemap_Module::class, 'register_rewrite_rules' ] );
         add_action( 'template_redirect', [ SWPS_Sitemap_Module::class, 'serve_sitemap' ] );
         add_action( 'publish_post', [ SWPS_Sitemap_Module::class, 'ping_search_engines' ] );
@@ -270,7 +285,7 @@ final class StrataWP_SEO {
             return;
         }
 
-        if ( ! str_contains( $hook, 'stratawp-seo' ) && ! str_contains( $hook, 'swps-generate' ) && ! str_contains( $hook, 'swps-voice-profiles' ) && ! str_contains( $hook, 'swps-seo-audit' ) && ! str_contains( $hook, 'swps-analytics' ) && ! in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
+        if ( ! str_contains( $hook, 'stratawp-seo' ) && ! str_contains( $hook, 'swps-generate' ) && ! str_contains( $hook, 'swps-voice-profiles' ) && ! str_contains( $hook, 'swps-seo-audit' ) && ! str_contains( $hook, 'swps-analytics' ) && ! str_contains( $hook, 'swps-keywords' ) && ! in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
             return;
         }
 
@@ -297,6 +312,7 @@ final class StrataWP_SEO {
             'templates'           => SWPS_Templates::get_options(),
             'rate_limit_remaining' => $this->rate_limiter->get_remaining_seconds(),
             'min_content_score'   => get_option( 'swps_min_content_score', 0 ),
+            'generate_url'        => admin_url( 'admin.php?page=swps-generate' ),
         ] );
 
         // Analytics dashboard JS.
@@ -304,6 +320,28 @@ final class StrataWP_SEO {
             wp_enqueue_script(
                 'swps-analytics',
                 SWPS_PLUGIN_URL . 'admin/js/analytics.js',
+                [ 'jquery', 'swps-admin' ],
+                SWPS_VERSION,
+                true
+            );
+        }
+
+        // Keywords page JS.
+        if ( str_contains( $hook, 'swps-keywords' ) ) {
+            wp_enqueue_script(
+                'swps-keywords',
+                SWPS_PLUGIN_URL . 'admin/js/keywords.js',
+                [ 'jquery', 'swps-admin' ],
+                SWPS_VERSION,
+                true
+            );
+        }
+
+        // Meta editor JS on post edit screens.
+        if ( in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
+            wp_enqueue_script(
+                'swps-meta-editor',
+                SWPS_PLUGIN_URL . 'admin/js/meta-editor.js',
                 [ 'jquery', 'swps-admin' ],
                 SWPS_VERSION,
                 true
@@ -851,6 +889,11 @@ function swps_activate(): void {
         'analytics_exclude_admins' => 1,
         'gsc_client_id'            => '',
         'gsc_client_secret'        => '',
+        // Keywords & Meta defaults.
+        'meta_editor_enabled'          => 1,
+        'meta_editor_post_types'       => 'post,page',
+        'meta_auto_generate'           => 0,
+        'keyword_tracking_frequency'   => 'weekly',
     ];
 
     foreach ( $defaults as $key => $value ) {
@@ -868,6 +911,8 @@ function swps_activate(): void {
     SWPS_Analytics_Tracker::create_tables();
     SWPS_Analytics_Tracker::schedule_cron();
     SWPS_Search_Console::schedule_cron();
+    SWPS_Keyword_Tracker::create_tables();
+    SWPS_Keyword_Tracker::schedule_cron();
 
     if ( get_option( 'swps_cron_enabled' ) ) {
         SWPS_Cron::schedule();
@@ -883,6 +928,7 @@ function swps_deactivate(): void {
     SWPS_SEO_Audit::unschedule_cron();
     SWPS_Analytics_Tracker::unschedule_cron();
     SWPS_Search_Console::unschedule_cron();
+    SWPS_Keyword_Tracker::unschedule_cron();
     flush_rewrite_rules();
 }
 register_deactivation_hook( __FILE__, 'swps_deactivate' );

--- a/templates/keywords-page.php
+++ b/templates/keywords-page.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Keywords page template.
+ *
+ * @var bool $gsc_connected Whether GSC is connected.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div class="wrap swps-keywords-wrap">
+    <h1><?php esc_html_e( 'Keyword Research & Tracking', 'stratawp-seo' ); ?></h1>
+
+    <!-- AI Suggestion Panel -->
+    <div class="swps-keywords-section swps-suggest-panel">
+        <h2><?php esc_html_e( 'Discover Keywords', 'stratawp-seo' ); ?></h2>
+        <div class="swps-suggest-form">
+            <input type="text" id="swps-seed-topic" class="regular-text"
+                   placeholder="<?php esc_attr_e( 'Enter a seed topic (e.g., home renovation tips)', 'stratawp-seo' ); ?>" />
+            <button class="button button-primary" id="swps-suggest-btn">
+                <?php esc_html_e( 'Get AI Suggestions', 'stratawp-seo' ); ?>
+            </button>
+            <span class="spinner" id="swps-suggest-spinner"></span>
+        </div>
+        <table class="widefat striped" id="swps-suggestions-table" style="display:none;">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e( 'Keyword', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Intent', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Difficulty', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Suggested Title', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+
+    <!-- Tracked Keywords -->
+    <div class="swps-keywords-section">
+        <h2><?php esc_html_e( 'Tracked Keywords', 'stratawp-seo' ); ?></h2>
+        <table class="widefat striped" id="swps-tracked-table">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e( 'Keyword', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Position', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Clicks', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'CTR', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Linked Post', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr><td colspan="7" class="swps-loading"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+            </tbody>
+        </table>
+    </div>
+
+    <?php if ( $gsc_connected ) : ?>
+    <!-- Opportunities -->
+    <div class="swps-keywords-section">
+        <h2><?php esc_html_e( 'Opportunities (Striking Distance)', 'stratawp-seo' ); ?></h2>
+        <p class="description"><?php esc_html_e( 'Keywords ranking position 8-20 with high impressions — optimize these for quick wins.', 'stratawp-seo' ); ?></p>
+        <table class="widefat striped" id="swps-opportunities-table">
+            <thead>
+                <tr>
+                    <th><?php esc_html_e( 'Keyword', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Position', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'CTR', 'stratawp-seo' ); ?></th>
+                    <th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr><td colspan="5" class="swps-loading"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+            </tbody>
+        </table>
+    </div>
+    <?php endif; ?>
+
+    <!-- Keyword History Modal -->
+    <div id="swps-keyword-history-modal" class="swps-modal" style="display:none;">
+        <div class="swps-modal-content">
+            <span class="swps-modal-close">&times;</span>
+            <h3 id="swps-history-title"></h3>
+            <div id="swps-history-chart" class="swps-chart"></div>
+        </div>
+    </div>
+</div>

--- a/templates/meta-editor-metabox.php
+++ b/templates/meta-editor-metabox.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Meta editor metabox template.
+ *
+ * Variables are set by SWPS_Meta_Editor::render_metabox().
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+?>
+<div class="swps-meta-editor" data-post-id="<?php echo esc_attr( $post->ID ); ?>">
+
+    <!-- Google Preview -->
+    <div class="swps-serp-preview">
+        <h4><?php esc_html_e( 'Google Preview', 'stratawp-seo' ); ?></h4>
+        <div class="swps-serp-mock">
+            <div class="swps-serp-title" id="swps-serp-title"><?php echo esc_html( $meta_title ?: $post->post_title ); ?></div>
+            <div class="swps-serp-url"><?php echo esc_url( get_permalink( $post->ID ) ); ?></div>
+            <div class="swps-serp-desc" id="swps-serp-desc"><?php echo esc_html( $meta_description ?: wp_trim_words( $post->post_content, 25, '...' ) ); ?></div>
+        </div>
+    </div>
+
+    <!-- Focus Keyword -->
+    <div class="swps-meta-row">
+        <label for="_swps_focus_keyword"><strong><?php esc_html_e( 'Focus Keyword', 'stratawp-seo' ); ?></strong></label>
+        <input type="text" name="_swps_focus_keyword" id="_swps_focus_keyword"
+               value="<?php echo esc_attr( $focus_keyword ); ?>" class="widefat"
+               placeholder="<?php esc_attr_e( 'e.g., best running shoes', 'stratawp-seo' ); ?>" />
+    </div>
+
+    <div class="swps-meta-row">
+        <label for="_swps_secondary_keywords"><?php esc_html_e( 'Secondary Keywords', 'stratawp-seo' ); ?></label>
+        <input type="text" name="_swps_secondary_keywords" id="_swps_secondary_keywords"
+               value="<?php echo esc_attr( $secondary_kws ); ?>" class="widefat"
+               placeholder="<?php esc_attr_e( 'Comma-separated: running gear, marathon training', 'stratawp-seo' ); ?>" />
+    </div>
+
+    <!-- Meta Title -->
+    <div class="swps-meta-row">
+        <label for="_swps_meta_title">
+            <?php esc_html_e( 'Meta Title', 'stratawp-seo' ); ?>
+            <span class="swps-char-count" id="swps-title-count">0</span>
+        </label>
+        <input type="text" name="_swps_meta_title" id="_swps_meta_title"
+               value="<?php echo esc_attr( $meta_title ); ?>" class="widefat"
+               placeholder="<?php echo esc_attr( $post->post_title ); ?>" />
+        <button type="button" class="button button-small" id="swps-ai-generate-meta">
+            <?php esc_html_e( 'AI Generate', 'stratawp-seo' ); ?>
+        </button>
+    </div>
+
+    <!-- Meta Description -->
+    <div class="swps-meta-row">
+        <label for="_swps_meta_description">
+            <?php esc_html_e( 'Meta Description', 'stratawp-seo' ); ?>
+            <span class="swps-char-count" id="swps-desc-count">0</span>
+        </label>
+        <textarea name="_swps_meta_description" id="_swps_meta_description" class="widefat" rows="3"
+                  placeholder="<?php esc_attr_e( 'Compelling description for search results...', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $meta_description ); ?></textarea>
+    </div>
+
+    <!-- SEO Checklist -->
+    <div class="swps-seo-checklist" id="swps-seo-checklist">
+        <h4><?php esc_html_e( 'SEO Checklist', 'stratawp-seo' ); ?></h4>
+        <ul>
+            <li data-check="keyword-in-title"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in meta title', 'stratawp-seo' ); ?></li>
+            <li data-check="keyword-in-desc"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in meta description', 'stratawp-seo' ); ?></li>
+            <li data-check="title-length"><span class="swps-check-icon"></span> <?php esc_html_e( 'Meta title length (50-60 chars)', 'stratawp-seo' ); ?></li>
+            <li data-check="desc-length"><span class="swps-check-icon"></span> <?php esc_html_e( 'Meta description length (140-160 chars)', 'stratawp-seo' ); ?></li>
+            <li data-check="keyword-in-content"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in first paragraph', 'stratawp-seo' ); ?></li>
+            <li data-check="keyword-in-h2"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in at least one H2', 'stratawp-seo' ); ?></li>
+        </ul>
+    </div>
+
+    <!-- Advanced: Canonical, Robots, Breadcrumb -->
+    <details class="swps-meta-advanced">
+        <summary><?php esc_html_e( 'Advanced', 'stratawp-seo' ); ?></summary>
+
+        <div class="swps-meta-row">
+            <label for="_swps_canonical_url"><?php esc_html_e( 'Canonical URL', 'stratawp-seo' ); ?></label>
+            <input type="url" name="_swps_canonical_url" id="_swps_canonical_url"
+                   value="<?php echo esc_url( $canonical_url ); ?>" class="widefat"
+                   placeholder="<?php echo esc_url( get_permalink( $post->ID ) ); ?>" />
+        </div>
+
+        <div class="swps-meta-row">
+            <label for="_swps_robots"><?php esc_html_e( 'Robots Meta', 'stratawp-seo' ); ?></label>
+            <select name="_swps_robots" id="_swps_robots">
+                <option value="" <?php selected( $robots, '' ); ?>><?php esc_html_e( 'Default (index, follow)', 'stratawp-seo' ); ?></option>
+                <option value="noindex, follow" <?php selected( $robots, 'noindex, follow' ); ?>><?php esc_html_e( 'noindex, follow', 'stratawp-seo' ); ?></option>
+                <option value="index, nofollow" <?php selected( $robots, 'index, nofollow' ); ?>><?php esc_html_e( 'index, nofollow', 'stratawp-seo' ); ?></option>
+                <option value="noindex, nofollow" <?php selected( $robots, 'noindex, nofollow' ); ?>><?php esc_html_e( 'noindex, nofollow', 'stratawp-seo' ); ?></option>
+            </select>
+        </div>
+
+        <div class="swps-meta-row">
+            <label for="_swps_breadcrumb_title"><?php esc_html_e( 'Breadcrumb Title', 'stratawp-seo' ); ?></label>
+            <input type="text" name="_swps_breadcrumb_title" id="_swps_breadcrumb_title"
+                   value="<?php echo esc_attr( $breadcrumb_title ); ?>" class="widefat"
+                   placeholder="<?php echo esc_attr( $post->post_title ); ?>" />
+        </div>
+    </details>
+
+    <!-- Social Preview -->
+    <details class="swps-meta-social">
+        <summary><?php esc_html_e( 'Social Previews', 'stratawp-seo' ); ?></summary>
+
+        <div class="swps-meta-row">
+            <label for="_swps_social_title"><?php esc_html_e( 'Social Title', 'stratawp-seo' ); ?></label>
+            <input type="text" name="_swps_social_title" id="_swps_social_title"
+                   value="<?php echo esc_attr( $social_title ); ?>" class="widefat"
+                   placeholder="<?php esc_attr_e( 'Falls back to meta title', 'stratawp-seo' ); ?>" />
+        </div>
+
+        <div class="swps-meta-row">
+            <label for="_swps_social_description"><?php esc_html_e( 'Social Description', 'stratawp-seo' ); ?></label>
+            <textarea name="_swps_social_description" id="_swps_social_description" class="widefat" rows="2"
+                      placeholder="<?php esc_attr_e( 'Falls back to meta description', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $social_desc ); ?></textarea>
+        </div>
+
+        <div class="swps-meta-row">
+            <label for="_swps_social_image"><?php esc_html_e( 'Social Image URL', 'stratawp-seo' ); ?></label>
+            <input type="url" name="_swps_social_image" id="_swps_social_image"
+                   value="<?php echo esc_url( $social_image ); ?>" class="widefat"
+                   placeholder="<?php esc_attr_e( 'Falls back to featured image', 'stratawp-seo' ); ?>" />
+        </div>
+
+        <!-- Facebook Preview Mock -->
+        <div class="swps-social-preview swps-fb-preview">
+            <h5><?php esc_html_e( 'Facebook Preview', 'stratawp-seo' ); ?></h5>
+            <div class="swps-social-card">
+                <div class="swps-social-image" id="swps-fb-image"></div>
+                <div class="swps-social-text">
+                    <div class="swps-social-domain"><?php echo esc_html( wp_parse_url( home_url(), PHP_URL_HOST ) ); ?></div>
+                    <div class="swps-social-title" id="swps-fb-title"></div>
+                    <div class="swps-social-desc" id="swps-fb-desc"></div>
+                </div>
+            </div>
+        </div>
+    </details>
+</div>


### PR DESCRIPTION
## Summary

- **Keyword Research & Tracking** — AI-powered keyword suggestions, GSC rank tracking via WP-Cron, striking-distance opportunities detection, position history with SVG charts
- **Per-Post Meta Editor** — SEO metabox with live SERP preview, character counters, 6-item SEO checklist, AI-generate meta, social previews (OG + Twitter Card), canonical URL, robots meta, breadcrumb title
- **Integration** — Settings UI for both modules, conflict detection (Yoast/RankMath/AIOSEO auto-disables frontend output), content generator saves meta fields, OG coordination between meta editor and audit module, 5 developer filter hooks

## New Files
- `includes/class-keyword-tracker.php` — DB table, CRUD, GSC sync, AI suggestions
- `includes/class-keywords-page.php` — Admin page + 7 AJAX handlers
- `includes/class-meta-editor.php` — Metabox, frontend output, conflict detection, auto-generate on publish
- `templates/keywords-page.php` — Keywords admin page template
- `templates/meta-editor-metabox.php` — Metabox template with SERP/social previews
- `admin/js/keywords.js` — Keywords page JS (AJAX, SVG chart)
- `admin/js/meta-editor.js` — Meta editor JS (live preview, checklist, AI generate)

## Modified Files
- `stratawp-seo.php` — Bootstrap, enqueue, activation/deactivation, version 2.2.0 → 2.3.0
- `includes/class-settings.php` — SEO Meta section + keyword tracking frequency
- `includes/class-hooks.php` — 5 new filter methods
- `includes/class-generator.php` — Auto-save _swps_ meta on generation
- `admin/css/admin.css` — Keywords page + meta editor styles
- `README.md` / `readme.txt` — v2.3.0 documentation

## Test Plan
- [ ] Activate plugin, verify `swps_keyword_tracking` table is created
- [ ] Visit Keywords page, enter seed topic, verify AI suggestions appear
- [ ] Track a keyword, verify it appears in tracked keywords table
- [ ] Connect GSC, verify rank data syncs on cron schedule
- [ ] Edit a post, verify SEO metabox renders with all fields
- [ ] Type in meta title/description, verify SERP preview updates live
- [ ] Verify character counters change color (green/yellow/red)
- [ ] Click AI Generate, verify meta fields populate
- [ ] Set focus keyword, verify SEO checklist evaluates correctly
- [ ] Publish post with empty meta + auto-generate enabled, verify meta is generated
- [ ] View published post source, verify meta tags, OG, Twitter Card output
- [ ] Activate Yoast/RankMath, verify conflict notice and meta output disabled
- [ ] Verify settings page shows SEO Meta section and keyword tracking frequency

