### PR TITLE
v4.2.2: Local SEO, Image SEO, Crawlers & Files, Backlinks tracker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Build & release plugin zip
+
+# Builds a production-ready WordPress plugin zip and publishes it as a GitHub
+# Release whenever the version in stratawp-seo.php changes.
+#
+# The README links to:
+#   releases/latest/download/stratawp-seo.zip
+# which always resolves to the asset attached to the most recent release.
+
+on:
+  push:
+    branches:
+      - main
+      - "feature/**"
+    paths:
+      - 'stratawp-seo.php'
+      - 'includes/**'
+      - 'admin/**'
+      - 'templates/**'
+      - 'css/**'
+      - 'readme.txt'
+      - 'uninstall.php'
+      - '.github/workflows/release.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Read plugin version from stratawp-seo.php
+        id: ver
+        run: |
+          VERSION=$(grep -E "^[[:space:]]*\*[[:space:]]*Version:" stratawp-seo.php | head -1 | awk -F': ' '{print $2}' | tr -d ' \r')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read Version: header from stratawp-seo.php"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Plugin version: $VERSION"
+
+      - name: Check if release already exists for this version
+        id: exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "v${{ steps.ver.outputs.version }}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release v${{ steps.ver.outputs.version }} already exists — skipping."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build production zip
+        if: steps.exists.outputs.exists == 'false'
+        run: |
+          set -e
+          mkdir -p build
+          rsync -a \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='docs' \
+            --exclude='screenshots' \
+            --exclude='build' \
+            --exclude='node_modules' \
+            --exclude='*.zip' \
+            --exclude='AGENTS.md' \
+            --exclude='CLAUDE.md' \
+            --exclude='.DS_Store' \
+            --exclude='**/.DS_Store' \
+            ./ build/stratawp-seo/
+          (cd build && zip -rq stratawp-seo.zip stratawp-seo)
+          ls -lh build/stratawp-seo.zip
+
+      - name: Publish GitHub Release
+        if: steps.exists.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.ver.outputs.version }}
+          name: v${{ steps.ver.outputs.version }}
+          files: build/stratawp-seo.zip
+          generate_release_notes: true
+          make_latest: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # StrataWP SEO
 
+<p align="center">
+  <a href="https://github.com/JonImmsWordpressDev/stratawp-seo/releases/latest/download/stratawp-seo.zip">
+    <img alt="Download the plugin (latest release)" src="https://img.shields.io/badge/⬇%20Download%20the%20plugin-Install%20on%20WordPress-10b981?style=for-the-badge&labelColor=059669" />
+  </a>
+</p>
+
+<p align="center">
+  <sub>One-click download of the latest production-ready zip. Always points to the most recent release —
+  rebuilt automatically on every push.</sub>
+</p>
+
+<p align="center">
+  <a href="https://github.com/JonImmsWordpressDev/stratawp-seo/releases">All releases</a> ·
+  <a href="#installation">Install instructions</a> ·
+  <a href="#how-to-guide-page-by-page">How-to guide</a>
+</p>
+
+---
+
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
 [![Version](https://img.shields.io/badge/version-4.2.2-blue.svg)]()

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # StrataWP SEO
 
-**AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, and a per-post meta editor — on autopilot or on demand.
+**AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.1.7-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.2.2-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -166,6 +166,46 @@ It's designed to **replace** Yoast/RankMath/AIOSEO if you want to, or **coexist*
 - **One-click apply** — only accepted edits are applied; the post is automatically re-scored after
 - **Threshold control** — surface only posts below your score floor (default 75)
 - **Per-row dismiss** — hide posts you don't want optimized
+
+### Local SEO (v4.2) ★
+
+- **30+ business types** — LocalBusiness, Restaurant, Plumber, Dentist, Hotel, RealEstateAgent, Attorney, AccountingService, BeautySalon, etc.
+- **NAP fields** — name, address (street/city/region/postal/country), phone, email, price range
+- **Opening hours per day** — 24-hour-format inputs, with a "Closed" tick for off-days
+- **Geo coordinates** — latitude/longitude for `GeoCoordinates` schema
+- **Area served** — newline-separated list of cities/regions for service-area businesses (plumbers, electricians)
+- **Google Place ID** — emits a `hasMap` link when set
+- **LocalBusiness JSON-LD** on the homepage with `OpeningHoursSpecification`, `PostalAddress`, `GeoCoordinates`, and the existing `swps_schema_logo` + `swps_schema_social_profiles` woven in as `image`/`logo`/`sameAs`
+- **Schema preview** — live JSON-LD preview on the settings page so you can validate before publishing
+- **Coexists with Yoast / RankMath / AIOSEO** — defers automatically when those plugins are active
+
+### Image SEO (v4.2) ★
+
+- **Auto-alt on upload** — heuristic mode (free, instant — derives alt from filename + parent post title) or AI mode (uses your configured AI provider for a one-line description; falls back to heuristic on error)
+- **Filename sanitization** — strips device prefixes (`IMG_`, `DSC_`, `Screenshot`), lowercases, dash-separates, on the way into the Media Library
+- **Lazy-loading enforcement** — adds `loading="lazy" decoding="async"` to any post-content `<img>` still missing it
+- **Bulk fix tool** — page-level button that processes the existing library in 20-image AJAX batches with live progress
+- **Stats tiles** — total images, missing alt, % covered
+
+### Crawlers & Files (v4.2) ★
+
+- **Edit /llms.txt** — toggle between **Auto** (StrataWP-generated default built from posts/pages/categories) and **Custom** (paste your own markdown, served verbatim)
+- **Edit /robots.txt** — toggle between **Auto** (WP default + AI-bot allow/disallow), **Append** (auto + your extra rules), or **Replace** (your content only)
+- **Side-by-side editor + preview** — write your version on the left, see the auto-generated default on the right; one-click "copy auto into editor" to use the default as a starting point
+- **Physical-file warning** — detects `robots.txt` in the site root and warns that it overrides the dynamic version
+- **Hooks into the existing pipeline** — custom mode rides the existing `swps_llms_txt_content` filter; robots filter runs at priority 200 so AI-bot rules added at priority 100 are preserved in Append mode
+
+### Backlinks (v4.2) ★
+
+- **Manual + CSV import** — add backlinks one at a time, or paste/upload a CSV (one URL per line, source/target/anchor CSV, or Google Search Console "Top linking sites" export — all auto-detected)
+- **Daily health monitoring** — WP-cron re-fetches every source page once a day, parses anchors, classifies as **Live** / **Lost** / **Broken** (HTTP error)
+- **Real anchor text + first/last seen** — captured on every successful verify
+- **AJAX bulk verify** — "Verify all" runs in 25-row batches with live progress
+- **Per-row re-verify and delete**
+- **CSV export** — full table export for offline analysis or to import into another tool
+- **Stats tiles** — total tracked, live, lost, broken, +30d gained, 30d lost, unique referring domains
+- **Dashboard widget** — live count + 3 most-recently-verified backlinks with status pills
+- **No paid index required** — tracks links you give it; pair with the GSC "Top linking sites" CSV for a real-world starting set
 
 ### Competitor Watch (v4.1) ★
 
@@ -661,6 +701,90 @@ Tracks competitor sites for content velocity, schema diff, title/H1 changes.
 
 **Limit:** 10 competitors. **Storage:** last 12 snapshots per competitor (~12 days of daily history). **Out of scope:** keyword-gap analysis (needs paid backlink API).
 
+### Local SEO (`SEO → Local SEO`) ★ v4.2
+
+LocalBusiness JSON-LD output for brick-and-mortar and service-area sites. Lives at `admin.php?page=swps-local-seo`.
+
+**How to use it:**
+1. Tick **Enable Local SEO schema output** at the top of the page. Schema only emits when this is on AND a business name + city are filled.
+2. Pick the most specific **Business type** that matches your business — Restaurant, Plumber, Dentist, Hotel, etc. (defaults to generic LocalBusiness). The picker covers 30+ schema.org sub-types.
+3. Fill **Business identity**: name, phone, email, price range (`$`/`$$`/`$$$`/`$$$$` or a range like `$10-30`).
+4. Fill **Address** fields: street, city, state/region, postal code, country (two-letter ISO preferred — `US`, `GB`, `AU`).
+5. **Map & geo (optional but recommended for ranking):** open Google Maps, right-click your location, click the lat/lng to copy, paste into the Latitude/Longitude fields. Optionally paste your **Google Place ID** to emit a `hasMap` link.
+6. **Opening hours:** for each day, set Open and Close in 24-hour format (`09:00`, `17:30`), or tick **Closed** for off-days. Days without hours are omitted from the schema.
+7. **Area served** (service-area businesses): paste one city/region per line, up to 25.
+8. Click **Save**. A **Schema preview** card renders at the bottom showing the exact JSON-LD that will be injected into your homepage `<head>`.
+9. Verify the live output with Google's [Rich Results Test](https://search.google.com/test/rich-results) once the homepage is published.
+
+**Coexistence:** if Yoast / RankMath / AIOSEO are active, StrataWP defers all schema output to them — turn this off and use their LocalBusiness panel instead.
+
+### Image SEO (`SEO → Image SEO`) ★ v4.2
+
+Auto-fills missing alt text, sanitizes filenames on upload, and enforces lazy-loading. Lives at `admin.php?page=swps-image-seo`.
+
+**How to use it:**
+1. Open the page — the **stats tiles** at the top show total library size, count missing alt text, % covered, and current auto-alt mode.
+2. **Bulk fix existing library:** click the **Fix missing alt text** button to write alt for every image that doesn't have any. Runs in 20-image batches via AJAX so you can leave the tab open while it works. Uses the auto-alt mode you have selected below.
+3. **Auto-alt on upload** card:
+   - Tick **Generate alt text automatically when an image is uploaded** to enable.
+   - Pick **Heuristic** (free, instant — derives alt from filename + parent post title) or **AI** (sends filename + post context to your configured AI provider for a one-line description; falls back to heuristic on error or quota).
+4. **Filename sanitization** card: tick to clean filenames on upload — `IMG_4523 Vacation.JPG` becomes `vacation.jpg`. Strips device prefixes (`IMG_`, `DSC_`, `DSCN`, `Screenshot`, etc.).
+5. **Lazy loading** card: tick to add `loading="lazy" decoding="async"` to any post-content `<img>` still missing those attributes. Improves Core Web Vitals.
+6. Click **Save Image SEO settings**.
+
+**Tips:** AI mode costs a fraction of a cent per image (one short call to your configured provider). For most sites, Heuristic mode is plenty good — it's especially strong when your filenames already have meaningful slugs (e.g. `seo-checklist-2026.jpg`).
+
+### Crawlers & Files (`SEO → Crawlers & Files`) ★ v4.2
+
+Edits the dynamic `/llms.txt` and `/robots.txt` files served by your site. Lives at `admin.php?page=swps-crawl-files`.
+
+**How to use the /llms.txt editor:**
+1. Pick a **mode**:
+   - **Auto** — serve the StrataWP-generated default (built from your most recent 100 posts, top-level pages, and busiest 20 categories with one-line summaries). This is the recommended default.
+   - **Custom** — serve the markdown you paste below, verbatim.
+2. The page shows two textareas side-by-side: **Your llms.txt** (editable) on the left and **Auto preview** (read-only) on the right.
+3. Click **↑ Copy auto-generated content into the editor** to start from the auto version, then tweak.
+4. Save — visit `/llms.txt` or click **View /llms.txt** in the page header to confirm.
+
+**How to use the /robots.txt editor:**
+1. If a physical `robots.txt` exists in your site root, you'll see a warning — that file always overrides the WordPress dynamic version. Delete it to use the editor.
+2. Pick a **mode**:
+   - **Auto** — what WordPress would normally serve, plus the AI-bot Allow/Disallow rules StrataWP adds.
+   - **Append** — Auto + your extra rules (good for adding `Disallow: /private/` or extra `Sitemap:` entries).
+   - **Replace** — serve only your content (full manual control — be careful, since this skips the AI-bot rules).
+3. Edit your version on the left; auto preview is on the right; "copy auto into editor" works the same way.
+4. Save — visit `/robots.txt` or click **View /robots.txt** to confirm.
+
+**Tip:** Append mode is the safest middle ground for most sites — keeps the StrataWP-managed AI bot allowlist intact while letting you add custom rules.
+
+### Backlinks (`Insights → Backlinks`) ★ v4.2
+
+Tracks pages that link to your site, with daily health monitoring. Lives at `admin.php?page=swps-backlinks`. No paid backlink index required.
+
+**How to seed your initial list:**
+- **Option A — manual:** use the **Add backlink** form. Paste the source URL (the page linking to you), optionally the target URL on your site and the anchor text, then click **Add & verify**. The page is fetched immediately so you see Live/Lost/Broken right away.
+- **Option B — CSV import (recommended):**
+  1. Go to Google Search Console → **Links** → **Top linking sites** → click the export button → save as CSV.
+  2. In the **Bulk import** card, paste the CSV (or just one URL per line) into the textarea.
+  3. Click **Import**. Existing source URLs are skipped automatically. The page reloads with the new rows pending verification.
+  4. Click **Verify all** in the page header to fetch every imported row in 25-row AJAX batches.
+
+**How rows get classified:**
+- **Live** (green) — page loaded and contains at least one `<a href="...">` whose href hostname matches yours
+- **Lost** (amber) — page loaded fine but no link to your site is on it any more
+- **Broken** (red) — page returned an HTTP error (4xx/5xx) or timed out; the HTTP code shows in the pill
+
+**Daily routine:**
+- A WP-cron job (`swps_backlinks_daily_verify`) re-checks every backlink once per day with 250ms politeness delays between requests
+- Anchor text + first/last-seen dates update automatically when a link is found
+- Use the **Lost** count as a link-reclamation list — those are sites that used to link to you and now don't
+
+**Per-row controls:** ⟳ re-verifies one row immediately; ✕ deletes it (history is gone — use Export CSV first if you want a backup).
+
+**Export:** the **Export CSV** button in the page header downloads everything (source, target, anchor, status, http code, first seen, last seen, last checked) — useful for offline analysis or migrating to another tool.
+
+**What this is NOT:** this does not *discover* new backlinks (no paid web index). It tracks the list you give it. To discover new ones, paste the GSC export periodically — that's GSC's view of who links to you.
+
 ### Settings (`System → Settings`)
 
 The control panel — split into tabs:
@@ -833,6 +957,12 @@ The plugin handles model-specific quirks automatically — for example, Claude 4
 | Internal Links | `swps-internal-links` | Link suggestions admin |
 | Sitemaps | `swps-sitemaps` | Sitemap status + IndexNow ping |
 | Redirects | `swps-redirects` | Redirect manager + 404 log |
+| Auto-Optimize | `swps-auto-optimize` | Re-score + AI proposals for low-scoring posts |
+| Competitors | `swps-competitors` | Competitor site tracker (RSS/sitemap diff) |
+| Local SEO | `swps-local-seo` | LocalBusiness JSON-LD: NAP, hours, geo, area served |
+| Image SEO | `swps-image-seo` | Auto-alt, filename sanitization, lazy-load, bulk fix |
+| Crawlers & Files | `swps-crawl-files` | Edit `/llms.txt` and `/robots.txt` (auto/custom modes) |
+| Backlinks | `swps-backlinks` | Manual + CSV-import backlink tracker with daily verify |
 | Debug | `swps-debug` | Last failed AI response (raw + cleaned) |
 
 ---
@@ -1075,9 +1205,37 @@ Two things: (1) writes `Allow: /` rules in robots.txt for the AI bots you've che
 
 Click **Sitemaps → Ping Search Engines** and the plugin submits your 50 most recently modified posts to `api.indexnow.org`. Bing, Yandex, and Seznam pick these up within minutes — and Bing's IndexNow feed is what powers ChatGPT's web search.
 
+### Do I need a paid Ahrefs or Moz account to use Backlinks?
+
+No. The Backlinks page tracks the links you provide it (manually or via CSV) and re-checks them daily. Pair it with the Google Search Console "Top linking sites" CSV export to seed a real-world list — that's GSC's view of who links to you, free. A direct paid-partner integration (Ahrefs/Moz/SE Ranking) is on the roadmap for a future release.
+
+### How does Local SEO interact with my existing schema settings?
+
+The Organization/Person schema configured under **System → Settings → Schema** (name, logo, social profiles) keeps emitting on the homepage. The new LocalBusiness schema is a *separate* JSON-LD block, but it reuses your existing logo (`swps_schema_logo`) as the `image`/`logo` property and your social profiles (`swps_schema_social_profiles`) as the `sameAs` property — so you don't have to re-enter that data. If Yoast/RankMath/AIOSEO is active, both blocks defer.
+
+### What's the difference between Image SEO's Heuristic and AI alt modes?
+
+Heuristic is free and instant — it derives alt text from the image filename plus the parent post's title (e.g. an image called `seo-checklist-2026.jpg` attached to a post titled "10 Steps to Better SEO" gets reasonable alt text without any API call). AI mode sends filename + parent context to your configured AI provider for a one-line description; it costs a fraction of a cent per image and is most useful when filenames are device-camera junk like `IMG_4523.JPG`. AI mode automatically falls back to Heuristic on error or quota.
+
+### Will editing /robots.txt in Crawlers & Files break the AI-bot allowlist?
+
+Only if you choose **Replace** mode — that serves your content verbatim with no auto rules. **Append** mode preserves everything (the WP defaults plus the StrataWP-managed AI-bot Allow/Disallow block) and adds your custom rules underneath. Use Append unless you have a specific reason to fully take over.
+
 ---
 
 ## Changelog
+
+### 4.2.2
+- **Backlinks (Insights → Backlinks):** new manual + CSV-import backlink tracker. Custom DB table, daily WP-cron health verification (live/lost/broken), AJAX bulk-verify with 25-row batches, per-row re-verify and delete, CSV import (auto-detects Google Search Console "Top linking sites" exports), CSV export, dashboard tile + recent-activity list. Replaces the previous "coming soon" placeholder with a real, working feature.
+
+### 4.2.1
+- **Crawlers & Files (SEO → Crawlers & Files):** new page to edit `/llms.txt` (Auto / Custom modes) and `/robots.txt` (Auto / Append / Replace modes) directly from the admin. Side-by-side editor + auto preview, one-click "copy auto into editor", warning when a physical robots.txt would override the dynamic version.
+
+### 4.2.0
+- **Local SEO (SEO → Local SEO):** LocalBusiness JSON-LD output for brick-and-mortar and service-area sites. 30+ business types (Restaurant, Plumber, Dentist, Hotel, etc.), full NAP fields, opening hours per day, geo coordinates, area served, Google Place ID. Live schema preview. Defers to Yoast/RankMath/AIOSEO when active.
+- **Image SEO (SEO → Image SEO):** auto-alt on upload (Heuristic free mode or AI mode using the configured provider), device-prefix-stripping filename sanitization, lazy-loading enforcement on `the_content`, bulk-fix tool for the existing media library with batched AJAX progress, library coverage stats.
+- **Modules registry:** Local SEO and Image SEO unlocked with NEW badges; Backlinks added as a "soon" entry; WooCommerce SEO retained as the only remaining "soon" module.
+- **Dashboard:** backlinks tiles updated to honest framing ("BYO API key" / "integration in development") prior to 4.2.2 lighting them up with live data.
 
 ### 4.1.7
 - **Critical fix:** moved `swps_render_optimize_row()` and `swps_render_competitor_row()` declarations to the top of their templates. PHP doesn't hoist conditionally-declared functions, so calling them from the queue/list loop before the `if ( ! function_exists() )` block ran was a fatal once any post had a cached score. Fixes "There has been a critical error" on Auto-Optimize and Competitors pages.

--- a/admin/css/pages/backlinks.css
+++ b/admin/css/pages/backlinks.css
@@ -1,0 +1,103 @@
+/* Backlinks page. */
+
+.swps-bl-stats {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
+    margin-bottom: 16px;
+}
+@media (max-width: 1100px) { .swps-bl-stats { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 600px)  { .swps-bl-stats { grid-template-columns: 1fr; } }
+
+.swps-bl-tools {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+@media (max-width: 1100px) { .swps-bl-tools { grid-template-columns: 1fr; } }
+
+.swps-bl-tools .swps-card,
+.swps-bl-table-card {
+    background: var(--swps-surface, #fff);
+    border: 1px solid var(--swps-border, #e2e4e9);
+    border-radius: 10px;
+    padding: 18px 20px;
+}
+.swps-bl-tools .swps-card h2,
+.swps-bl-table-card h2 {
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    color: var(--swps-text-muted, #6b7280);
+}
+
+.swps-bl-add-form {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px 12px;
+    align-items: end;
+}
+.swps-bl-add-form > button { grid-column: span 2; justify-self: start; }
+
+.swps-bl-field { display: flex; flex-direction: column; gap: 4px; }
+.swps-bl-field span {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    color: var(--swps-text-muted, #6b7280);
+    font-weight: 600;
+}
+.swps-bl-field input { width: 100%; }
+.swps-bl-field em { font-style: normal; color: var(--swps-text-faint, #9ca3af); font-weight: 400; }
+
+.swps-bl-import-area {
+    width: 100%;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12.5px;
+    background: var(--swps-surface-2, #0f1115);
+    color: var(--swps-text, #e7e9ee);
+    border: 1px solid var(--swps-border, #2a2e36);
+    border-radius: 6px;
+    padding: 10px 12px;
+    resize: vertical;
+}
+
+.swps-bl-table-card { margin-top: 8px; }
+.swps-bl-table-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+.swps-bl-progress {
+    font-size: 12px;
+    color: var(--swps-text-muted, #6b7280);
+}
+
+.swps-bl-table { margin-top: 4px; }
+.swps-bl-table th, .swps-bl-table td { vertical-align: top; padding: 10px 8px; }
+.swps-bl-table tr.is-pulsing { opacity: .55; transition: opacity .2s; }
+
+.swps-bl-status {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+}
+.swps-bl-status small { font-weight: 400; opacity: .8; margin-left: 2px; }
+.swps-bl-status.is-live    { background: rgba(16,185,129,.15); color: #059669; }
+.swps-bl-status.is-lost    { background: rgba(245,158,11,.15); color: #b45309; }
+.swps-bl-status.is-broken  { background: rgba(239,68,68,.15);  color: #b91c1c; }
+.swps-bl-status.is-pending { background: rgba(107,114,128,.15); color: #4b5563; }
+
+.swps-bl-verify, .swps-bl-delete {
+    text-decoration: none;
+    font-size: 14px;
+    line-height: 1;
+    margin-left: 6px;
+    cursor: pointer;
+}

--- a/admin/css/pages/crawl-files.css
+++ b/admin/css/pages/crawl-files.css
@@ -1,0 +1,68 @@
+/* Crawlers & Files page — side-by-side editor + auto preview. */
+
+.swps-crawl-files-form .swps-card,
+.swps-crawl-card {
+    background: var(--swps-surface, #fff);
+    border: 1px solid var(--swps-border, #e2e4e9);
+    border-radius: 10px;
+    padding: 18px 20px;
+}
+
+.swps-crawl-card-head h2 {
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: none;
+    color: var(--swps-text, inherit);
+}
+
+.swps-crawl-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+}
+
+@media (max-width: 1100px) {
+    .swps-crawl-grid { grid-template-columns: 1fr; }
+}
+
+.swps-crawl-col {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.swps-crawl-col-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    color: var(--swps-text-muted, #6b7280);
+}
+
+.swps-crawl-textarea {
+    width: 100%;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12.5px;
+    line-height: 1.55;
+    background: var(--swps-surface-2, #0f1115);
+    color: var(--swps-text, #e7e9ee);
+    border: 1px solid var(--swps-border, #2a2e36);
+    border-radius: 6px;
+    padding: 10px 12px;
+    resize: vertical;
+}
+
+.swps-crawl-textarea.is-readonly {
+    background: var(--swps-surface-3, #1a1c22);
+    color: var(--swps-text-muted, #9ca3af);
+}
+
+.swps-crawl-copy-default {
+    align-self: flex-start;
+    font-size: 12px;
+    color: var(--swps-accent-1, #3b82f6);
+    text-decoration: none;
+    cursor: pointer;
+}
+.swps-crawl-copy-default:hover { text-decoration: underline; }

--- a/admin/css/pages/image-seo.css
+++ b/admin/css/pages/image-seo.css
@@ -1,0 +1,30 @@
+/* Image SEO settings page. */
+
+.swps-image-seo-stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+@media (max-width: 900px) {
+    .swps-image-seo-stats { grid-template-columns: 1fr; }
+}
+
+.swps-image-seo-form .swps-card,
+.swps-card {
+    background: var(--swps-surface, #fff);
+    border: 1px solid var(--swps-border, #e2e4e9);
+    border-radius: 10px;
+    padding: 18px 20px;
+}
+
+.swps-image-seo-form .swps-card h2,
+.swps-card > h2:first-child {
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: .02em;
+    text-transform: uppercase;
+    color: var(--swps-text-muted, #6b7280);
+    margin-bottom: 12px;
+}

--- a/admin/css/pages/local-seo.css
+++ b/admin/css/pages/local-seo.css
@@ -1,0 +1,26 @@
+/* Local SEO settings page — minimal overrides on top of components/templates. */
+
+.swps-local-seo-form .swps-card {
+    background: var(--swps-surface, #fff);
+    border: 1px solid var(--swps-border, #e2e4e9);
+    border-radius: 10px;
+    padding: 18px 20px;
+}
+
+.swps-local-seo-form .swps-card h2 {
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: .02em;
+    text-transform: uppercase;
+    color: var(--swps-text-muted, #6b7280);
+    margin-bottom: 12px;
+}
+
+.swps-local-seo-form .form-table th {
+    width: 200px;
+}
+
+.swps-local-seo-form input[type="time"] {
+    padding: 4px 6px;
+    font-family: inherit;
+}

--- a/admin/js/backlinks.js
+++ b/admin/js/backlinks.js
@@ -1,0 +1,184 @@
+/* global jQuery, swpsBacklinks */
+(function ($) {
+    'use strict';
+
+    var i18n = swpsBacklinks.i18n;
+
+    function setStats(stats) {
+        if (!stats) return;
+        $('#swps-bl-stat-total').text((stats.total || 0).toLocaleString());
+        $('#swps-bl-stat-live').text((stats.live || 0).toLocaleString());
+        $('#swps-bl-stat-lost').text((stats.lost || 0).toLocaleString());
+        $('#swps-bl-stat-broken').text((stats.broken || 0).toLocaleString());
+    }
+
+    function statusPill(row) {
+        var cls = 'is-' + row.status;
+        var label = row.status.charAt(0).toUpperCase() + row.status.slice(1);
+        var http = (row.status === 'broken' && row.http_status > 0)
+            ? ' <small>(' + row.http_status + ')</small>'
+            : '';
+        return '<span class="swps-bl-status ' + cls + '">' + label + http + '</span>';
+    }
+
+    function escapeHtml(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function renderRow(row) {
+        var $existing = $('#swps-bl-tbody tr[data-id="' + row.id + '"]');
+        var html = '' +
+            '<td>' + statusPill(row) + '</td>' +
+            '<td><a href="' + escapeHtml(row.source_url) + '" target="_blank" rel="noopener">' +
+                escapeHtml(row.source_host || row.source_url) + '</a>' +
+                (row.notes ? '<div style="font-size:11px;color:var(--swps-text-muted);margin-top:2px">' + escapeHtml(row.notes) + '</div>' : '') +
+            '</td>' +
+            '<td><span style="font-size:12px">' + (row.anchor_text ? escapeHtml(row.anchor_text) : '<span style="color:var(--swps-text-faint)">—</span>') + '</span></td>' +
+            '<td>' + (row.target_url
+                ? '<a href="' + escapeHtml(row.target_url) + '" target="_blank" rel="noopener" style="font-size:12px">' + escapeHtml(row.target_url.replace(/^https?:\/\/[^\/]+/, '') || row.target_url) + '</a>'
+                : '<span style="color:var(--swps-text-faint);font-size:12px">—</span>') + '</td>' +
+            '<td style="font-size:12px;color:var(--swps-text-muted)">' + (row.first_seen ? row.first_seen.slice(0, 10) : '—') + '</td>' +
+            '<td style="font-size:12px;color:var(--swps-text-muted)">' + (row.last_checked ? 'just now' : 'never') + '</td>' +
+            '<td style="text-align:right;white-space:nowrap">' +
+                '<button type="button" class="button-link swps-bl-verify" title="Re-verify">⟳</button>' +
+                '<button type="button" class="button-link swps-bl-delete" title="Delete" style="color:#ef4444">✕</button>' +
+            '</td>';
+
+        if ($existing.length) {
+            $existing.html(html).removeClass('is-pulsing');
+        } else {
+            var $tbody = $('#swps-bl-tbody');
+            if (!$tbody.length) {
+                window.location.reload();
+                return;
+            }
+            $tbody.prepend('<tr data-id="' + row.id + '">' + html + '</tr>');
+        }
+    }
+
+    // Add backlink
+    $('#swps-bl-add').on('submit', function (e) {
+        e.preventDefault();
+        var $form   = $(this);
+        var $status = $form.find('.swps-bl-add-status');
+        var data    = {
+            action:      'swps_backlink_save',
+            nonce:       swpsBacklinks.nonce,
+            source_url:  $form.find('[name=source_url]').val(),
+            target_url:  $form.find('[name=target_url]').val(),
+            anchor_text: $form.find('[name=anchor_text]').val()
+        };
+        $status.text(i18n.saving);
+        $.post(swpsBacklinks.ajaxUrl, data).then(function (resp) {
+            if (resp && resp.success) {
+                $status.text('');
+                if (resp.data.row) renderRow(resp.data.row);
+                setStats(resp.data.stats);
+                $form[0].reset();
+            } else {
+                $status.text((resp && resp.data && resp.data.message) || i18n.failed);
+            }
+        }).fail(function () { $status.text(i18n.failed); });
+    });
+
+    // Import
+    $('#swps-bl-import').on('submit', function (e) {
+        e.preventDefault();
+        var $form   = $(this);
+        var $status = $form.find('.swps-bl-import-status');
+        var csv     = $form.find('[name=csv]').val();
+        if (!csv) return;
+        $status.text(i18n.importing);
+        $.post(swpsBacklinks.ajaxUrl, {
+            action: 'swps_backlink_import',
+            nonce:  swpsBacklinks.nonce,
+            csv:    csv
+        }).then(function (resp) {
+            if (resp && resp.success) {
+                var n = resp.data.imported || 0;
+                $status.text(n > 0 ? i18n.imported.replace('%d', n) : i18n.noNewLinks);
+                setStats(resp.data.stats);
+                if (n > 0) setTimeout(function () { window.location.reload(); }, 800);
+            } else {
+                $status.text((resp && resp.data && resp.data.message) || i18n.failed);
+            }
+        }).fail(function () { $status.text(i18n.failed); });
+    });
+
+    // Delete + verify (delegated)
+    $('#swps-bl-tbody').on('click', '.swps-bl-delete', function () {
+        if (!window.confirm(i18n.confirmDelete)) return;
+        var $tr = $(this).closest('tr');
+        var id  = $tr.data('id');
+        $tr.addClass('is-pulsing');
+        $.post(swpsBacklinks.ajaxUrl, {
+            action: 'swps_backlink_delete',
+            nonce:  swpsBacklinks.nonce,
+            id:     id
+        }).then(function (resp) {
+            if (resp && resp.success) {
+                $tr.fadeOut(150, function () { $tr.remove(); });
+                setStats(resp.data.stats);
+            } else {
+                $tr.removeClass('is-pulsing');
+            }
+        }).fail(function () { $tr.removeClass('is-pulsing'); });
+    });
+
+    $('#swps-bl-tbody').on('click', '.swps-bl-verify', function () {
+        var $tr = $(this).closest('tr');
+        var id  = $tr.data('id');
+        $tr.addClass('is-pulsing');
+        $.post(swpsBacklinks.ajaxUrl, {
+            action: 'swps_backlink_verify',
+            nonce:  swpsBacklinks.nonce,
+            id:     id
+        }).then(function (resp) {
+            if (resp && resp.success && resp.data.row) {
+                renderRow(resp.data.row);
+                setStats(resp.data.stats);
+            } else {
+                $tr.removeClass('is-pulsing');
+            }
+        }).fail(function () { $tr.removeClass('is-pulsing'); });
+    });
+
+    // Verify all
+    $('#swps-bl-verify-all').on('click', function (e) {
+        e.preventDefault();
+        var $btn      = $(this);
+        var $progress = $('#swps-bl-progress').removeAttr('hidden');
+        $btn.prop('disabled', true);
+
+        function runFrom(offset) {
+            $progress.find('span').text(i18n.verifyingAll + ' (offset ' + offset + ')');
+            return $.post(swpsBacklinks.ajaxUrl, {
+                action: 'swps_backlink_verify',
+                nonce:  swpsBacklinks.nonce,
+                offset: offset
+            }).then(function (resp) {
+                if (!resp || !resp.success) throw new Error(i18n.failed);
+                setStats(resp.data.stats);
+                if (resp.data.processed > 0 && resp.data.remaining > 0) {
+                    return runFrom(resp.data.next);
+                }
+                return resp.data;
+            });
+        }
+
+        runFrom(0)
+            .then(function () {
+                $progress.find('span').text(i18n.verifyingAll + ' — done.');
+                setTimeout(function () { window.location.reload(); }, 800);
+            })
+            .fail(function (err) {
+                $progress.find('span').text((err && err.message) || i18n.failed);
+                $btn.prop('disabled', false);
+            });
+    });
+}(jQuery));

--- a/admin/js/image-seo.js
+++ b/admin/js/image-seo.js
@@ -1,0 +1,56 @@
+/* global jQuery, swpsImageSeo */
+(function ($) {
+    'use strict';
+
+    var BATCH_SIZE = 20;
+    var $btn      = $('#swps-img-bulk-fix');
+    var $status   = $('#swps-img-status');
+    var $missing  = $('#swps-img-missing');
+
+    if (!$btn.length) return;
+
+    function setStatus(msg) {
+        $status.text(msg);
+    }
+
+    function fixBatch(totalFixed) {
+        return $.post(swpsImageSeo.ajaxUrl, {
+            action: 'swps_image_seo_fix',
+            nonce:  swpsImageSeo.nonce,
+            batch:  BATCH_SIZE
+        }).then(function (resp) {
+            if (!resp || !resp.success) {
+                throw new Error((resp && resp.data && resp.data.message) || swpsImageSeo.i18n.failed);
+            }
+            var data        = resp.data;
+            var newTotal    = totalFixed + (data.fixed || 0);
+            var remaining   = data.remaining || 0;
+            $missing.text(remaining.toLocaleString());
+
+            if ((data.attempted || 0) === 0 || remaining === 0) {
+                return newTotal;
+            }
+            setStatus(
+                swpsImageSeo.i18n.fixing + ' (' + newTotal + ' fixed, ' + remaining + ' remaining)'
+            );
+            return fixBatch(newTotal);
+        });
+    }
+
+    $btn.on('click', function () {
+        $btn.prop('disabled', true);
+        setStatus(swpsImageSeo.i18n.scanning);
+
+        fixBatch(0)
+            .then(function (totalFixed) {
+                var template = totalFixed === 1 ? swpsImageSeo.i18n.fixedOne : swpsImageSeo.i18n.fixedMany;
+                setStatus(template.replace('%d', totalFixed) + ' ' + swpsImageSeo.i18n.done);
+            })
+            .fail(function (err) {
+                setStatus((err && err.message) ? err.message : swpsImageSeo.i18n.failed);
+            })
+            .always(function () {
+                $btn.prop('disabled', $missing.text() === '0');
+            });
+    });
+}(jQuery));

--- a/includes/class-admin-shell.php
+++ b/includes/class-admin-shell.php
@@ -44,6 +44,10 @@ class SWPS_Admin_Shell {
         'swps-search-console',
         'swps-auto-optimize',
         'swps-competitors',
+        'swps-local-seo',
+        'swps-image-seo',
+        'swps-crawl-files',
+        'swps-backlinks',
     ];
 
     private SWPS_User_Prefs $prefs;
@@ -285,11 +289,15 @@ class SWPS_Admin_Shell {
                 [ 'slug' => 'swps-sitemaps',          'label' => __( 'Sitemaps', 'stratawp-seo' ) ],
                 [ 'slug' => 'swps-redirects',         'label' => __( 'Redirects', 'stratawp-seo' ) ],
                 [ 'slug' => 'swps-internal-links',    'label' => __( 'Internal Links', 'stratawp-seo' ) ],
+                [ 'slug' => 'swps-local-seo',         'label' => __( 'Local SEO', 'stratawp-seo' ),  'badge' => [ 'type' => 'new', 'label' => 'NEW' ] ],
+                [ 'slug' => 'swps-image-seo',         'label' => __( 'Image SEO', 'stratawp-seo' ),  'badge' => [ 'type' => 'new', 'label' => 'NEW' ] ],
+                [ 'slug' => 'swps-crawl-files',       'label' => __( 'Crawlers & Files', 'stratawp-seo' ), 'badge' => [ 'type' => 'new', 'label' => 'NEW' ] ],
             ],
             __( 'Insights', 'stratawp-seo' ) => [
                 [ 'slug' => 'swps-analytics',   'label' => __( 'Analytics', 'stratawp-seo' ) ],
                 [ 'slug' => 'swps-keywords',    'label' => __( 'Keywords', 'stratawp-seo' ) ],
                 [ 'slug' => 'swps-competitors', 'label' => __( 'Competitors', 'stratawp-seo' ), 'badge' => [ 'type' => 'new', 'label' => 'NEW' ] ],
+                [ 'slug' => 'swps-backlinks',   'label' => __( 'Backlinks', 'stratawp-seo' ),   'badge' => [ 'type' => 'new', 'label' => 'NEW' ] ],
             ],
             __( 'System', 'stratawp-seo' ) => [
                 [ 'slug' => 'stratawp-seo', 'label' => __( 'Settings', 'stratawp-seo' ) ],

--- a/includes/class-backlinks.php
+++ b/includes/class-backlinks.php
@@ -1,0 +1,592 @@
+<?php
+/**
+ * Backlinks tracker — manual + CSV-import backlink monitoring.
+ *
+ * Stores user-supplied backlinks in {$wpdb->prefix}swps_backlinks. A daily
+ * cron job re-fetches each source page, looks for any link whose href contains
+ * the site's host, captures anchor text, and updates a status of:
+ *
+ *   live    — found at least one link to this domain on the source page
+ *   lost    — page loaded fine but no link to this domain anywhere on it
+ *   broken  — source page returned an HTTP error (4xx / 5xx) or timed out
+ *
+ * No external paid index — this tracks a list you give it and tells you what
+ * happens to those links over time. Pair with a GSC "Top linking sites" CSV
+ * export to get a real-world starting set.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SWPS_Backlinks {
+
+    public const TABLE         = 'swps_backlinks';
+    public const CRON_HOOK     = 'swps_backlinks_daily_verify';
+    public const HTTP_TIMEOUT  = 12;
+    public const VERIFY_BATCH  = 25;
+    public const DB_VERSION    = '1';
+    public const OPT_DB_VER    = 'swps_backlinks_db_version';
+
+    public function __construct() {
+        // Runtime upgrade: ensure the table exists on existing installs that
+        // didn't run the activation hook (i.e. plugin updated, not reactivated).
+        if ( self::DB_VERSION !== get_option( self::OPT_DB_VER ) ) {
+            self::create_tables();
+            update_option( self::OPT_DB_VER, self::DB_VERSION );
+        }
+
+        add_action( 'admin_menu',            [ $this, 'register_menu' ], 20 );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+        add_action( 'init',                  [ $this, 'maybe_schedule_cron' ] );
+
+        add_action( 'wp_ajax_swps_backlink_save',     [ $this, 'ajax_save' ] );
+        add_action( 'wp_ajax_swps_backlink_delete',   [ $this, 'ajax_delete' ] );
+        add_action( 'wp_ajax_swps_backlink_verify',   [ $this, 'ajax_verify' ] );
+        add_action( 'wp_ajax_swps_backlink_import',   [ $this, 'ajax_import' ] );
+        add_action( 'wp_ajax_swps_backlink_export',   [ $this, 'ajax_export' ] );
+
+        add_action( self::CRON_HOOK, [ $this, 'cron_verify_all' ] );
+    }
+
+    // ---------- Schema ----------
+
+    public static function table_name(): string {
+        global $wpdb;
+        return $wpdb->prefix . self::TABLE;
+    }
+
+    public static function create_tables(): void {
+        global $wpdb;
+        $table   = self::table_name();
+        $charset = $wpdb->get_charset_collate();
+
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            source_url   VARCHAR(2048) NOT NULL,
+            source_host  VARCHAR(255) NOT NULL DEFAULT '',
+            target_url   VARCHAR(2048) NOT NULL DEFAULT '',
+            anchor_text  VARCHAR(500) NOT NULL DEFAULT '',
+            status       VARCHAR(20)  NOT NULL DEFAULT 'pending',
+            http_status  SMALLINT     NOT NULL DEFAULT 0,
+            first_seen   DATETIME     NULL,
+            last_seen    DATETIME     NULL,
+            last_checked DATETIME     NULL,
+            notes        TEXT         NULL,
+            created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            KEY status (status),
+            KEY source_host (source_host),
+            KEY last_checked (last_checked)
+        ) {$charset};";
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta( $sql );
+    }
+
+    public static function schedule_cron(): void {
+        if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+            wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', self::CRON_HOOK );
+        }
+    }
+
+    public static function unschedule_cron(): void {
+        $ts = wp_next_scheduled( self::CRON_HOOK );
+        if ( $ts ) {
+            wp_unschedule_event( $ts, self::CRON_HOOK );
+        }
+        wp_unschedule_hook( self::CRON_HOOK );
+    }
+
+    public function maybe_schedule_cron(): void {
+        self::schedule_cron();
+    }
+
+    // ---------- Admin menu / assets ----------
+
+    public function register_menu(): void {
+        add_submenu_page(
+            'stratawp-seo',
+            __( 'Backlinks', 'stratawp-seo' ),
+            __( 'Backlinks', 'stratawp-seo' ),
+            'manage_options',
+            'swps-backlinks',
+            [ $this, 'render_page' ]
+        );
+    }
+
+    public function render_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
+        }
+        require SWPS_PLUGIN_DIR . 'templates/backlinks-page.php';
+    }
+
+    public function enqueue_assets( string $hook ): void {
+        if ( 'stratawp-seo_page_swps-backlinks' !== $hook ) {
+            return;
+        }
+        wp_enqueue_style(
+            'swps-page-backlinks',
+            SWPS_PLUGIN_URL . 'admin/css/pages/backlinks.css',
+            [ 'swps-tokens', 'swps-components', 'swps-templates' ],
+            SWPS_VERSION
+        );
+        wp_enqueue_script(
+            'swps-backlinks',
+            SWPS_PLUGIN_URL . 'admin/js/backlinks.js',
+            [ 'jquery' ],
+            SWPS_VERSION,
+            true
+        );
+        wp_localize_script( 'swps-backlinks', 'swpsBacklinks', [
+            'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+            'nonce'   => wp_create_nonce( 'swps_nonce' ),
+            'i18n'    => [
+                'verifying'    => __( 'Verifying...', 'stratawp-seo' ),
+                'verifyingAll' => __( 'Verifying all backlinks...', 'stratawp-seo' ),
+                'saving'       => __( 'Saving...', 'stratawp-seo' ),
+                'importing'    => __( 'Importing...', 'stratawp-seo' ),
+                'failed'       => __( 'Request failed.', 'stratawp-seo' ),
+                'invalidUrl'   => __( 'Please enter a valid http(s) URL.', 'stratawp-seo' ),
+                'confirmDelete'=> __( 'Delete this backlink?', 'stratawp-seo' ),
+                'imported'     => __( 'Imported %d backlinks.', 'stratawp-seo' ),
+                'noNewLinks'   => __( 'No new links found in import.', 'stratawp-seo' ),
+            ],
+        ] );
+    }
+
+    // ---------- AJAX ----------
+
+    public function ajax_save(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
+        }
+
+        $id          = isset( $_POST['id'] )          ? (int) $_POST['id'] : 0;
+        $source      = isset( $_POST['source_url'] )  ? esc_url_raw( wp_unslash( $_POST['source_url'] ) ) : '';
+        $target      = isset( $_POST['target_url'] )  ? esc_url_raw( wp_unslash( $_POST['target_url'] ) ) : '';
+        $anchor      = isset( $_POST['anchor_text'] ) ? sanitize_text_field( wp_unslash( $_POST['anchor_text'] ) ) : '';
+
+        if ( '' === $source || ! preg_match( '#^https?://#i', $source ) ) {
+            wp_send_json_error( [ 'message' => __( 'Please enter a valid http(s) URL.', 'stratawp-seo' ) ] );
+        }
+
+        if ( $id > 0 ) {
+            $this->update_row( $id, [
+                'source_url'  => $source,
+                'source_host' => $this->host_of( $source ),
+                'target_url'  => $target,
+                'anchor_text' => $anchor,
+            ] );
+        } else {
+            $id = $this->insert_row( [
+                'source_url'  => $source,
+                'source_host' => $this->host_of( $source ),
+                'target_url'  => $target,
+                'anchor_text' => $anchor,
+                'status'      => 'pending',
+                'created_at'  => current_time( 'mysql' ),
+            ] );
+            if ( ! $id ) {
+                wp_send_json_error( [ 'message' => __( 'Save failed.', 'stratawp-seo' ) ] );
+            }
+        }
+
+        // Verify immediately so the row shows fresh data.
+        $this->verify_one( $id );
+        wp_send_json_success( [ 'row' => $this->get_row( $id ), 'stats' => $this->get_stats() ] );
+    }
+
+    public function ajax_delete(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
+        }
+        $id = isset( $_POST['id'] ) ? (int) $_POST['id'] : 0;
+        if ( $id <= 0 ) {
+            wp_send_json_error( [ 'message' => __( 'Invalid id.', 'stratawp-seo' ) ] );
+        }
+        global $wpdb;
+        $wpdb->delete( self::table_name(), [ 'id' => $id ], [ '%d' ] ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+        wp_send_json_success( [ 'stats' => $this->get_stats() ] );
+    }
+
+    public function ajax_verify(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
+        }
+
+        $id = isset( $_POST['id'] ) ? (int) $_POST['id'] : 0;
+        if ( $id > 0 ) {
+            $this->verify_one( $id );
+            wp_send_json_success( [ 'row' => $this->get_row( $id ), 'stats' => $this->get_stats() ] );
+        }
+
+        if ( function_exists( 'set_time_limit' ) ) {
+            @set_time_limit( 120 );
+        }
+        $offset = isset( $_POST['offset'] ) ? max( 0, (int) $_POST['offset'] ) : 0;
+        $batch  = $this->get_ids_for_verify( $offset, self::VERIFY_BATCH );
+        foreach ( $batch as $row_id ) {
+            $this->verify_one( (int) $row_id );
+        }
+        $remaining = max( 0, $this->count_total() - ( $offset + count( $batch ) ) );
+        wp_send_json_success( [
+            'processed' => count( $batch ),
+            'next'      => $offset + count( $batch ),
+            'remaining' => $remaining,
+            'stats'     => $this->get_stats(),
+        ] );
+    }
+
+    public function ajax_import(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
+        }
+        $raw = isset( $_POST['csv'] ) ? (string) wp_unslash( $_POST['csv'] ) : '';
+        if ( '' === trim( $raw ) ) {
+            wp_send_json_error( [ 'message' => __( 'Nothing to import.', 'stratawp-seo' ) ] );
+        }
+
+        $imported = $this->import_csv( $raw );
+        wp_send_json_success( [
+            'imported' => $imported,
+            'stats'    => $this->get_stats(),
+        ] );
+    }
+
+    public function ajax_export(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Insufficient permissions.', 'stratawp-seo' ) );
+        }
+        $rows = $this->get_all();
+        nocache_headers();
+        header( 'Content-Type: text/csv; charset=utf-8' );
+        header( 'Content-Disposition: attachment; filename="stratawp-backlinks-' . gmdate( 'Y-m-d' ) . '.csv"' );
+
+        $out = fopen( 'php://output', 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+        fputcsv( $out, [ 'source_url', 'target_url', 'anchor_text', 'status', 'http_status', 'first_seen', 'last_seen', 'last_checked' ] );
+        foreach ( $rows as $r ) {
+            fputcsv( $out, [
+                $r['source_url'],
+                $r['target_url'],
+                $r['anchor_text'],
+                $r['status'],
+                $r['http_status'],
+                $r['first_seen'],
+                $r['last_seen'],
+                $r['last_checked'],
+            ] );
+        }
+        fclose( $out ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+        exit;
+    }
+
+    // ---------- CSV ----------
+
+    /**
+     * Import CSV. Accepts either:
+     *   - GSC "Top linking sites" export (single column of source domains)
+     *   - Generic source_url[,target_url[,anchor_text]] CSV
+     *   - One URL per line
+     *
+     * Returns count of newly inserted rows. Existing source_urls are skipped.
+     */
+    public function import_csv( string $raw ): int {
+        $raw   = str_replace( [ "\r\n", "\r" ], "\n", $raw );
+        $lines = array_filter( array_map( 'trim', explode( "\n", $raw ) ) );
+
+        $existing = array_flip( $this->get_all_source_urls() );
+        $count    = 0;
+
+        foreach ( $lines as $i => $line ) {
+            // Skip header rows (first non-URL row).
+            if ( 0 === $i && false === stripos( $line, 'http' ) ) {
+                continue;
+            }
+            $cols = str_getcsv( $line );
+            if ( empty( $cols ) ) {
+                continue;
+            }
+            $source = trim( (string) $cols[0] );
+            if ( '' === $source ) {
+                continue;
+            }
+            // Bare-domain rows from GSC — promote to https://.
+            if ( ! preg_match( '#^https?://#i', $source ) ) {
+                if ( preg_match( '#^[a-z0-9.-]+\.[a-z]{2,}$#i', $source ) ) {
+                    $source = 'https://' . ltrim( $source, '/' );
+                } else {
+                    continue;
+                }
+            }
+            if ( isset( $existing[ $source ] ) ) {
+                continue;
+            }
+            $target = isset( $cols[1] ) ? trim( (string) $cols[1] ) : '';
+            $anchor = isset( $cols[2] ) ? trim( (string) $cols[2] ) : '';
+
+            $id = $this->insert_row( [
+                'source_url'  => esc_url_raw( $source ),
+                'source_host' => $this->host_of( $source ),
+                'target_url'  => $target ? esc_url_raw( $target ) : '',
+                'anchor_text' => sanitize_text_field( $anchor ),
+                'status'      => 'pending',
+                'created_at'  => current_time( 'mysql' ),
+            ] );
+            if ( $id ) {
+                $existing[ $source ] = true;
+                $count++;
+            }
+        }
+        return $count;
+    }
+
+    // ---------- Cron ----------
+
+    public function cron_verify_all(): void {
+        if ( function_exists( 'set_time_limit' ) ) {
+            @set_time_limit( 0 );
+        }
+        $offset = 0;
+        do {
+            $batch = $this->get_ids_for_verify( $offset, self::VERIFY_BATCH );
+            foreach ( $batch as $id ) {
+                $this->verify_one( (int) $id );
+                usleep( 250000 ); // 0.25s — be polite.
+            }
+            $offset += count( $batch );
+        } while ( ! empty( $batch ) );
+    }
+
+    // ---------- Verify ----------
+
+    public function verify_one( int $id ): array {
+        $row = $this->get_row( $id );
+        if ( ! $row ) {
+            return [];
+        }
+
+        $source = (string) $row['source_url'];
+        $now    = current_time( 'mysql' );
+        $resp   = wp_remote_get( $source, [
+            'timeout'     => self::HTTP_TIMEOUT,
+            'redirection' => 4,
+            'user-agent'  => 'StrataWP-SEO/' . SWPS_VERSION . ' (+https://stratawpseo.com; backlink verifier)',
+            'headers'     => [ 'Accept' => 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.8' ],
+        ] );
+
+        $update = [
+            'last_checked' => $now,
+            'http_status'  => 0,
+            'status'       => 'broken',
+            'anchor_text'  => $row['anchor_text'],
+            'target_url'   => $row['target_url'],
+        ];
+
+        if ( is_wp_error( $resp ) ) {
+            $update['notes'] = mb_substr( (string) $resp->get_error_message(), 0, 200 );
+        } else {
+            $code = (int) wp_remote_retrieve_response_code( $resp );
+            $update['http_status'] = $code;
+            if ( $code < 200 || $code >= 400 ) {
+                $update['notes'] = sprintf( /* translators: %d HTTP status */ __( 'HTTP %d', 'stratawp-seo' ), $code );
+            } else {
+                $body  = (string) wp_remote_retrieve_body( $resp );
+                $found = $this->find_link( $body );
+                if ( $found ) {
+                    $update['status']      = 'live';
+                    $update['anchor_text'] = '' !== ( $found['anchor'] ?? '' ) ? $found['anchor'] : $row['anchor_text'];
+                    $update['target_url']  = '' !== ( $found['href'] ?? '' )   ? $found['href']   : $row['target_url'];
+                    $update['notes']       = '';
+                    if ( empty( $row['first_seen'] ) ) {
+                        $update['first_seen'] = $now;
+                    }
+                    $update['last_seen'] = $now;
+                } else {
+                    $update['status'] = 'lost';
+                    $update['notes']  = __( 'Page loaded but contained no link to this site.', 'stratawp-seo' );
+                }
+            }
+        }
+
+        $this->update_row( $id, $update );
+        return $this->get_row( $id );
+    }
+
+    /**
+     * Look for any anchor in $html whose href contains the home host. Returns
+     * the first match's href + anchor text, or null.
+     *
+     * @return array{href:string, anchor:string}|null
+     */
+    private function find_link( string $html ): ?array {
+        $home_host = $this->home_host();
+        if ( '' === $home_host ) {
+            return null;
+        }
+
+        if ( ! preg_match_all( '#<a\b([^>]*?)href\s*=\s*["\']([^"\']+)["\']([^>]*)>(.*?)</a>#is', $html, $m, PREG_SET_ORDER ) ) {
+            return null;
+        }
+
+        foreach ( $m as $match ) {
+            $href = trim( $match[2] );
+            if ( '' === $href ) {
+                continue;
+            }
+            $href_host = $this->host_of( $href );
+            if ( '' !== $href_host && $this->hosts_match( $href_host, $home_host ) ) {
+                $anchor = trim( wp_strip_all_tags( $match[4] ) );
+                if ( mb_strlen( $anchor ) > 200 ) {
+                    $anchor = mb_substr( $anchor, 0, 200 );
+                }
+                return [ 'href' => $href, 'anchor' => $anchor ];
+            }
+        }
+        return null;
+    }
+
+    private function hosts_match( string $a, string $b ): bool {
+        $a = strtolower( preg_replace( '/^www\./i', '', $a ) ?: $a );
+        $b = strtolower( preg_replace( '/^www\./i', '', $b ) ?: $b );
+        return $a === $b;
+    }
+
+    private function host_of( string $url ): string {
+        $h = wp_parse_url( $url, PHP_URL_HOST );
+        return is_string( $h ) ? strtolower( $h ) : '';
+    }
+
+    private function home_host(): string {
+        return $this->host_of( home_url() );
+    }
+
+    // ---------- Storage ----------
+
+    public function insert_row( array $data ): int {
+        global $wpdb;
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+        $wpdb->insert( self::table_name(), $data );
+        return (int) $wpdb->insert_id;
+    }
+
+    public function update_row( int $id, array $data ): void {
+        if ( $id <= 0 || empty( $data ) ) {
+            return;
+        }
+        global $wpdb;
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+        $wpdb->update( self::table_name(), $data, [ 'id' => $id ] );
+    }
+
+    public function get_row( int $id ): ?array {
+        global $wpdb;
+        $table = self::table_name();
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
+        $row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $id ), ARRAY_A );
+        return $row ?: null;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function get_all( string $status_filter = '', string $order_by = 'last_checked DESC' ): array {
+        global $wpdb;
+        $table = self::table_name();
+        $allow = [ 'last_checked DESC', 'last_seen DESC', 'first_seen DESC', 'source_host ASC' ];
+        if ( ! in_array( $order_by, $allow, true ) ) {
+            $order_by = 'last_checked DESC';
+        }
+        if ( '' !== $status_filter ) {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
+            $rows = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE status = %s ORDER BY {$order_by}", $status_filter ), ARRAY_A );
+        } else {
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
+            $rows = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY {$order_by}", ARRAY_A );
+        }
+        return is_array( $rows ) ? $rows : [];
+    }
+
+    public function get_all_source_urls(): array {
+        global $wpdb;
+        $table = self::table_name();
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
+        return array_map( 'strval', (array) $wpdb->get_col( "SELECT source_url FROM {$table}" ) );
+    }
+
+    public function get_ids_for_verify( int $offset, int $limit ): array {
+        global $wpdb;
+        $table = self::table_name();
+        $offset = max( 0, $offset );
+        $limit  = max( 1, min( 100, $limit ) );
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
+        return array_map( 'intval', (array) $wpdb->get_col( $wpdb->prepare(
+            "SELECT id FROM {$table} ORDER BY (last_checked IS NULL) DESC, last_checked ASC LIMIT %d, %d",
+            $offset,
+            $limit
+        ) ) );
+    }
+
+    public function count_total(): int {
+        global $wpdb;
+        $table = self::table_name();
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
+        return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table}" );
+    }
+
+    public function get_stats(): array {
+        global $wpdb;
+        $table = self::table_name();
+        // phpcs:disable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
+        $by_status = $wpdb->get_results( "SELECT status, COUNT(*) AS c FROM {$table} GROUP BY status", ARRAY_A );
+        $stats = [ 'total' => 0, 'live' => 0, 'lost' => 0, 'broken' => 0, 'pending' => 0 ];
+        foreach ( $by_status as $r ) {
+            $key = (string) $r['status'];
+            $stats[ $key ] = (int) $r['c'];
+            $stats['total'] += (int) $r['c'];
+        }
+
+        $now30 = gmdate( 'Y-m-d H:i:s', strtotime( '-30 days' ) ?: time() );
+        $stats['new_30d']  = (int) $wpdb->get_var( $wpdb->prepare(
+            "SELECT COUNT(*) FROM {$table} WHERE first_seen IS NOT NULL AND first_seen >= %s", $now30
+        ) );
+        $stats['lost_30d'] = (int) $wpdb->get_var( $wpdb->prepare(
+            "SELECT COUNT(*) FROM {$table} WHERE status = 'lost' AND last_checked >= %s", $now30
+        ) );
+        $stats['unique_domains'] = (int) $wpdb->get_var( "SELECT COUNT(DISTINCT source_host) FROM {$table} WHERE source_host <> ''" );
+        // phpcs:enable
+
+        return $stats;
+    }
+
+    /**
+     * 3 most-recently-changed backlinks for the dashboard tile.
+     *
+     * @return array<int, array{label:string,url:string,status:string,when:string}>
+     */
+    public function get_dashboard_recent( int $limit = 3 ): array {
+        global $wpdb;
+        $table = self::table_name();
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
+        $rows = $wpdb->get_results( $wpdb->prepare(
+            "SELECT source_host, source_url, status, last_checked FROM {$table} WHERE last_checked IS NOT NULL ORDER BY last_checked DESC LIMIT %d",
+            max( 1, min( 10, $limit ) )
+        ), ARRAY_A );
+        return array_map( static function ( $r ) {
+            return [
+                'label'  => '' !== $r['source_host'] ? $r['source_host'] : $r['source_url'],
+                'url'    => $r['source_url'],
+                'status' => $r['status'],
+                'when'   => $r['last_checked'],
+            ];
+        }, is_array( $rows ) ? $rows : [] );
+    }
+}

--- a/includes/class-crawl-files.php
+++ b/includes/class-crawl-files.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Crawlers & Files — edit /llms.txt and /robots.txt directly inside the plugin.
+ *
+ * Two files, two modes per file:
+ *   llms.txt:    auto (default) | custom (user-written body served verbatim)
+ *   robots.txt:  auto (default) | append (auto + user lines) | replace (user only)
+ *
+ * Hooks into the existing pipeline:
+ *   - llms.txt → filter `swps_llms_txt_content` (added by SWPS_AI_Bots).
+ *   - robots.txt → filter `robots_txt` at priority 200 (after AI-bots writes its
+ *     allow/disallow block at priority 100).
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SWPS_Crawl_Files {
+
+    public const OPT_LLMS_MODE     = 'swps_llms_txt_mode';
+    public const OPT_LLMS_CUSTOM   = 'swps_llms_txt_custom';
+    public const OPT_ROBOTS_MODE   = 'swps_robots_txt_mode';
+    public const OPT_ROBOTS_CUSTOM = 'swps_robots_txt_custom';
+
+    public const MODE_AUTO    = 'auto';
+    public const MODE_CUSTOM  = 'custom';
+    public const MODE_APPEND  = 'append';
+    public const MODE_REPLACE = 'replace';
+
+    public function __construct() {
+        add_action( 'admin_menu',            [ $this, 'register_menu' ], 21 );
+        add_action( 'admin_init',            [ $this, 'register_settings' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+
+        // Edit-on-frontend hooks.
+        add_filter( 'swps_llms_txt_content', [ $this, 'filter_llms_content' ], 100 );
+        add_filter( 'robots_txt',            [ $this, 'filter_robots_txt' ], 200, 2 );
+    }
+
+    public function register_menu(): void {
+        add_submenu_page(
+            'stratawp-seo',
+            __( 'Crawlers & Files', 'stratawp-seo' ),
+            __( 'Crawlers & Files', 'stratawp-seo' ),
+            'manage_options',
+            'swps-crawl-files',
+            [ $this, 'render_page' ]
+        );
+    }
+
+    public function render_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
+        }
+        require SWPS_PLUGIN_DIR . 'templates/crawl-files-page.php';
+    }
+
+    public function enqueue_assets( string $hook ): void {
+        if ( 'stratawp-seo_page_swps-crawl-files' !== $hook ) {
+            return;
+        }
+        wp_enqueue_style(
+            'swps-page-crawl-files',
+            SWPS_PLUGIN_URL . 'admin/css/pages/crawl-files.css',
+            [ 'swps-tokens', 'swps-components', 'swps-templates' ],
+            SWPS_VERSION
+        );
+    }
+
+    public function register_settings(): void {
+        register_setting( 'swps_crawl_files_group', self::OPT_LLMS_MODE, [
+            'type'              => 'string',
+            'sanitize_callback' => [ $this, 'sanitize_llms_mode' ],
+            'default'           => self::MODE_AUTO,
+        ] );
+        register_setting( 'swps_crawl_files_group', self::OPT_LLMS_CUSTOM, [
+            'type'              => 'string',
+            'sanitize_callback' => [ $this, 'sanitize_textfile' ],
+            'default'           => '',
+        ] );
+        register_setting( 'swps_crawl_files_group', self::OPT_ROBOTS_MODE, [
+            'type'              => 'string',
+            'sanitize_callback' => [ $this, 'sanitize_robots_mode' ],
+            'default'           => self::MODE_AUTO,
+        ] );
+        register_setting( 'swps_crawl_files_group', self::OPT_ROBOTS_CUSTOM, [
+            'type'              => 'string',
+            'sanitize_callback' => [ $this, 'sanitize_textfile' ],
+            'default'           => '',
+        ] );
+    }
+
+    public function sanitize_llms_mode( $value ): string {
+        return self::MODE_CUSTOM === $value ? self::MODE_CUSTOM : self::MODE_AUTO;
+    }
+
+    public function sanitize_robots_mode( $value ): string {
+        $value = is_string( $value ) ? $value : '';
+        if ( in_array( $value, [ self::MODE_APPEND, self::MODE_REPLACE ], true ) ) {
+            return $value;
+        }
+        return self::MODE_AUTO;
+    }
+
+    /**
+     * Strip control chars except tab/newline/CR. Capped at 64KB to keep rows sane.
+     */
+    public function sanitize_textfile( $value ): string {
+        if ( ! is_string( $value ) ) {
+            return '';
+        }
+        $value = wp_check_invalid_utf8( $value );
+        $value = preg_replace( "/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/u", '', $value ) ?? '';
+        // Normalize line endings.
+        $value = str_replace( [ "\r\n", "\r" ], "\n", $value );
+        if ( strlen( $value ) > 65536 ) {
+            $value = substr( $value, 0, 65536 );
+        }
+        return $value;
+    }
+
+    // ---------- Public mode/value helpers (used by the template) ----------
+
+    public function get_llms_mode(): string {
+        return self::MODE_CUSTOM === get_option( self::OPT_LLMS_MODE, self::MODE_AUTO ) ? self::MODE_CUSTOM : self::MODE_AUTO;
+    }
+
+    public function get_robots_mode(): string {
+        $mode = (string) get_option( self::OPT_ROBOTS_MODE, self::MODE_AUTO );
+        return in_array( $mode, [ self::MODE_AUTO, self::MODE_APPEND, self::MODE_REPLACE ], true ) ? $mode : self::MODE_AUTO;
+    }
+
+    public function get_llms_custom(): string {
+        return (string) get_option( self::OPT_LLMS_CUSTOM, '' );
+    }
+
+    public function get_robots_custom(): string {
+        return (string) get_option( self::OPT_ROBOTS_CUSTOM, '' );
+    }
+
+    /**
+     * Render the auto llms.txt the way the public endpoint would.
+     */
+    public function render_auto_llms( SWPS_AI_Bots $bots ): string {
+        // Run the bots class generator, but bypass our own custom-mode filter.
+        remove_filter( 'swps_llms_txt_content', [ $this, 'filter_llms_content' ], 100 );
+        $out = $bots->generate_llms_txt();
+        add_filter( 'swps_llms_txt_content', [ $this, 'filter_llms_content' ], 100 );
+        return $out;
+    }
+
+    /**
+     * Render the auto robots.txt by re-running the chain WordPress would,
+     * but skipping our own filter so users see the raw "auto" baseline.
+     */
+    public function render_auto_robots(): string {
+        remove_filter( 'robots_txt', [ $this, 'filter_robots_txt' ], 200 );
+        $public = (int) get_option( 'blog_public' );
+        // Mimic WP core default body, then run filters as core would.
+        if ( 0 === $public ) {
+            $output = "User-agent: *\nDisallow: /\n";
+        } else {
+            $site_url = wp_parse_url( site_url() );
+            $path     = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
+            $output   = "User-agent: *\nDisallow: {$path}/wp-admin/\nAllow: {$path}/wp-admin/admin-ajax.php\n";
+        }
+        $output = (string) apply_filters( 'robots_txt', $output, $public );
+        add_filter( 'robots_txt', [ $this, 'filter_robots_txt' ], 200, 2 );
+        return $output;
+    }
+
+    // ---------- Filters ----------
+
+    public function filter_llms_content( string $content ): string {
+        if ( self::MODE_CUSTOM !== $this->get_llms_mode() ) {
+            return $content;
+        }
+        $custom = trim( $this->get_llms_custom() );
+        if ( '' === $custom ) {
+            return $content;
+        }
+        return rtrim( $custom ) . "\n";
+    }
+
+    public function filter_robots_txt( string $output, $public ): string {
+        if ( ! $public ) {
+            return $output;
+        }
+        $mode   = $this->get_robots_mode();
+        $custom = trim( $this->get_robots_custom() );
+        if ( '' === $custom || self::MODE_AUTO === $mode ) {
+            return $output;
+        }
+
+        if ( self::MODE_REPLACE === $mode ) {
+            return rtrim( $custom ) . "\n";
+        }
+        // append
+        return rtrim( $output ) . "\n\n# Custom — managed by StrataWP SEO\n" . rtrim( $custom ) . "\n";
+    }
+}

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -101,6 +101,7 @@ class SWPS_Dashboard {
             'top_queries'        => $this->safe_get_top_gsc_queries(),
             'auto_optimize_queue' => [], // Phase 7 fills in.
             'competitors'        => $this->safe_get_competitor_summary(),
+            'backlinks'          => $this->safe_get_backlinks_summary(),
             'modules'            => $this->get_modules_for_grid(),
         ];
     }
@@ -260,6 +261,21 @@ class SWPS_Dashboard {
             return $competitors->get_dashboard_summary( 3 );
         } catch ( \Throwable $e ) {
             return [];
+        }
+    }
+
+    private function safe_get_backlinks_summary(): array {
+        try {
+            $bl = stratawp_seo()->backlinks;
+            return [
+                'stats'  => $bl->get_stats(),
+                'recent' => $bl->get_dashboard_recent( 3 ),
+            ];
+        } catch ( \Throwable $e ) {
+            return [
+                'stats'  => [ 'total' => 0, 'live' => 0, 'lost' => 0, 'broken' => 0, 'new_30d' => 0, 'lost_30d' => 0, 'unique_domains' => 0 ],
+                'recent' => [],
+            ];
         }
     }
 

--- a/includes/class-image-seo.php
+++ b/includes/class-image-seo.php
@@ -1,0 +1,413 @@
+<?php
+/**
+ * Image SEO — auto-alt, filename sanitization, lazy-loading enforcement,
+ * and bulk fix for the existing Media Library.
+ *
+ * Auto-alt strategy (v1):
+ *   - Heuristic mode (free): derives alt from the image filename + parent post
+ *     title. Works offline, instant, no provider call.
+ *   - AI mode (optional):    sends filename + parent context to the configured
+ *     SWPS_AI_Provider for a one-line description. Falls back to heuristic on
+ *     error or quota.
+ *
+ * Filenames are sanitized to lowercase-with-dashes on upload (preserves the
+ * original via `_swps_orig_filename` post meta).
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SWPS_Image_SEO {
+
+    public const OPTION_KEY = 'swps_image_seo';
+
+    public function __construct() {
+        add_action( 'admin_menu',            [ $this, 'register_menu' ], 20 );
+        add_action( 'admin_init',            [ $this, 'register_settings' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+
+        $opts = $this->get();
+
+        if ( ! empty( $opts['filename_sanitize'] ) ) {
+            add_filter( 'sanitize_file_name', [ $this, 'filter_filename' ], 20, 2 );
+        }
+
+        if ( ! empty( $opts['auto_alt'] ) ) {
+            add_action( 'add_attachment',          [ $this, 'auto_alt_on_upload' ] );
+            add_filter( 'wp_generate_attachment_metadata', [ $this, 'auto_alt_on_metadata' ], 10, 2 );
+        }
+
+        if ( ! empty( $opts['lazy_load'] ) ) {
+            add_filter( 'the_content', [ $this, 'enforce_lazy_loading' ], 99 );
+        }
+
+        // Bulk fix AJAX.
+        add_action( 'wp_ajax_swps_image_seo_scan',  [ $this, 'ajax_scan' ] );
+        add_action( 'wp_ajax_swps_image_seo_fix',   [ $this, 'ajax_fix' ] );
+    }
+
+    public function register_menu(): void {
+        add_submenu_page(
+            'stratawp-seo',
+            __( 'Image SEO', 'stratawp-seo' ),
+            __( 'Image SEO', 'stratawp-seo' ),
+            'manage_options',
+            'swps-image-seo',
+            [ $this, 'render_page' ]
+        );
+    }
+
+    public function render_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
+        }
+        require SWPS_PLUGIN_DIR . 'templates/image-seo-page.php';
+    }
+
+    public function enqueue_assets( string $hook ): void {
+        if ( 'stratawp-seo_page_swps-image-seo' !== $hook ) {
+            return;
+        }
+        wp_enqueue_style(
+            'swps-page-image-seo',
+            SWPS_PLUGIN_URL . 'admin/css/pages/image-seo.css',
+            [ 'swps-tokens', 'swps-components', 'swps-templates' ],
+            SWPS_VERSION
+        );
+        wp_enqueue_script(
+            'swps-image-seo',
+            SWPS_PLUGIN_URL . 'admin/js/image-seo.js',
+            [ 'jquery' ],
+            SWPS_VERSION,
+            true
+        );
+        wp_localize_script( 'swps-image-seo', 'swpsImageSeo', [
+            'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+            'nonce'   => wp_create_nonce( 'swps_nonce' ),
+            'i18n'    => [
+                'scanning'  => __( 'Scanning library...', 'stratawp-seo' ),
+                'fixing'    => __( 'Generating alt text...', 'stratawp-seo' ),
+                'done'      => __( 'Done.', 'stratawp-seo' ),
+                'failed'    => __( 'Request failed.', 'stratawp-seo' ),
+                'fixedOne'  => __( 'Fixed %d image.', 'stratawp-seo' ),
+                'fixedMany' => __( 'Fixed %d images.', 'stratawp-seo' ),
+            ],
+        ] );
+    }
+
+    // ---------- Settings ----------
+
+    public function register_settings(): void {
+        register_setting(
+            'swps_image_seo_group',
+            self::OPTION_KEY,
+            [
+                'type'              => 'array',
+                'sanitize_callback' => [ $this, 'sanitize' ],
+                'default'           => $this->defaults(),
+            ]
+        );
+    }
+
+    public function defaults(): array {
+        return [
+            'auto_alt'          => 1,
+            'alt_mode'          => 'heuristic', // heuristic | ai
+            'filename_sanitize' => 1,
+            'lazy_load'         => 1,
+        ];
+    }
+
+    public function get(): array {
+        $stored = get_option( self::OPTION_KEY, [] );
+        return wp_parse_args( is_array( $stored ) ? $stored : [], $this->defaults() );
+    }
+
+    public function sanitize( $input ): array {
+        $clean = $this->defaults();
+        if ( ! is_array( $input ) ) {
+            return $clean;
+        }
+        $clean['auto_alt']          = empty( $input['auto_alt'] )          ? 0 : 1;
+        $clean['filename_sanitize'] = empty( $input['filename_sanitize'] ) ? 0 : 1;
+        $clean['lazy_load']         = empty( $input['lazy_load'] )         ? 0 : 1;
+        $clean['alt_mode']          = ( isset( $input['alt_mode'] ) && 'ai' === $input['alt_mode'] ) ? 'ai' : 'heuristic';
+        return $clean;
+    }
+
+    // ---------- Filename sanitization ----------
+
+    /**
+     * Lowercase, dash-separated, strip device-camera prefixes (IMG_, DSC_, etc.).
+     * Keeps the existing WP-sanitized name as a base so we don't fight WP.
+     */
+    public function filter_filename( string $filename, string $original = '' ): string {
+        $info = pathinfo( $filename );
+        $name = $info['filename'] ?? $filename;
+        $ext  = isset( $info['extension'] ) ? '.' . strtolower( $info['extension'] ) : '';
+
+        // Strip common camera-roll prefixes.
+        $name = preg_replace( '/^(img|dsc|dscf|dscn|p\d{0,3}|photo|image|screenshot)[-_ ]+/i', '', (string) $name ) ?: $name;
+        // Lowercase + dash-separate.
+        $name = strtolower( $name );
+        $name = preg_replace( '/[^a-z0-9]+/', '-', $name );
+        $name = trim( (string) $name, '-' );
+        if ( '' === $name ) {
+            $name = 'image';
+        }
+        return $name . $ext;
+    }
+
+    // ---------- Auto-alt ----------
+
+    /**
+     * Hooked on `add_attachment`. Runs only for images. Skips when alt is
+     * already set (e.g., user pasted alt during upload).
+     */
+    public function auto_alt_on_upload( int $attachment_id ): void {
+        if ( ! wp_attachment_is_image( $attachment_id ) ) {
+            return;
+        }
+        $existing = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+        if ( ! empty( $existing ) ) {
+            return;
+        }
+        $alt = $this->generate_alt_for( $attachment_id );
+        if ( '' !== $alt ) {
+            update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt );
+        }
+    }
+
+    /**
+     * Hooked on `wp_generate_attachment_metadata` — covers cases where
+     * `add_attachment` fired before metadata existed (some upload flows).
+     */
+    public function auto_alt_on_metadata( $metadata, int $attachment_id ) {
+        $this->auto_alt_on_upload( $attachment_id );
+        return $metadata;
+    }
+
+    /**
+     * Build an alt string for a single attachment. Public so the bulk tool
+     * and CLI can reuse it.
+     */
+    public function generate_alt_for( int $attachment_id ): string {
+        $opts = $this->get();
+        $mode = $opts['alt_mode'] ?? 'heuristic';
+
+        $context = $this->context_for_attachment( $attachment_id );
+
+        if ( 'ai' === $mode ) {
+            $ai = $this->generate_alt_via_ai( $context );
+            if ( '' !== $ai ) {
+                return $ai;
+            }
+        }
+
+        return $this->generate_alt_heuristic( $context );
+    }
+
+    /**
+     * Filename + parent-post context used by both alt strategies.
+     *
+     * @return array{filename:string, slug_words:string, parent_title:string, post_title:string}
+     */
+    private function context_for_attachment( int $attachment_id ): array {
+        $file = get_attached_file( $attachment_id );
+        $base = $file ? basename( $file ) : '';
+        $slug = $base ? pathinfo( $base, PATHINFO_FILENAME ) : '';
+
+        $post = get_post( $attachment_id );
+
+        $parent_id    = $post && $post->post_parent ? (int) $post->post_parent : 0;
+        $parent_title = $parent_id ? get_the_title( $parent_id ) : '';
+
+        $slug_words = trim( preg_replace( '/[^a-z0-9]+/i', ' ', $slug ) ?: '' );
+
+        return [
+            'filename'     => $base,
+            'slug_words'   => $slug_words,
+            'parent_title' => (string) $parent_title,
+            'post_title'   => (string) ( $post->post_title ?? '' ),
+        ];
+    }
+
+    private function generate_alt_heuristic( array $ctx ): string {
+        $words  = $ctx['slug_words'];
+        $title  = $ctx['post_title'];
+        $parent = $ctx['parent_title'];
+
+        // Prefer the cleanest source: parent title > post title > slug words.
+        $base = '';
+        if ( '' !== $parent ) {
+            $base = $parent;
+        } elseif ( '' !== $title && ! preg_match( '/^image[-_ ]?\d*$/i', $title ) ) {
+            $base = $title;
+        } elseif ( '' !== $words ) {
+            $base = ucfirst( $words );
+        }
+
+        $base = trim( $base );
+        if ( '' === $base ) {
+            return '';
+        }
+
+        // Truncate at word boundary to ~120 chars (Google guidance: keep alts short + descriptive).
+        if ( mb_strlen( $base ) > 120 ) {
+            $base = mb_substr( $base, 0, 120 );
+            $base = preg_replace( '/\s+\S*$/', '', $base ) ?: $base;
+        }
+        return $base;
+    }
+
+    private function generate_alt_via_ai( array $ctx ): string {
+        if ( ! function_exists( 'stratawp_seo' ) ) {
+            return '';
+        }
+        $plugin = stratawp_seo();
+        if ( ! isset( $plugin->api ) || ! ( $plugin->api instanceof SWPS_AI_Provider ) ) {
+            return '';
+        }
+
+        $system = 'You write short, descriptive alt text for images on a WordPress site. '
+                . 'Return ONE concise sentence (10-15 words max), no quotes, no trailing period if it is a noun phrase, '
+                . 'no "image of", no "photo of", and no marketing fluff. Use only what the context gives you.';
+
+        $user = sprintf(
+            "Filename: %s\nFilename words: %s\nParent post title: %s\n\nWrite the alt text:",
+            $ctx['filename'],
+            $ctx['slug_words'],
+            $ctx['parent_title'] ?: '(none)'
+        );
+
+        $resp = $plugin->api->chat( $system, $user, 80 );
+        if ( is_wp_error( $resp ) || ! is_string( $resp ) ) {
+            return '';
+        }
+        $resp = trim( $resp );
+        $resp = trim( $resp, "\"' \t\n\r" );
+        // First line only.
+        if ( false !== ( $nl = strpos( $resp, "\n" ) ) ) {
+            $resp = substr( $resp, 0, $nl );
+        }
+        return $resp;
+    }
+
+    // ---------- Lazy loading ----------
+
+    /**
+     * Belt-and-braces lazy-loading on rendered post content. WP core adds
+     * loading="lazy" automatically since 5.5 for content images, but only
+     * when `width`/`height` are present. This pass adds it to anything
+     * that's still missing.
+     */
+    public function enforce_lazy_loading( string $html ): string {
+        if ( '' === trim( $html ) || false === stripos( $html, '<img' ) ) {
+            return $html;
+        }
+
+        return preg_replace_callback(
+            '/<img\b([^>]*)>/i',
+            static function ( $m ) {
+                $attrs = $m[1];
+                if ( preg_match( '/\bloading\s*=/i', $attrs ) ) {
+                    return $m[0];
+                }
+                return '<img' . $attrs . ' loading="lazy" decoding="async">';
+            },
+            $html
+        ) ?: $html;
+    }
+
+    // ---------- Bulk fix ----------
+
+    /**
+     * Count attachments with missing alt text.
+     */
+    public function get_missing_alt_count(): int {
+        global $wpdb;
+        // phpcs:disable WordPress.DB.DirectDatabaseQuery
+        $sql = "
+            SELECT COUNT(p.ID)
+            FROM {$wpdb->posts} p
+            LEFT JOIN {$wpdb->postmeta} m
+              ON m.post_id = p.ID AND m.meta_key = '_wp_attachment_image_alt'
+            WHERE p.post_type = 'attachment'
+              AND p.post_mime_type LIKE 'image/%'
+              AND ( m.meta_value IS NULL OR m.meta_value = '' )
+        ";
+        return (int) $wpdb->get_var( $sql );
+        // phpcs:enable
+    }
+
+    /**
+     * Get up to $limit attachment IDs missing alt text.
+     *
+     * @return int[]
+     */
+    public function get_missing_alt_ids( int $limit = 25 ): array {
+        global $wpdb;
+        $limit = max( 1, min( 100, $limit ) );
+        // phpcs:disable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
+        $sql = $wpdb->prepare(
+            "
+            SELECT p.ID
+            FROM {$wpdb->posts} p
+            LEFT JOIN {$wpdb->postmeta} m
+              ON m.post_id = p.ID AND m.meta_key = '_wp_attachment_image_alt'
+            WHERE p.post_type = 'attachment'
+              AND p.post_mime_type LIKE 'image/%%'
+              AND ( m.meta_value IS NULL OR m.meta_value = '' )
+            ORDER BY p.ID DESC
+            LIMIT %d
+            ",
+            $limit
+        );
+        return array_map( 'intval', (array) $wpdb->get_col( $sql ) );
+        // phpcs:enable
+    }
+
+    public function ajax_scan(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
+        }
+        global $wpdb;
+        // phpcs:disable WordPress.DB.DirectDatabaseQuery
+        $total = (int) $wpdb->get_var( "
+            SELECT COUNT(*) FROM {$wpdb->posts}
+            WHERE post_type = 'attachment' AND post_mime_type LIKE 'image/%'
+        " );
+        // phpcs:enable
+        wp_send_json_success( [
+            'total'   => $total,
+            'missing' => $this->get_missing_alt_count(),
+        ] );
+    }
+
+    public function ajax_fix(): void {
+        check_ajax_referer( 'swps_nonce', 'nonce' );
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
+        }
+        $batch = isset( $_POST['batch'] ) ? max( 1, min( 50, (int) $_POST['batch'] ) ) : 20;
+
+        $ids   = $this->get_missing_alt_ids( $batch );
+        $fixed = 0;
+        foreach ( $ids as $id ) {
+            $alt = $this->generate_alt_for( $id );
+            if ( '' !== $alt ) {
+                update_post_meta( $id, '_wp_attachment_image_alt', $alt );
+                $fixed++;
+            }
+        }
+        wp_send_json_success( [
+            'fixed'     => $fixed,
+            'attempted' => count( $ids ),
+            'remaining' => $this->get_missing_alt_count(),
+        ] );
+    }
+}

--- a/includes/class-local-seo.php
+++ b/includes/class-local-seo.php
@@ -1,0 +1,365 @@
+<?php
+/**
+ * Local SEO — NAP (name/address/phone), opening hours, geo, area served,
+ * and LocalBusiness JSON-LD output for brick-and-mortar / service-area sites.
+ *
+ * Settings page lives at admin.php?page=swps-local-seo. Schema is injected
+ * on the homepage (and optionally a designated "contact" page) via wp_head.
+ * Defers entirely when Yoast / RankMath / AIOSEO are active (same as
+ * SWPS_Schema).
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class SWPS_Local_SEO {
+
+    public const OPTION_KEY = 'swps_local_seo';
+
+    /**
+     * Schema.org LocalBusiness sub-types we surface in the picker.
+     * Not exhaustive — covers the most common small-business cases.
+     */
+    public const BUSINESS_TYPES = [
+        'LocalBusiness'        => 'Local business (generic)',
+        'Restaurant'           => 'Restaurant',
+        'CafeOrCoffeeShop'     => 'Cafe / coffee shop',
+        'Bakery'               => 'Bakery',
+        'Store'                => 'Store / retail',
+        'ClothingStore'        => 'Clothing store',
+        'GroceryStore'         => 'Grocery store',
+        'Dentist'              => 'Dentist',
+        'MedicalClinic'        => 'Medical clinic',
+        'Physician'            => 'Physician',
+        'HealthAndBeautyBusiness' => 'Health & beauty',
+        'BeautySalon'          => 'Beauty salon',
+        'HairSalon'            => 'Hair salon',
+        'DaySpa'               => 'Day spa',
+        'AutoRepair'           => 'Auto repair',
+        'Plumber'              => 'Plumber',
+        'Electrician'          => 'Electrician',
+        'HVACBusiness'         => 'HVAC',
+        'RoofingContractor'    => 'Roofing contractor',
+        'GeneralContractor'    => 'General contractor',
+        'HomeAndConstructionBusiness' => 'Home & construction',
+        'RealEstateAgent'      => 'Real estate agent',
+        'LegalService'         => 'Legal services',
+        'Attorney'             => 'Attorney',
+        'AccountingService'    => 'Accounting',
+        'FinancialService'     => 'Financial services',
+        'InsuranceAgency'      => 'Insurance',
+        'TravelAgency'         => 'Travel agency',
+        'Hotel'                => 'Hotel',
+        'LodgingBusiness'      => 'Lodging',
+        'GymLocation'          => 'Gym',
+        'SportsActivityLocation' => 'Sports / fitness',
+        'ChildCare'            => 'Childcare',
+        'EducationOrganization' => 'Education',
+        'ProfessionalService'  => 'Professional services',
+    ];
+
+    public const DAYS = [
+        'Monday'    => 'Mon',
+        'Tuesday'   => 'Tue',
+        'Wednesday' => 'Wed',
+        'Thursday'  => 'Thu',
+        'Friday'    => 'Fri',
+        'Saturday'  => 'Sat',
+        'Sunday'    => 'Sun',
+    ];
+
+    public function __construct() {
+        add_action( 'admin_menu',            [ $this, 'register_menu' ], 20 );
+        add_action( 'admin_init',            [ $this, 'register_settings' ] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+
+        if ( ! is_admin() && $this->is_enabled() && ! $this->other_seo_plugin_active() ) {
+            add_action( 'wp_head', [ $this, 'output_schema' ], 2 );
+        }
+    }
+
+    public function register_menu(): void {
+        add_submenu_page(
+            'stratawp-seo',
+            __( 'Local SEO', 'stratawp-seo' ),
+            __( 'Local SEO', 'stratawp-seo' ),
+            'manage_options',
+            'swps-local-seo',
+            [ $this, 'render_page' ]
+        );
+    }
+
+    public function render_page(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
+        }
+        require SWPS_PLUGIN_DIR . 'templates/local-seo-page.php';
+    }
+
+    public function enqueue_assets( string $hook ): void {
+        if ( 'stratawp-seo_page_swps-local-seo' !== $hook ) {
+            return;
+        }
+        wp_enqueue_style(
+            'swps-page-local-seo',
+            SWPS_PLUGIN_URL . 'admin/css/pages/local-seo.css',
+            [ 'swps-tokens', 'swps-components', 'swps-templates' ],
+            SWPS_VERSION
+        );
+    }
+
+    // ---------- Settings ----------
+
+    public function register_settings(): void {
+        register_setting(
+            'swps_local_seo_group',
+            self::OPTION_KEY,
+            [
+                'type'              => 'array',
+                'sanitize_callback' => [ $this, 'sanitize' ],
+                'default'           => $this->defaults(),
+            ]
+        );
+    }
+
+    public function defaults(): array {
+        return [
+            'enabled'        => 0,
+            'business_type'  => 'LocalBusiness',
+            'name'           => '',
+            'phone'          => '',
+            'email'          => '',
+            'price_range'    => '',
+            'street'         => '',
+            'locality'       => '',
+            'region'         => '',
+            'postal_code'    => '',
+            'country'        => '',
+            'latitude'       => '',
+            'longitude'      => '',
+            'area_served'    => '', // newline-separated list
+            'hours'          => [], // day => [ 'open' => 'HH:MM', 'close' => 'HH:MM', 'closed' => 0 ]
+            'place_id'       => '', // Google Business Profile place ID (optional)
+        ];
+    }
+
+    public function get(): array {
+        $stored = get_option( self::OPTION_KEY, [] );
+        return wp_parse_args( is_array( $stored ) ? $stored : [], $this->defaults() );
+    }
+
+    public function is_enabled(): bool {
+        $data = $this->get();
+        if ( empty( $data['enabled'] ) ) {
+            return false;
+        }
+        // Need at least a name + locality to publish anything meaningful.
+        return '' !== trim( (string) $data['name'] ) && '' !== trim( (string) $data['locality'] );
+    }
+
+    public function sanitize( $input ): array {
+        $defaults = $this->defaults();
+        $clean    = $defaults;
+
+        if ( ! is_array( $input ) ) {
+            return $clean;
+        }
+
+        $clean['enabled']       = empty( $input['enabled'] ) ? 0 : 1;
+        $clean['business_type'] = isset( $input['business_type'], self::BUSINESS_TYPES[ $input['business_type'] ] )
+            ? sanitize_text_field( $input['business_type'] )
+            : 'LocalBusiness';
+
+        foreach ( [ 'name', 'phone', 'price_range', 'street', 'locality', 'region', 'postal_code', 'country', 'place_id' ] as $key ) {
+            $clean[ $key ] = isset( $input[ $key ] ) ? sanitize_text_field( $input[ $key ] ) : '';
+        }
+
+        $clean['email'] = isset( $input['email'] ) ? sanitize_email( $input['email'] ) : '';
+
+        // Geo — must be valid float-ish (or empty). Stored as string to preserve formatting.
+        foreach ( [ 'latitude', 'longitude' ] as $geo ) {
+            $val = isset( $input[ $geo ] ) ? trim( (string) $input[ $geo ] ) : '';
+            if ( '' === $val ) {
+                $clean[ $geo ] = '';
+            } elseif ( is_numeric( $val ) ) {
+                $clean[ $geo ] = (string) (float) $val;
+            } else {
+                $clean[ $geo ] = '';
+            }
+        }
+
+        // Area served — newline-separated list, one location per line.
+        $area_raw = isset( $input['area_served'] ) ? (string) $input['area_served'] : '';
+        $lines    = array_filter( array_map( 'trim', preg_split( '/\r\n|\r|\n/', $area_raw ) ?: [] ) );
+        $lines    = array_map( 'sanitize_text_field', $lines );
+        $clean['area_served'] = implode( "\n", array_slice( $lines, 0, 25 ) );
+
+        // Hours — keyed by canonical day name.
+        $clean['hours'] = [];
+        $hours_in       = isset( $input['hours'] ) && is_array( $input['hours'] ) ? $input['hours'] : [];
+        foreach ( array_keys( self::DAYS ) as $day ) {
+            $row    = isset( $hours_in[ $day ] ) && is_array( $hours_in[ $day ] ) ? $hours_in[ $day ] : [];
+            $closed = ! empty( $row['closed'] ) ? 1 : 0;
+            $open   = isset( $row['open'] )  ? $this->normalize_time( $row['open'] )  : '';
+            $close  = isset( $row['close'] ) ? $this->normalize_time( $row['close'] ) : '';
+            $clean['hours'][ $day ] = [
+                'closed' => $closed,
+                'open'   => $closed ? '' : $open,
+                'close'  => $closed ? '' : $close,
+            ];
+        }
+
+        return $clean;
+    }
+
+    private function normalize_time( string $val ): string {
+        $val = trim( $val );
+        if ( '' === $val ) {
+            return '';
+        }
+        if ( preg_match( '/^([01]?\d|2[0-3]):([0-5]\d)$/', $val, $m ) ) {
+            return sprintf( '%02d:%02d', (int) $m[1], (int) $m[2] );
+        }
+        return '';
+    }
+
+    // ---------- Schema ----------
+
+    private function other_seo_plugin_active(): bool {
+        return defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' );
+    }
+
+    /**
+     * Output LocalBusiness JSON-LD on the homepage (and any page slug listed
+     * via the `swps_local_seo_schema_pages` filter — defaults to homepage only).
+     */
+    public function output_schema(): void {
+        $show_on_home = is_front_page() || is_home();
+
+        /**
+         * Filter which contexts get the LocalBusiness schema.
+         *
+         * @param bool $show True to emit on this request.
+         */
+        $show = (bool) apply_filters( 'swps_local_seo_emit', $show_on_home );
+
+        if ( ! $show ) {
+            return;
+        }
+
+        $schema = $this->build_schema();
+        if ( empty( $schema ) ) {
+            return;
+        }
+
+        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON-LD.
+        echo '<script type="application/ld+json">'
+            . wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT )
+            . '</script>' . "\n";
+    }
+
+    public function build_schema(): array {
+        $d = $this->get();
+
+        if ( '' === trim( (string) $d['name'] ) ) {
+            return [];
+        }
+
+        $schema = [
+            '@context' => 'https://schema.org',
+            '@type'    => $d['business_type'] ?: 'LocalBusiness',
+            'name'     => $d['name'],
+            'url'      => home_url( '/' ),
+        ];
+
+        if ( '' !== trim( $d['phone'] ) ) {
+            $schema['telephone'] = $d['phone'];
+        }
+        if ( '' !== trim( $d['email'] ) ) {
+            $schema['email'] = $d['email'];
+        }
+        if ( '' !== trim( $d['price_range'] ) ) {
+            $schema['priceRange'] = $d['price_range'];
+        }
+
+        $address = [];
+        if ( '' !== trim( $d['street'] ) )      { $address['streetAddress']    = $d['street']; }
+        if ( '' !== trim( $d['locality'] ) )    { $address['addressLocality']  = $d['locality']; }
+        if ( '' !== trim( $d['region'] ) )      { $address['addressRegion']    = $d['region']; }
+        if ( '' !== trim( $d['postal_code'] ) ) { $address['postalCode']       = $d['postal_code']; }
+        if ( '' !== trim( $d['country'] ) )     { $address['addressCountry']   = $d['country']; }
+        if ( ! empty( $address ) ) {
+            $address['@type']   = 'PostalAddress';
+            $schema['address']  = $address;
+        }
+
+        if ( '' !== $d['latitude'] && '' !== $d['longitude'] ) {
+            $schema['geo'] = [
+                '@type'     => 'GeoCoordinates',
+                'latitude'  => (float) $d['latitude'],
+                'longitude' => (float) $d['longitude'],
+            ];
+        }
+
+        // Logo / image: reuse the existing organization logo setting if present.
+        $logo = get_option( 'swps_schema_logo', '' );
+        if ( ! empty( $logo ) ) {
+            $schema['image'] = $logo;
+            $schema['logo']  = $logo;
+        }
+
+        // Hours.
+        $opening = [];
+        foreach ( array_keys( self::DAYS ) as $day ) {
+            $row = $d['hours'][ $day ] ?? [];
+            if ( empty( $row ) || ! empty( $row['closed'] ) ) {
+                continue;
+            }
+            $open  = (string) ( $row['open']  ?? '' );
+            $close = (string) ( $row['close'] ?? '' );
+            if ( '' === $open || '' === $close ) {
+                continue;
+            }
+            $opening[] = [
+                '@type'     => 'OpeningHoursSpecification',
+                'dayOfWeek' => 'https://schema.org/' . $day,
+                'opens'     => $open,
+                'closes'    => $close,
+            ];
+        }
+        if ( ! empty( $opening ) ) {
+            $schema['openingHoursSpecification'] = $opening;
+        }
+
+        // Area served.
+        $area_lines = array_filter( array_map( 'trim', explode( "\n", (string) $d['area_served'] ) ) );
+        if ( ! empty( $area_lines ) ) {
+            $schema['areaServed'] = array_values( $area_lines );
+        }
+
+        // Same-as: reuse existing social profiles.
+        $social_raw = (string) get_option( 'swps_schema_social_profiles', '' );
+        if ( '' !== trim( $social_raw ) ) {
+            $urls = array_filter( array_map( 'trim', explode( "\n", $social_raw ) ) );
+            if ( ! empty( $urls ) ) {
+                $schema['sameAs'] = array_values( $urls );
+            }
+        }
+
+        // Google Place ID — optional hasMap.
+        if ( '' !== trim( (string) $d['place_id'] ) ) {
+            $schema['hasMap'] = 'https://www.google.com/maps/place/?q=place_id:' . rawurlencode( $d['place_id'] );
+        }
+
+        /**
+         * Filter the LocalBusiness schema before output.
+         *
+         * @param array $schema  The assembled schema array.
+         * @param array $data    Raw settings.
+         */
+        return (array) apply_filters( 'swps_local_seo_schema', $schema, $d );
+    }
+}

--- a/includes/class-modules.php
+++ b/includes/class-modules.php
@@ -51,10 +51,14 @@ class SWPS_Modules {
         $this->register( 'auto-optimize',  [ 'name' => __( 'AI Auto-Optimize', 'stratawp-seo' ),       'desc' => __( 'Auto-refresh old posts: kw in H2, first paragraph, schema, alt text.', 'stratawp-seo' ), 'icon' => '↻', 'group' => 'content',  'default_on' => false, 'badge' => 'ai',  'settings_url' => admin_url( 'admin.php?page=swps-auto-optimize' ) ] );
         $this->register( 'competitors',    [ 'name' => __( 'Competitors', 'stratawp-seo' ),            'desc' => __( 'Track sites, schema, keyword gaps, content velocity.', 'stratawp-seo' ),         'icon' => '◎', 'group' => 'insights', 'default_on' => false, 'badge' => 'new', 'settings_url' => admin_url( 'admin.php?page=swps-competitors' ) ] );
 
+        // v4.2 — newly shipped modules.
+        $this->register( 'local-seo',      [ 'name' => __( 'Local SEO', 'stratawp-seo' ),              'desc' => __( 'NAP, opening hours, LocalBusiness JSON-LD for local + service-area sites.', 'stratawp-seo' ), 'icon' => '◉', 'group' => 'seo', 'default_on' => false, 'badge' => 'new', 'settings_url' => admin_url( 'admin.php?page=swps-local-seo' ) ] );
+        $this->register( 'image-seo',      [ 'name' => __( 'Image SEO', 'stratawp-seo' ),              'desc' => __( 'AI auto-alt, filename sanitization, lazy-loading, image sitemap.', 'stratawp-seo' ),     'icon' => '◈', 'group' => 'seo', 'default_on' => false, 'badge' => 'new', 'settings_url' => admin_url( 'admin.php?page=swps-image-seo' ) ] );
+
+        $this->register( 'backlinks',      [ 'name' => __( 'Backlinks', 'stratawp-seo' ),              'desc' => __( 'Manual + CSV-import backlink tracker with daily health monitoring.', 'stratawp-seo' ), 'icon' => '⇄', 'group' => 'insights', 'default_on' => false, 'badge' => 'new', 'settings_url' => admin_url( 'admin.php?page=swps-backlinks' ) ] );
+
         // Coming soon — disabled, not user-toggleable.
-        $this->register( 'local-seo',      [ 'name' => __( 'Local SEO', 'stratawp-seo' ),              'desc' => __( 'Google Business profile, NAP, LocalBusiness schema.', 'stratawp-seo' ),         'icon' => '◉', 'group' => 'seo',      'default_on' => false, 'badge' => 'soon', 'settings_url' => '', 'locked' => true ] );
         $this->register( 'woocommerce',    [ 'name' => __( 'WooCommerce SEO', 'stratawp-seo' ),        'desc' => __( 'Product schema, category SEO, OG for variations.', 'stratawp-seo' ),            'icon' => '⌥', 'group' => 'seo',      'default_on' => false, 'badge' => 'soon', 'settings_url' => '', 'locked' => true ] );
-        $this->register( 'image-seo',      [ 'name' => __( 'Image SEO', 'stratawp-seo' ),              'desc' => __( 'Auto-alt, auto-rename, compression, WebP.', 'stratawp-seo' ),                  'icon' => '◈', 'group' => 'seo',      'default_on' => false, 'badge' => 'soon', 'settings_url' => '', 'locked' => true ] );
 
         /**
          * Fires after default modules are registered. Use this to add custom modules.

--- a/readme.txt
+++ b/readme.txt
@@ -4,11 +4,11 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.1.7
+Stable tag: 4.2.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, structured data, analytics, keyword tracking, meta editing, and technical SEO.
+AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, structured data, analytics, keyword tracking, meta editing, technical SEO, Local SEO (LocalBusiness schema with NAP and opening hours), Image SEO (auto-alt + filename sanitization + lazy-load), in-admin /llms.txt and /robots.txt editors, and a manual/CSV-import backlink tracker with daily health monitoring.
 
 == Description ==
 
@@ -127,6 +127,46 @@ StrataWP SEO is an AI-powered content generation and technical SEO plugin for Wo
 * **robots.txt injection** — allowed bots get explicit Allow rules; unchecked known bots get Disallow
 * **Dynamic llms.txt** — served at /llms.txt, built from your site description and posts/pages/categories with one-line summaries
 
+= Local SEO (v4.2) =
+
+* **30+ business types** — Restaurant, Plumber, Dentist, Hotel, RealEstateAgent, Attorney, BeautySalon, etc.
+* **NAP fields** — name, address, phone, email, price range
+* **Opening hours per day** with "Closed" tick for off-days
+* **Geo coordinates** — latitude/longitude for `GeoCoordinates` schema
+* **Area served** — newline-separated cities/regions for service-area businesses
+* **Google Place ID** — emits a `hasMap` link
+* **LocalBusiness JSON-LD** on the homepage with `OpeningHoursSpecification`, `PostalAddress`, `GeoCoordinates`
+* **Schema preview** card on the settings page
+* Defers automatically to Yoast / RankMath / AIOSEO when those are active
+
+= Image SEO (v4.2) =
+
+* **Auto-alt on upload** — Heuristic mode (free, derives from filename + parent post title) or AI mode (uses your configured provider; falls back on error)
+* **Filename sanitization** — strips device prefixes (IMG_, DSC_, Screenshot), lowercases, dash-separates
+* **Lazy-loading enforcement** — adds `loading="lazy" decoding="async"` to any post-content image still missing it
+* **Bulk fix tool** — processes the existing media library in 20-image AJAX batches with live progress
+* **Stats tiles** — total images, missing alt, % covered
+
+= Crawlers & Files (v4.2) =
+
+* **/llms.txt editor** — Auto (StrataWP-generated) or Custom (your markdown served verbatim)
+* **/robots.txt editor** — Auto, Append (auto + your rules), or Replace (your content only)
+* **Side-by-side editor + auto preview** — one-click "copy auto into editor"
+* **Physical-file warning** — detects a real `robots.txt` in the site root and warns it would override the dynamic version
+* **Hooks into the existing AI-bot allowlist** — Append mode preserves the StrataWP-managed AI bot rules
+
+= Backlinks (v4.2) =
+
+* **Manual + CSV import** — add backlinks one at a time, or paste/upload a CSV (auto-detects Google Search Console "Top linking sites" exports)
+* **Daily WP-cron health monitoring** — re-fetches every source page once a day; classifies as Live, Lost, or Broken
+* **Real anchor text + first/last seen** captured on every successful verify
+* **AJAX bulk verify** — runs in 25-row batches with progress
+* **Per-row re-verify and delete**
+* **CSV export**
+* **Stats tiles** — total tracked, live, lost, broken, +30d gained, 30d lost, unique referring domains
+* **Dashboard widget** — live count + 3 most-recently-verified backlinks with status pills
+* No paid backlink index required — tracks the list you give it
+
 = AI Auto-Optimize (v4.1) =
 
 * **Re-score all published posts** — chunked scanning (10 posts per batch) with live progress; works on busy sites without hitting PHP timeouts
@@ -211,6 +251,18 @@ Yes. The built-in analytics tracker is cookie-free and does not use any external
 No. GSC integration is optional. The on-site analytics works entirely without any external services. Add Google OAuth credentials only if you want search clicks, impressions, and ranking data.
 
 == Changelog ==
+
+= 4.2.2 =
+* New: Backlinks page (Insights → Backlinks). Manual + CSV-import backlink tracker. Daily WP-cron classifies each link as Live, Lost, or Broken; captures real anchor text and first/last seen dates. AJAX bulk-verify in 25-row batches, per-row re-verify and delete, CSV import (auto-detects Google Search Console "Top linking sites" exports), CSV export. Backed by a custom DB table created via dbDelta with a runtime upgrade path so existing installs get the table without re-activation. Replaces the previous "coming soon" placeholder with a real, working feature.
+* Dashboard tiles light up with live backlink stats (total / live / lost / domains, plus 3 most-recently-verified).
+
+= 4.2.1 =
+* New: Crawlers & Files page (SEO → Crawlers & Files). Edit /llms.txt (Auto / Custom modes) and /robots.txt (Auto / Append / Replace modes) directly from the admin. Side-by-side editor + auto preview, one-click "copy auto into editor", warning when a physical robots.txt would override the dynamic version. Hooks into the existing pipeline so the AI-bot allowlist is preserved in Append mode.
+
+= 4.2.0 =
+* New: Local SEO page (SEO → Local SEO). LocalBusiness JSON-LD output for brick-and-mortar and service-area sites. 30+ business types (Restaurant, Plumber, Dentist, Hotel, etc.), full NAP fields, opening hours per day, geo coordinates, area served, Google Place ID. Live schema preview. Defers to Yoast / RankMath / AIOSEO when active.
+* New: Image SEO page (SEO → Image SEO). Auto-alt on upload (Heuristic free mode or AI mode using the configured provider), device-prefix-stripping filename sanitization, lazy-loading enforcement on the_content, bulk-fix tool for the existing media library with batched AJAX progress, library coverage stats.
+* Modules registry: Local SEO and Image SEO unlocked with NEW badges; Backlinks added as a "soon" entry; WooCommerce SEO retained as the only remaining "soon" module.
 
 = 4.1.7 =
 * Critical fix: render functions for the Auto-Optimize queue and Competitors list moved to the top of their templates. PHP doesn't hoist conditionally-declared functions, so the prior placement caused a fatal error ("There has been a critical error") once any post had a cached score.
@@ -336,6 +388,15 @@ No. GSC integration is optional. The on-site analytics works entirely without an
 * Scheduled publishing
 
 == Upgrade Notice ==
+
+= 4.2.2 =
+Adds the Backlinks tracker (Insights → Backlinks) — manual + CSV-import with daily health monitoring (Live / Lost / Broken). Imports the Google Search Console "Top linking sites" CSV directly. Runs DB migration on first load.
+
+= 4.2.1 =
+New Crawlers & Files page lets you edit /llms.txt and /robots.txt from the admin with auto/custom modes and side-by-side preview.
+
+= 4.2.0 =
+Two new modules: Local SEO (LocalBusiness JSON-LD with NAP, hours, geo, area served) and Image SEO (auto-alt, filename sanitization, lazy-load, bulk-fix tool). No breaking changes.
 
 = 4.1.7 =
 Critical fix for Auto-Optimize and Competitors pages — fatal error when displaying queue rows. Strongly recommended.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.1.7
+ * Version: 4.2.2
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'SWPS_VERSION', '4.1.7' );
+define( 'SWPS_VERSION', '4.2.2' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -95,6 +95,18 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-auto-optimize.php';
 
 // Competitors (v4.1).
 require_once SWPS_PLUGIN_DIR . 'includes/class-competitors.php';
+
+// Local SEO (v4.2).
+require_once SWPS_PLUGIN_DIR . 'includes/class-local-seo.php';
+
+// Image SEO (v4.2).
+require_once SWPS_PLUGIN_DIR . 'includes/class-image-seo.php';
+
+// Crawlers & Files (v4.2) — edit /llms.txt and /robots.txt.
+require_once SWPS_PLUGIN_DIR . 'includes/class-crawl-files.php';
+
+// Backlinks (v4.2.2) — manual/CSV-import backlink tracker with health monitor.
+require_once SWPS_PLUGIN_DIR . 'includes/class-backlinks.php';
 
 // v3.0 classes.
 require_once SWPS_PLUGIN_DIR . 'includes/class-head-cleanup.php';
@@ -183,6 +195,10 @@ final class StrataWP_SEO {
     public SWPS_AI_Bots $ai_bots;
     public SWPS_Auto_Optimize $auto_optimize;
     public SWPS_Competitors $competitors;
+    public SWPS_Local_SEO $local_seo;
+    public SWPS_Image_SEO $image_seo;
+    public SWPS_Crawl_Files $crawl_files;
+    public SWPS_Backlinks $backlinks;
 
     // v4.0 admin shell.
     public SWPS_User_Prefs $user_prefs;
@@ -240,6 +256,10 @@ final class StrataWP_SEO {
         $this->ai_bots             = new SWPS_AI_Bots();
         $this->auto_optimize       = new SWPS_Auto_Optimize( $this->content_scorer );
         $this->competitors         = new SWPS_Competitors();
+        $this->local_seo           = new SWPS_Local_SEO();
+        $this->image_seo           = new SWPS_Image_SEO();
+        $this->crawl_files         = new SWPS_Crawl_Files();
+        $this->backlinks           = new SWPS_Backlinks();
         $this->settings  = new SWPS_Settings();
         $this->analyzer  = new SWPS_Analyzer( $this->cache_manager );
         $this->generator = new SWPS_Generator(
@@ -1105,6 +1125,9 @@ function swps_activate(): void {
     SWPS_Internal_Links::create_tables();
     SWPS_Internal_Links::schedule_cron();
 
+    SWPS_Backlinks::create_tables();
+    SWPS_Backlinks::schedule_cron();
+
     if ( ! wp_next_scheduled( 'swps_prune_404_logs' ) ) {
         wp_schedule_event( time(), 'daily', 'swps_prune_404_logs' );
     }
@@ -1125,6 +1148,7 @@ function swps_deactivate(): void {
     SWPS_Search_Console::unschedule_cron();
     SWPS_Keyword_Tracker::unschedule_cron();
     SWPS_Competitors::unschedule_cron();
+    SWPS_Backlinks::unschedule_cron();
     flush_rewrite_rules();
 }
 register_deactivation_hook( __FILE__, 'swps_deactivate' );

--- a/templates/backlinks-page.php
+++ b/templates/backlinks-page.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Backlinks page (v4.2.2).
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$bl    = stratawp_seo()->backlinks;
+$stats = $bl->get_stats();
+$rows  = $bl->get_all();
+
+$home_host = wp_parse_url( home_url(), PHP_URL_HOST );
+?>
+<div class="wrap">
+    <?php
+    $title    = __( 'Backlinks', 'stratawp-seo' );
+    $subtitle = sprintf(
+        /* translators: %s: site host */
+        esc_html__( 'Track pages that link to %s. Add backlinks one at a time, or paste a CSV (e.g. the "Top linking sites" export from Google Search Console). StrataWP re-checks each link daily and tells you when one disappears.', 'stratawp-seo' ),
+        '<code>' . esc_html( $home_host ) . '</code>'
+    );
+    $actions  = [
+        [
+            'label' => __( 'Verify all', 'stratawp-seo' ),
+            'url'   => '',
+            'class' => 'swps-btn-grad',
+            'attrs' => 'id="swps-bl-verify-all"',
+        ],
+        [
+            'label' => __( 'Export CSV', 'stratawp-seo' ),
+            'url'   => add_query_arg( [
+                'action' => 'swps_backlink_export',
+                'nonce'  => wp_create_nonce( 'swps_nonce' ),
+            ], admin_url( 'admin-ajax.php' ) ),
+            'class' => 'swps-btn-secondary',
+        ],
+    ];
+    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+    ?>
+
+    <!-- Stats tiles -->
+    <div class="swps-bl-stats">
+        <div class="swps-tile">
+            <div class="swps-tile-h"><?php esc_html_e( 'Total tracked', 'stratawp-seo' ); ?></div>
+            <div class="swps-tile-stat" id="swps-bl-stat-total"><?php echo number_format( (int) $stats['total'] ); ?></div>
+            <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+                <?php
+                printf(
+                    /* translators: %d: unique referring domains */
+                    esc_html__( '%d unique referring domains', 'stratawp-seo' ),
+                    (int) $stats['unique_domains']
+                );
+                ?>
+            </div>
+        </div>
+        <div class="swps-tile">
+            <div class="swps-tile-h"><?php esc_html_e( 'Live', 'stratawp-seo' ); ?></div>
+            <div class="swps-tile-stat" id="swps-bl-stat-live" style="color:#10b981"><?php echo number_format( (int) $stats['live'] ); ?></div>
+            <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+                <?php
+                printf(
+                    /* translators: %d: count gained in last 30 days */
+                    esc_html__( '+%d in last 30 days', 'stratawp-seo' ),
+                    (int) $stats['new_30d']
+                );
+                ?>
+            </div>
+        </div>
+        <div class="swps-tile">
+            <div class="swps-tile-h"><?php esc_html_e( 'Lost', 'stratawp-seo' ); ?></div>
+            <div class="swps-tile-stat" id="swps-bl-stat-lost" style="color:#f59e0b"><?php echo number_format( (int) $stats['lost'] ); ?></div>
+            <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+                <?php
+                printf(
+                    /* translators: %d: count lost in last 30 days */
+                    esc_html__( '%d lost in last 30 days', 'stratawp-seo' ),
+                    (int) $stats['lost_30d']
+                );
+                ?>
+            </div>
+        </div>
+        <div class="swps-tile">
+            <div class="swps-tile-h"><?php esc_html_e( 'Broken', 'stratawp-seo' ); ?></div>
+            <div class="swps-tile-stat" id="swps-bl-stat-broken" style="color:#ef4444"><?php echo number_format( (int) $stats['broken'] ); ?></div>
+            <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+                <?php esc_html_e( 'Source page returns an error', 'stratawp-seo' ); ?>
+            </div>
+        </div>
+    </div>
+
+    <!-- Add + import row -->
+    <div class="swps-bl-tools">
+        <div class="swps-card">
+            <h2 style="margin-top:0"><?php esc_html_e( 'Add backlink', 'stratawp-seo' ); ?></h2>
+            <form id="swps-bl-add" class="swps-bl-add-form" autocomplete="off">
+                <label class="swps-bl-field">
+                    <span><?php esc_html_e( 'Source URL', 'stratawp-seo' ); ?></span>
+                    <input type="url" name="source_url" required placeholder="https://example.com/article-linking-to-you" />
+                </label>
+                <label class="swps-bl-field">
+                    <span><?php esc_html_e( 'Target URL on your site', 'stratawp-seo' ); ?> <em><?php esc_html_e( '(optional)', 'stratawp-seo' ); ?></em></span>
+                    <input type="url" name="target_url" placeholder="<?php echo esc_attr( home_url( '/' ) ); ?>" />
+                </label>
+                <label class="swps-bl-field">
+                    <span><?php esc_html_e( 'Anchor text', 'stratawp-seo' ); ?> <em><?php esc_html_e( '(optional)', 'stratawp-seo' ); ?></em></span>
+                    <input type="text" name="anchor_text" />
+                </label>
+                <button type="submit" class="swps-btn swps-btn-grad"><?php esc_html_e( 'Add & verify', 'stratawp-seo' ); ?></button>
+                <span class="swps-bl-add-status" style="margin-left:8px;color:var(--swps-text-muted);font-size:12px"></span>
+            </form>
+        </div>
+
+        <div class="swps-card">
+            <h2 style="margin-top:0"><?php esc_html_e( 'Bulk import', 'stratawp-seo' ); ?></h2>
+            <p class="description" style="margin-top:0">
+                <?php esc_html_e( 'Paste rows below: one source URL per line, or a CSV in the format source_url,target_url,anchor_text. The "Top linking sites" CSV export from Google Search Console works directly.', 'stratawp-seo' ); ?>
+            </p>
+            <form id="swps-bl-import">
+                <textarea name="csv" rows="6" class="swps-bl-import-area"
+                          placeholder="https://blog.example.com/post-1&#10;https://news.example.org/page-2"></textarea>
+                <div style="display:flex;align-items:center;gap:10px;margin-top:8px">
+                    <button type="submit" class="swps-btn swps-btn-grad"><?php esc_html_e( 'Import', 'stratawp-seo' ); ?></button>
+                    <span class="swps-bl-import-status" style="color:var(--swps-text-muted);font-size:12px"></span>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Table -->
+    <div class="swps-card swps-bl-table-card">
+        <div class="swps-bl-table-head">
+            <h2 style="margin:0;font-size:14px;text-transform:uppercase;letter-spacing:.04em;color:var(--swps-text-muted)">
+                <?php esc_html_e( 'Tracked backlinks', 'stratawp-seo' ); ?>
+            </h2>
+            <div class="swps-bl-progress" id="swps-bl-progress" hidden>
+                <span></span>
+            </div>
+        </div>
+
+        <?php if ( empty( $rows ) ) : ?>
+            <p style="color:var(--swps-text-muted);font-size:13px;margin:8px 0 0">
+                <?php esc_html_e( 'No backlinks yet. Add one above, or paste a CSV from GSC.', 'stratawp-seo' ); ?>
+            </p>
+        <?php else : ?>
+            <table class="widefat striped swps-bl-table">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'Status', 'stratawp-seo' ); ?></th>
+                        <th><?php esc_html_e( 'Source', 'stratawp-seo' ); ?></th>
+                        <th><?php esc_html_e( 'Anchor', 'stratawp-seo' ); ?></th>
+                        <th><?php esc_html_e( 'Target', 'stratawp-seo' ); ?></th>
+                        <th><?php esc_html_e( 'First seen', 'stratawp-seo' ); ?></th>
+                        <th><?php esc_html_e( 'Last checked', 'stratawp-seo' ); ?></th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody id="swps-bl-tbody">
+                    <?php foreach ( $rows as $row ) : ?>
+                        <?php $status = (string) $row['status']; ?>
+                        <tr data-id="<?php echo (int) $row['id']; ?>">
+                            <td>
+                                <span class="swps-bl-status is-<?php echo esc_attr( $status ); ?>">
+                                    <?php echo esc_html( ucfirst( $status ) ); ?>
+                                    <?php if ( (int) $row['http_status'] > 0 && in_array( $status, [ 'broken' ], true ) ) : ?>
+                                        <small>(<?php echo (int) $row['http_status']; ?>)</small>
+                                    <?php endif; ?>
+                                </span>
+                            </td>
+                            <td>
+                                <a href="<?php echo esc_url( $row['source_url'] ); ?>" target="_blank" rel="noopener noreferrer">
+                                    <?php echo esc_html( $row['source_host'] ?: $row['source_url'] ); ?>
+                                </a>
+                                <?php if ( ! empty( $row['notes'] ) ) : ?>
+                                    <div style="font-size:11px;color:var(--swps-text-muted);margin-top:2px">
+                                        <?php echo esc_html( $row['notes'] ); ?>
+                                    </div>
+                                <?php endif; ?>
+                            </td>
+                            <td>
+                                <?php if ( ! empty( $row['anchor_text'] ) ) : ?>
+                                    <span style="font-size:12px"><?php echo esc_html( $row['anchor_text'] ); ?></span>
+                                <?php else : ?>
+                                    <span style="color:var(--swps-text-faint);font-size:12px">—</span>
+                                <?php endif; ?>
+                            </td>
+                            <td>
+                                <?php if ( ! empty( $row['target_url'] ) ) : ?>
+                                    <a href="<?php echo esc_url( $row['target_url'] ); ?>" target="_blank" rel="noopener" style="font-size:12px">
+                                        <?php echo esc_html( wp_parse_url( $row['target_url'], PHP_URL_PATH ) ?: $row['target_url'] ); ?>
+                                    </a>
+                                <?php else : ?>
+                                    <span style="color:var(--swps-text-faint);font-size:12px">—</span>
+                                <?php endif; ?>
+                            </td>
+                            <td style="font-size:12px;color:var(--swps-text-muted)">
+                                <?php echo $row['first_seen'] ? esc_html( mysql2date( 'Y-m-d', $row['first_seen'] ) ) : '—'; ?>
+                            </td>
+                            <td style="font-size:12px;color:var(--swps-text-muted)">
+                                <?php echo $row['last_checked'] ? esc_html( human_time_diff( strtotime( $row['last_checked'] ) ) . ' ago' ) : esc_html__( 'never', 'stratawp-seo' ); ?>
+                            </td>
+                            <td style="text-align:right;white-space:nowrap">
+                                <button type="button" class="button-link swps-bl-verify" title="<?php esc_attr_e( 'Re-verify now', 'stratawp-seo' ); ?>">⟳</button>
+                                <button type="button" class="button-link swps-bl-delete" title="<?php esc_attr_e( 'Delete', 'stratawp-seo' ); ?>" style="color:#ef4444">✕</button>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        <?php endif; ?>
+    </div>
+</div>

--- a/templates/crawl-files-page.php
+++ b/templates/crawl-files-page.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Crawlers & Files settings page (v4.2).
+ *
+ * Edits /llms.txt and /robots.txt with auto/custom toggles.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$plugin = stratawp_seo();
+$cf     = $plugin->crawl_files;
+$bots   = $plugin->ai_bots;
+
+$llms_mode    = $cf->get_llms_mode();
+$llms_custom  = $cf->get_llms_custom();
+$robots_mode  = $cf->get_robots_mode();
+$robots_custom = $cf->get_robots_custom();
+
+$auto_llms   = $cf->render_auto_llms( $bots );
+$auto_robots = $cf->render_auto_robots();
+
+$llms_url   = home_url( '/llms.txt' );
+$robots_url = home_url( '/robots.txt' );
+?>
+<div class="wrap">
+    <?php
+    $title    = __( 'Crawlers & Files', 'stratawp-seo' );
+    $subtitle = __( 'Edit the dynamic /llms.txt and /robots.txt files served by your site. Use auto for the StrataWP-generated defaults, or paste your own content to override.', 'stratawp-seo' );
+    $actions  = [
+        [
+            'label' => __( 'View /llms.txt', 'stratawp-seo' ),
+            'url'   => $llms_url,
+            'class' => 'swps-btn-secondary',
+            'attrs' => 'target="_blank" rel="noopener"',
+        ],
+        [
+            'label' => __( 'View /robots.txt', 'stratawp-seo' ),
+            'url'   => $robots_url,
+            'class' => 'swps-btn-secondary',
+            'attrs' => 'target="_blank" rel="noopener"',
+        ],
+    ];
+    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+    ?>
+
+    <form method="post" action="options.php" class="swps-crawl-files-form">
+        <?php settings_fields( 'swps_crawl_files_group' ); ?>
+
+        <!-- llms.txt -->
+        <div class="swps-card swps-crawl-card">
+            <div class="swps-crawl-card-head">
+                <div>
+                    <h2 style="margin:0">/llms.txt</h2>
+                    <p class="description" style="margin:4px 0 0">
+                        <?php esc_html_e( 'A markdown index that helps AI crawlers (ChatGPT, Claude, Perplexity) understand the structure of your site. By default StrataWP builds it from your most recent posts, top-level pages, and busiest categories.', 'stratawp-seo' ); ?>
+                    </p>
+                </div>
+            </div>
+
+            <fieldset style="margin-top:14px">
+                <legend class="screen-reader-text"><?php esc_html_e( 'llms.txt mode', 'stratawp-seo' ); ?></legend>
+                <label style="display:inline-flex;gap:8px;align-items:center;margin-right:24px">
+                    <input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_LLMS_MODE ); ?>"
+                           value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_AUTO ); ?>"
+                           <?php checked( $llms_mode, SWPS_Crawl_Files::MODE_AUTO ); ?>
+                           data-swps-mode-target="llms" />
+                    <strong><?php esc_html_e( 'Auto', 'stratawp-seo' ); ?></strong>
+                    <span style="color:var(--swps-text-muted);font-size:12px"><?php esc_html_e( 'Use the generated default', 'stratawp-seo' ); ?></span>
+                </label>
+                <label style="display:inline-flex;gap:8px;align-items:center">
+                    <input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_LLMS_MODE ); ?>"
+                           value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_CUSTOM ); ?>"
+                           <?php checked( $llms_mode, SWPS_Crawl_Files::MODE_CUSTOM ); ?>
+                           data-swps-mode-target="llms" />
+                    <strong><?php esc_html_e( 'Custom', 'stratawp-seo' ); ?></strong>
+                    <span style="color:var(--swps-text-muted);font-size:12px"><?php esc_html_e( 'Serve the markdown below verbatim', 'stratawp-seo' ); ?></span>
+                </label>
+            </fieldset>
+
+            <div class="swps-crawl-grid" style="margin-top:14px">
+                <div class="swps-crawl-col">
+                    <label for="swps-llms-custom" class="swps-crawl-col-label">
+                        <?php esc_html_e( 'Your llms.txt', 'stratawp-seo' ); ?>
+                    </label>
+                    <textarea id="swps-llms-custom" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_LLMS_CUSTOM ); ?>"
+                              class="swps-crawl-textarea"
+                              rows="22"
+                              spellcheck="false"
+                              placeholder="<?php esc_attr_e( 'Paste markdown here. Used only when Custom is selected above.', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $llms_custom ); ?></textarea>
+                    <button type="button" class="button-link swps-crawl-copy-default"
+                            data-swps-copy-target="swps-llms-custom"
+                            data-swps-copy-source="swps-llms-default">
+                        <?php esc_html_e( '↑ Copy auto-generated content into the editor', 'stratawp-seo' ); ?>
+                    </button>
+                </div>
+                <div class="swps-crawl-col">
+                    <label class="swps-crawl-col-label"><?php esc_html_e( 'Auto preview', 'stratawp-seo' ); ?></label>
+                    <textarea id="swps-llms-default" class="swps-crawl-textarea is-readonly" rows="22" readonly><?php echo esc_textarea( $auto_llms ); ?></textarea>
+                </div>
+            </div>
+        </div>
+
+        <!-- robots.txt -->
+        <div class="swps-card swps-crawl-card" style="margin-top:16px">
+            <div class="swps-crawl-card-head">
+                <div>
+                    <h2 style="margin:0">/robots.txt</h2>
+                    <p class="description" style="margin:4px 0 0">
+                        <?php esc_html_e( 'Tells search engines and crawlers which paths are off-limits. The auto baseline is what WordPress would normally serve, plus the AI-bot allow/disallow rules StrataWP adds. Append to extend it; replace to take full control.', 'stratawp-seo' ); ?>
+                    </p>
+                </div>
+            </div>
+
+            <?php if ( file_exists( ABSPATH . 'robots.txt' ) ) : ?>
+                <p class="notice notice-warning" style="margin:12px 0 0;padding:8px 12px">
+                    <?php esc_html_e( 'A physical robots.txt exists in your site root. WordPress (and this plugin) will be ignored — that file is served instead. Delete it to use the dynamic version.', 'stratawp-seo' ); ?>
+                </p>
+            <?php endif; ?>
+
+            <fieldset style="margin-top:14px">
+                <legend class="screen-reader-text"><?php esc_html_e( 'robots.txt mode', 'stratawp-seo' ); ?></legend>
+                <label style="display:inline-flex;gap:8px;align-items:center;margin-right:24px">
+                    <input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_ROBOTS_MODE ); ?>"
+                           value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_AUTO ); ?>"
+                           <?php checked( $robots_mode, SWPS_Crawl_Files::MODE_AUTO ); ?> />
+                    <strong><?php esc_html_e( 'Auto', 'stratawp-seo' ); ?></strong>
+                </label>
+                <label style="display:inline-flex;gap:8px;align-items:center;margin-right:24px">
+                    <input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_ROBOTS_MODE ); ?>"
+                           value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_APPEND ); ?>"
+                           <?php checked( $robots_mode, SWPS_Crawl_Files::MODE_APPEND ); ?> />
+                    <strong><?php esc_html_e( 'Append', 'stratawp-seo' ); ?></strong>
+                    <span style="color:var(--swps-text-muted);font-size:12px"><?php esc_html_e( 'Auto + your extra rules', 'stratawp-seo' ); ?></span>
+                </label>
+                <label style="display:inline-flex;gap:8px;align-items:center">
+                    <input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_ROBOTS_MODE ); ?>"
+                           value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_REPLACE ); ?>"
+                           <?php checked( $robots_mode, SWPS_Crawl_Files::MODE_REPLACE ); ?> />
+                    <strong><?php esc_html_e( 'Replace', 'stratawp-seo' ); ?></strong>
+                    <span style="color:var(--swps-text-muted);font-size:12px"><?php esc_html_e( 'Serve only your content', 'stratawp-seo' ); ?></span>
+                </label>
+            </fieldset>
+
+            <div class="swps-crawl-grid" style="margin-top:14px">
+                <div class="swps-crawl-col">
+                    <label for="swps-robots-custom" class="swps-crawl-col-label">
+                        <?php esc_html_e( 'Your robots.txt', 'stratawp-seo' ); ?>
+                    </label>
+                    <textarea id="swps-robots-custom" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_ROBOTS_CUSTOM ); ?>"
+                              class="swps-crawl-textarea"
+                              rows="16"
+                              spellcheck="false"
+                              placeholder="<?php esc_attr_e( "User-agent: *\nDisallow: /private/\n\nSitemap: https://example.com/sitemap.xml", 'stratawp-seo' ); ?>"><?php echo esc_textarea( $robots_custom ); ?></textarea>
+                    <button type="button" class="button-link swps-crawl-copy-default"
+                            data-swps-copy-target="swps-robots-custom"
+                            data-swps-copy-source="swps-robots-default">
+                        <?php esc_html_e( '↑ Copy auto-generated content into the editor', 'stratawp-seo' ); ?>
+                    </button>
+                </div>
+                <div class="swps-crawl-col">
+                    <label class="swps-crawl-col-label"><?php esc_html_e( 'Auto preview', 'stratawp-seo' ); ?></label>
+                    <textarea id="swps-robots-default" class="swps-crawl-textarea is-readonly" rows="16" readonly><?php echo esc_textarea( $auto_robots ); ?></textarea>
+                </div>
+            </div>
+        </div>
+
+        <?php submit_button( __( 'Save changes', 'stratawp-seo' ) ); ?>
+    </form>
+</div>
+
+<script>
+(function () {
+    document.querySelectorAll('.swps-crawl-copy-default').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var target = document.getElementById(btn.dataset.swpsCopyTarget);
+            var source = document.getElementById(btn.dataset.swpsCopySource);
+            if (target && source) {
+                target.value = source.value;
+                target.focus();
+            }
+        });
+    });
+}());
+</script>

--- a/templates/dashboard-page.php
+++ b/templates/dashboard-page.php
@@ -21,6 +21,9 @@ $issues          = $data['top_issues'] ?? [];
 $top_queries     = $data['top_queries'] ?? [];
 $auto_q          = $data['auto_optimize_queue'] ?? [];
 $competitors     = $data['competitors'] ?? [];
+$backlinks_data  = $data['backlinks'] ?? [ 'stats' => [], 'recent' => [] ];
+$bl_stats        = (array) ( $backlinks_data['stats']  ?? [] );
+$bl_recent       = (array) ( $backlinks_data['recent'] ?? [] );
 $modules         = $data['modules'] ?? [];
 
 $score           = (int) ( $health['score'] ?? 0 );
@@ -111,12 +114,29 @@ $welcome_msg = sprintf(
 
         <div class="swps-tile">
             <div class="swps-tile-h"><?php esc_html_e( 'Backlinks', 'stratawp-seo' ); ?></div>
-            <div class="swps-tile-stat" style="font-size:18px;-webkit-text-fill-color:var(--swps-text-muted);background:none;color:var(--swps-text-muted)">
-                <?php esc_html_e( '— Connect a source', 'stratawp-seo' ); ?>
-            </div>
-            <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
-                <?php esc_html_e( 'Ahrefs / Moz / SE Ranking — coming soon', 'stratawp-seo' ); ?>
-            </div>
+            <?php if ( (int) ( $bl_stats['total'] ?? 0 ) > 0 ) : ?>
+                <div class="swps-tile-stat"><?php echo number_format( (int) $bl_stats['total'] ); ?></div>
+                <div class="swps-tile-trend" style="color:var(--swps-text-muted)">
+                    <?php
+                    printf(
+                        /* translators: 1: live count, 2: lost count, 3: unique domains */
+                        esc_html__( '%1$d live · %2$d lost · %3$d domains', 'stratawp-seo' ),
+                        (int) ( $bl_stats['live'] ?? 0 ),
+                        (int) ( $bl_stats['lost'] ?? 0 ),
+                        (int) ( $bl_stats['unique_domains'] ?? 0 )
+                    );
+                    ?>
+                </div>
+            <?php else : ?>
+                <div class="swps-tile-stat" style="font-size:18px;-webkit-text-fill-color:var(--swps-text-muted);background:none;color:var(--swps-text-muted)">
+                    <?php esc_html_e( '— Add some', 'stratawp-seo' ); ?>
+                </div>
+                <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+                    <a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-backlinks' ) ); ?>" style="color:inherit;text-decoration:underline">
+                        <?php esc_html_e( 'Track inbound links →', 'stratawp-seo' ); ?>
+                    </a>
+                </div>
+            <?php endif; ?>
         </div>
 
         <div class="swps-tile">
@@ -304,10 +324,38 @@ $welcome_msg = sprintf(
         </div>
 
         <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'Backlinks', 'stratawp-seo' ); ?></div>
-            <p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
-                <?php esc_html_e( 'Connect Ahrefs / Moz / SE Ranking to track backlinks. Coming after a paid data partner is wired up.', 'stratawp-seo' ); ?>
-            </p>
+            <div class="swps-tile-h" style="display:flex;justify-content:space-between;align-items:baseline;gap:8px">
+                <span><?php esc_html_e( 'Backlinks', 'stratawp-seo' ); ?></span>
+                <a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-backlinks' ) ); ?>"
+                   style="color:var(--swps-accent-1);font-size:11px;font-weight:600;text-decoration:none">
+                    <?php esc_html_e( 'Manage →', 'stratawp-seo' ); ?>
+                </a>
+            </div>
+            <?php if ( empty( $bl_recent ) ) : ?>
+                <p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+                    <?php esc_html_e( 'No backlinks tracked yet. Add manually or paste a CSV from Google Search Console (Top linking sites).', 'stratawp-seo' ); ?>
+                </p>
+            <?php else : ?>
+                <div class="swps-dash-list">
+                    <?php foreach ( $bl_recent as $bl ) :
+                        $status_color = 'live' === $bl['status'] ? '#10b981' : ( 'lost' === $bl['status'] ? '#f59e0b' : ( 'broken' === $bl['status'] ? '#ef4444' : '#6b7280' ) );
+                    ?>
+                        <div class="swps-dash-list-row">
+                            <div class="swps-dash-list-main">
+                                <div class="swps-dash-list-title"><?php echo esc_html( $bl['label'] ); ?></div>
+                                <div class="swps-dash-list-sub">
+                                    <span style="color:<?php echo esc_attr( $status_color ); ?>;font-weight:600;text-transform:uppercase;font-size:10px;letter-spacing:.05em">
+                                        <?php echo esc_html( $bl['status'] ); ?>
+                                    </span>
+                                    <?php if ( ! empty( $bl['when'] ) ) : ?>
+                                        · <?php echo esc_html( human_time_diff( strtotime( $bl['when'] ) ) . ' ago' ); ?>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
         </div>
     </div>
 

--- a/templates/image-seo-page.php
+++ b/templates/image-seo-page.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Image SEO settings page (v4.2).
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$image_seo = stratawp_seo()->image_seo;
+$opts      = $image_seo->get();
+$missing   = $image_seo->get_missing_alt_count();
+
+global $wpdb;
+// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+$total = (int) $wpdb->get_var( "
+    SELECT COUNT(*) FROM {$wpdb->posts}
+    WHERE post_type = 'attachment' AND post_mime_type LIKE 'image/%'
+" );
+$ok    = max( 0, $total - $missing );
+$pct   = $total > 0 ? round( ( $ok / $total ) * 100 ) : 100;
+?>
+<div class="wrap">
+    <?php
+    $title    = __( 'Image SEO', 'stratawp-seo' );
+    $subtitle = __( 'Auto-fill missing alt text, sanitize uploaded filenames, and keep images lazy-loaded. Helps both search ranking and accessibility.', 'stratawp-seo' );
+    $actions  = [];
+    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+    ?>
+
+    <!-- Stats tiles -->
+    <div class="swps-image-seo-stats">
+        <div class="swps-tile">
+            <div class="swps-tile-h"><?php esc_html_e( 'Images in library', 'stratawp-seo' ); ?></div>
+            <div class="swps-tile-stat"><?php echo number_format( $total ); ?></div>
+        </div>
+        <div class="swps-tile">
+            <div class="swps-tile-h"><?php esc_html_e( 'Missing alt text', 'stratawp-seo' ); ?></div>
+            <div class="swps-tile-stat" id="swps-img-missing"><?php echo number_format( $missing ); ?></div>
+            <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+                <?php
+                printf(
+                    /* translators: %d: percent with alt */
+                    esc_html__( '%d%% have alt text', 'stratawp-seo' ),
+                    (int) $pct
+                );
+                ?>
+            </div>
+        </div>
+        <div class="swps-tile">
+            <div class="swps-tile-h"><?php esc_html_e( 'Auto-alt mode', 'stratawp-seo' ); ?></div>
+            <div class="swps-tile-stat" style="font-size:18px">
+                <?php echo 'ai' === ( $opts['alt_mode'] ?? 'heuristic' ) ? esc_html__( 'AI', 'stratawp-seo' ) : esc_html__( 'Heuristic', 'stratawp-seo' ); ?>
+            </div>
+            <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+                <?php echo empty( $opts['auto_alt'] ) ? esc_html__( 'Disabled', 'stratawp-seo' ) : esc_html__( 'Active on upload', 'stratawp-seo' ); ?>
+            </div>
+        </div>
+    </div>
+
+    <!-- Bulk fix -->
+    <div class="swps-card" style="margin-bottom:16px">
+        <h2 style="margin-top:0"><?php esc_html_e( 'Bulk fix missing alt text', 'stratawp-seo' ); ?></h2>
+        <p class="description" style="margin-top:0">
+            <?php esc_html_e( 'Process the existing library and write alt text for every image that does not have any. Uses the auto-alt mode you have selected below. Runs in batches of 20 — safe to leave open while it works.', 'stratawp-seo' ); ?>
+        </p>
+        <div class="swps-image-seo-bulk-actions" style="display:flex;align-items:center;gap:12px;margin-top:12px">
+            <button type="button" class="swps-btn swps-btn-grad" id="swps-img-bulk-fix"
+                    <?php disabled( 0 === $missing ); ?>>
+                <?php esc_html_e( 'Fix missing alt text', 'stratawp-seo' ); ?>
+            </button>
+            <span class="swps-image-seo-status" id="swps-img-status" style="color:var(--swps-text-muted);font-size:13px">
+                <?php
+                if ( 0 === $missing ) {
+                    esc_html_e( 'All images have alt text. Nothing to do here.', 'stratawp-seo' );
+                } else {
+                    printf(
+                        /* translators: %d: count missing */
+                        esc_html__( '%d images need alt text.', 'stratawp-seo' ),
+                        (int) $missing
+                    );
+                }
+                ?>
+            </span>
+        </div>
+    </div>
+
+    <!-- Settings form -->
+    <form method="post" action="options.php" class="swps-image-seo-form">
+        <?php settings_fields( 'swps_image_seo_group' ); ?>
+
+        <div class="swps-card" style="margin-bottom:16px">
+            <h2 style="margin-top:0"><?php esc_html_e( 'Auto-alt on upload', 'stratawp-seo' ); ?></h2>
+
+            <label style="display:flex;align-items:center;gap:10px;margin-bottom:10px">
+                <input type="checkbox"
+                       name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[auto_alt]"
+                       value="1" <?php checked( ! empty( $opts['auto_alt'] ) ); ?> />
+                <span style="font-weight:600"><?php esc_html_e( 'Generate alt text automatically when an image is uploaded', 'stratawp-seo' ); ?></span>
+            </label>
+
+            <fieldset style="margin-left:28px;margin-top:8px">
+                <legend class="screen-reader-text"><?php esc_html_e( 'Alt text generation mode', 'stratawp-seo' ); ?></legend>
+                <label style="display:block;margin-bottom:6px">
+                    <input type="radio"
+                           name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[alt_mode]"
+                           value="heuristic" <?php checked( ( $opts['alt_mode'] ?? 'heuristic' ), 'heuristic' ); ?> />
+                    <strong><?php esc_html_e( 'Heuristic (free, instant)', 'stratawp-seo' ); ?></strong>
+                    <span style="color:var(--swps-text-muted);font-size:12px">
+                        — <?php esc_html_e( 'Derives alt from filename + parent post title. No API calls.', 'stratawp-seo' ); ?>
+                    </span>
+                </label>
+                <label style="display:block">
+                    <input type="radio"
+                           name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[alt_mode]"
+                           value="ai" <?php checked( ( $opts['alt_mode'] ?? 'heuristic' ), 'ai' ); ?> />
+                    <strong><?php esc_html_e( 'AI (uses your configured provider)', 'stratawp-seo' ); ?></strong>
+                    <span style="color:var(--swps-text-muted);font-size:12px">
+                        — <?php esc_html_e( 'Sends filename + post context to your AI provider. Falls back to heuristic on error. Each call costs a fraction of a cent.', 'stratawp-seo' ); ?>
+                    </span>
+                </label>
+            </fieldset>
+        </div>
+
+        <div class="swps-card" style="margin-bottom:16px">
+            <h2 style="margin-top:0"><?php esc_html_e( 'Filename sanitization', 'stratawp-seo' ); ?></h2>
+            <label style="display:flex;align-items:center;gap:10px">
+                <input type="checkbox"
+                       name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[filename_sanitize]"
+                       value="1" <?php checked( ! empty( $opts['filename_sanitize'] ) ); ?> />
+                <span style="font-weight:600"><?php esc_html_e( 'Clean up filenames on upload', 'stratawp-seo' ); ?></span>
+            </label>
+            <p class="description" style="margin:6px 0 0 28px">
+                <?php esc_html_e( 'Strips device prefixes (IMG_, DSC_), lowercases, and converts spaces/underscores to dashes. Example: "IMG_4523 Vacation.JPG" → "vacation.jpg".', 'stratawp-seo' ); ?>
+            </p>
+        </div>
+
+        <div class="swps-card" style="margin-bottom:16px">
+            <h2 style="margin-top:0"><?php esc_html_e( 'Lazy loading', 'stratawp-seo' ); ?></h2>
+            <label style="display:flex;align-items:center;gap:10px">
+                <input type="checkbox"
+                       name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[lazy_load]"
+                       value="1" <?php checked( ! empty( $opts['lazy_load'] ) ); ?> />
+                <span style="font-weight:600"><?php esc_html_e( 'Force loading="lazy" + decoding="async" on all post-content images', 'stratawp-seo' ); ?></span>
+            </label>
+            <p class="description" style="margin:6px 0 0 28px">
+                <?php esc_html_e( 'WordPress already lazy-loads images that have width/height attributes. This adds the attributes to any image still missing them, which improves Core Web Vitals.', 'stratawp-seo' ); ?>
+            </p>
+        </div>
+
+        <?php submit_button( __( 'Save Image SEO settings', 'stratawp-seo' ) ); ?>
+    </form>
+</div>

--- a/templates/local-seo-page.php
+++ b/templates/local-seo-page.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Local SEO settings page (v4.2).
+ *
+ * Wrapped by SWPS_Admin_Shell. Captures NAP, hours, geo, area served and
+ * outputs LocalBusiness JSON-LD on the homepage.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$local = stratawp_seo()->local_seo;
+$d     = $local->get();
+$types = SWPS_Local_SEO::BUSINESS_TYPES;
+$days  = SWPS_Local_SEO::DAYS;
+
+$preview = $local->build_schema();
+?>
+<div class="wrap">
+    <?php
+    $title    = __( 'Local SEO', 'stratawp-seo' );
+    $subtitle = __( 'Add your business name, address, phone, and hours. StrataWP outputs LocalBusiness JSON-LD on your homepage so Google can show your hours, location, and contact info in search.', 'stratawp-seo' );
+    $actions  = [];
+    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+    ?>
+
+    <form method="post" action="options.php" class="swps-local-seo-form">
+        <?php settings_fields( 'swps_local_seo_group' ); ?>
+
+        <div class="swps-card" style="margin-bottom:16px">
+            <label class="swps-toggle-row" style="display:flex;align-items:center;gap:10px">
+                <input type="checkbox"
+                       name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[enabled]"
+                       value="1"
+                       <?php checked( ! empty( $d['enabled'] ) ); ?> />
+                <span style="font-weight:600"><?php esc_html_e( 'Enable Local SEO schema output', 'stratawp-seo' ); ?></span>
+            </label>
+            <p class="description" style="margin:6px 0 0 28px">
+                <?php esc_html_e( 'When enabled (and a business name + city are set), LocalBusiness JSON-LD is added to your homepage. If Yoast/RankMath/AIOSEO are active, StrataWP defers to them.', 'stratawp-seo' ); ?>
+            </p>
+        </div>
+
+        <!-- Business identity -->
+        <div class="swps-card" style="margin-bottom:16px">
+            <h2 style="margin-top:0"><?php esc_html_e( 'Business identity', 'stratawp-seo' ); ?></h2>
+            <table class="form-table" role="presentation">
+                <tbody>
+                <tr>
+                    <th scope="row"><label for="swps-bt"><?php esc_html_e( 'Business type', 'stratawp-seo' ); ?></label></th>
+                    <td>
+                        <select id="swps-bt" name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[business_type]">
+                            <?php foreach ( $types as $val => $label ) : ?>
+                                <option value="<?php echo esc_attr( $val ); ?>" <?php selected( $d['business_type'], $val ); ?>>
+                                    <?php echo esc_html( $label ); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                        <p class="description"><?php esc_html_e( 'Picks the most specific schema.org type Google understands for your business.', 'stratawp-seo' ); ?></p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="swps-name"><?php esc_html_e( 'Business name', 'stratawp-seo' ); ?></label></th>
+                    <td>
+                        <input id="swps-name" type="text" class="regular-text"
+                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[name]"
+                               value="<?php echo esc_attr( $d['name'] ); ?>" />
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="swps-phone"><?php esc_html_e( 'Phone', 'stratawp-seo' ); ?></label></th>
+                    <td>
+                        <input id="swps-phone" type="text" class="regular-text"
+                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[phone]"
+                               value="<?php echo esc_attr( $d['phone'] ); ?>"
+                               placeholder="+1-555-555-1234" />
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="swps-email"><?php esc_html_e( 'Email', 'stratawp-seo' ); ?></label></th>
+                    <td>
+                        <input id="swps-email" type="email" class="regular-text"
+                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[email]"
+                               value="<?php echo esc_attr( $d['email'] ); ?>" />
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="swps-price"><?php esc_html_e( 'Price range', 'stratawp-seo' ); ?></label></th>
+                    <td>
+                        <input id="swps-price" type="text" class="regular-text"
+                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[price_range]"
+                               value="<?php echo esc_attr( $d['price_range'] ); ?>"
+                               placeholder="$$ or $10-30" />
+                        <p class="description"><?php esc_html_e( 'Use $, $$, $$$, $$$$ — or a range like $10-30.', 'stratawp-seo' ); ?></p>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Address -->
+        <div class="swps-card" style="margin-bottom:16px">
+            <h2 style="margin-top:0"><?php esc_html_e( 'Address', 'stratawp-seo' ); ?></h2>
+            <table class="form-table" role="presentation">
+                <tbody>
+                <tr>
+                    <th scope="row"><label for="swps-street"><?php esc_html_e( 'Street', 'stratawp-seo' ); ?></label></th>
+                    <td>
+                        <input id="swps-street" type="text" class="regular-text"
+                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[street]"
+                               value="<?php echo esc_attr( $d['street'] ); ?>" />
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="swps-loc"><?php esc_html_e( 'City', 'stratawp-seo' ); ?></label></th>
+                    <td>
+                        <input id="swps-loc" type="text" class="regular-text"
+                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[locality]"
+                               value="<?php echo esc_attr( $d['locality'] ); ?>" />
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="swps-region"><?php esc_html_e( 'State / region', 'stratawp-seo' ); ?></label></th>
+                    <td>
+                        <input id="swps-region" type="text" class="regular-text"
+                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[region]"
+                               value="<?php echo esc_attr( $d['region'] ); ?>" />
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="swps-zip"><?php esc_html_e( 'Postal code', 'stratawp-seo' ); ?></label></th>
+                    <td>
+                        <input id="swps-zip" type="text" class="regular-text"
+                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[postal_code]"
+                               value="<?php echo esc_attr( $d['postal_code'] ); ?>" />
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="swps-country"><?php esc_html_e( 'Country', 'stratawp-seo' ); ?></label></th>
+                    <td>
+                        <input id="swps-country" type="text" class="regular-text"
+                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[country]"
+                               value="<?php echo esc_attr( $d['country'] ); ?>"
+                               placeholder="US, GB, DE..." />
+                        <p class="description"><?php esc_html_e( 'Two-letter ISO code preferred (US, GB, DE, AU…). Full names also work.', 'stratawp-seo' ); ?></p>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Geo + place -->
+        <div class="swps-card" style="margin-bottom:16px">
+            <h2 style="margin-top:0"><?php esc_html_e( 'Map & geo', 'stratawp-seo' ); ?></h2>
+            <table class="form-table" role="presentation">
+                <tbody>
+                <tr>
+                    <th scope="row"><label for="swps-lat"><?php esc_html_e( 'Latitude', 'stratawp-seo' ); ?></label></th>
+                    <td>
+                        <input id="swps-lat" type="text" class="regular-text"
+                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[latitude]"
+                               value="<?php echo esc_attr( $d['latitude'] ); ?>"
+                               placeholder="-37.8136" />
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="swps-lng"><?php esc_html_e( 'Longitude', 'stratawp-seo' ); ?></label></th>
+                    <td>
+                        <input id="swps-lng" type="text" class="regular-text"
+                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[longitude]"
+                               value="<?php echo esc_attr( $d['longitude'] ); ?>"
+                               placeholder="144.9631" />
+                        <p class="description"><?php esc_html_e( 'Open Google Maps, right-click your location, click the lat/lng to copy.', 'stratawp-seo' ); ?></p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="swps-place"><?php esc_html_e( 'Google Place ID', 'stratawp-seo' ); ?></label></th>
+                    <td>
+                        <input id="swps-place" type="text" class="regular-text"
+                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[place_id]"
+                               value="<?php echo esc_attr( $d['place_id'] ); ?>"
+                               placeholder="ChIJ..." />
+                        <p class="description">
+                            <?php
+                            printf(
+                                /* translators: %s: place ID finder URL */
+                                esc_html__( 'Optional. Find yours at %s.', 'stratawp-seo' ),
+                                '<a href="https://developers.google.com/maps/documentation/javascript/examples/places-placeid-finder" target="_blank" rel="noopener noreferrer">developers.google.com</a>' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                            );
+                            ?>
+                        </p>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Hours -->
+        <div class="swps-card" style="margin-bottom:16px">
+            <h2 style="margin-top:0"><?php esc_html_e( 'Opening hours', 'stratawp-seo' ); ?></h2>
+            <p class="description" style="margin-top:0">
+                <?php esc_html_e( 'Use 24-hour format (e.g. 09:00 / 17:30). Tick "Closed" for days you are not open.', 'stratawp-seo' ); ?>
+            </p>
+            <table class="widefat striped" style="max-width:680px">
+                <thead>
+                    <tr>
+                        <th><?php esc_html_e( 'Day', 'stratawp-seo' ); ?></th>
+                        <th><?php esc_html_e( 'Open', 'stratawp-seo' ); ?></th>
+                        <th><?php esc_html_e( 'Close', 'stratawp-seo' ); ?></th>
+                        <th><?php esc_html_e( 'Closed', 'stratawp-seo' ); ?></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ( $days as $day_key => $day_short ) :
+                    $row    = $d['hours'][ $day_key ] ?? [ 'open' => '', 'close' => '', 'closed' => 0 ];
+                    $name   = SWPS_Local_SEO::OPTION_KEY . '[hours][' . $day_key . ']';
+                ?>
+                    <tr>
+                        <td><strong><?php echo esc_html( $day_key ); ?></strong></td>
+                        <td>
+                            <input type="time" name="<?php echo esc_attr( $name ); ?>[open]"
+                                   value="<?php echo esc_attr( $row['open'] ?? '' ); ?>" />
+                        </td>
+                        <td>
+                            <input type="time" name="<?php echo esc_attr( $name ); ?>[close]"
+                                   value="<?php echo esc_attr( $row['close'] ?? '' ); ?>" />
+                        </td>
+                        <td>
+                            <label>
+                                <input type="checkbox" name="<?php echo esc_attr( $name ); ?>[closed]" value="1"
+                                       <?php checked( ! empty( $row['closed'] ) ); ?> />
+                                <?php esc_html_e( 'Closed', 'stratawp-seo' ); ?>
+                            </label>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Area served -->
+        <div class="swps-card" style="margin-bottom:16px">
+            <h2 style="margin-top:0"><?php esc_html_e( 'Area served', 'stratawp-seo' ); ?></h2>
+            <p class="description" style="margin-top:0">
+                <?php esc_html_e( 'For service-area businesses (plumbers, electricians, etc.). One city or region per line — up to 25.', 'stratawp-seo' ); ?>
+            </p>
+            <textarea name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[area_served]"
+                      rows="6" class="large-text code"
+                      placeholder="Melbourne, VIC&#10;Geelong, VIC&#10;Ballarat, VIC"><?php echo esc_textarea( $d['area_served'] ); ?></textarea>
+        </div>
+
+        <?php submit_button( __( 'Save Local SEO settings', 'stratawp-seo' ) ); ?>
+    </form>
+
+    <?php if ( ! empty( $preview ) ) : ?>
+        <div class="swps-card" style="margin-top:24px">
+            <h2 style="margin-top:0"><?php esc_html_e( 'Schema preview', 'stratawp-seo' ); ?></h2>
+            <p class="description" style="margin-top:0">
+                <?php esc_html_e( 'This is the JSON-LD that will be injected into your homepage <head>. Test it with Google\'s Rich Results Test once your homepage is live.', 'stratawp-seo' ); ?>
+            </p>
+            <pre style="background:var(--swps-surface-2,#0f1115);color:var(--swps-text,#e7e9ee);padding:14px;border-radius:6px;overflow:auto;max-height:420px;font-size:12px;line-height:1.5"><?php echo esc_html( wp_json_encode( $preview, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+        </div>
+    <?php endif; ?>
+</div>


### PR DESCRIPTION
Four new modules ship in this release, replacing the placeholder "coming soon" entries with real working features.

Local SEO (SEO → Local SEO)
- 30+ business types (Restaurant, Plumber, Dentist, Hotel, etc.)
- Full NAP, opening hours per day, geo lat/lng, area served, Google Place ID
- LocalBusiness JSON-LD on the homepage with OpeningHoursSpecification, PostalAddress, GeoCoordinates; reuses swps_schema_logo and social profiles
- Live JSON-LD preview; defers to Yoast/RankMath/AIOSEO when active

Image SEO (SEO → Image SEO)
- Auto-alt on upload: Heuristic (free, derives from filename + parent post title) or AI mode (uses configured provider; falls back on error)
- Filename sanitization strips IMG_/DSC_/Screenshot prefixes, lowercases, dash-separates
- Lazy-loading enforcement on the_content
- Bulk-fix tool for the existing library: AJAX, 20-image batches, live progress
- Stats tiles for total / missing / coverage %

Crawlers & Files (SEO → Crawlers & Files)
- Edit /llms.txt: Auto (StrataWP-generated) or Custom (your markdown verbatim)
- Edit /robots.txt: Auto / Append (auto + your rules) / Replace
- Side-by-side editor + auto preview, "copy auto into editor" helper
- Detects physical robots.txt and warns it overrides the dynamic version
- Hooks at priority 200 so AI-bot rules at priority 100 are preserved on Append

Backlinks (Insights → Backlinks)
- Custom DB table swps_backlinks via dbDelta + runtime upgrade path so existing installs get the table without re-activation
- Manual add or CSV import (auto-detects the GSC "Top linking sites" export)
- Daily WP-cron health verification: classifies each as Live / Lost / Broken
- Captures real anchor text + first/last seen on every successful verify
- AJAX bulk-verify in 25-row batches, per-row re-verify and delete, CSV export
- Stats tiles + dashboard widget (live count + 3 most-recently-verified)

Modules registry / admin shell
- Local SEO + Image SEO + Crawlers & Files + Backlinks added to the SEO and Insights nav groups with NEW badges
- WooCommerce SEO retained as the only remaining "soon" module

Documentation
- README.md: new feature sections, page-by-page how-to entries for all four pages, FAQ updates, admin pages table, changelog 4.2.0–4.2.2
- readme.txt: feature blocks, changelog, upgrade notice for 4.2.0–4.2.2