### PR TITLE
feat: improve JSON output handling and validation, bump version to 3.8.0

### DIFF
--- a/includes/class-ai-provider.php
+++ b/includes/class-ai-provider.php
@@ -214,6 +214,18 @@ abstract class SWPS_AI_Provider {
             return $decoded;
         }
 
+        // Attempt 6: Strip stray escape sequences (\n, \r, \t, etc.) that the
+        // model emitted *outside* of string literals. Walk the string tracking
+        // whether we're inside a JSON string; if we see a backslash outside a
+        // string, drop it and the following character.
+        $stripped = $this->strip_stray_escapes( $combined );
+        if ( $stripped !== $combined ) {
+            $decoded = json_decode( $stripped, true, 512, JSON_INVALID_UTF8_SUBSTITUTE );
+            if ( json_last_error() === JSON_ERROR_NONE ) {
+                return $decoded;
+            }
+        }
+
         // All attempts failed — persist the raw response for debugging and
         // return error with diagnostic info.
         set_transient(
@@ -301,6 +313,69 @@ abstract class SWPS_AI_Provider {
 
             $result .= $str_content . '"';
             $i++; // Skip the closing quote.
+        }
+
+        return $result;
+    }
+
+    /**
+     * Strip stray escape sequences that appear outside of string literals.
+     *
+     * The model occasionally emits literal backslash-letter pairs (e.g. "\n")
+     * between JSON tokens, which is invalid. Walk the string tracking whether
+     * we're inside a quoted string; outside strings, drop any backslash and
+     * the character that follows it.
+     *
+     * @param string $json The JSON string to clean.
+     * @return string The cleaned JSON string.
+     */
+    protected function strip_stray_escapes( string $json ): string {
+        $len      = strlen( $json );
+        $result   = '';
+        $i        = 0;
+        $in_string = false;
+
+        while ( $i < $len ) {
+            $ch = $json[ $i ];
+
+            if ( $in_string ) {
+                if ( $ch === '\\' && $i + 1 < $len ) {
+                    // Inside a string — preserve escape sequences verbatim.
+                    $result .= $ch . $json[ $i + 1 ];
+                    $i += 2;
+                    continue;
+                }
+                if ( $ch === '"' ) {
+                    $in_string = false;
+                }
+                $result .= $ch;
+                $i++;
+                continue;
+            }
+
+            // Outside a string.
+            if ( $ch === '"' ) {
+                $in_string = true;
+                $result   .= $ch;
+                $i++;
+                continue;
+            }
+
+            if ( $ch === '\\' && $i + 1 < $len ) {
+                // Stray escape between tokens — drop the backslash AND the
+                // following char only if it is a typical escape letter.
+                // Otherwise, drop just the backslash.
+                $next = $json[ $i + 1 ];
+                if ( strpos( "nrtbf/\\\"u", $next ) !== false ) {
+                    $i += 2;
+                } else {
+                    $i += 1;
+                }
+                continue;
+            }
+
+            $result .= $ch;
+            $i++;
         }
 
         return $result;

--- a/includes/class-generator.php
+++ b/includes/class-generator.php
@@ -229,7 +229,17 @@ PROMPT;
         $prompt .= <<<'PROMPT'
 
 
-RESPONSE FORMAT: Respond ONLY with a valid JSON object. No markdown fences, no explanation, just JSON.
+RESPONSE FORMAT: Respond ONLY with a single, strictly valid RFC 8259 JSON object. No markdown fences, no prose, no explanation.
+
+JSON SYNTAX REQUIREMENTS (NON-NEGOTIABLE — output MUST parse with strict JSON parsers):
+- Every string value must be properly quoted with " and any inner " escaped as \".
+- Escape sequences (\n, \r, \t, \", \\) are ONLY valid INSIDE string literals. NEVER emit a backslash-letter sequence between tokens, between array elements, between object members, or anywhere outside of a quoted string.
+- Use real whitespace (spaces, real newlines) between JSON tokens — never literal \n or \t characters as separators.
+- No trailing commas before } or ].
+- No comments (// or /* */).
+- No control characters (0x00–0x1F) inside strings — encode them as \n, \r, \t, etc.
+- Balanced brackets: every { has a matching } and every [ has a matching ].
+- Before finishing your response, mentally re-parse it as JSON and confirm it is valid.
 
 Required JSON structure:
 {

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 3.7.9
+ * Version: 3.8.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'SWPS_VERSION', '3.7.9' );
+define( 'SWPS_VERSION', '3.8.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
- Updated JSON response format requirements in class-generator.php for stricter compliance with RFC 8259.
- Introduced a new `strip_stray_escapes` method in class-ai-provider.php to clean up invalid escape sequences outside JSON string literals.
- Added logic to retry JSON decoding with cleaned data when encountering parsing errors.
- Version bump from 3.7.9 to 3.8.0.