### PR TITLE
v4.4.2: Fix scheduled posts missing images

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.4.1-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.4.2-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1262,6 +1262,9 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### 4.4.2
+- **Fix — Scheduled posts had no images:** WP-Cron-generated posts were being saved without a featured image or in-content images, and nothing was reaching `debug.log`. Root cause was PHP `max_execution_time` killing the worker mid-image-download — AI text + Gemini featured image + 3 in-content Gemini images stack well past the 30–60s default cron limit, and `error_log()` calls inside the catch paths can't fire when PHP dies inside `wp_remote_post`. `SWPS_Generator::generate_post()` now calls `@set_time_limit(0)`, `wp_raise_memory_limit('admin')`, and `ignore_user_abort(true)` before kicking off the pipeline. Manual generation worked already (admin-ajax has its own request context); the fix covers cron, background processor, REST, CLI, and bulk AJAX entry points. Any real provider errors (blocked prompts, missing keys, decode failures) now surface through the existing handlers in `class-gemini-provider.php` instead of being swallowed by a timeout.
 
 ### 4.4.1
 - **Fix (#24):** Saving the Google (Gemini) API key from the Settings screen had no effect. The same `swps_google_api_key` field was registered in both the AI Provider and Featured Images sections, so the form contained two inputs with the same name. The hidden Featured Images duplicate (empty by default) was submitted last and overwrote the value the user typed in the AI Provider section. The Featured Images section now shows an info row pointing to the AI Provider key instead of duplicating the input.

--- a/includes/class-generator.php
+++ b/includes/class-generator.php
@@ -44,6 +44,17 @@ class SWPS_Generator {
      * @return array|WP_Error Post data on success, error on failure.
      */
     public function generate_post( string $topic = '', string $template = 'auto' ): array|WP_Error {
+        // Image generation (especially Gemini) can take several minutes per post.
+        // Lift PHP execution caps so cron/background jobs don't die mid-download,
+        // leaving posts with no images and an empty debug.log.
+        if ( function_exists( 'set_time_limit' ) ) {
+            @set_time_limit( 0 );
+        }
+        if ( function_exists( 'wp_raise_memory_limit' ) ) {
+            wp_raise_memory_limit( 'admin' );
+        }
+        ignore_user_abort( true );
+
         // Fire before_generate action.
         SWPS_Hooks::do_before_generate( $topic, $template );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.4.1
+Stable tag: 4.4.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -251,6 +251,9 @@ Yes. The built-in analytics tracker is cookie-free and does not use any external
 No. GSC integration is optional. The on-site analytics works entirely without any external services. Add Google OAuth credentials only if you want search clicks, impressions, and ranking data.
 
 == Changelog ==
+
+= 4.4.2 =
+* Fix: Scheduled (WP-Cron) posts were created without a featured image or in-content images, with nothing logged to debug.log. Root cause was PHP `max_execution_time` killing the worker mid-image-download — the AI text call plus Gemini image generation easily exceeds the 30–60s default. `SWPS_Generator::generate_post()` now calls `@set_time_limit(0)`, raises the memory limit, and sets `ignore_user_abort(true)` before kicking off the pipeline. Manual generation was unaffected; only cron/background paths benefit.
 
 = 4.4.1 =
 * Fix: Saving the Google (Gemini) API key from the Settings screen had no effect. The same field was registered in both the AI Provider and Featured Images sections, so a hidden duplicate input overwrote the value with an empty string on save. The Featured Images section now references the AI Provider key instead of duplicating the input. (#24)

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.4.1
+ * Version: 4.4.2
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'SWPS_VERSION', '4.4.1' );
+define( 'SWPS_VERSION', '4.4.2' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
WP-Cron post generation was timing out mid-image-download. AI text + Gemini featured image + 3 in-content Gemini images stack well past the 30-60s PHP max_execution_time default, killing the worker after wp_insert_post but before set_featured_image / insert_images completed. The error_log calls in the catch paths never fired because PHP died inside wp_remote_post — hence the empty debug.log.

SWPS_Generator::generate_post() now calls @set_time_limit(0), wp_raise_memory_limit('admin'), and ignore_user_abort(true) before the pipeline. Covers cron, background processor, REST, CLI, and bulk AJAX paths; manual admin-ajax was unaffected because it already had a generous request context. Matches the existing pattern in class-backlinks.php and class-auto-optimize.php.