### PR TITLE
style: auto-fix WPCS violations with phpcbf

### DIFF
--- a/includes/audit/class-canonical-module.php
+++ b/includes/audit/class-canonical-module.php
@@ -28,26 +28,26 @@ class SWPS_Canonical_Module extends SWPS_Audit_Module {
 
 	public function run(): array {
 		$posts  = $this->get_public_posts();
-		$issues = [];
+		$issues = array();
 
 		foreach ( $posts as $post ) {
 			// Check if Yoast or RankMath provides a canonical.
-			$yoast_canonical     = get_post_meta( $post->ID, '_yoast_wpseo_canonical', true );
-			$rankmath_canonical  = get_post_meta( $post->ID, 'rank_math_canonical_url', true );
-			$has_seo_canonical   = ! empty( $yoast_canonical ) || ! empty( $rankmath_canonical );
+			$yoast_canonical    = get_post_meta( $post->ID, '_yoast_wpseo_canonical', true );
+			$rankmath_canonical = get_post_meta( $post->ID, 'rank_math_canonical_url', true );
+			$has_seo_canonical  = ! empty( $yoast_canonical ) || ! empty( $rankmath_canonical );
 
 			// Check if our auto-canonical is enabled.
 			$our_canonical = (bool) get_option( 'swps_audit_auto_canonical', 1 );
 
 			if ( ! $has_seo_canonical && ! $our_canonical ) {
-				$issues[] = [
+				$issues[] = array(
 					'post_id' => $post->ID,
 					'message' => sprintf(
 						__( '"%s" has no canonical tag.', 'stratawp-seo' ),
 						$post->post_title
 					),
 					'fixable' => true,
-				];
+				);
 			}
 		}
 
@@ -55,24 +55,24 @@ class SWPS_Canonical_Module extends SWPS_Audit_Module {
 		$failing = count( $issues );
 		$score   = $total > 0 ? (int) round( ( ( $total - $failing ) / $total ) * 100 ) : 100;
 
-		return [
+		return array(
 			'score'   => $score,
 			'status'  => $this->status_from_score( $score ),
 			'issues'  => $issues,
 			'summary' => 0 === $failing
 				? __( 'All posts have canonical tags.', 'stratawp-seo' )
 				: sprintf( __( '%d posts missing canonical tags.', 'stratawp-seo' ), $failing ),
-		];
+		);
 	}
 
 	public function auto_fix( array $issues ): array {
 		// Enable the auto-canonical option.
 		update_option( 'swps_audit_auto_canonical', 1 );
 
-		return [
+		return array(
 			'fixed'    => count( $issues ),
-			'messages' => [ __( 'Auto-canonical injection enabled. Canonical tags will be output via wp_head.', 'stratawp-seo' ) ],
-		];
+			'messages' => array( __( 'Auto-canonical injection enabled. Canonical tags will be output via wp_head.', 'stratawp-seo' ) ),
+		);
 	}
 
 	/**

--- a/includes/audit/class-image-seo-module.php
+++ b/includes/audit/class-image-seo-module.php
@@ -29,53 +29,55 @@ class SWPS_Image_SEO_Module extends SWPS_Audit_Module {
 	}
 
 	public function run(): array {
-		$issues = [];
+		$issues = array();
 
 		// Query recent attachments (images).
-		$attachments = get_posts( [
-			'post_type'      => 'attachment',
-			'post_mime_type' => 'image',
-			'post_status'    => 'inherit',
-			'posts_per_page' => 200,
-			'orderby'        => 'date',
-			'order'          => 'DESC',
-			'no_found_rows'  => true,
-		] );
+		$attachments = get_posts(
+			array(
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image',
+				'post_status'    => 'inherit',
+				'posts_per_page' => 200,
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+				'no_found_rows'  => true,
+			)
+		);
 
-		$missing_alt    = 0;
-		$bad_filenames  = 0;
-		$fixable_ids    = [];
+		$missing_alt   = 0;
+		$bad_filenames = 0;
+		$fixable_ids   = array();
 
 		foreach ( $attachments as $attachment ) {
 			$alt = get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true );
 
 			if ( '' === trim( (string) $alt ) ) {
-				$missing_alt++;
+				++$missing_alt;
 				$fixable_ids[] = $attachment->ID;
 
-				$issues[] = [
+				$issues[] = array(
 					'post_id' => $attachment->ID,
 					'message' => sprintf(
 						__( 'Image "%s" is missing alt text.', 'stratawp-seo' ),
 						basename( get_attached_file( $attachment->ID ) )
 					),
 					'fixable' => true,
-				];
+				);
 			}
 
 			// Check filename quality.
 			$filename = basename( get_attached_file( $attachment->ID ) );
 			if ( preg_match( '/^(IMG_|DSC_|Screenshot|image|photo)\d*/i', $filename ) ) {
-				$bad_filenames++;
+				++$bad_filenames;
 
-				$issues[] = [
+				$issues[] = array(
 					'post_id' => $attachment->ID,
 					'message' => sprintf(
 						__( 'Image "%s" has a non-descriptive filename.', 'stratawp-seo' ),
 						$filename
 					),
 					'fixable' => false,
-				];
+				);
 			}
 		}
 
@@ -83,18 +85,18 @@ class SWPS_Image_SEO_Module extends SWPS_Audit_Module {
 		$failing = $missing_alt + $bad_filenames;
 		$score   = $total > 0 ? max( 0, (int) round( ( ( $total - $failing ) / $total ) * 100 ) ) : 100;
 
-		return [
+		return array(
 			'score'   => $score,
 			'status'  => $this->status_from_score( $score ),
 			'issues'  => $issues,
 			'summary' => 0 === $failing
 				? __( 'All images have alt text and descriptive filenames.', 'stratawp-seo' )
 				: sprintf(
-					__( '%d missing alt text, %d non-descriptive filenames.', 'stratawp-seo' ),
+					__( '%1$d missing alt text, %2$d non-descriptive filenames.', 'stratawp-seo' ),
 					$missing_alt,
 					$bad_filenames
 				),
-		];
+		);
 	}
 
 	public function auto_fix( array $issues ): array {
@@ -102,7 +104,7 @@ class SWPS_Image_SEO_Module extends SWPS_Audit_Module {
 		$fixable = array_slice( $fixable, 0, self::MAX_BATCH );
 
 		$fixed    = 0;
-		$messages = [];
+		$messages = array();
 
 		foreach ( $fixable as $issue ) {
 			$attachment = get_post( $issue['post_id'] );
@@ -115,19 +117,19 @@ class SWPS_Image_SEO_Module extends SWPS_Audit_Module {
 
 			if ( ! empty( $alt ) ) {
 				update_post_meta( $attachment->ID, '_wp_attachment_image_alt', sanitize_text_field( $alt ) );
-				$fixed++;
+				++$fixed;
 				$messages[] = sprintf(
-					__( 'Set alt text for "%s": "%s"', 'stratawp-seo' ),
+					__( 'Set alt text for "%1$s": "%2$s"', 'stratawp-seo' ),
 					basename( get_attached_file( $attachment->ID ) ),
 					$alt
 				);
 			}
 		}
 
-		return [
+		return array(
 			'fixed'    => $fixed,
 			'messages' => $messages,
-		];
+		);
 	}
 
 	/**
@@ -163,6 +165,6 @@ class SWPS_Image_SEO_Module extends SWPS_Audit_Module {
 
 		// Last resort: clean up filename.
 		$filename = pathinfo( basename( get_attached_file( $attachment->ID ) ), PATHINFO_FILENAME );
-		return ucfirst( str_replace( [ '-', '_' ], ' ', $filename ) );
+		return ucfirst( str_replace( array( '-', '_' ), ' ', $filename ) );
 	}
 }

--- a/includes/audit/class-meta-robots-module.php
+++ b/includes/audit/class-meta-robots-module.php
@@ -28,10 +28,10 @@ class SWPS_Meta_Robots_Module extends SWPS_Audit_Module {
 
 	public function run(): array {
 		$posts  = $this->get_public_posts();
-		$issues = [];
+		$issues = array();
 
 		foreach ( $posts as $post ) {
-			$problems = [];
+			$problems = array();
 
 			// Yoast noindex check.
 			$yoast_noindex = get_post_meta( $post->ID, '_yoast_wpseo_meta-robots-noindex', true );
@@ -57,15 +57,15 @@ class SWPS_Meta_Robots_Module extends SWPS_Audit_Module {
 			}
 
 			if ( ! empty( $problems ) ) {
-				$issues[] = [
+				$issues[] = array(
 					'post_id' => $post->ID,
 					'message' => sprintf(
-						__( '"%s" has restrictive meta robots: %s.', 'stratawp-seo' ),
+						__( '"%1$s" has restrictive meta robots: %2$s.', 'stratawp-seo' ),
 						$post->post_title,
 						implode( ', ', $problems )
 					),
 					'fixable' => false,
-				];
+				);
 			}
 		}
 
@@ -73,13 +73,13 @@ class SWPS_Meta_Robots_Module extends SWPS_Audit_Module {
 		$failing = count( $issues );
 		$score   = $total > 0 ? (int) round( ( ( $total - $failing ) / $total ) * 100 ) : 100;
 
-		return [
+		return array(
 			'score'   => $score,
 			'status'  => $this->status_from_score( $score ),
 			'issues'  => $issues,
 			'summary' => 0 === $failing
 				? __( 'No conflicting meta robots directives found.', 'stratawp-seo' )
 				: sprintf( __( '%d published posts have restrictive robots settings.', 'stratawp-seo' ), $failing ),
-		];
+		);
 	}
 }

--- a/includes/audit/class-opengraph-module.php
+++ b/includes/audit/class-opengraph-module.php
@@ -28,16 +28,16 @@ class SWPS_OpenGraph_Module extends SWPS_Audit_Module {
 
 	public function run(): array {
 		$posts  = $this->get_public_posts();
-		$issues = [];
+		$issues = array();
 
 		// If another SEO plugin handles OG or we handle it, skip post-level checks.
 		if ( defined( 'WPSEO_VERSION' ) || class_exists( 'RankMath' ) ) {
-			return [
+			return array(
 				'score'   => 100,
 				'status'  => 'pass',
-				'issues'  => [],
+				'issues'  => array(),
 				'summary' => __( 'Open Graph tags managed by SEO plugin.', 'stratawp-seo' ),
-			];
+			);
 		}
 
 		$our_og = (bool) get_option( 'swps_audit_auto_og', 1 );
@@ -46,28 +46,28 @@ class SWPS_OpenGraph_Module extends SWPS_Audit_Module {
 			// Check posts for missing OG signals (no featured image = no OG image).
 			foreach ( $posts as $post ) {
 				if ( ! has_post_thumbnail( $post->ID ) ) {
-					$issues[] = [
+					$issues[] = array(
 						'post_id' => $post->ID,
 						'message' => sprintf(
 							__( '"%s" has no featured image for og:image.', 'stratawp-seo' ),
 							$post->post_title
 						),
 						'fixable' => false,
-					];
+					);
 				}
 			}
 		} else {
 			// OG enabled — just check for missing images.
 			foreach ( $posts as $post ) {
 				if ( ! has_post_thumbnail( $post->ID ) ) {
-					$issues[] = [
+					$issues[] = array(
 						'post_id' => $post->ID,
 						'message' => sprintf(
 							__( '"%s" will use fallback og:image (no featured image).', 'stratawp-seo' ),
 							$post->post_title
 						),
 						'fixable' => false,
-					];
+					);
 				}
 			}
 		}
@@ -80,23 +80,23 @@ class SWPS_OpenGraph_Module extends SWPS_Audit_Module {
 			$score = 50;
 		}
 
-		return [
+		return array(
 			'score'   => $score,
 			'status'  => $this->status_from_score( $score ),
 			'issues'  => $issues,
 			'summary' => 0 === $failing
 				? __( 'All posts have Open Graph tags.', 'stratawp-seo' )
 				: sprintf( __( '%d posts with OG image issues.', 'stratawp-seo' ), $failing ),
-		];
+		);
 	}
 
 	public function auto_fix( array $issues ): array {
 		update_option( 'swps_audit_auto_og', 1 );
 
-		return [
+		return array(
 			'fixed'    => 1,
-			'messages' => [ __( 'Auto Open Graph tag output enabled.', 'stratawp-seo' ) ],
-		];
+			'messages' => array( __( 'Auto Open Graph tag output enabled.', 'stratawp-seo' ) ),
+		);
 	}
 
 	/**

--- a/includes/audit/class-pagespeed-module.php
+++ b/includes/audit/class-pagespeed-module.php
@@ -28,7 +28,7 @@ class SWPS_PageSpeed_Module extends SWPS_Audit_Module {
 	}
 
 	public function run(): array {
-		$issues = [];
+		$issues = array();
 
 		// Check recent posts for image issues in content.
 		$posts = $this->get_public_posts( 50 );
@@ -44,37 +44,37 @@ class SWPS_PageSpeed_Module extends SWPS_Audit_Module {
 				foreach ( $matches[0] as $img_tag ) {
 					// Check for width/height attributes.
 					if ( ! preg_match( '/\bwidth\s*=/', $img_tag ) || ! preg_match( '/\bheight\s*=/', $img_tag ) ) {
-						$missing_dimensions++;
+						++$missing_dimensions;
 					}
 
 					// Check for lazy loading.
 					if ( false === stripos( $img_tag, 'loading=' ) ) {
-						$missing_lazy++;
+						++$missing_lazy;
 					}
 				}
 			}
 		}
 
 		if ( $missing_dimensions > 0 ) {
-			$issues[] = [
+			$issues[] = array(
 				'post_id' => null,
 				'message' => sprintf(
 					__( '%d images across recent posts are missing width/height attributes (causes layout shift).', 'stratawp-seo' ),
 					$missing_dimensions
 				),
 				'fixable' => false,
-			];
+			);
 		}
 
 		if ( $missing_lazy > 0 ) {
-			$issues[] = [
+			$issues[] = array(
 				'post_id' => null,
 				'message' => sprintf(
 					__( '%d images are missing loading="lazy" attribute.', 'stratawp-seo' ),
 					$missing_lazy
 				),
 				'fixable' => false,
-			];
+			);
 		}
 
 		// Note: WordPress 5.5+ adds lazy loading and 5.9+ adds dimensions automatically
@@ -96,13 +96,13 @@ class SWPS_PageSpeed_Module extends SWPS_Audit_Module {
 
 		$score = max( 0, $score );
 
-		return [
+		return array(
 			'score'   => $score,
 			'status'  => $this->status_from_score( $score ),
 			'issues'  => $issues,
 			'summary' => empty( $issues )
 				? __( 'No page speed issues detected in recent content.', 'stratawp-seo' )
 				: sprintf( __( '%d performance issue(s) found.', 'stratawp-seo' ), count( $issues ) ),
-		];
+		);
 	}
 }

--- a/includes/audit/class-robots-module.php
+++ b/includes/audit/class-robots-module.php
@@ -27,7 +27,7 @@ class SWPS_Robots_Module extends SWPS_Audit_Module {
 	}
 
 	public function run(): array {
-		$issues = [];
+		$issues = array();
 
 		// Check for a physical robots.txt.
 		$has_physical = file_exists( ABSPATH . 'robots.txt' );
@@ -40,20 +40,20 @@ class SWPS_Robots_Module extends SWPS_Audit_Module {
 
 			// Check for blocking /wp-content/.
 			if ( false !== stripos( $content, 'disallow: /wp-content/' ) ) {
-				$issues[] = [
+				$issues[] = array(
 					'post_id' => null,
 					'message' => __( 'robots.txt blocks /wp-content/ which may prevent image indexing.', 'stratawp-seo' ),
 					'fixable' => false, // Don't auto-modify a physical file.
-				];
+				);
 			}
 
 			// Check for sitemap line.
 			if ( false === stripos( $content, 'sitemap:' ) ) {
-				$issues[] = [
+				$issues[] = array(
 					'post_id' => null,
 					'message' => __( 'robots.txt does not include a Sitemap directive.', 'stratawp-seo' ),
 					'fixable' => false,
-				];
+				);
 			}
 		}
 		// WordPress virtual robots.txt is always present if no physical file exists.
@@ -62,22 +62,22 @@ class SWPS_Robots_Module extends SWPS_Audit_Module {
 		$failing = count( $issues );
 		$score   = 0 === $failing ? 100 : ( 1 === $failing ? 60 : 30 );
 
-		return [
+		return array(
 			'score'   => $score,
 			'status'  => $this->status_from_score( $score ),
 			'issues'  => $issues,
 			'summary' => 0 === $failing
 				? __( 'robots.txt is properly configured.', 'stratawp-seo' )
 				: sprintf( __( '%d robots.txt issue(s) found.', 'stratawp-seo' ), $failing ),
-		];
+		);
 	}
 
 	public function auto_fix( array $issues ): array {
 		// We can't modify a physical file, but we can ensure our filter is active.
-		return [
+		return array(
 			'fixed'    => 0,
-			'messages' => [ __( 'SWPS enhances the virtual robots.txt with sitemap directives automatically.', 'stratawp-seo' ) ],
-		];
+			'messages' => array( __( 'SWPS enhances the virtual robots.txt with sitemap directives automatically.', 'stratawp-seo' ) ),
+		);
 	}
 
 	/**

--- a/includes/audit/class-sitemap-module.php
+++ b/includes/audit/class-sitemap-module.php
@@ -28,67 +28,67 @@ class SWPS_Sitemap_Module extends SWPS_Audit_Module {
 	}
 
 	public function run(): array {
-		$issues = [];
+		$issues = array();
 
 		$has_other_sitemap = $this->detect_other_sitemap();
 
 		if ( $has_other_sitemap ) {
-			return [
+			return array(
 				'score'   => 100,
 				'status'  => 'pass',
-				'issues'  => [],
+				'issues'  => array(),
 				'summary' => __( 'Sitemap provided by another plugin.', 'stratawp-seo' ),
-			];
+			);
 		}
 
 		$our_sitemap_enabled = (bool) get_option( 'swps_audit_auto_sitemap', 1 );
 
 		if ( ! $our_sitemap_enabled ) {
-			$issues[] = [
+			$issues[] = array(
 				'post_id' => null,
 				'message' => __( 'No sitemap detected and SWPS sitemap generation is disabled.', 'stratawp-seo' ),
 				'fixable' => true,
-			];
+			);
 
-			return [
+			return array(
 				'score'   => 0,
 				'status'  => 'fail',
 				'issues'  => $issues,
 				'summary' => __( 'No sitemap found.', 'stratawp-seo' ),
-			];
+			);
 		}
 
 		// Sitemap is enabled — check that posts are covered.
-		$posts = $this->get_public_posts();
+		$posts         = $this->get_public_posts();
 		$noindex_count = 0;
 
 		foreach ( $posts as $post ) {
-			$noindex = get_post_meta( $post->ID, '_yoast_wpseo_meta-robots-noindex', true );
+			$noindex   = get_post_meta( $post->ID, '_yoast_wpseo_meta-robots-noindex', true );
 			$rm_robots = get_post_meta( $post->ID, 'rank_math_robots', true );
 
 			if ( '1' === $noindex || ( is_array( $rm_robots ) && in_array( 'noindex', $rm_robots, true ) ) ) {
-				$noindex_count++;
+				++$noindex_count;
 			}
 		}
 
 		$indexed = count( $posts ) - $noindex_count;
 
-		return [
+		return array(
 			'score'   => 100,
 			'status'  => 'pass',
-			'issues'  => [],
+			'issues'  => array(),
 			'summary' => sprintf( __( 'SWPS sitemap active with %d URLs.', 'stratawp-seo' ), $indexed ),
-		];
+		);
 	}
 
 	public function auto_fix( array $issues ): array {
 		update_option( 'swps_audit_auto_sitemap', 1 );
 		flush_rewrite_rules();
 
-		return [
+		return array(
 			'fixed'    => 1,
-			'messages' => [ __( 'SWPS sitemap generation enabled at /swps-sitemap.xml.', 'stratawp-seo' ) ],
-		];
+			'messages' => array( __( 'SWPS sitemap generation enabled at /swps-sitemap.xml.', 'stratawp-seo' ) ),
+		);
 	}
 
 	/**
@@ -126,10 +126,13 @@ class SWPS_Sitemap_Module extends SWPS_Audit_Module {
 		}
 
 		add_rewrite_rule( 'swps-sitemap\.xml$', 'index.php?swps_sitemap=1', 'top' );
-		add_filter( 'query_vars', function ( array $vars ): array {
-			$vars[] = 'swps_sitemap';
-			return $vars;
-		} );
+		add_filter(
+			'query_vars',
+			function ( array $vars ): array {
+				$vars[] = 'swps_sitemap';
+				return $vars;
+			}
+		);
 	}
 
 	/**
@@ -165,20 +168,22 @@ class SWPS_Sitemap_Module extends SWPS_Audit_Module {
 			gmdate( 'Y-m-d\TH:i:s+00:00' )
 		);
 
-		$posts = get_posts( [
-			'post_type'      => get_post_types( [ 'public' => true ] ),
-			'post_status'    => 'publish',
-			'posts_per_page' => 2000,
-			'orderby'        => 'modified',
-			'order'          => 'DESC',
-			'no_found_rows'  => true,
-		] );
+		$posts = get_posts(
+			array(
+				'post_type'      => get_post_types( array( 'public' => true ) ),
+				'post_status'    => 'publish',
+				'posts_per_page' => 2000,
+				'orderby'        => 'modified',
+				'order'          => 'DESC',
+				'no_found_rows'  => true,
+			)
+		);
 
 		$now = time();
 
 		foreach ( $posts as $post ) {
 			// Skip noindex posts.
-			$noindex = get_post_meta( $post->ID, '_yoast_wpseo_meta-robots-noindex', true );
+			$noindex   = get_post_meta( $post->ID, '_yoast_wpseo_meta-robots-noindex', true );
 			$rm_robots = get_post_meta( $post->ID, 'rank_math_robots', true );
 			if ( '1' === $noindex || ( is_array( $rm_robots ) && in_array( 'noindex', $rm_robots, true ) ) ) {
 				continue;
@@ -225,16 +230,22 @@ class SWPS_Sitemap_Module extends SWPS_Audit_Module {
 
 		$sitemap_url = home_url( '/swps-sitemap.xml' );
 
-		wp_remote_get( 'https://www.google.com/ping?sitemap=' . urlencode( $sitemap_url ), [
-			'timeout'   => 5,
-			'blocking'  => false,
-			'sslverify' => false,
-		] );
+		wp_remote_get(
+			'https://www.google.com/ping?sitemap=' . urlencode( $sitemap_url ),
+			array(
+				'timeout'   => 5,
+				'blocking'  => false,
+				'sslverify' => false,
+			)
+		);
 
-		wp_remote_get( 'https://www.bing.com/ping?sitemap=' . urlencode( $sitemap_url ), [
-			'timeout'   => 5,
-			'blocking'  => false,
-			'sslverify' => false,
-		] );
+		wp_remote_get(
+			'https://www.bing.com/ping?sitemap=' . urlencode( $sitemap_url ),
+			array(
+				'timeout'   => 5,
+				'blocking'  => false,
+				'sslverify' => false,
+			)
+		);
 	}
 }

--- a/includes/audit/class-twitter-module.php
+++ b/includes/audit/class-twitter-module.php
@@ -30,46 +30,46 @@ class SWPS_Twitter_Module extends SWPS_Audit_Module {
 		// Twitter cards are output by the OpenGraph module.
 		// This module just checks the same conditions.
 		if ( defined( 'WPSEO_VERSION' ) || class_exists( 'RankMath' ) ) {
-			return [
+			return array(
 				'score'   => 100,
 				'status'  => 'pass',
-				'issues'  => [],
+				'issues'  => array(),
 				'summary' => __( 'Twitter Cards managed by SEO plugin.', 'stratawp-seo' ),
-			];
+			);
 		}
 
 		$our_og = (bool) get_option( 'swps_audit_auto_og', 1 );
 
 		if ( $our_og ) {
-			return [
+			return array(
 				'score'   => 100,
 				'status'  => 'pass',
-				'issues'  => [],
+				'issues'  => array(),
 				'summary' => __( 'Twitter Cards output via SWPS OG auto-tags.', 'stratawp-seo' ),
-			];
+			);
 		}
 
-		return [
+		return array(
 			'score'   => 0,
 			'status'  => 'fail',
-			'issues'  => [
-				[
+			'issues'  => array(
+				array(
 					'post_id' => null,
 					'message' => __( 'No Twitter Card tags detected. Enable OG auto-tags to fix.', 'stratawp-seo' ),
 					'fixable' => true,
-				],
-			],
+				),
+			),
 			'summary' => __( 'No Twitter Card tags found.', 'stratawp-seo' ),
-		];
+		);
 	}
 
 	public function auto_fix( array $issues ): array {
 		// Enable OG (which includes Twitter tags).
 		update_option( 'swps_audit_auto_og', 1 );
 
-		return [
+		return array(
 			'fixed'    => 1,
-			'messages' => [ __( 'OG auto-tags enabled (includes Twitter Cards).', 'stratawp-seo' ) ],
-		];
+			'messages' => array( __( 'OG auto-tags enabled (includes Twitter Cards).', 'stratawp-seo' ) ),
+		);
 	}
 }

--- a/includes/class-admin-shell.php
+++ b/includes/class-admin-shell.php
@@ -6,343 +6,430 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Admin_Shell {
 
-    /**
-     * Hook-suffix prefixes that mark a page as ours.
-     * Used to gate shell rendering and CSS/JS enqueue.
-     */
-    private const HOOK_PREFIXES = [
-        'toplevel_page_stratawp-seo',
-        'toplevel_page_swps-',
-        'stratawp-seo_page_',
-        'swps-seo_page_',
-    ];
+	/**
+	 * Hook-suffix prefixes that mark a page as ours.
+	 * Used to gate shell rendering and CSS/JS enqueue.
+	 */
+	private const HOOK_PREFIXES = array(
+		'toplevel_page_stratawp-seo',
+		'toplevel_page_swps-',
+		'stratawp-seo_page_',
+		'swps-seo_page_',
+	);
 
-    /**
-     * Page slugs that StrataWP owns. Used as a fallback when matching
-     * by hook-suffix isn't available (e.g., during enqueue scoping).
-     */
-    private const OWN_SLUGS = [
-        'stratawp-seo',
-        'swps-dashboard',
-        'swps-generate',
-        'swps-voice-profiles',
-        'swps-seo-audit',
-        'swps-search-appearance',
-        'swps-redirects',
-        'swps-debug',
-        'swps-analytics',
-        'swps-keywords',
-        'swps-calendar',
-        'swps-sitemaps',
-        'swps-internal-links',
-        'swps-schema',
-        'swps-search-console',
-        'swps-auto-optimize',
-        'swps-competitors',
-        'swps-local-seo',
-        'swps-image-seo',
-        'swps-crawl-files',
-        'swps-backlinks',
-    ];
+	/**
+	 * Page slugs that StrataWP owns. Used as a fallback when matching
+	 * by hook-suffix isn't available (e.g., during enqueue scoping).
+	 */
+	private const OWN_SLUGS = array(
+		'stratawp-seo',
+		'swps-dashboard',
+		'swps-generate',
+		'swps-voice-profiles',
+		'swps-seo-audit',
+		'swps-search-appearance',
+		'swps-redirects',
+		'swps-debug',
+		'swps-analytics',
+		'swps-keywords',
+		'swps-calendar',
+		'swps-sitemaps',
+		'swps-internal-links',
+		'swps-schema',
+		'swps-search-console',
+		'swps-auto-optimize',
+		'swps-competitors',
+		'swps-local-seo',
+		'swps-image-seo',
+		'swps-crawl-files',
+		'swps-backlinks',
+	);
 
-    private SWPS_User_Prefs $prefs;
+	private SWPS_User_Prefs $prefs;
 
-    public function __construct( SWPS_User_Prefs $prefs ) {
-        $this->prefs = $prefs;
+	public function __construct( SWPS_User_Prefs $prefs ) {
+		$this->prefs = $prefs;
 
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
-        add_action( 'in_admin_header',       [ $this, 'render_chrome' ], 1 );
-        add_filter( 'admin_body_class',      [ $this, 'add_body_class' ] );
-        add_filter( 'language_attributes',   [ $this, 'add_html_theme_attr' ] );
-    }
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'in_admin_header', array( $this, 'render_chrome' ), 1 );
+		add_filter( 'admin_body_class', array( $this, 'add_body_class' ) );
+		add_filter( 'language_attributes', array( $this, 'add_html_theme_attr' ) );
+	}
 
-    /**
-     * Add data-swps-theme to <html> via the language_attributes filter so
-     * CSS variables resolve correctly on first paint (no FOUC).
-     */
-    public function add_html_theme_attr( string $output ): string {
-        if ( ! is_admin() || ! self::is_own_page() ) {
-            return $output;
-        }
-        return $output . ' data-swps-theme="' . esc_attr( $this->prefs->get_theme() ) . '"';
-    }
+	/**
+	 * Add data-swps-theme to <html> via the language_attributes filter so
+	 * CSS variables resolve correctly on first paint (no FOUC).
+	 */
+	public function add_html_theme_attr( string $output ): string {
+		if ( ! is_admin() || ! self::is_own_page() ) {
+			return $output;
+		}
+		return $output . ' data-swps-theme="' . esc_attr( $this->prefs->get_theme() ) . '"';
+	}
 
-    /**
-     * Is the current admin page one of ours?
-     */
-    public static function is_own_page( string $hook = '' ): bool {
-        if ( '' === $hook ) {
-            $hook = $GLOBALS['hook_suffix'] ?? '';
-        }
-        if ( '' === $hook ) {
-            return false;
-        }
-        foreach ( self::HOOK_PREFIXES as $prefix ) {
-            if ( str_starts_with( $hook, $prefix ) ) {
-                return true;
-            }
-        }
-        // Fallback: check ?page= against known slugs (covers some renamed top-level scenarios).
-        $page = $_GET['page'] ?? '';
-        if ( is_string( $page ) && in_array( $page, self::OWN_SLUGS, true ) ) {
-            return true;
-        }
-        return false;
-    }
+	/**
+	 * Is the current admin page one of ours?
+	 */
+	public static function is_own_page( string $hook = '' ): bool {
+		if ( '' === $hook ) {
+			$hook = $GLOBALS['hook_suffix'] ?? '';
+		}
+		if ( '' === $hook ) {
+			return false;
+		}
+		foreach ( self::HOOK_PREFIXES as $prefix ) {
+			if ( str_starts_with( $hook, $prefix ) ) {
+				return true;
+			}
+		}
+		// Fallback: check ?page= against known slugs (covers some renamed top-level scenarios).
+		$page = $_GET['page'] ?? '';
+		if ( is_string( $page ) && in_array( $page, self::OWN_SLUGS, true ) ) {
+			return true;
+		}
+		return false;
+	}
 
-    /**
-     * Add body class so shell.css can scope WP overrides.
-     */
-    public function add_body_class( string $classes ): string {
-        if ( self::is_own_page() ) {
-            $classes .= ' swps-has-shell';
-        }
-        return $classes;
-    }
+	/**
+	 * Add body class so shell.css can scope WP overrides.
+	 */
+	public function add_body_class( string $classes ): string {
+		if ( self::is_own_page() ) {
+			$classes .= ' swps-has-shell';
+		}
+		return $classes;
+	}
 
-    /**
-     * Enqueue tokens, shell, components CSS + shell.js.
-     */
-    public function enqueue_assets( string $hook ): void {
-        if ( ! self::is_own_page( $hook ) ) {
-            return;
-        }
+	/**
+	 * Enqueue tokens, shell, components CSS + shell.js.
+	 */
+	public function enqueue_assets( string $hook ): void {
+		if ( ! self::is_own_page( $hook ) ) {
+			return;
+		}
 
-        // v4.0.4: Poppins (heading) + Open Sans (body) — match jonimms.com.
-        wp_enqueue_style(
-            'swps-fonts',
-            'https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Open+Sans:wght@400;500;600&display=swap',
-            [],
-            SWPS_VERSION
-        );
+		// v4.0.4: Poppins (heading) + Open Sans (body) — match jonimms.com.
+		wp_enqueue_style(
+			'swps-fonts',
+			'https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Open+Sans:wght@400;500;600&display=swap',
+			array(),
+			SWPS_VERSION
+		);
 
-        wp_enqueue_style(
-            'swps-tokens',
-            SWPS_PLUGIN_URL . 'admin/css/tokens.css',
-            [ 'swps-fonts' ],
-            SWPS_VERSION
-        );
+		wp_enqueue_style(
+			'swps-tokens',
+			SWPS_PLUGIN_URL . 'admin/css/tokens.css',
+			array( 'swps-fonts' ),
+			SWPS_VERSION
+		);
 
-        wp_enqueue_style(
-            'swps-shell',
-            SWPS_PLUGIN_URL . 'admin/css/shell.css',
-            [ 'swps-tokens', 'dashicons' ],
-            SWPS_VERSION
-        );
+		wp_enqueue_style(
+			'swps-shell',
+			SWPS_PLUGIN_URL . 'admin/css/shell.css',
+			array( 'swps-tokens', 'dashicons' ),
+			SWPS_VERSION
+		);
 
-        wp_enqueue_style(
-            'swps-components',
-            SWPS_PLUGIN_URL . 'admin/css/components.css',
-            [ 'swps-tokens' ],
-            SWPS_VERSION
-        );
+		wp_enqueue_style(
+			'swps-components',
+			SWPS_PLUGIN_URL . 'admin/css/components.css',
+			array( 'swps-tokens' ),
+			SWPS_VERSION
+		);
 
-        wp_enqueue_style(
-            'swps-templates',
-            SWPS_PLUGIN_URL . 'admin/css/templates.css',
-            [ 'swps-tokens', 'swps-components' ],
-            SWPS_VERSION
-        );
+		wp_enqueue_style(
+			'swps-templates',
+			SWPS_PLUGIN_URL . 'admin/css/templates.css',
+			array( 'swps-tokens', 'swps-components' ),
+			SWPS_VERSION
+		);
 
-        wp_enqueue_script(
-            'swps-shell',
-            SWPS_PLUGIN_URL . 'admin/js/shell.js',
-            [],
-            SWPS_VERSION,
-            true
-        );
+		wp_enqueue_script(
+			'swps-shell',
+			SWPS_PLUGIN_URL . 'admin/js/shell.js',
+			array(),
+			SWPS_VERSION,
+			true
+		);
 
-        wp_localize_script( 'swps-shell', 'swpsShell', [
-            'restUrl'   => esc_url_raw( rest_url() ),
-            'restNonce' => wp_create_nonce( 'wp_rest' ),
-            'theme'     => $this->prefs->get_theme(),
-        ] );
-    }
+		wp_localize_script(
+			'swps-shell',
+			'swpsShell',
+			array(
+				'restUrl'   => esc_url_raw( rest_url() ),
+				'restNonce' => wp_create_nonce( 'wp_rest' ),
+				'theme'     => $this->prefs->get_theme(),
+			)
+		);
+	}
 
-    /**
-     * Render top bar inside #wpcontent.
-     *
-     * v4.0.4: dropped the in-shell nav entirely. WP's native admin
-     * sidebar + StrataWP submenu is the only navigation — no
-     * duplication, no horizontal scroll issues.
-     */
-    public function render_chrome(): void {
-        if ( ! self::is_own_page() ) {
-            return;
-        }
-        $page = $_GET['page'] ?? 'stratawp-seo';
-        $this->render_top_bar( $page );
-    }
+	/**
+	 * Render top bar inside #wpcontent.
+	 *
+	 * v4.0.4: dropped the in-shell nav entirely. WP's native admin
+	 * sidebar + StrataWP submenu is the only navigation — no
+	 * duplication, no horizontal scroll issues.
+	 */
+	public function render_chrome(): void {
+		if ( ! self::is_own_page() ) {
+			return;
+		}
+		$page = $_GET['page'] ?? 'stratawp-seo';
+		$this->render_top_bar( $page );
+	}
 
-    /**
-     * Top bar: logo, breadcrumb, search, theme toggle, help.
-     */
-    private function render_top_bar( string $current_page ): void {
-        $crumb       = $this->breadcrumb_for( $current_page );
-        $theme       = $this->prefs->get_theme();
-        $toggle_icon = ( self::THEME_DARK_NAME === $theme ) ? 'dashicons-sun' : 'dashicons-moon';
-        $toggle_lbl  = ( self::THEME_DARK_NAME === $theme )
-            ? __( 'Switch to light mode', 'stratawp-seo' )
-            : __( 'Switch to dark mode', 'stratawp-seo' );
-        $dashboard   = admin_url( 'admin.php?page=stratawp-seo' );
-        ?>
-        <div class="swps-shell-top">
-            <a class="swps-shell-logo" href="<?php echo esc_url( $dashboard ); ?>">
-                <span class="swps-shell-logo-mark">S</span>
-                <span>StrataWP SEO</span>
-            </a>
-            <span class="swps-shell-breadcrumb"><?php echo wp_kses_post( $crumb ); ?></span>
-            <div class="swps-shell-spacer"></div>
-            <input
-                type="search"
-                class="swps-shell-search"
-                placeholder="<?php esc_attr_e( 'Search settings, posts, keywords...', 'stratawp-seo' ); ?>"
-                data-swps-search
-                aria-label="<?php esc_attr_e( 'Search StrataWP SEO', 'stratawp-seo' ); ?>"
-            />
-            <button
-                type="button"
-                class="swps-shell-iconbtn"
-                data-swps-theme-toggle
-                aria-label="<?php echo esc_attr( $toggle_lbl ); ?>"
-                title="<?php echo esc_attr( $toggle_lbl ); ?>"
-            >
-                <span class="dashicons <?php echo esc_attr( $toggle_icon ); ?>"></span>
-            </button>
-            <a class="swps-shell-iconbtn"
-               href="https://github.com/jonimms/stratawp-seo"
-               target="_blank"
-               rel="noopener noreferrer"
-               aria-label="<?php esc_attr_e( 'Help &amp; docs', 'stratawp-seo' ); ?>"
-               title="<?php esc_attr_e( 'Help &amp; docs', 'stratawp-seo' ); ?>"
-            >
-                <span class="dashicons dashicons-editor-help"></span>
-            </a>
-        </div>
-        <?php
-    }
+	/**
+	 * Top bar: logo, breadcrumb, search, theme toggle, help.
+	 */
+	private function render_top_bar( string $current_page ): void {
+		$crumb       = $this->breadcrumb_for( $current_page );
+		$theme       = $this->prefs->get_theme();
+		$toggle_icon = ( self::THEME_DARK_NAME === $theme ) ? 'dashicons-sun' : 'dashicons-moon';
+		$toggle_lbl  = ( self::THEME_DARK_NAME === $theme )
+			? __( 'Switch to light mode', 'stratawp-seo' )
+			: __( 'Switch to dark mode', 'stratawp-seo' );
+		$dashboard   = admin_url( 'admin.php?page=stratawp-seo' );
+		?>
+		<div class="swps-shell-top">
+			<a class="swps-shell-logo" href="<?php echo esc_url( $dashboard ); ?>">
+				<span class="swps-shell-logo-mark">S</span>
+				<span>StrataWP SEO</span>
+			</a>
+			<span class="swps-shell-breadcrumb"><?php echo wp_kses_post( $crumb ); ?></span>
+			<div class="swps-shell-spacer"></div>
+			<input
+				type="search"
+				class="swps-shell-search"
+				placeholder="<?php esc_attr_e( 'Search settings, posts, keywords...', 'stratawp-seo' ); ?>"
+				data-swps-search
+				aria-label="<?php esc_attr_e( 'Search StrataWP SEO', 'stratawp-seo' ); ?>"
+			/>
+			<button
+				type="button"
+				class="swps-shell-iconbtn"
+				data-swps-theme-toggle
+				aria-label="<?php echo esc_attr( $toggle_lbl ); ?>"
+				title="<?php echo esc_attr( $toggle_lbl ); ?>"
+			>
+				<span class="dashicons <?php echo esc_attr( $toggle_icon ); ?>"></span>
+			</button>
+			<a class="swps-shell-iconbtn"
+				href="https://github.com/jonimms/stratawp-seo"
+				target="_blank"
+				rel="noopener noreferrer"
+				aria-label="<?php esc_attr_e( 'Help &amp; docs', 'stratawp-seo' ); ?>"
+				title="<?php esc_attr_e( 'Help &amp; docs', 'stratawp-seo' ); ?>"
+			>
+				<span class="dashicons dashicons-editor-help"></span>
+			</a>
+		</div>
+		<?php
+	}
 
-    /**
-     * Horizontal top nav with grouped pill items.
-     *
-     * v4.0.2: replaces the old left sidebar. Items are arranged inline
-     * with section dividers; nav scrolls horizontally if total width
-     * exceeds the viewport.
-     */
-    private function render_top_nav( string $current_page ): void {
-        $items = $this->get_nav_items();
-        ?>
-        <nav class="swps-shell-nav" aria-label="<?php esc_attr_e( 'StrataWP SEO navigation', 'stratawp-seo' ); ?>">
-            <?php foreach ( $items as $group_label => $group_items ) :
-                $is_dashboard_group = ( '' === $group_label );
-            ?>
-                <div class="swps-shell-nav-group">
-                    <?php if ( ! $is_dashboard_group ) : ?>
-                        <span class="swps-shell-nav-label"><?php echo esc_html( $group_label ); ?></span>
-                    <?php endif; ?>
+	/**
+	 * Horizontal top nav with grouped pill items.
+	 *
+	 * v4.0.2: replaces the old left sidebar. Items are arranged inline
+	 * with section dividers; nav scrolls horizontally if total width
+	 * exceeds the viewport.
+	 */
+	private function render_top_nav( string $current_page ): void {
+		$items = $this->get_nav_items();
+		?>
+		<nav class="swps-shell-nav" aria-label="<?php esc_attr_e( 'StrataWP SEO navigation', 'stratawp-seo' ); ?>">
+			<?php
+			foreach ( $items as $group_label => $group_items ) :
+				$is_dashboard_group = ( '' === $group_label );
+				?>
+				<div class="swps-shell-nav-group">
+					<?php if ( ! $is_dashboard_group ) : ?>
+						<span class="swps-shell-nav-label"><?php echo esc_html( $group_label ); ?></span>
+					<?php endif; ?>
 
-                    <?php foreach ( $group_items as $item ) :
-                        $url    = admin_url( 'admin.php?page=' . $item['slug'] );
-                        $active = ( $item['slug'] === $current_page ) ? ' is-active' : '';
-                    ?>
-                        <a class="swps-shell-nav-item<?php echo esc_attr( $active ); ?>"
-                           href="<?php echo esc_url( $url ); ?>">
-                            <?php echo esc_html( $item['label'] ); ?>
-                            <?php if ( ! empty( $item['badge'] ) ) : ?>
-                                <span class="swps-shell-nav-item-badge<?php echo $item['badge']['type'] === 'new' ? ' is-new' : ''; ?>">
-                                    <?php echo esc_html( $item['badge']['label'] ); ?>
-                                </span>
-                            <?php endif; ?>
-                        </a>
-                    <?php endforeach; ?>
-                </div>
-            <?php endforeach; ?>
-        </nav>
-        <?php
-    }
+					<?php
+					foreach ( $group_items as $item ) :
+						$url    = admin_url( 'admin.php?page=' . $item['slug'] );
+						$active = ( $item['slug'] === $current_page ) ? ' is-active' : '';
+						?>
+						<a class="swps-shell-nav-item<?php echo esc_attr( $active ); ?>"
+							href="<?php echo esc_url( $url ); ?>">
+							<?php echo esc_html( $item['label'] ); ?>
+							<?php if ( ! empty( $item['badge'] ) ) : ?>
+								<span class="swps-shell-nav-item-badge<?php echo $item['badge']['type'] === 'new' ? ' is-new' : ''; ?>">
+									<?php echo esc_html( $item['badge']['label'] ); ?>
+								</span>
+							<?php endif; ?>
+						</a>
+					<?php endforeach; ?>
+				</div>
+			<?php endforeach; ?>
+		</nav>
+		<?php
+	}
 
-    /**
-     * Static nav items (groups → items). Filterable for extensions and
-     * later replacement by the Modules registry.
-     *
-     * @return array<string, array<int, array{slug:string,label:string,badge?:array{type:string,label:string}}>>
-     */
-    private function get_nav_items(): array {
-        $items = [
-            '' => [
-                [ 'slug' => 'stratawp-seo', 'label' => __( 'Dashboard', 'stratawp-seo' ) ],
-            ],
-            __( 'Content', 'stratawp-seo' ) => [
-                [ 'slug' => 'swps-generate',       'label' => __( 'Generate', 'stratawp-seo' ) ],
-                [ 'slug' => 'swps-auto-optimize',  'label' => __( 'Auto-Optimize', 'stratawp-seo' ), 'badge' => [ 'type' => 'new', 'label' => 'NEW' ] ],
-                [ 'slug' => 'swps-calendar',       'label' => __( 'Calendar', 'stratawp-seo' ) ],
-                [ 'slug' => 'swps-voice-profiles', 'label' => __( 'Voice Profiles', 'stratawp-seo' ) ],
-            ],
-            __( 'SEO', 'stratawp-seo' ) => [
-                [ 'slug' => 'swps-seo-audit',         'label' => __( 'Audit', 'stratawp-seo' ) ],
-                [ 'slug' => 'swps-search-appearance', 'label' => __( 'Search Appearance', 'stratawp-seo' ) ],
-                [ 'slug' => 'swps-sitemaps',          'label' => __( 'Sitemaps', 'stratawp-seo' ) ],
-                [ 'slug' => 'swps-redirects',         'label' => __( 'Redirects', 'stratawp-seo' ) ],
-                [ 'slug' => 'swps-internal-links',    'label' => __( 'Internal Links', 'stratawp-seo' ) ],
-                [ 'slug' => 'swps-local-seo',         'label' => __( 'Local SEO', 'stratawp-seo' ),  'badge' => [ 'type' => 'new', 'label' => 'NEW' ] ],
-                [ 'slug' => 'swps-image-seo',         'label' => __( 'Image SEO', 'stratawp-seo' ),  'badge' => [ 'type' => 'new', 'label' => 'NEW' ] ],
-                [ 'slug' => 'swps-crawl-files',       'label' => __( 'Crawlers & Files', 'stratawp-seo' ), 'badge' => [ 'type' => 'new', 'label' => 'NEW' ] ],
-            ],
-            __( 'Insights', 'stratawp-seo' ) => [
-                [ 'slug' => 'swps-analytics',   'label' => __( 'Analytics', 'stratawp-seo' ) ],
-                [ 'slug' => 'swps-keywords',    'label' => __( 'Keywords', 'stratawp-seo' ) ],
-                [ 'slug' => 'swps-competitors', 'label' => __( 'Competitors', 'stratawp-seo' ), 'badge' => [ 'type' => 'new', 'label' => 'NEW' ] ],
-                [ 'slug' => 'swps-backlinks',   'label' => __( 'Backlinks', 'stratawp-seo' ),   'badge' => [ 'type' => 'new', 'label' => 'NEW' ] ],
-            ],
-            __( 'System', 'stratawp-seo' ) => [
-                [ 'slug' => 'stratawp-seo', 'label' => __( 'Settings', 'stratawp-seo' ) ],
-                [ 'slug' => 'swps-debug',   'label' => __( 'Debug', 'stratawp-seo' ) ],
-            ],
-        ];
-        // The "Settings" entry under System and the "Dashboard" entry up top both
-        // currently point to the same slug (stratawp-seo). Phase 2 splits them.
+	/**
+	 * Static nav items (groups → items). Filterable for extensions and
+	 * later replacement by the Modules registry.
+	 *
+	 * @return array<string, array<int, array{slug:string,label:string,badge?:array{type:string,label:string}}>>
+	 */
+	private function get_nav_items(): array {
+		$items = array(
+			''                               => array(
+				array(
+					'slug'  => 'stratawp-seo',
+					'label' => __( 'Dashboard', 'stratawp-seo' ),
+				),
+			),
+			__( 'Content', 'stratawp-seo' )  => array(
+				array(
+					'slug'  => 'swps-generate',
+					'label' => __( 'Generate', 'stratawp-seo' ),
+				),
+				array(
+					'slug'  => 'swps-auto-optimize',
+					'label' => __( 'Auto-Optimize', 'stratawp-seo' ),
+					'badge' => array(
+						'type'  => 'new',
+						'label' => 'NEW',
+					),
+				),
+				array(
+					'slug'  => 'swps-calendar',
+					'label' => __( 'Calendar', 'stratawp-seo' ),
+				),
+				array(
+					'slug'  => 'swps-voice-profiles',
+					'label' => __( 'Voice Profiles', 'stratawp-seo' ),
+				),
+			),
+			__( 'SEO', 'stratawp-seo' )      => array(
+				array(
+					'slug'  => 'swps-seo-audit',
+					'label' => __( 'Audit', 'stratawp-seo' ),
+				),
+				array(
+					'slug'  => 'swps-search-appearance',
+					'label' => __( 'Search Appearance', 'stratawp-seo' ),
+				),
+				array(
+					'slug'  => 'swps-sitemaps',
+					'label' => __( 'Sitemaps', 'stratawp-seo' ),
+				),
+				array(
+					'slug'  => 'swps-redirects',
+					'label' => __( 'Redirects', 'stratawp-seo' ),
+				),
+				array(
+					'slug'  => 'swps-internal-links',
+					'label' => __( 'Internal Links', 'stratawp-seo' ),
+				),
+				array(
+					'slug'  => 'swps-local-seo',
+					'label' => __( 'Local SEO', 'stratawp-seo' ),
+					'badge' => array(
+						'type'  => 'new',
+						'label' => 'NEW',
+					),
+				),
+				array(
+					'slug'  => 'swps-image-seo',
+					'label' => __( 'Image SEO', 'stratawp-seo' ),
+					'badge' => array(
+						'type'  => 'new',
+						'label' => 'NEW',
+					),
+				),
+				array(
+					'slug'  => 'swps-crawl-files',
+					'label' => __( 'Crawlers & Files', 'stratawp-seo' ),
+					'badge' => array(
+						'type'  => 'new',
+						'label' => 'NEW',
+					),
+				),
+			),
+			__( 'Insights', 'stratawp-seo' ) => array(
+				array(
+					'slug'  => 'swps-analytics',
+					'label' => __( 'Analytics', 'stratawp-seo' ),
+				),
+				array(
+					'slug'  => 'swps-keywords',
+					'label' => __( 'Keywords', 'stratawp-seo' ),
+				),
+				array(
+					'slug'  => 'swps-competitors',
+					'label' => __( 'Competitors', 'stratawp-seo' ),
+					'badge' => array(
+						'type'  => 'new',
+						'label' => 'NEW',
+					),
+				),
+				array(
+					'slug'  => 'swps-backlinks',
+					'label' => __( 'Backlinks', 'stratawp-seo' ),
+					'badge' => array(
+						'type'  => 'new',
+						'label' => 'NEW',
+					),
+				),
+			),
+			__( 'System', 'stratawp-seo' )   => array(
+				array(
+					'slug'  => 'stratawp-seo',
+					'label' => __( 'Settings', 'stratawp-seo' ),
+				),
+				array(
+					'slug'  => 'swps-debug',
+					'label' => __( 'Debug', 'stratawp-seo' ),
+				),
+			),
+		);
+		// The "Settings" entry under System and the "Dashboard" entry up top both
+		// currently point to the same slug (stratawp-seo). Phase 2 splits them.
 
-        /**
-         * Filter the admin shell sidebar items.
-         *
-         * @param array $items Group label => items array.
-         */
-        return apply_filters( 'swps_admin_shell_nav', $items );
-    }
+		/**
+		 * Filter the admin shell sidebar items.
+		 *
+		 * @param array $items Group label => items array.
+		 */
+		return apply_filters( 'swps_admin_shell_nav', $items );
+	}
 
-    /**
-     * Build the breadcrumb trail HTML for a given slug.
-     */
-    private function breadcrumb_for( string $page ): string {
-        $items = $this->get_nav_items();
-        foreach ( $items as $group_label => $group_items ) {
-            foreach ( $group_items as $item ) {
-                if ( $item['slug'] === $page ) {
-                    if ( '' === $group_label ) {
-                        return sprintf(
-                            '<span class="swps-shell-breadcrumb-sep">/</span><strong>%s</strong>',
-                            esc_html( $item['label'] )
-                        );
-                    }
-                    return sprintf(
-                        '<span class="swps-shell-breadcrumb-sep">/</span>%s<span class="swps-shell-breadcrumb-sep">/</span><strong>%s</strong>',
-                        esc_html( $group_label ),
-                        esc_html( $item['label'] )
-                    );
-                }
-            }
-        }
-        return sprintf(
-            '<span class="swps-shell-breadcrumb-sep">/</span><strong>%s</strong>',
-            esc_html__( 'Dashboard', 'stratawp-seo' )
-        );
-    }
+	/**
+	 * Build the breadcrumb trail HTML for a given slug.
+	 */
+	private function breadcrumb_for( string $page ): string {
+		$items = $this->get_nav_items();
+		foreach ( $items as $group_label => $group_items ) {
+			foreach ( $group_items as $item ) {
+				if ( $item['slug'] === $page ) {
+					if ( '' === $group_label ) {
+						return sprintf(
+							'<span class="swps-shell-breadcrumb-sep">/</span><strong>%s</strong>',
+							esc_html( $item['label'] )
+						);
+					}
+					return sprintf(
+						'<span class="swps-shell-breadcrumb-sep">/</span>%s<span class="swps-shell-breadcrumb-sep">/</span><strong>%s</strong>',
+						esc_html( $group_label ),
+						esc_html( $item['label'] )
+					);
+				}
+			}
+		}
+		return sprintf(
+			'<span class="swps-shell-breadcrumb-sep">/</span><strong>%s</strong>',
+			esc_html__( 'Dashboard', 'stratawp-seo' )
+		);
+	}
 
-    /* Constants for the toggle icon swap so we don't depend on the prefs class loading order. */
-    private const THEME_DARK_NAME = 'dark';
+	/* Constants for the toggle icon swap so we don't depend on the prefs class loading order. */
+	private const THEME_DARK_NAME = 'dark';
 }

--- a/includes/class-ai-bots.php
+++ b/includes/class-ai-bots.php
@@ -6,306 +6,306 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_AI_Bots {
 
-    /**
-     * Known AI crawler user agents. The key is what gets stored in the option;
-     * the value is the User-agent token written to robots.txt.
-     */
-    public const KNOWN_BOTS = [
-        'gptbot'              => 'GPTBot',
-        'oai_searchbot'       => 'OAI-SearchBot',
-        'chatgpt_user'        => 'ChatGPT-User',
-        'claudebot'           => 'ClaudeBot',
-        'claude_web'          => 'Claude-Web',
-        'anthropic_ai'        => 'anthropic-ai',
-        'perplexitybot'       => 'PerplexityBot',
-        'perplexity_user'     => 'Perplexity-User',
-        'google_extended'     => 'Google-Extended',
-        'applebot_extended'   => 'Applebot-Extended',
-        'ccbot'               => 'CCBot',
-        'meta_externalagent'  => 'Meta-ExternalAgent',
-        'bytespider'          => 'Bytespider',
-        'amazonbot'           => 'Amazonbot',
-        'duckassistbot'       => 'DuckAssistBot',
-    ];
+	/**
+	 * Known AI crawler user agents. The key is what gets stored in the option;
+	 * the value is the User-agent token written to robots.txt.
+	 */
+	public const KNOWN_BOTS = array(
+		'gptbot'             => 'GPTBot',
+		'oai_searchbot'      => 'OAI-SearchBot',
+		'chatgpt_user'       => 'ChatGPT-User',
+		'claudebot'          => 'ClaudeBot',
+		'claude_web'         => 'Claude-Web',
+		'anthropic_ai'       => 'anthropic-ai',
+		'perplexitybot'      => 'PerplexityBot',
+		'perplexity_user'    => 'Perplexity-User',
+		'google_extended'    => 'Google-Extended',
+		'applebot_extended'  => 'Applebot-Extended',
+		'ccbot'              => 'CCBot',
+		'meta_externalagent' => 'Meta-ExternalAgent',
+		'bytespider'         => 'Bytespider',
+		'amazonbot'          => 'Amazonbot',
+		'duckassistbot'      => 'DuckAssistBot',
+	);
 
-    public function __construct() {
-        add_filter( 'robots_txt', [ $this, 'filter_robots_txt' ], 100, 2 );
-        add_action( 'init', [ $this, 'maybe_serve_llms_txt' ], 1 );
-    }
+	public function __construct() {
+		add_filter( 'robots_txt', array( $this, 'filter_robots_txt' ), 100, 2 );
+		add_action( 'init', array( $this, 'maybe_serve_llms_txt' ), 1 );
+	}
 
-    /**
-     * Return the canonical bot list. Filter `swps_ai_bots_known` lets third
-     * parties add custom AI crawlers (custom keys → UA tokens).
-     *
-     * @return array<string, string> Map of bot key → User-agent token.
-     */
-    public static function get_bots(): array {
-        return (array) apply_filters( 'swps_ai_bots_known', self::KNOWN_BOTS );
-    }
+	/**
+	 * Return the canonical bot list. Filter `swps_ai_bots_known` lets third
+	 * parties add custom AI crawlers (custom keys → UA tokens).
+	 *
+	 * @return array<string, string> Map of bot key → User-agent token.
+	 */
+	public static function get_bots(): array {
+		return (array) apply_filters( 'swps_ai_bots_known', self::KNOWN_BOTS );
+	}
 
-    /**
-     * Append AI bot allow/disallow rules to robots.txt.
-     */
-    public function filter_robots_txt( string $output, $public ): string {
-        if ( ! $public ) {
-            return $output;
-        }
+	/**
+	 * Append AI bot allow/disallow rules to robots.txt.
+	 */
+	public function filter_robots_txt( string $output, $public ): string {
+		if ( ! $public ) {
+			return $output;
+		}
 
-        $allowed = $this->get_allowed_bots();
-        $blocked = $this->get_blocked_bots();
+		$allowed = $this->get_allowed_bots();
+		$blocked = $this->get_blocked_bots();
 
-        if ( empty( $allowed ) && empty( $blocked ) ) {
-            return $output;
-        }
+		if ( empty( $allowed ) && empty( $blocked ) ) {
+			return $output;
+		}
 
-        $lines = [ '', '# AI crawlers — managed by StrataWP SEO' ];
+		$lines = array( '', '# AI crawlers — managed by StrataWP SEO' );
 
-        foreach ( $allowed as $token ) {
-            $lines[] = '';
-            $lines[] = 'User-agent: ' . $token;
-            $lines[] = 'Allow: /';
-        }
+		foreach ( $allowed as $token ) {
+			$lines[] = '';
+			$lines[] = 'User-agent: ' . $token;
+			$lines[] = 'Allow: /';
+		}
 
-        foreach ( $blocked as $token ) {
-            $lines[] = '';
-            $lines[] = 'User-agent: ' . $token;
-            $lines[] = 'Disallow: /';
-        }
+		foreach ( $blocked as $token ) {
+			$lines[] = '';
+			$lines[] = 'User-agent: ' . $token;
+			$lines[] = 'Disallow: /';
+		}
 
-        return $output . implode( "\n", $lines ) . "\n";
-    }
+		return $output . implode( "\n", $lines ) . "\n";
+	}
 
-    /**
-     * Get the list of bot user-agent tokens the user has allowed.
-     */
-    private function get_allowed_bots(): array {
-        $stored = get_option( 'swps_ai_bots_allowed', null );
+	/**
+	 * Get the list of bot user-agent tokens the user has allowed.
+	 */
+	private function get_allowed_bots(): array {
+		$stored = get_option( 'swps_ai_bots_allowed', null );
 
-        // Default: allow every known bot if the option has never been saved.
-        if ( null === $stored ) {
-            return array_values( self::KNOWN_BOTS );
-        }
+		// Default: allow every known bot if the option has never been saved.
+		if ( null === $stored ) {
+			return array_values( self::KNOWN_BOTS );
+		}
 
-        $stored = is_array( $stored ) ? $stored : [];
-        $tokens = [];
-        foreach ( $stored as $key ) {
-            if ( isset( self::KNOWN_BOTS[ $key ] ) ) {
-                $tokens[] = self::KNOWN_BOTS[ $key ];
-            }
-        }
-        return $tokens;
-    }
+		$stored = is_array( $stored ) ? $stored : array();
+		$tokens = array();
+		foreach ( $stored as $key ) {
+			if ( isset( self::KNOWN_BOTS[ $key ] ) ) {
+				$tokens[] = self::KNOWN_BOTS[ $key ];
+			}
+		}
+		return $tokens;
+	}
 
-    /**
-     * Get the list of bot tokens explicitly blocked (known bots not in the allow list).
-     * Only emits a Disallow when the user has saved the option (otherwise default = allow all).
-     */
-    private function get_blocked_bots(): array {
-        $stored = get_option( 'swps_ai_bots_allowed', null );
-        if ( null === $stored ) {
-            return [];
-        }
-        $stored = is_array( $stored ) ? $stored : [];
-        $blocked = [];
-        foreach ( self::KNOWN_BOTS as $key => $token ) {
-            if ( ! in_array( $key, $stored, true ) ) {
-                $blocked[] = $token;
-            }
-        }
-        return $blocked;
-    }
+	/**
+	 * Get the list of bot tokens explicitly blocked (known bots not in the allow list).
+	 * Only emits a Disallow when the user has saved the option (otherwise default = allow all).
+	 */
+	private function get_blocked_bots(): array {
+		$stored = get_option( 'swps_ai_bots_allowed', null );
+		if ( null === $stored ) {
+			return array();
+		}
+		$stored  = is_array( $stored ) ? $stored : array();
+		$blocked = array();
+		foreach ( self::KNOWN_BOTS as $key => $token ) {
+			if ( ! in_array( $key, $stored, true ) ) {
+				$blocked[] = $token;
+			}
+		}
+		return $blocked;
+	}
 
-    /**
-     * Intercept requests for /llms.txt and serve the generated file.
-     */
-    public function maybe_serve_llms_txt(): void {
-        if ( ! get_option( 'swps_llms_txt_enabled', 1 ) ) {
-            return;
-        }
+	/**
+	 * Intercept requests for /llms.txt and serve the generated file.
+	 */
+	public function maybe_serve_llms_txt(): void {
+		if ( ! get_option( 'swps_llms_txt_enabled', 1 ) ) {
+			return;
+		}
 
-        $uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH ) : '';
-        if ( '/llms.txt' !== $uri ) {
-            return;
-        }
+		$uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH ) : '';
+		if ( '/llms.txt' !== $uri ) {
+			return;
+		}
 
-        nocache_headers();
-        header( 'Content-Type: text/markdown; charset=utf-8' );
-        header( 'X-Robots-Tag: noindex' );
-        echo $this->generate_llms_txt(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped — markdown body
-        exit;
-    }
+		nocache_headers();
+		header( 'Content-Type: text/markdown; charset=utf-8' );
+		header( 'X-Robots-Tag: noindex' );
+		echo $this->generate_llms_txt(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped — markdown body
+		exit;
+	}
 
-    /**
-     * Build the llms.txt content from site options + recent published posts.
-     */
-    public function generate_llms_txt(): string {
-        $site_name = wp_strip_all_tags( get_bloginfo( 'name' ) );
-        $home      = home_url( '/' );
-        $tagline   = wp_strip_all_tags( get_bloginfo( 'description' ) );
+	/**
+	 * Build the llms.txt content from site options + recent published posts.
+	 */
+	public function generate_llms_txt(): string {
+		$site_name = wp_strip_all_tags( get_bloginfo( 'name' ) );
+		$home      = home_url( '/' );
+		$tagline   = wp_strip_all_tags( get_bloginfo( 'description' ) );
 
-        // Prefer the plugin's Site Description over the WP tagline if set.
-        $description = (string) get_option( 'swps_site_description', '' );
-        $description = trim( wp_strip_all_tags( $description ) );
-        if ( '' === $description ) {
-            $description = $tagline;
-        }
-        $description = $this->collapse_whitespace( $description );
+		// Prefer the plugin's Site Description over the WP tagline if set.
+		$description = (string) get_option( 'swps_site_description', '' );
+		$description = trim( wp_strip_all_tags( $description ) );
+		if ( '' === $description ) {
+			$description = $tagline;
+		}
+		$description = $this->collapse_whitespace( $description );
 
-        $out  = "# {$site_name}\n\n";
-        $out .= "> " . $description . "\n\n";
-        $out .= "Site: {$home}\n";
+		$out  = "# {$site_name}\n\n";
+		$out .= '> ' . $description . "\n\n";
+		$out .= "Site: {$home}\n";
 
-        $sitemap_url = $this->detect_sitemap_url();
-        if ( $sitemap_url ) {
-            $out .= "Sitemap: {$sitemap_url}\n";
-        }
-        $out .= "\n";
+		$sitemap_url = $this->detect_sitemap_url();
+		if ( $sitemap_url ) {
+			$out .= "Sitemap: {$sitemap_url}\n";
+		}
+		$out .= "\n";
 
-        // Posts.
-        $posts = get_posts(
-            [
-                'post_type'      => 'post',
-                'post_status'    => 'publish',
-                'posts_per_page' => (int) apply_filters( 'swps_llms_txt_post_limit', 100 ),
-                'orderby'        => 'date',
-                'order'          => 'DESC',
-            ]
-        );
+		// Posts.
+		$posts = get_posts(
+			array(
+				'post_type'      => 'post',
+				'post_status'    => 'publish',
+				'posts_per_page' => (int) apply_filters( 'swps_llms_txt_post_limit', 100 ),
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			)
+		);
 
-        if ( ! empty( $posts ) ) {
-            $out .= "## Posts\n";
-            foreach ( $posts as $post ) {
-                $out .= $this->format_entry( $post );
-            }
-            $out .= "\n";
-        }
+		if ( ! empty( $posts ) ) {
+			$out .= "## Posts\n";
+			foreach ( $posts as $post ) {
+				$out .= $this->format_entry( $post );
+			}
+			$out .= "\n";
+		}
 
-        // Pages (top-level only, exclude home).
-        $pages = get_posts(
-            [
-                'post_type'      => 'page',
-                'post_status'    => 'publish',
-                'posts_per_page' => 25,
-                'post_parent'    => 0,
-                'orderby'        => 'menu_order title',
-                'order'          => 'ASC',
-            ]
-        );
-        $front_id = (int) get_option( 'page_on_front' );
-        $pages    = array_filter(
-            $pages,
-            static fn( $p ) => (int) $p->ID !== $front_id
-        );
+		// Pages (top-level only, exclude home).
+		$pages    = get_posts(
+			array(
+				'post_type'      => 'page',
+				'post_status'    => 'publish',
+				'posts_per_page' => 25,
+				'post_parent'    => 0,
+				'orderby'        => 'menu_order title',
+				'order'          => 'ASC',
+			)
+		);
+		$front_id = (int) get_option( 'page_on_front' );
+		$pages    = array_filter(
+			$pages,
+			static fn( $p ) => (int) $p->ID !== $front_id
+		);
 
-        if ( ! empty( $pages ) ) {
-            $out .= "## Pages\n";
-            foreach ( $pages as $page ) {
-                $out .= $this->format_entry( $page );
-            }
-            $out .= "\n";
-        }
+		if ( ! empty( $pages ) ) {
+			$out .= "## Pages\n";
+			foreach ( $pages as $page ) {
+				$out .= $this->format_entry( $page );
+			}
+			$out .= "\n";
+		}
 
-        // Categories.
-        $cats = get_categories(
-            [
-                'hide_empty' => true,
-                'number'     => 20,
-                'orderby'    => 'count',
-                'order'      => 'DESC',
-            ]
-        );
-        if ( ! empty( $cats ) ) {
-            $out .= "## Categories\n";
-            foreach ( $cats as $cat ) {
-                $name = $this->collapse_whitespace( wp_strip_all_tags( $cat->name ) );
-                $url  = get_category_link( $cat->term_id );
-                $out .= "- [{$name}]({$url})\n";
-            }
-            $out .= "\n";
-        }
+		// Categories.
+		$cats = get_categories(
+			array(
+				'hide_empty' => true,
+				'number'     => 20,
+				'orderby'    => 'count',
+				'order'      => 'DESC',
+			)
+		);
+		if ( ! empty( $cats ) ) {
+			$out .= "## Categories\n";
+			foreach ( $cats as $cat ) {
+				$name = $this->collapse_whitespace( wp_strip_all_tags( $cat->name ) );
+				$url  = get_category_link( $cat->term_id );
+				$out .= "- [{$name}]({$url})\n";
+			}
+			$out .= "\n";
+		}
 
-        return apply_filters( 'swps_llms_txt_content', $out );
-    }
+		return apply_filters( 'swps_llms_txt_content', $out );
+	}
 
-    /**
-     * Format one post/page entry as a markdown bullet with a one-line summary.
-     */
-    private function format_entry( WP_Post $post ): string {
-        $title   = $this->collapse_whitespace( wp_strip_all_tags( get_the_title( $post ) ) );
-        $url     = get_permalink( $post );
-        $summary = $this->build_summary( $post );
+	/**
+	 * Format one post/page entry as a markdown bullet with a one-line summary.
+	 */
+	private function format_entry( WP_Post $post ): string {
+		$title   = $this->collapse_whitespace( wp_strip_all_tags( get_the_title( $post ) ) );
+		$url     = get_permalink( $post );
+		$summary = $this->build_summary( $post );
 
-        if ( '' !== $summary ) {
-            return "- [{$title}]({$url}): {$summary}\n";
-        }
-        return "- [{$title}]({$url})\n";
-    }
+		if ( '' !== $summary ) {
+			return "- [{$title}]({$url}): {$summary}\n";
+		}
+		return "- [{$title}]({$url})\n";
+	}
 
-    /**
-     * Build a one-line summary from (in order): plugin meta description, post excerpt,
-     * trimmed first paragraph of the content.
-     */
-    private function build_summary( WP_Post $post ): string {
-        $candidates = [
-            (string) get_post_meta( $post->ID, '_swps_meta_description', true ),
-            (string) get_post_meta( $post->ID, '_yoast_wpseo_metadesc', true ),
-            (string) get_post_meta( $post->ID, 'rank_math_description', true ),
-            (string) $post->post_excerpt,
-            wp_strip_all_tags( strip_shortcodes( (string) $post->post_content ) ),
-        ];
+	/**
+	 * Build a one-line summary from (in order): plugin meta description, post excerpt,
+	 * trimmed first paragraph of the content.
+	 */
+	private function build_summary( WP_Post $post ): string {
+		$candidates = array(
+			(string) get_post_meta( $post->ID, '_swps_meta_description', true ),
+			(string) get_post_meta( $post->ID, '_yoast_wpseo_metadesc', true ),
+			(string) get_post_meta( $post->ID, 'rank_math_description', true ),
+			(string) $post->post_excerpt,
+			wp_strip_all_tags( strip_shortcodes( (string) $post->post_content ) ),
+		);
 
-        foreach ( $candidates as $candidate ) {
-            $candidate = $this->collapse_whitespace( wp_strip_all_tags( $candidate ) );
-            if ( '' !== $candidate ) {
-                return $this->trim_to_length( $candidate, 200 );
-            }
-        }
+		foreach ( $candidates as $candidate ) {
+			$candidate = $this->collapse_whitespace( wp_strip_all_tags( $candidate ) );
+			if ( '' !== $candidate ) {
+				return $this->trim_to_length( $candidate, 200 );
+			}
+		}
 
-        return '';
-    }
+		return '';
+	}
 
-    private function collapse_whitespace( string $s ): string {
-        $s = preg_replace( '/\s+/', ' ', $s );
-        return trim( $s );
-    }
+	private function collapse_whitespace( string $s ): string {
+		$s = preg_replace( '/\s+/', ' ', $s );
+		return trim( $s );
+	}
 
-    private function trim_to_length( string $s, int $max ): string {
-        if ( mb_strlen( $s ) <= $max ) {
-            return $s;
-        }
-        $cut = mb_substr( $s, 0, $max );
-        // Trim back to the last sentence/word boundary.
-        $last_period = strrpos( $cut, '. ' );
-        if ( $last_period !== false && $last_period > $max * 0.6 ) {
-            return rtrim( mb_substr( $cut, 0, $last_period + 1 ) );
-        }
-        $last_space = strrpos( $cut, ' ' );
-        if ( $last_space !== false ) {
-            $cut = mb_substr( $cut, 0, $last_space );
-        }
-        return rtrim( $cut, " ,;:" ) . '…';
-    }
+	private function trim_to_length( string $s, int $max ): string {
+		if ( mb_strlen( $s ) <= $max ) {
+			return $s;
+		}
+		$cut = mb_substr( $s, 0, $max );
+		// Trim back to the last sentence/word boundary.
+		$last_period = strrpos( $cut, '. ' );
+		if ( $last_period !== false && $last_period > $max * 0.6 ) {
+			return rtrim( mb_substr( $cut, 0, $last_period + 1 ) );
+		}
+		$last_space = strrpos( $cut, ' ' );
+		if ( $last_space !== false ) {
+			$cut = mb_substr( $cut, 0, $last_space );
+		}
+		return rtrim( $cut, ' ,;:' ) . '…';
+	}
 
-    /**
-     * Detect the canonical sitemap URL from common providers.
-     */
-    private function detect_sitemap_url(): ?string {
-        if ( defined( 'WPSEO_VERSION' ) ) {
-            return home_url( '/sitemap_index.xml' );
-        }
-        if ( class_exists( 'RankMath' ) ) {
-            return home_url( '/sitemap_index.xml' );
-        }
-        if ( defined( 'AIOSEO_VERSION' ) ) {
-            return home_url( '/sitemap.xml' );
-        }
+	/**
+	 * Detect the canonical sitemap URL from common providers.
+	 */
+	private function detect_sitemap_url(): ?string {
+		if ( defined( 'WPSEO_VERSION' ) ) {
+			return home_url( '/sitemap_index.xml' );
+		}
+		if ( class_exists( 'RankMath' ) ) {
+			return home_url( '/sitemap_index.xml' );
+		}
+		if ( defined( 'AIOSEO_VERSION' ) ) {
+			return home_url( '/sitemap.xml' );
+		}
 
-        // StrataWP SEO disables the WP core sitemap and serves its own index.
-        return home_url( '/sitemap_index.xml' );
-    }
+		// StrataWP SEO disables the WP core sitemap and serves its own index.
+		return home_url( '/sitemap_index.xml' );
+	}
 }

--- a/includes/class-ai-provider.php
+++ b/includes/class-ai-provider.php
@@ -6,408 +6,408 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 abstract class SWPS_AI_Provider {
 
-    /**
-     * Last API call usage data (set by providers after successful calls).
-     *
-     * @var array{input_tokens: int, output_tokens: int}|null
-     */
-    protected ?array $last_usage = null;
+	/**
+	 * Last API call usage data (set by providers after successful calls).
+	 *
+	 * @var array{input_tokens: int, output_tokens: int}|null
+	 */
+	protected ?array $last_usage = null;
 
-    /**
-     * Stop reason from the last API call (e.g., 'end_turn', 'max_tokens').
-     * Set by providers after successful calls.
-     */
-    protected ?string $last_stop_reason = null;
+	/**
+	 * Stop reason from the last API call (e.g., 'end_turn', 'max_tokens').
+	 * Set by providers after successful calls.
+	 */
+	protected ?string $last_stop_reason = null;
 
-    /**
-     * Whether the current request expects a JSON response.
-     * Providers should check this to enable JSON mode when available.
-     */
-    protected bool $requesting_json = false;
+	/**
+	 * Whether the current request expects a JSON response.
+	 * Providers should check this to enable JSON mode when available.
+	 */
+	protected bool $requesting_json = false;
 
-    /**
-     * Send a message to the AI and get a text response.
-     *
-     * @param string $system_prompt The system instructions.
-     * @param string $user_message  The user message/prompt.
-     * @param int    $max_tokens    Maximum tokens in response.
-     * @return string|WP_Error The response text or error.
-     */
-    abstract public function chat( string $system_prompt, string $user_message, int $max_tokens = 4096 ): string|WP_Error;
+	/**
+	 * Send a message to the AI and get a text response.
+	 *
+	 * @param string $system_prompt The system instructions.
+	 * @param string $user_message  The user message/prompt.
+	 * @param int    $max_tokens    Maximum tokens in response.
+	 * @return string|WP_Error The response text or error.
+	 */
+	abstract public function chat( string $system_prompt, string $user_message, int $max_tokens = 4096 ): string|WP_Error;
 
-    /**
-     * Test the API key by making a minimal request.
-     *
-     * @param string $api_key The key to test.
-     * @return bool|WP_Error True if valid, WP_Error if not.
-     */
-    abstract public function test_key( string $api_key ): bool|WP_Error;
+	/**
+	 * Test the API key by making a minimal request.
+	 *
+	 * @param string $api_key The key to test.
+	 * @return bool|WP_Error True if valid, WP_Error if not.
+	 */
+	abstract public function test_key( string $api_key ): bool|WP_Error;
 
-    /**
-     * Get available models for this provider.
-     *
-     * @return array<string, string> Model ID => display name.
-     */
-    abstract public function get_available_models(): array;
+	/**
+	 * Get available models for this provider.
+	 *
+	 * @return array<string, string> Model ID => display name.
+	 */
+	abstract public function get_available_models(): array;
 
-    /**
-     * Get the provider slug (e.g., 'anthropic', 'openai').
-     */
-    abstract public function get_slug(): string;
+	/**
+	 * Get the provider slug (e.g., 'anthropic', 'openai').
+	 */
+	abstract public function get_slug(): string;
 
-    /**
-     * Get the provider display name (e.g., 'Anthropic (Claude)').
-     */
-    abstract public function get_name(): string;
+	/**
+	 * Get the provider display name (e.g., 'Anthropic (Claude)').
+	 */
+	abstract public function get_name(): string;
 
-    /**
-     * Get the URL where users can obtain an API key.
-     */
-    abstract public function get_api_key_url(): string;
+	/**
+	 * Get the URL where users can obtain an API key.
+	 */
+	abstract public function get_api_key_url(): string;
 
-    /**
-     * Send a message and parse the response as JSON.
-     *
-     * @param string $system_prompt The system instructions.
-     * @param string $user_message  The user message/prompt.
-     * @param int    $max_tokens    Maximum tokens in response.
-     * @return array|WP_Error Parsed JSON array or error.
-     */
-    public function chat_json( string $system_prompt, string $user_message, int $max_tokens = 4096 ): array|WP_Error {
-        $this->last_usage       = null;
-        $this->last_stop_reason = null;
-        $this->requesting_json  = true;
+	/**
+	 * Send a message and parse the response as JSON.
+	 *
+	 * @param string $system_prompt The system instructions.
+	 * @param string $user_message  The user message/prompt.
+	 * @param int    $max_tokens    Maximum tokens in response.
+	 * @return array|WP_Error Parsed JSON array or error.
+	 */
+	public function chat_json( string $system_prompt, string $user_message, int $max_tokens = 4096 ): array|WP_Error {
+		$this->last_usage       = null;
+		$this->last_stop_reason = null;
+		$this->requesting_json  = true;
 
-        $response = $this->chat( $system_prompt, $user_message, $max_tokens );
+		$response = $this->chat( $system_prompt, $user_message, $max_tokens );
 
-        $this->requesting_json = false;
+		$this->requesting_json = false;
 
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
-        // Detect truncation before parsing — the AI hit max_tokens.
-        if ( $this->last_stop_reason === 'max_tokens' ) {
-            return new WP_Error(
-                'swps_response_truncated',
-                sprintf(
-                    __( 'AI response was truncated (hit %d token limit). Try reducing word count or increasing the token budget.', 'stratawp-seo' ),
-                    $max_tokens
-                )
-            );
-        }
+		// Detect truncation before parsing — the AI hit max_tokens.
+		if ( $this->last_stop_reason === 'max_tokens' ) {
+			return new WP_Error(
+				'swps_response_truncated',
+				sprintf(
+					__( 'AI response was truncated (hit %d token limit). Try reducing word count or increasing the token budget.', 'stratawp-seo' ),
+					$max_tokens
+				)
+			);
+		}
 
-        $decoded = $this->parse_json_response( $response );
+		$decoded = $this->parse_json_response( $response );
 
-        if ( is_wp_error( $decoded ) ) {
-            return $decoded;
-        }
+		if ( is_wp_error( $decoded ) ) {
+			return $decoded;
+		}
 
-        // Inject usage data from the provider if available.
-        if ( ! empty( $this->last_usage ) ) {
-            $decoded['_usage'] = $this->last_usage;
-        }
+		// Inject usage data from the provider if available.
+		if ( ! empty( $this->last_usage ) ) {
+			$decoded['_usage'] = $this->last_usage;
+		}
 
-        return $decoded;
-    }
+		return $decoded;
+	}
 
-    /**
-     * Parse an AI response string as JSON with multiple fallback strategies.
-     *
-     * @param string $response The raw AI response text.
-     * @return array|WP_Error Parsed JSON array or error.
-     */
-    protected function parse_json_response( string $response ): array|WP_Error {
-        $raw     = $response;
-        $cleaned = trim( $response );
+	/**
+	 * Parse an AI response string as JSON with multiple fallback strategies.
+	 *
+	 * @param string $response The raw AI response text.
+	 * @return array|WP_Error Parsed JSON array or error.
+	 */
+	protected function parse_json_response( string $response ): array|WP_Error {
+		$raw     = $response;
+		$cleaned = trim( $response );
 
-        // Strip BOM if present.
-        $cleaned = ltrim( $cleaned, "\xEF\xBB\xBF" );
+		// Strip BOM if present.
+		$cleaned = ltrim( $cleaned, "\xEF\xBB\xBF" );
 
-        // Strip Unicode line/paragraph separators (U+2028, U+2029) that some
-        // PHP versions reject inside JSON strings.
-        $cleaned = str_replace( [ "\xe2\x80\xa8", "\xe2\x80\xa9" ], '', $cleaned );
+		// Strip Unicode line/paragraph separators (U+2028, U+2029) that some
+		// PHP versions reject inside JSON strings.
+		$cleaned = str_replace( array( "\xe2\x80\xa8", "\xe2\x80\xa9" ), '', $cleaned );
 
-        // Strip markdown code fences if present.
-        $cleaned = preg_replace( '/^```(?:json)?\s*/s', '', $cleaned );
-        $cleaned = preg_replace( '/\s*```\s*$/s', '', $cleaned );
-        $cleaned = trim( $cleaned );
+		// Strip markdown code fences if present.
+		$cleaned = preg_replace( '/^```(?:json)?\s*/s', '', $cleaned );
+		$cleaned = preg_replace( '/\s*```\s*$/s', '', $cleaned );
+		$cleaned = trim( $cleaned );
 
-        // Strip any text before the first { or after the last }.
-        $first_brace = strpos( $cleaned, '{' );
-        $last_brace  = strrpos( $cleaned, '}' );
-        if ( $first_brace !== false && $last_brace !== false && $last_brace > $first_brace ) {
-            $cleaned = substr( $cleaned, $first_brace, $last_brace - $first_brace + 1 );
-        }
+		// Strip any text before the first { or after the last }.
+		$first_brace = strpos( $cleaned, '{' );
+		$last_brace  = strrpos( $cleaned, '}' );
+		if ( $first_brace !== false && $last_brace !== false && $last_brace > $first_brace ) {
+			$cleaned = substr( $cleaned, $first_brace, $last_brace - $first_brace + 1 );
+		}
 
-        // Attempt 1: Direct parse.
-        $decoded = json_decode( $cleaned, true );
-        if ( json_last_error() === JSON_ERROR_NONE ) {
-            return $decoded;
-        }
+		// Attempt 1: Direct parse.
+		$decoded = json_decode( $cleaned, true );
+		if ( json_last_error() === JSON_ERROR_NONE ) {
+			return $decoded;
+		}
 
-        // Attempt 2: Sanitize control characters inside JSON string values.
-        // Replace literal control chars (0x00-0x1F) that aren't already escaped.
-        $sanitized = preg_replace_callback(
-            '/"((?:[^"\\\\]|\\\\.)*)"/s',
-            function ( $m ) {
-                $val = $m[1];
-                // Escape literal control characters that break JSON.
-                $val = str_replace(
-                    [ "\n", "\r", "\t", "\x08", "\x0C" ],
-                    [ '\\n', '\\r', '\\t', '\\b', '\\f' ],
-                    $val
-                );
-                // Remove any remaining control characters (0x00-0x1F) except already-escaped ones.
-                $val = preg_replace( '/[\x00-\x1F]/', '', $val );
-                return '"' . $val . '"';
-            },
-            $cleaned
-        );
+		// Attempt 2: Sanitize control characters inside JSON string values.
+		// Replace literal control chars (0x00-0x1F) that aren't already escaped.
+		$sanitized = preg_replace_callback(
+			'/"((?:[^"\\\\]|\\\\.)*)"/s',
+			function ( $m ) {
+				$val = $m[1];
+				// Escape literal control characters that break JSON.
+				$val = str_replace(
+					array( "\n", "\r", "\t", "\x08", "\x0C" ),
+					array( '\\n', '\\r', '\\t', '\\b', '\\f' ),
+					$val
+				);
+				// Remove any remaining control characters (0x00-0x1F) except already-escaped ones.
+				$val = preg_replace( '/[\x00-\x1F]/', '', $val );
+				return '"' . $val . '"';
+			},
+			$cleaned
+		);
 
-        $decoded = json_decode( $sanitized, true );
-        if ( json_last_error() === JSON_ERROR_NONE ) {
-            return $decoded;
-        }
+		$decoded = json_decode( $sanitized, true );
+		if ( json_last_error() === JSON_ERROR_NONE ) {
+			return $decoded;
+		}
 
-        // Attempt 3: Try with JSON_INVALID_UTF8_SUBSTITUTE to handle encoding issues.
-        $decoded = json_decode( $sanitized, true, 512, JSON_INVALID_UTF8_SUBSTITUTE );
-        if ( json_last_error() === JSON_ERROR_NONE ) {
-            return $decoded;
-        }
+		// Attempt 3: Try with JSON_INVALID_UTF8_SUBSTITUTE to handle encoding issues.
+		$decoded = json_decode( $sanitized, true, 512, JSON_INVALID_UTF8_SUBSTITUTE );
+		if ( json_last_error() === JSON_ERROR_NONE ) {
+			return $decoded;
+		}
 
-        // Attempt 4: Fix unescaped double quotes inside JSON string values.
-        // Walk the string character-by-character, tracking whether we're inside a
-        // string value, and escape any unescaped quotes that aren't structural.
-        $repaired = $this->repair_json_quotes( $cleaned );
-        if ( $repaired !== $cleaned ) {
-            $decoded = json_decode( $repaired, true, 512, JSON_INVALID_UTF8_SUBSTITUTE );
-            if ( json_last_error() === JSON_ERROR_NONE ) {
-                return $decoded;
-            }
-        }
+		// Attempt 4: Fix unescaped double quotes inside JSON string values.
+		// Walk the string character-by-character, tracking whether we're inside a
+		// string value, and escape any unescaped quotes that aren't structural.
+		$repaired = $this->repair_json_quotes( $cleaned );
+		if ( $repaired !== $cleaned ) {
+			$decoded = json_decode( $repaired, true, 512, JSON_INVALID_UTF8_SUBSTITUTE );
+			if ( json_last_error() === JSON_ERROR_NONE ) {
+				return $decoded;
+			}
+		}
 
-        // Attempt 5: Combine quote repair AND control-char sanitization.
-        // The earlier sanitize regex bails out at the first unescaped quote, so
-        // combining repair (which fixes structure) with sanitize (which fixes
-        // control chars) catches responses with both issues.
-        $combined = preg_replace_callback(
-            '/"((?:[^"\\\\]|\\\\.)*)"/s',
-            function ( $m ) {
-                $val = str_replace(
-                    [ "\n", "\r", "\t", "\x08", "\x0C" ],
-                    [ '\\n', '\\r', '\\t', '\\b', '\\f' ],
-                    $m[1]
-                );
-                $val = preg_replace( '/[\x00-\x1F]/', '', $val );
-                return '"' . $val . '"';
-            },
-            $repaired
-        );
-        $decoded = json_decode( $combined, true, 512, JSON_INVALID_UTF8_SUBSTITUTE );
-        if ( json_last_error() === JSON_ERROR_NONE ) {
-            return $decoded;
-        }
+		// Attempt 5: Combine quote repair AND control-char sanitization.
+		// The earlier sanitize regex bails out at the first unescaped quote, so
+		// combining repair (which fixes structure) with sanitize (which fixes
+		// control chars) catches responses with both issues.
+		$combined = preg_replace_callback(
+			'/"((?:[^"\\\\]|\\\\.)*)"/s',
+			function ( $m ) {
+				$val = str_replace(
+					array( "\n", "\r", "\t", "\x08", "\x0C" ),
+					array( '\\n', '\\r', '\\t', '\\b', '\\f' ),
+					$m[1]
+				);
+				$val = preg_replace( '/[\x00-\x1F]/', '', $val );
+				return '"' . $val . '"';
+			},
+			$repaired
+		);
+		$decoded  = json_decode( $combined, true, 512, JSON_INVALID_UTF8_SUBSTITUTE );
+		if ( json_last_error() === JSON_ERROR_NONE ) {
+			return $decoded;
+		}
 
-        // Attempt 6: Strip stray escape sequences (\n, \r, \t, etc.) that the
-        // model emitted *outside* of string literals. Walk the string tracking
-        // whether we're inside a JSON string; if we see a backslash outside a
-        // string, drop it and the following character.
-        $stripped = $this->strip_stray_escapes( $combined );
-        if ( $stripped !== $combined ) {
-            $decoded = json_decode( $stripped, true, 512, JSON_INVALID_UTF8_SUBSTITUTE );
-            if ( json_last_error() === JSON_ERROR_NONE ) {
-                return $decoded;
-            }
-        }
+		// Attempt 6: Strip stray escape sequences (\n, \r, \t, etc.) that the
+		// model emitted *outside* of string literals. Walk the string tracking
+		// whether we're inside a JSON string; if we see a backslash outside a
+		// string, drop it and the following character.
+		$stripped = $this->strip_stray_escapes( $combined );
+		if ( $stripped !== $combined ) {
+			$decoded = json_decode( $stripped, true, 512, JSON_INVALID_UTF8_SUBSTITUTE );
+			if ( json_last_error() === JSON_ERROR_NONE ) {
+				return $decoded;
+			}
+		}
 
-        // All attempts failed — persist the raw response for debugging and
-        // return error with diagnostic info.
-        set_transient(
-            'swps_last_ai_failure',
-            [
-                'time'    => current_time( 'mysql' ),
-                'error'   => json_last_error_msg(),
-                'raw'     => $raw,
-                'cleaned' => $cleaned,
-            ],
-            DAY_IN_SECONDS
-        );
+		// All attempts failed — persist the raw response for debugging and
+		// return error with diagnostic info.
+		set_transient(
+			'swps_last_ai_failure',
+			array(
+				'time'    => current_time( 'mysql' ),
+				'error'   => json_last_error_msg(),
+				'raw'     => $raw,
+				'cleaned' => $cleaned,
+			),
+			DAY_IN_SECONDS
+		);
 
-        $len  = strlen( $cleaned );
-        $tail = $len > 120 ? substr( $cleaned, -120 ) : $cleaned;
+		$len  = strlen( $cleaned );
+		$tail = $len > 120 ? substr( $cleaned, -120 ) : $cleaned;
 
-        return new WP_Error(
-            'swps_json_parse_error',
-            sprintf(
-                __( 'Failed to parse AI response as JSON: %s [len=%d, tail="%s"]. Raw response saved — view at Settings → StrataWP SEO → Tools → Last AI Failure.', 'stratawp-seo' ),
-                json_last_error_msg(),
-                $len,
-                $tail
-            )
-        );
-    }
+		return new WP_Error(
+			'swps_json_parse_error',
+			sprintf(
+				__( 'Failed to parse AI response as JSON: %1$s [len=%2$d, tail="%3$s"]. Raw response saved — view at Settings → StrataWP SEO → Tools → Last AI Failure.', 'stratawp-seo' ),
+				json_last_error_msg(),
+				$len,
+				$tail
+			)
+		);
+	}
 
-    /**
-     * Attempt to repair unescaped double quotes inside JSON string values.
-     *
-     * Walks the string character-by-character to find quotes that appear inside
-     * a JSON string value but aren't escaped, then escapes them.
-     *
-     * @param string $json The JSON string to repair.
-     * @return string The repaired JSON string.
-     */
-    protected function repair_json_quotes( string $json ): string {
-        $len    = strlen( $json );
-        $result = '';
-        $i      = 0;
+	/**
+	 * Attempt to repair unescaped double quotes inside JSON string values.
+	 *
+	 * Walks the string character-by-character to find quotes that appear inside
+	 * a JSON string value but aren't escaped, then escapes them.
+	 *
+	 * @param string $json The JSON string to repair.
+	 * @return string The repaired JSON string.
+	 */
+	protected function repair_json_quotes( string $json ): string {
+		$len    = strlen( $json );
+		$result = '';
+		$i      = 0;
 
-        while ( $i < $len ) {
-            $ch = $json[ $i ];
+		while ( $i < $len ) {
+			$ch = $json[ $i ];
 
-            // Outside a string: copy everything until we hit a quote.
-            if ( $ch !== '"' ) {
-                $result .= $ch;
-                $i++;
-                continue;
-            }
+			// Outside a string: copy everything until we hit a quote.
+			if ( $ch !== '"' ) {
+				$result .= $ch;
+				++$i;
+				continue;
+			}
 
-            // Opening quote of a string value — find the proper closing quote.
-            $result .= '"';
-            $i++;
-            $str_content = '';
+			// Opening quote of a string value — find the proper closing quote.
+			$result .= '"';
+			++$i;
+			$str_content = '';
 
-            while ( $i < $len ) {
-                $ch = $json[ $i ];
+			while ( $i < $len ) {
+				$ch = $json[ $i ];
 
-                if ( $ch === '\\' && $i + 1 < $len ) {
-                    // Already-escaped character — keep as-is.
-                    $str_content .= $ch . $json[ $i + 1 ];
-                    $i += 2;
-                    continue;
-                }
+				if ( $ch === '\\' && $i + 1 < $len ) {
+					// Already-escaped character — keep as-is.
+					$str_content .= $ch . $json[ $i + 1 ];
+					$i           += 2;
+					continue;
+				}
 
-                if ( $ch === '"' ) {
-                    // Is this the real closing quote?
-                    // Look ahead: after skipping whitespace, the next char should be
-                    // a structural JSON character: , ] } or :
-                    $ahead = ltrim( substr( $json, $i + 1, 10 ) );
-                    if ( $ahead === '' || strpos( ',]}:', $ahead[0] ) !== false ) {
-                        // Real closing quote.
-                        break;
-                    }
-                    // Unescaped quote inside the value — escape it.
-                    $str_content .= '\\"';
-                    $i++;
-                    continue;
-                }
+				if ( $ch === '"' ) {
+					// Is this the real closing quote?
+					// Look ahead: after skipping whitespace, the next char should be
+					// a structural JSON character: , ] } or :
+					$ahead = ltrim( substr( $json, $i + 1, 10 ) );
+					if ( $ahead === '' || strpos( ',]}:', $ahead[0] ) !== false ) {
+						// Real closing quote.
+						break;
+					}
+					// Unescaped quote inside the value — escape it.
+					$str_content .= '\\"';
+					++$i;
+					continue;
+				}
 
-                $str_content .= $ch;
-                $i++;
-            }
+				$str_content .= $ch;
+				++$i;
+			}
 
-            $result .= $str_content . '"';
-            $i++; // Skip the closing quote.
-        }
+			$result .= $str_content . '"';
+			++$i; // Skip the closing quote.
+		}
 
-        return $result;
-    }
+		return $result;
+	}
 
-    /**
-     * Strip stray escape sequences that appear outside of string literals.
-     *
-     * The model occasionally emits literal backslash-letter pairs (e.g. "\n")
-     * between JSON tokens, which is invalid. Walk the string tracking whether
-     * we're inside a quoted string; outside strings, drop any backslash and
-     * the character that follows it.
-     *
-     * @param string $json The JSON string to clean.
-     * @return string The cleaned JSON string.
-     */
-    protected function strip_stray_escapes( string $json ): string {
-        $len      = strlen( $json );
-        $result   = '';
-        $i        = 0;
-        $in_string = false;
+	/**
+	 * Strip stray escape sequences that appear outside of string literals.
+	 *
+	 * The model occasionally emits literal backslash-letter pairs (e.g. "\n")
+	 * between JSON tokens, which is invalid. Walk the string tracking whether
+	 * we're inside a quoted string; outside strings, drop any backslash and
+	 * the character that follows it.
+	 *
+	 * @param string $json The JSON string to clean.
+	 * @return string The cleaned JSON string.
+	 */
+	protected function strip_stray_escapes( string $json ): string {
+		$len       = strlen( $json );
+		$result    = '';
+		$i         = 0;
+		$in_string = false;
 
-        while ( $i < $len ) {
-            $ch = $json[ $i ];
+		while ( $i < $len ) {
+			$ch = $json[ $i ];
 
-            if ( $in_string ) {
-                if ( $ch === '\\' && $i + 1 < $len ) {
-                    // Inside a string — preserve escape sequences verbatim.
-                    $result .= $ch . $json[ $i + 1 ];
-                    $i += 2;
-                    continue;
-                }
-                if ( $ch === '"' ) {
-                    $in_string = false;
-                }
-                $result .= $ch;
-                $i++;
-                continue;
-            }
+			if ( $in_string ) {
+				if ( $ch === '\\' && $i + 1 < $len ) {
+					// Inside a string — preserve escape sequences verbatim.
+					$result .= $ch . $json[ $i + 1 ];
+					$i      += 2;
+					continue;
+				}
+				if ( $ch === '"' ) {
+					$in_string = false;
+				}
+				$result .= $ch;
+				++$i;
+				continue;
+			}
 
-            // Outside a string.
-            if ( $ch === '"' ) {
-                $in_string = true;
-                $result   .= $ch;
-                $i++;
-                continue;
-            }
+			// Outside a string.
+			if ( $ch === '"' ) {
+				$in_string = true;
+				$result   .= $ch;
+				++$i;
+				continue;
+			}
 
-            if ( $ch === '\\' && $i + 1 < $len ) {
-                // Stray escape between tokens — drop the backslash AND the
-                // following char only if it is a typical escape letter.
-                // Otherwise, drop just the backslash.
-                $next = $json[ $i + 1 ];
-                if ( strpos( "nrtbf/\\\"u", $next ) !== false ) {
-                    $i += 2;
-                } else {
-                    $i += 1;
-                }
-                continue;
-            }
+			if ( $ch === '\\' && $i + 1 < $len ) {
+				// Stray escape between tokens — drop the backslash AND the
+				// following char only if it is a typical escape letter.
+				// Otherwise, drop just the backslash.
+				$next = $json[ $i + 1 ];
+				if ( strpos( 'nrtbf/\\"u', $next ) !== false ) {
+					$i += 2;
+				} else {
+					$i += 1;
+				}
+				continue;
+			}
 
-            $result .= $ch;
-            $i++;
-        }
+			$result .= $ch;
+			++$i;
+		}
 
-        return $result;
-    }
+		return $result;
+	}
 
-    /**
-     * Get the stored API key for this provider.
-     */
-    public function get_api_key(): string {
-        return (string) get_option( $this->get_api_key_option(), '' );
-    }
+	/**
+	 * Get the stored API key for this provider.
+	 */
+	public function get_api_key(): string {
+		return (string) get_option( $this->get_api_key_option(), '' );
+	}
 
-    /**
-     * Get the option name for this provider's API key.
-     */
-    public function get_api_key_option(): string {
-        return 'swps_' . $this->get_slug() . '_api_key';
-    }
+	/**
+	 * Get the option name for this provider's API key.
+	 */
+	public function get_api_key_option(): string {
+		return 'swps_' . $this->get_slug() . '_api_key';
+	}
 
-    /**
-     * Get the validated model — falls back to the first available model
-     * if the stored model is not valid for this provider.
-     */
-    public function get_validated_model(): string {
-        $stored = get_option( 'swps_model', '' );
-        $models = $this->get_available_models();
+	/**
+	 * Get the validated model — falls back to the first available model
+	 * if the stored model is not valid for this provider.
+	 */
+	public function get_validated_model(): string {
+		$stored = get_option( 'swps_model', '' );
+		$models = $this->get_available_models();
 
-        if ( ! empty( $stored ) && array_key_exists( $stored, $models ) ) {
-            return $stored;
-        }
+		if ( ! empty( $stored ) && array_key_exists( $stored, $models ) ) {
+			return $stored;
+		}
 
-        // Fall back to the first model for this provider.
-        return array_key_first( $models );
-    }
+		// Fall back to the first model for this provider.
+		return array_key_first( $models );
+	}
 }

--- a/includes/class-analytics-dashboard.php
+++ b/includes/class-analytics-dashboard.php
@@ -6,377 +6,384 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Analytics_Dashboard {
 
-    private SWPS_Analytics_Tracker $tracker;
-    private SWPS_Search_Console $search_console;
-
-    public function __construct( SWPS_Analytics_Tracker $tracker, SWPS_Search_Console $search_console ) {
-        $this->tracker        = $tracker;
-        $this->search_console = $search_console;
-
-        // Admin menu — priority 20 so parent menu (registered at 10) exists first.
-        add_action( 'admin_menu', [ $this, 'register_menu' ], 20 );
-
-        // AJAX endpoints.
-        add_action( 'wp_ajax_swps_analytics_overview', [ $this, 'ajax_overview' ] );
-        add_action( 'wp_ajax_swps_analytics_top_pages', [ $this, 'ajax_top_pages' ] );
-        add_action( 'wp_ajax_swps_analytics_top_queries', [ $this, 'ajax_top_queries' ] );
-        add_action( 'wp_ajax_swps_analytics_post_stats', [ $this, 'ajax_post_stats' ] );
-        add_action( 'wp_ajax_swps_gsc_disconnect', [ $this, 'ajax_disconnect_gsc' ] );
-        add_action( 'wp_ajax_swps_gsc_refresh', [ $this, 'ajax_refresh_gsc' ] );
-        add_action( 'wp_ajax_swps_gsc_save_property', [ $this, 'ajax_save_property' ] );
-
-        // Post list column.
-        add_filter( 'manage_posts_columns', [ $this, 'add_views_column' ] );
-        add_action( 'manage_posts_custom_column', [ $this, 'render_views_column' ], 10, 2 );
-        add_filter( 'manage_edit-post_sortable_columns', [ $this, 'sortable_views_column' ] );
-
-        // Post metabox.
-        add_action( 'add_meta_boxes', [ $this, 'register_metabox' ] );
-    }
-
-    /**
-     * Register the Analytics submenu page.
-     */
-    public function register_menu(): void {
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Analytics', 'stratawp-seo' ),
-            __( 'Analytics', 'stratawp-seo' ),
-            'manage_options',
-            'swps-analytics',
-            [ $this, 'render_page' ]
-        );
-    }
-
-    /**
-     * Render the analytics page.
-     */
-    public function render_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            return;
-        }
-
-        $gsc_connected = $this->search_console->is_connected();
-        $gsc_property  = get_option( 'swps_gsc_property', '' );
-        $gsc_auth_url  = $this->search_console->get_auth_url();
-        $properties    = $gsc_connected ? $this->search_console->get_properties() : [];
-
-        // AI Bot Analytics — server-side crawler insights.
-        $bot_tracker = stratawp_seo()->bot_analytics_tracker ?? null;
-        $bot_data    = [];
-        if ( $bot_tracker instanceof SWPS_Bot_Analytics_Tracker ) {
-            $bot_data = [
-                'totals'    => $bot_tracker->get_totals( 30 ),
-                'bots'      => $bot_tracker->get_bot_summary( 30 ),
-                'top_pages' => $bot_tracker->get_top_pages( 30, 15 ),
-                'gaps'      => $bot_tracker->get_gap_posts( 30, 10 ),
-                'top_404s'  => $bot_tracker->get_top_404s( 30, 10 ),
-            ];
-        }
-
-        include SWPS_PLUGIN_DIR . 'templates/analytics-page.php';
-    }
-
-    /**
-     * AJAX: Get overview data for the dashboard.
-     */
-    public function ajax_overview(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $days = absint( $_POST['days'] ?? 30 );
-        $days = in_array( $days, [ 7, 30, 90 ], true ) ? $days : 30;
-
-        $daily_stats = $this->tracker->get_daily_stats( $days );
-
-        // Calculate totals.
-        $total_views   = array_sum( array_column( $daily_stats, 'views' ) );
-        $avg_time      = $total_views > 0 ? round( array_sum( array_column( $daily_stats, 'avg_time' ) ) / max( count( $daily_stats ), 1 ) ) : 0;
-        $total_bounces = array_sum( array_column( $daily_stats, 'bounces' ) );
-        $bounce_rate   = $total_views > 0 ? round( ( $total_bounces / $total_views ) * 100 ) : 0;
-
-        // Previous period for comparison.
-        $prev_stats    = $this->tracker->get_daily_stats( $days * 2 );
-        $prev_views    = 0;
-
-        foreach ( $prev_stats as $row ) {
-            if ( $row['date'] < gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) ) {
-                $prev_views += (int) $row['views'];
-            }
-        }
-
-        $views_change = $prev_views > 0 ? round( ( ( $total_views - $prev_views ) / $prev_views ) * 100 ) : 0;
-
-        $result = [
-            'daily'        => $daily_stats,
-            'total_views'  => $total_views,
-            'avg_time'     => $avg_time,
-            'bounce_rate'  => $bounce_rate,
-            'views_change' => $views_change,
-        ];
-
-        // Add GSC data if connected.
-        if ( $this->search_console->is_connected() ) {
-            $gsc_data = $this->search_console->get_search_data( $days );
-
-            $total_clicks      = 0;
-            $total_impressions = 0;
-
-            foreach ( $gsc_data['daily'] ?? [] as $row ) {
-                $total_clicks      += $row['clicks'] ?? 0;
-                $total_impressions += $row['impressions'] ?? 0;
-            }
-
-            $result['gsc_clicks']      = $total_clicks;
-            $result['gsc_impressions'] = $total_impressions;
-            $result['gsc_daily']       = $gsc_data['daily'] ?? [];
-        }
-
-        wp_send_json_success( $result );
-    }
-
-    /**
-     * AJAX: Get top pages.
-     */
-    public function ajax_top_pages(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $days  = absint( $_POST['days'] ?? 30 );
-        $pages = $this->tracker->get_top_pages( $days );
-
-        // Enrich with post titles.
-        foreach ( $pages as &$page ) {
-            $post = get_post( (int) $page['post_id'] );
-            $page['title'] = $post ? $post->post_title : __( '(Unknown)', 'stratawp-seo' );
-            $page['url']   = $post ? get_permalink( $post ) : '';
-            $page['bounce_rate'] = $page['views'] > 0
-                ? round( ( $page['bounces'] / $page['views'] ) * 100 )
-                : 0;
-        }
-
-        // Merge GSC data if connected.
-        if ( $this->search_console->is_connected() ) {
-            $gsc_data = $this->search_console->get_search_data( $days );
-
-            $gsc_by_url = [];
-            foreach ( $gsc_data['pages'] ?? [] as $row ) {
-                $url = $row['keys'][0] ?? '';
-                $gsc_by_url[ $url ] = $row;
-            }
-
-            foreach ( $pages as &$page ) {
-                if ( ! empty( $page['url'] ) && isset( $gsc_by_url[ $page['url'] ] ) ) {
-                    $gsc_row = $gsc_by_url[ $page['url'] ];
-                    $page['gsc_clicks']      = $gsc_row['clicks'] ?? 0;
-                    $page['gsc_impressions'] = $gsc_row['impressions'] ?? 0;
-                    $page['gsc_position']    = round( $gsc_row['position'] ?? 0, 1 );
-                }
-            }
-        }
-
-        wp_send_json_success( $pages );
-    }
-
-    /**
-     * AJAX: Get top queries (GSC only).
-     */
-    public function ajax_top_queries(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        if ( ! $this->search_console->is_connected() ) {
-            wp_send_json_error( [ 'message' => 'Search Console not connected.' ] );
-        }
-
-        $days     = absint( $_POST['days'] ?? 30 );
-        $gsc_data = $this->search_console->get_search_data( $days );
-        $queries  = [];
-
-        foreach ( $gsc_data['queries'] ?? [] as $row ) {
-            $queries[] = [
-                'query'       => $row['keys'][0] ?? '',
-                'clicks'      => $row['clicks'] ?? 0,
-                'impressions' => $row['impressions'] ?? 0,
-                'ctr'         => round( ( $row['ctr'] ?? 0 ) * 100, 1 ),
-                'position'    => round( $row['position'] ?? 0, 1 ),
-            ];
-        }
-
-        wp_send_json_success( $queries );
-    }
-
-    /**
-     * AJAX: Get stats for a single post (used by metabox).
-     */
-    public function ajax_post_stats(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $post_id = absint( $_POST['post_id'] ?? 0 );
-
-        if ( ! $post_id ) {
-            wp_send_json_error( [ 'message' => 'Invalid post ID.' ] );
-        }
-
-        $stats_7d  = $this->tracker->get_post_stats( $post_id, 7 );
-        $stats_30d = $this->tracker->get_post_stats( $post_id, 30 );
-
-        $result = [
-            'views_7d'         => $stats_7d['views'],
-            'views_30d'        => $stats_30d['views'],
-            'avg_time_on_page' => $stats_30d['avg_time_on_page'],
-            'avg_scroll_depth' => $stats_30d['avg_scroll_depth'],
-            'bounce_rate'      => $stats_30d['bounce_rate'],
-        ];
-
-        // Bot crawler stats for this post.
-        $bot_tracker = stratawp_seo()->bot_analytics_tracker ?? null;
-        if ( $bot_tracker instanceof SWPS_Bot_Analytics_Tracker ) {
-            $bot_stats           = $bot_tracker->get_post_stats( $post_id );
-            $result['bot_hits_7d']  = $bot_stats['hits_7d'];
-            $result['bot_hits_30d'] = $bot_stats['hits_30d'];
-            $result['bot_last_seen'] = $bot_stats['last_seen']
-                ? human_time_diff( strtotime( $bot_stats['last_seen'] ), time() ) . ' ago'
-                : null;
-        }
-
-        // GSC queries for this post.
-        if ( $this->search_console->is_connected() ) {
-            $url     = get_permalink( $post_id );
-            $queries = $this->search_console->get_page_queries( $url, 90 );
-
-            $result['gsc_queries'] = array_slice( array_map( function ( $row ) {
-                return [
-                    'query'    => $row['keys'][0] ?? '',
-                    'clicks'   => $row['clicks'] ?? 0,
-                    'position' => round( $row['position'] ?? 0, 1 ),
-                ];
-            }, $queries ), 0, 5 );
-        }
-
-        wp_send_json_success( $result );
-    }
-
-    /**
-     * AJAX: Disconnect GSC.
-     */
-    public function ajax_disconnect_gsc(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $this->search_console->disconnect();
-
-        wp_send_json_success();
-    }
-
-    /**
-     * AJAX: Refresh GSC data.
-     */
-    public function ajax_refresh_gsc(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $this->search_console->clear_cache();
-
-        wp_send_json_success();
-    }
-
-    /**
-     * AJAX: Save selected GSC property.
-     */
-    public function ajax_save_property(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $property = esc_url_raw( $_POST['property'] ?? '' );
-        update_option( 'swps_gsc_property', $property );
-
-        $this->search_console->clear_cache();
-
-        wp_send_json_success();
-    }
-
-    /**
-     * Add Views column to posts list.
-     */
-    public function add_views_column( array $columns ): array {
-        $columns['swps_views'] = __( 'Views (30d)', 'stratawp-seo' );
-        return $columns;
-    }
-
-    /**
-     * Render the Views column.
-     */
-    public function render_views_column( string $column, int $post_id ): void {
-        if ( 'swps_views' !== $column ) {
-            return;
-        }
-
-        $stats = $this->tracker->get_post_stats( $post_id, 30 );
-        echo esc_html( number_format_i18n( $stats['views'] ) );
-    }
-
-    /**
-     * Make Views column sortable.
-     */
-    public function sortable_views_column( array $columns ): array {
-        $columns['swps_views'] = 'swps_views';
-        return $columns;
-    }
-
-    /**
-     * Register the analytics metabox on post edit screens.
-     */
-    public function register_metabox(): void {
-        add_meta_box(
-            'swps_analytics_metabox',
-            __( 'StrataWP Analytics', 'stratawp-seo' ),
-            [ $this, 'render_metabox' ],
-            'post',
-            'side',
-            'default'
-        );
-    }
-
-    /**
-     * Render the analytics metabox.
-     */
-    public function render_metabox( WP_Post $post ): void {
-        $nonce = wp_create_nonce( 'swps_nonce' );
-        printf(
-            '<div id="swps-analytics-metabox" data-post-id="%d" data-nonce="%s">
+	private SWPS_Analytics_Tracker $tracker;
+	private SWPS_Search_Console $search_console;
+
+	public function __construct( SWPS_Analytics_Tracker $tracker, SWPS_Search_Console $search_console ) {
+		$this->tracker        = $tracker;
+		$this->search_console = $search_console;
+
+		// Admin menu — priority 20 so parent menu (registered at 10) exists first.
+		add_action( 'admin_menu', array( $this, 'register_menu' ), 20 );
+
+		// AJAX endpoints.
+		add_action( 'wp_ajax_swps_analytics_overview', array( $this, 'ajax_overview' ) );
+		add_action( 'wp_ajax_swps_analytics_top_pages', array( $this, 'ajax_top_pages' ) );
+		add_action( 'wp_ajax_swps_analytics_top_queries', array( $this, 'ajax_top_queries' ) );
+		add_action( 'wp_ajax_swps_analytics_post_stats', array( $this, 'ajax_post_stats' ) );
+		add_action( 'wp_ajax_swps_gsc_disconnect', array( $this, 'ajax_disconnect_gsc' ) );
+		add_action( 'wp_ajax_swps_gsc_refresh', array( $this, 'ajax_refresh_gsc' ) );
+		add_action( 'wp_ajax_swps_gsc_save_property', array( $this, 'ajax_save_property' ) );
+
+		// Post list column.
+		add_filter( 'manage_posts_columns', array( $this, 'add_views_column' ) );
+		add_action( 'manage_posts_custom_column', array( $this, 'render_views_column' ), 10, 2 );
+		add_filter( 'manage_edit-post_sortable_columns', array( $this, 'sortable_views_column' ) );
+
+		// Post metabox.
+		add_action( 'add_meta_boxes', array( $this, 'register_metabox' ) );
+	}
+
+	/**
+	 * Register the Analytics submenu page.
+	 */
+	public function register_menu(): void {
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Analytics', 'stratawp-seo' ),
+			__( 'Analytics', 'stratawp-seo' ),
+			'manage_options',
+			'swps-analytics',
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Render the analytics page.
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$gsc_connected = $this->search_console->is_connected();
+		$gsc_property  = get_option( 'swps_gsc_property', '' );
+		$gsc_auth_url  = $this->search_console->get_auth_url();
+		$properties    = $gsc_connected ? $this->search_console->get_properties() : array();
+
+		// AI Bot Analytics — server-side crawler insights.
+		$bot_tracker = stratawp_seo()->bot_analytics_tracker ?? null;
+		$bot_data    = array();
+		if ( $bot_tracker instanceof SWPS_Bot_Analytics_Tracker ) {
+			$bot_data = array(
+				'totals'    => $bot_tracker->get_totals( 30 ),
+				'bots'      => $bot_tracker->get_bot_summary( 30 ),
+				'top_pages' => $bot_tracker->get_top_pages( 30, 15 ),
+				'gaps'      => $bot_tracker->get_gap_posts( 30, 10 ),
+				'top_404s'  => $bot_tracker->get_top_404s( 30, 10 ),
+			);
+		}
+
+		include SWPS_PLUGIN_DIR . 'templates/analytics-page.php';
+	}
+
+	/**
+	 * AJAX: Get overview data for the dashboard.
+	 */
+	public function ajax_overview(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$days = absint( $_POST['days'] ?? 30 );
+		$days = in_array( $days, array( 7, 30, 90 ), true ) ? $days : 30;
+
+		$daily_stats = $this->tracker->get_daily_stats( $days );
+
+		// Calculate totals.
+		$total_views   = array_sum( array_column( $daily_stats, 'views' ) );
+		$avg_time      = $total_views > 0 ? round( array_sum( array_column( $daily_stats, 'avg_time' ) ) / max( count( $daily_stats ), 1 ) ) : 0;
+		$total_bounces = array_sum( array_column( $daily_stats, 'bounces' ) );
+		$bounce_rate   = $total_views > 0 ? round( ( $total_bounces / $total_views ) * 100 ) : 0;
+
+		// Previous period for comparison.
+		$prev_stats = $this->tracker->get_daily_stats( $days * 2 );
+		$prev_views = 0;
+
+		foreach ( $prev_stats as $row ) {
+			if ( $row['date'] < gmdate( 'Y-m-d', strtotime( "-{$days} days" ) ) ) {
+				$prev_views += (int) $row['views'];
+			}
+		}
+
+		$views_change = $prev_views > 0 ? round( ( ( $total_views - $prev_views ) / $prev_views ) * 100 ) : 0;
+
+		$result = array(
+			'daily'        => $daily_stats,
+			'total_views'  => $total_views,
+			'avg_time'     => $avg_time,
+			'bounce_rate'  => $bounce_rate,
+			'views_change' => $views_change,
+		);
+
+		// Add GSC data if connected.
+		if ( $this->search_console->is_connected() ) {
+			$gsc_data = $this->search_console->get_search_data( $days );
+
+			$total_clicks      = 0;
+			$total_impressions = 0;
+
+			foreach ( $gsc_data['daily'] ?? array() as $row ) {
+				$total_clicks      += $row['clicks'] ?? 0;
+				$total_impressions += $row['impressions'] ?? 0;
+			}
+
+			$result['gsc_clicks']      = $total_clicks;
+			$result['gsc_impressions'] = $total_impressions;
+			$result['gsc_daily']       = $gsc_data['daily'] ?? array();
+		}
+
+		wp_send_json_success( $result );
+	}
+
+	/**
+	 * AJAX: Get top pages.
+	 */
+	public function ajax_top_pages(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$days  = absint( $_POST['days'] ?? 30 );
+		$pages = $this->tracker->get_top_pages( $days );
+
+		// Enrich with post titles.
+		foreach ( $pages as &$page ) {
+			$post                = get_post( (int) $page['post_id'] );
+			$page['title']       = $post ? $post->post_title : __( '(Unknown)', 'stratawp-seo' );
+			$page['url']         = $post ? get_permalink( $post ) : '';
+			$page['bounce_rate'] = $page['views'] > 0
+				? round( ( $page['bounces'] / $page['views'] ) * 100 )
+				: 0;
+		}
+
+		// Merge GSC data if connected.
+		if ( $this->search_console->is_connected() ) {
+			$gsc_data = $this->search_console->get_search_data( $days );
+
+			$gsc_by_url = array();
+			foreach ( $gsc_data['pages'] ?? array() as $row ) {
+				$url                = $row['keys'][0] ?? '';
+				$gsc_by_url[ $url ] = $row;
+			}
+
+			foreach ( $pages as &$page ) {
+				if ( ! empty( $page['url'] ) && isset( $gsc_by_url[ $page['url'] ] ) ) {
+					$gsc_row                 = $gsc_by_url[ $page['url'] ];
+					$page['gsc_clicks']      = $gsc_row['clicks'] ?? 0;
+					$page['gsc_impressions'] = $gsc_row['impressions'] ?? 0;
+					$page['gsc_position']    = round( $gsc_row['position'] ?? 0, 1 );
+				}
+			}
+		}
+
+		wp_send_json_success( $pages );
+	}
+
+	/**
+	 * AJAX: Get top queries (GSC only).
+	 */
+	public function ajax_top_queries(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		if ( ! $this->search_console->is_connected() ) {
+			wp_send_json_error( array( 'message' => 'Search Console not connected.' ) );
+		}
+
+		$days     = absint( $_POST['days'] ?? 30 );
+		$gsc_data = $this->search_console->get_search_data( $days );
+		$queries  = array();
+
+		foreach ( $gsc_data['queries'] ?? array() as $row ) {
+			$queries[] = array(
+				'query'       => $row['keys'][0] ?? '',
+				'clicks'      => $row['clicks'] ?? 0,
+				'impressions' => $row['impressions'] ?? 0,
+				'ctr'         => round( ( $row['ctr'] ?? 0 ) * 100, 1 ),
+				'position'    => round( $row['position'] ?? 0, 1 ),
+			);
+		}
+
+		wp_send_json_success( $queries );
+	}
+
+	/**
+	 * AJAX: Get stats for a single post (used by metabox).
+	 */
+	public function ajax_post_stats(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$post_id = absint( $_POST['post_id'] ?? 0 );
+
+		if ( ! $post_id ) {
+			wp_send_json_error( array( 'message' => 'Invalid post ID.' ) );
+		}
+
+		$stats_7d  = $this->tracker->get_post_stats( $post_id, 7 );
+		$stats_30d = $this->tracker->get_post_stats( $post_id, 30 );
+
+		$result = array(
+			'views_7d'         => $stats_7d['views'],
+			'views_30d'        => $stats_30d['views'],
+			'avg_time_on_page' => $stats_30d['avg_time_on_page'],
+			'avg_scroll_depth' => $stats_30d['avg_scroll_depth'],
+			'bounce_rate'      => $stats_30d['bounce_rate'],
+		);
+
+		// Bot crawler stats for this post.
+		$bot_tracker = stratawp_seo()->bot_analytics_tracker ?? null;
+		if ( $bot_tracker instanceof SWPS_Bot_Analytics_Tracker ) {
+			$bot_stats               = $bot_tracker->get_post_stats( $post_id );
+			$result['bot_hits_7d']   = $bot_stats['hits_7d'];
+			$result['bot_hits_30d']  = $bot_stats['hits_30d'];
+			$result['bot_last_seen'] = $bot_stats['last_seen']
+				? human_time_diff( strtotime( $bot_stats['last_seen'] ), time() ) . ' ago'
+				: null;
+		}
+
+		// GSC queries for this post.
+		if ( $this->search_console->is_connected() ) {
+			$url     = get_permalink( $post_id );
+			$queries = $this->search_console->get_page_queries( $url, 90 );
+
+			$result['gsc_queries'] = array_slice(
+				array_map(
+					function ( $row ) {
+						return array(
+							'query'    => $row['keys'][0] ?? '',
+							'clicks'   => $row['clicks'] ?? 0,
+							'position' => round( $row['position'] ?? 0, 1 ),
+						);
+					},
+					$queries
+				),
+				0,
+				5
+			);
+		}
+
+		wp_send_json_success( $result );
+	}
+
+	/**
+	 * AJAX: Disconnect GSC.
+	 */
+	public function ajax_disconnect_gsc(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$this->search_console->disconnect();
+
+		wp_send_json_success();
+	}
+
+	/**
+	 * AJAX: Refresh GSC data.
+	 */
+	public function ajax_refresh_gsc(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$this->search_console->clear_cache();
+
+		wp_send_json_success();
+	}
+
+	/**
+	 * AJAX: Save selected GSC property.
+	 */
+	public function ajax_save_property(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$property = esc_url_raw( $_POST['property'] ?? '' );
+		update_option( 'swps_gsc_property', $property );
+
+		$this->search_console->clear_cache();
+
+		wp_send_json_success();
+	}
+
+	/**
+	 * Add Views column to posts list.
+	 */
+	public function add_views_column( array $columns ): array {
+		$columns['swps_views'] = __( 'Views (30d)', 'stratawp-seo' );
+		return $columns;
+	}
+
+	/**
+	 * Render the Views column.
+	 */
+	public function render_views_column( string $column, int $post_id ): void {
+		if ( 'swps_views' !== $column ) {
+			return;
+		}
+
+		$stats = $this->tracker->get_post_stats( $post_id, 30 );
+		echo esc_html( number_format_i18n( $stats['views'] ) );
+	}
+
+	/**
+	 * Make Views column sortable.
+	 */
+	public function sortable_views_column( array $columns ): array {
+		$columns['swps_views'] = 'swps_views';
+		return $columns;
+	}
+
+	/**
+	 * Register the analytics metabox on post edit screens.
+	 */
+	public function register_metabox(): void {
+		add_meta_box(
+			'swps_analytics_metabox',
+			__( 'StrataWP Analytics', 'stratawp-seo' ),
+			array( $this, 'render_metabox' ),
+			'post',
+			'side',
+			'default'
+		);
+	}
+
+	/**
+	 * Render the analytics metabox.
+	 */
+	public function render_metabox( WP_Post $post ): void {
+		$nonce = wp_create_nonce( 'swps_nonce' );
+		printf(
+			'<div id="swps-analytics-metabox" data-post-id="%d" data-nonce="%s">
                 <p class="swps-loading">%s</p>
             </div>',
-            $post->ID,
-            esc_attr( $nonce ),
-            esc_html__( 'Loading analytics...', 'stratawp-seo' )
-        );
-    }
+			$post->ID,
+			esc_attr( $nonce ),
+			esc_html__( 'Loading analytics...', 'stratawp-seo' )
+		);
+	}
 }

--- a/includes/class-analytics-tracker.php
+++ b/includes/class-analytics-tracker.php
@@ -9,38 +9,38 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Analytics_Tracker {
 
-    private const RAW_TABLE    = 'swps_analytics';
-    private const DAILY_TABLE  = 'swps_analytics_daily';
-    private const CRON_HOOK    = 'swps_analytics_aggregate';
+	private const RAW_TABLE   = 'swps_analytics';
+	private const DAILY_TABLE = 'swps_analytics_daily';
+	private const CRON_HOOK   = 'swps_analytics_aggregate';
 
-    public function __construct() {
-        // Record endpoint — available to all visitors (nopriv).
-        add_action( 'wp_ajax_swps_track', [ $this, 'ajax_track' ] );
-        add_action( 'wp_ajax_nopriv_swps_track', [ $this, 'ajax_track' ] );
+	public function __construct() {
+		// Record endpoint — available to all visitors (nopriv).
+		add_action( 'wp_ajax_swps_track', array( $this, 'ajax_track' ) );
+		add_action( 'wp_ajax_nopriv_swps_track', array( $this, 'ajax_track' ) );
 
-        // Frontend tracking script.
-        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_tracker' ] );
+		// Frontend tracking script.
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_tracker' ) );
 
-        // Aggregation cron.
-        add_action( self::CRON_HOOK, [ $this, 'aggregate_and_prune' ] );
-    }
+		// Aggregation cron.
+		add_action( self::CRON_HOOK, array( $this, 'aggregate_and_prune' ) );
+	}
 
-    /**
-     * Create custom database tables. Called on activation.
-     */
-    public static function create_tables(): void {
-        global $wpdb;
+	/**
+	 * Create custom database tables. Called on activation.
+	 */
+	public static function create_tables(): void {
+		global $wpdb;
 
-        $charset = $wpdb->get_charset_collate();
-        $raw     = $wpdb->prefix . self::RAW_TABLE;
-        $daily   = $wpdb->prefix . self::DAILY_TABLE;
+		$charset = $wpdb->get_charset_collate();
+		$raw     = $wpdb->prefix . self::RAW_TABLE;
+		$daily   = $wpdb->prefix . self::DAILY_TABLE;
 
-        $sql_raw = "CREATE TABLE {$raw} (
+		$sql_raw = "CREATE TABLE {$raw} (
             id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
             post_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
             page_url VARCHAR(500) NOT NULL DEFAULT '',
@@ -54,7 +54,7 @@ class SWPS_Analytics_Tracker {
             KEY idx_post_id (post_id)
         ) {$charset};";
 
-        $sql_daily = "CREATE TABLE {$daily} (
+		$sql_daily = "CREATE TABLE {$daily} (
             id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
             post_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
             date DATE NOT NULL,
@@ -66,128 +66,145 @@ class SWPS_Analytics_Tracker {
             UNIQUE KEY idx_post_date (post_id, date)
         ) {$charset};";
 
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        dbDelta( $sql_raw );
-        dbDelta( $sql_daily );
-    }
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql_raw );
+		dbDelta( $sql_daily );
+	}
 
-    /**
-     * Schedule the daily aggregation cron.
-     */
-    public static function schedule_cron(): void {
-        if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-            wp_schedule_event( time(), 'daily', self::CRON_HOOK );
-        }
-    }
+	/**
+	 * Schedule the daily aggregation cron.
+	 */
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+		}
+	}
 
-    /**
-     * Unschedule the aggregation cron.
-     */
-    public static function unschedule_cron(): void {
-        $timestamp = wp_next_scheduled( self::CRON_HOOK );
+	/**
+	 * Unschedule the aggregation cron.
+	 */
+	public static function unschedule_cron(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
 
-        if ( $timestamp ) {
-            wp_unschedule_event( $timestamp, self::CRON_HOOK );
-        }
-    }
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
 
-    /**
-     * Enqueue the frontend tracking snippet.
-     */
-    public function enqueue_tracker(): void {
-        if ( is_admin() ) {
-            return;
-        }
+	/**
+	 * Enqueue the frontend tracking snippet.
+	 */
+	public function enqueue_tracker(): void {
+		if ( is_admin() ) {
+			return;
+		}
 
-        if ( ! get_option( 'swps_analytics_enabled', 1 ) ) {
-            return;
-        }
+		if ( ! get_option( 'swps_analytics_enabled', 1 ) ) {
+			return;
+		}
 
-        // Exclude admin users if configured.
-        if ( get_option( 'swps_analytics_exclude_admins', 1 ) && current_user_can( 'manage_options' ) ) {
-            return;
-        }
+		// Exclude admin users if configured.
+		if ( get_option( 'swps_analytics_exclude_admins', 1 ) && current_user_can( 'manage_options' ) ) {
+			return;
+		}
 
-        $post_id = is_singular() ? get_the_ID() : 0;
+		$post_id = is_singular() ? get_the_ID() : 0;
 
-        wp_enqueue_script(
-            'swps-analytics-tracker',
-            SWPS_PLUGIN_URL . 'admin/js/analytics-tracker.js',
-            [],
-            SWPS_VERSION,
-            [ 'in_footer' => true, 'strategy' => 'async' ]
-        );
+		wp_enqueue_script(
+			'swps-analytics-tracker',
+			SWPS_PLUGIN_URL . 'admin/js/analytics-tracker.js',
+			array(),
+			SWPS_VERSION,
+			array(
+				'in_footer' => true,
+				'strategy'  => 'async',
+			)
+		);
 
-        wp_localize_script( 'swps-analytics-tracker', 'swpsTracker', [
-            'ajax_url' => admin_url( 'admin-ajax.php' ),
-            'post_id'  => $post_id,
-            'nonce'    => wp_create_nonce( 'swps_track' ),
-        ] );
-    }
+		wp_localize_script(
+			'swps-analytics-tracker',
+			'swpsTracker',
+			array(
+				'ajax_url' => admin_url( 'admin-ajax.php' ),
+				'post_id'  => $post_id,
+				'nonce'    => wp_create_nonce( 'swps_track' ),
+			)
+		);
+	}
 
-    /**
-     * AJAX handler: Record a page hit.
-     */
-    public function ajax_track(): void {
-        check_ajax_referer( 'swps_track', 'nonce' );
+	/**
+	 * AJAX handler: Record a page hit.
+	 */
+	public function ajax_track(): void {
+		check_ajax_referer( 'swps_track', 'nonce' );
 
-        global $wpdb;
+		global $wpdb;
 
-        $post_id       = absint( $_POST['post_id'] ?? 0 );
-        $page_url      = esc_url_raw( $_POST['page_url'] ?? '' );
-        $referrer      = esc_url_raw( $_POST['referrer'] ?? '' );
-        $time_on_page  = min( absint( $_POST['time_on_page'] ?? 0 ), 3600 );
-        $scroll_depth  = min( absint( $_POST['scroll_depth'] ?? 0 ), 100 );
-        $is_bounce     = absint( $_POST['is_bounce'] ?? 1 ) ? 1 : 0;
+		$post_id      = absint( $_POST['post_id'] ?? 0 );
+		$page_url     = esc_url_raw( $_POST['page_url'] ?? '' );
+		$referrer     = esc_url_raw( $_POST['referrer'] ?? '' );
+		$time_on_page = min( absint( $_POST['time_on_page'] ?? 0 ), 3600 );
+		$scroll_depth = min( absint( $_POST['scroll_depth'] ?? 0 ), 100 );
+		$is_bounce    = absint( $_POST['is_bounce'] ?? 1 ) ? 1 : 0;
 
-        $data = [
-            'post_id'       => $post_id,
-            'page_url'      => $page_url,
-            'referrer'      => $referrer,
-            'time_on_page'  => $time_on_page,
-            'scroll_depth'  => $scroll_depth,
-            'is_bounce'     => $is_bounce,
-        ];
+		$data = array(
+			'post_id'      => $post_id,
+			'page_url'     => $page_url,
+			'referrer'     => $referrer,
+			'time_on_page' => $time_on_page,
+			'scroll_depth' => $scroll_depth,
+			'is_bounce'    => $is_bounce,
+		);
 
-        /**
-         * Filter tracking data before storage.
-         *
-         * Return empty array to block this hit.
-         *
-         * @param array $data    Tracking data.
-         * @param int   $post_id Post ID.
-         */
-        $data = SWPS_Hooks::filter_analytics_track( $data, $post_id );
+		/**
+		 * Filter tracking data before storage.
+		 *
+		 * Return empty array to block this hit.
+		 *
+		 * @param array $data    Tracking data.
+		 * @param int   $post_id Post ID.
+		 */
+		$data = SWPS_Hooks::filter_analytics_track( $data, $post_id );
 
-        if ( empty( $data ) ) {
-            wp_send_json_success();
-            return;
-        }
+		if ( empty( $data ) ) {
+			wp_send_json_success();
+			return;
+		}
 
-        $table = $wpdb->prefix . self::RAW_TABLE;
+		$table = $wpdb->prefix . self::RAW_TABLE;
 
-        $wpdb->insert( $table, $data, [
-            '%d', '%s', '%s', '%d', '%d', '%d',
-        ] );
+		$wpdb->insert(
+			$table,
+			$data,
+			array(
+				'%d',
+				'%s',
+				'%s',
+				'%d',
+				'%d',
+				'%d',
+			)
+		);
 
-        wp_send_json_success();
-    }
+		wp_send_json_success();
+	}
 
-    /**
-     * Aggregate raw hits older than 7 days into daily summary, then prune.
-     */
-    public function aggregate_and_prune(): void {
-        global $wpdb;
+	/**
+	 * Aggregate raw hits older than 7 days into daily summary, then prune.
+	 */
+	public function aggregate_and_prune(): void {
+		global $wpdb;
 
-        $raw   = $wpdb->prefix . self::RAW_TABLE;
-        $daily = $wpdb->prefix . self::DAILY_TABLE;
+		$raw   = $wpdb->prefix . self::RAW_TABLE;
+		$daily = $wpdb->prefix . self::DAILY_TABLE;
 
-        $cutoff = gmdate( 'Y-m-d H:i:s', strtotime( '-7 days' ) );
+		$cutoff = gmdate( 'Y-m-d H:i:s', strtotime( '-7 days' ) );
 
-        // Aggregate raw rows into daily summary.
+		// Aggregate raw rows into daily summary.
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $wpdb->query( $wpdb->prepare(
-            "INSERT INTO {$daily} (post_id, date, views, avg_time_on_page, avg_scroll_depth, bounces)
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$daily} (post_id, date, views, avg_time_on_page, avg_scroll_depth, bounces)
              SELECT post_id, DATE(created_at), COUNT(*), AVG(time_on_page), AVG(scroll_depth), SUM(is_bounce)
              FROM {$raw}
              WHERE created_at < %s
@@ -197,42 +214,48 @@ class SWPS_Analytics_Tracker {
                 avg_time_on_page = (avg_time_on_page + VALUES(avg_time_on_page)) / 2,
                 avg_scroll_depth = (avg_scroll_depth + VALUES(avg_scroll_depth)) / 2,
                 bounces = bounces + VALUES(bounces)",
-            $cutoff
-        ) );
+				$cutoff
+			)
+		);
 
-        // Delete aggregated raw rows.
-        $wpdb->query( $wpdb->prepare(
-            "DELETE FROM {$raw} WHERE created_at < %s",
-            $cutoff
-        ) );
+		// Delete aggregated raw rows.
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$raw} WHERE created_at < %s",
+				$cutoff
+			)
+		);
 
-        // Prune daily summary beyond retention.
-        $retention_days = (int) get_option( 'swps_analytics_retention', 90 );
-        $prune_date     = gmdate( 'Y-m-d', strtotime( "-{$retention_days} days" ) );
+		// Prune daily summary beyond retention.
+		$retention_days = (int) get_option( 'swps_analytics_retention', 90 );
+		$prune_date     = gmdate( 'Y-m-d', strtotime( "-{$retention_days} days" ) );
 
-        $wpdb->query( $wpdb->prepare(
-            "DELETE FROM {$daily} WHERE date < %s",
-            $prune_date
-        ) );
-    }
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$daily} WHERE date < %s",
+				$prune_date
+			)
+		);
+	}
 
-    /**
-     * Get page view stats for the dashboard.
-     *
-     * @param int $days Number of days to look back.
-     * @return array Daily view data.
-     */
-    public function get_daily_stats( int $days = 30 ): array {
-        global $wpdb;
+	/**
+	 * Get page view stats for the dashboard.
+	 *
+	 * @param int $days Number of days to look back.
+	 * @return array Daily view data.
+	 */
+	public function get_daily_stats( int $days = 30 ): array {
+		global $wpdb;
 
-        $raw   = $wpdb->prefix . self::RAW_TABLE;
-        $daily = $wpdb->prefix . self::DAILY_TABLE;
-        $since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+		$raw   = $wpdb->prefix . self::RAW_TABLE;
+		$daily = $wpdb->prefix . self::DAILY_TABLE;
+		$since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
 
-        // Combine raw (recent) + daily (aggregated) data.
+		// Combine raw (recent) + daily (aggregated) data.
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $results = $wpdb->get_results( $wpdb->prepare(
-            "SELECT date, SUM(views) as views, AVG(avg_time) as avg_time,
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT date, SUM(views) as views, AVG(avg_time) as avg_time,
                     AVG(avg_scroll) as avg_scroll, SUM(bounces) as bounces
              FROM (
                  SELECT DATE(created_at) as date, 1 as views, time_on_page as avg_time,
@@ -247,29 +270,33 @@ class SWPS_Analytics_Tracker {
              ) combined
              GROUP BY date
              ORDER BY date ASC",
-            $since, $since
-        ), ARRAY_A );
+				$since,
+				$since
+			),
+			ARRAY_A
+		);
 
-        return $results ?: [];
-    }
+		return $results ?: array();
+	}
 
-    /**
-     * Get top pages by views.
-     *
-     * @param int $days  Number of days.
-     * @param int $limit Max pages.
-     * @return array Top pages data.
-     */
-    public function get_top_pages( int $days = 30, int $limit = 20 ): array {
-        global $wpdb;
+	/**
+	 * Get top pages by views.
+	 *
+	 * @param int $days  Number of days.
+	 * @param int $limit Max pages.
+	 * @return array Top pages data.
+	 */
+	public function get_top_pages( int $days = 30, int $limit = 20 ): array {
+		global $wpdb;
 
-        $raw   = $wpdb->prefix . self::RAW_TABLE;
-        $daily = $wpdb->prefix . self::DAILY_TABLE;
-        $since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+		$raw   = $wpdb->prefix . self::RAW_TABLE;
+		$daily = $wpdb->prefix . self::DAILY_TABLE;
+		$since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
 
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $results = $wpdb->get_results( $wpdb->prepare(
-            "SELECT post_id, SUM(views) as views, AVG(avg_time) as avg_time_on_page,
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_id, SUM(views) as views, AVG(avg_time) as avg_time_on_page,
                     AVG(avg_scroll) as avg_scroll_depth, SUM(bounces) as bounces
              FROM (
                  SELECT post_id, 1 as views, time_on_page as avg_time,
@@ -285,29 +312,34 @@ class SWPS_Analytics_Tracker {
              GROUP BY post_id
              ORDER BY views DESC
              LIMIT %d",
-            $since, $since, $limit
-        ), ARRAY_A );
+				$since,
+				$since,
+				$limit
+			),
+			ARRAY_A
+		);
 
-        return $results ?: [];
-    }
+		return $results ?: array();
+	}
 
-    /**
-     * Get stats for a single post.
-     *
-     * @param int $post_id Post ID.
-     * @param int $days    Number of days.
-     * @return array Post stats.
-     */
-    public function get_post_stats( int $post_id, int $days = 30 ): array {
-        global $wpdb;
+	/**
+	 * Get stats for a single post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @param int $days    Number of days.
+	 * @return array Post stats.
+	 */
+	public function get_post_stats( int $post_id, int $days = 30 ): array {
+		global $wpdb;
 
-        $raw   = $wpdb->prefix . self::RAW_TABLE;
-        $daily = $wpdb->prefix . self::DAILY_TABLE;
-        $since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+		$raw   = $wpdb->prefix . self::RAW_TABLE;
+		$daily = $wpdb->prefix . self::DAILY_TABLE;
+		$since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
 
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $result = $wpdb->get_row( $wpdb->prepare(
-            "SELECT SUM(views) as views, AVG(avg_time) as avg_time_on_page,
+		$result = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT SUM(views) as views, AVG(avg_time) as avg_time_on_page,
                     AVG(avg_scroll) as avg_scroll_depth, SUM(bounces) as bounces
              FROM (
                  SELECT 1 as views, time_on_page as avg_time,
@@ -320,37 +352,42 @@ class SWPS_Analytics_Tracker {
                  FROM {$daily}
                  WHERE post_id = %d AND date >= %s
              ) combined",
-            $post_id, $since, $post_id, $since
-        ), ARRAY_A );
+				$post_id,
+				$since,
+				$post_id,
+				$since
+			),
+			ARRAY_A
+		);
 
-        if ( ! $result || ! $result['views'] ) {
-            return [
-                'views'            => 0,
-                'avg_time_on_page' => 0,
-                'avg_scroll_depth' => 0,
-                'bounce_rate'      => 0,
-            ];
-        }
+		if ( ! $result || ! $result['views'] ) {
+			return array(
+				'views'            => 0,
+				'avg_time_on_page' => 0,
+				'avg_scroll_depth' => 0,
+				'bounce_rate'      => 0,
+			);
+		}
 
-        return [
-            'views'            => (int) $result['views'],
-            'avg_time_on_page' => (int) round( $result['avg_time_on_page'] ),
-            'avg_scroll_depth' => (int) round( $result['avg_scroll_depth'] ),
-            'bounce_rate'      => $result['views'] > 0
-                ? round( ( $result['bounces'] / $result['views'] ) * 100 )
-                : 0,
-        ];
-    }
+		return array(
+			'views'            => (int) $result['views'],
+			'avg_time_on_page' => (int) round( $result['avg_time_on_page'] ),
+			'avg_scroll_depth' => (int) round( $result['avg_scroll_depth'] ),
+			'bounce_rate'      => $result['views'] > 0
+				? round( ( $result['bounces'] / $result['views'] ) * 100 )
+				: 0,
+		);
+	}
 
-    /**
-     * Drop custom tables. Called on uninstall.
-     */
-    public static function drop_tables(): void {
-        global $wpdb;
+	/**
+	 * Drop custom tables. Called on uninstall.
+	 */
+	public static function drop_tables(): void {
+		global $wpdb;
 
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . self::RAW_TABLE );
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . self::RAW_TABLE );
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . self::DAILY_TABLE );
-    }
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . self::DAILY_TABLE );
+	}
 }

--- a/includes/class-analyzer.php
+++ b/includes/class-analyzer.php
@@ -9,263 +9,280 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Analyzer {
 
-    private ?SWPS_Cache_Manager $cache;
+	private ?SWPS_Cache_Manager $cache;
 
-    public function __construct( ?SWPS_Cache_Manager $cache = null ) {
-        $this->cache = $cache;
-    }
+	public function __construct( ?SWPS_Cache_Manager $cache = null ) {
+		$this->cache = $cache;
+	}
 
-    /**
-     * Get a structured summary of the site's content for Claude.
-     *
-     * @param int $max_posts Maximum posts to include.
-     * @return array Site summary data.
-     */
-    public function get_site_summary( int $max_posts = 50 ): array {
-        $cache_key = 'site_summary_' . $max_posts;
+	/**
+	 * Get a structured summary of the site's content for Claude.
+	 *
+	 * @param int $max_posts Maximum posts to include.
+	 * @return array Site summary data.
+	 */
+	public function get_site_summary( int $max_posts = 50 ): array {
+		$cache_key = 'site_summary_' . $max_posts;
 
-        if ( $this->cache ) {
-            $cached = $this->cache->get( $cache_key );
-            if ( false !== $cached ) {
-                return $cached;
-            }
-        }
+		if ( $this->cache ) {
+			$cached = $this->cache->get( $cache_key );
+			if ( false !== $cached ) {
+				return $cached;
+			}
+		}
 
-        $summary = [
-            'site_info'    => $this->get_site_info(),
-            'posts'        => $this->get_posts_summary( $max_posts ),
-            'categories'   => $this->get_categories(),
-            'tags'         => $this->get_popular_tags( 30 ),
-            'content_stats' => $this->get_content_stats(),
-        ];
+		$summary = array(
+			'site_info'     => $this->get_site_info(),
+			'posts'         => $this->get_posts_summary( $max_posts ),
+			'categories'    => $this->get_categories(),
+			'tags'          => $this->get_popular_tags( 30 ),
+			'content_stats' => $this->get_content_stats(),
+		);
 
-        if ( $this->cache ) {
-            $this->cache->set( $cache_key, $summary );
-        }
+		if ( $this->cache ) {
+			$this->cache->set( $cache_key, $summary );
+		}
 
-        return $summary;
-    }
+		return $summary;
+	}
 
-    /**
-     * Get basic site information.
-     */
-    public function get_site_info(): array {
-        return [
-            'name'        => get_bloginfo( 'name' ),
-            'description' => get_bloginfo( 'description' ),
-            'url'         => home_url(),
-            'niche'       => get_option( 'swps_site_niche', '' ),
-            'site_desc'   => get_option( 'swps_site_description', '' ),
-        ];
-    }
+	/**
+	 * Get basic site information.
+	 */
+	public function get_site_info(): array {
+		return array(
+			'name'        => get_bloginfo( 'name' ),
+			'description' => get_bloginfo( 'description' ),
+			'url'         => home_url(),
+			'niche'       => get_option( 'swps_site_niche', '' ),
+			'site_desc'   => get_option( 'swps_site_description', '' ),
+		);
+	}
 
-    /**
-     * Get a summary of published posts (title, URL, excerpt, categories).
-     *
-     * @param int $max Maximum posts to retrieve.
-     * @return array Post summaries.
-     */
-    public function get_posts_summary( int $max = 50 ): array {
-        $posts = get_posts( [
-            'post_type'      => 'post',
-            'post_status'    => 'publish',
-            'posts_per_page' => $max,
-            'orderby'        => 'date',
-            'order'          => 'DESC',
-        ] );
+	/**
+	 * Get a summary of published posts (title, URL, excerpt, categories).
+	 *
+	 * @param int $max Maximum posts to retrieve.
+	 * @return array Post summaries.
+	 */
+	public function get_posts_summary( int $max = 50 ): array {
+		$posts = get_posts(
+			array(
+				'post_type'      => 'post',
+				'post_status'    => 'publish',
+				'posts_per_page' => $max,
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			)
+		);
 
-        $summaries = [];
+		$summaries = array();
 
-        foreach ( $posts as $post ) {
-            $categories = wp_get_post_categories( $post->ID, [ 'fields' => 'names' ] );
-            $tags       = wp_get_post_tags( $post->ID, [ 'fields' => 'names' ] );
+		foreach ( $posts as $post ) {
+			$categories = wp_get_post_categories( $post->ID, array( 'fields' => 'names' ) );
+			$tags       = wp_get_post_tags( $post->ID, array( 'fields' => 'names' ) );
 
-            $content    = wp_strip_all_tags( $post->post_content );
-            $words      = explode( ' ', $content );
-            $excerpt    = implode( ' ', array_slice( $words, 0, 200 ) );
-            $word_count = count( $words );
+			$content    = wp_strip_all_tags( $post->post_content );
+			$words      = explode( ' ', $content );
+			$excerpt    = implode( ' ', array_slice( $words, 0, 200 ) );
+			$word_count = count( $words );
 
-            $headings = $this->extract_headings( $post->post_content );
+			$headings = $this->extract_headings( $post->post_content );
 
-            $summaries[] = [
-                'id'          => $post->ID,
-                'title'       => $post->post_title,
-                'url'         => get_permalink( $post->ID ),
-                'slug'        => $post->post_name,
-                'date'        => $post->post_date,
-                'excerpt'     => $excerpt,
-                'word_count'  => $word_count,
-                'categories'  => $categories,
-                'tags'        => $tags,
-                'headings'    => $headings,
-                'has_featured_image' => has_post_thumbnail( $post->ID ),
-            ];
-        }
+			$summaries[] = array(
+				'id'                 => $post->ID,
+				'title'              => $post->post_title,
+				'url'                => get_permalink( $post->ID ),
+				'slug'               => $post->post_name,
+				'date'               => $post->post_date,
+				'excerpt'            => $excerpt,
+				'word_count'         => $word_count,
+				'categories'         => $categories,
+				'tags'               => $tags,
+				'headings'           => $headings,
+				'has_featured_image' => has_post_thumbnail( $post->ID ),
+			);
+		}
 
-        return $summaries;
-    }
+		return $summaries;
+	}
 
-    /**
-     * Get all categories with post counts.
-     */
-    public function get_categories(): array {
-        $categories = get_categories( [
-            'hide_empty' => false,
-            'orderby'    => 'count',
-            'order'      => 'DESC',
-        ] );
+	/**
+	 * Get all categories with post counts.
+	 */
+	public function get_categories(): array {
+		$categories = get_categories(
+			array(
+				'hide_empty' => false,
+				'orderby'    => 'count',
+				'order'      => 'DESC',
+			)
+		);
 
-        return array_map( function ( $cat ) {
-            return [
-                'id'    => $cat->term_id,
-                'name'  => $cat->name,
-                'slug'  => $cat->slug,
-                'count' => $cat->count,
-                'url'   => get_category_link( $cat->term_id ),
-            ];
-        }, $categories );
-    }
+		return array_map(
+			function ( $cat ) {
+				return array(
+					'id'    => $cat->term_id,
+					'name'  => $cat->name,
+					'slug'  => $cat->slug,
+					'count' => $cat->count,
+					'url'   => get_category_link( $cat->term_id ),
+				);
+			},
+			$categories
+		);
+	}
 
-    /**
-     * Get popular tags.
-     *
-     * @param int $limit Max tags to return.
-     */
-    public function get_popular_tags( int $limit = 30 ): array {
-        $tags = get_tags( [
-            'orderby' => 'count',
-            'order'   => 'DESC',
-            'number'  => $limit,
-        ] );
+	/**
+	 * Get popular tags.
+	 *
+	 * @param int $limit Max tags to return.
+	 */
+	public function get_popular_tags( int $limit = 30 ): array {
+		$tags = get_tags(
+			array(
+				'orderby' => 'count',
+				'order'   => 'DESC',
+				'number'  => $limit,
+			)
+		);
 
-        if ( is_wp_error( $tags ) || empty( $tags ) ) {
-            return [];
-        }
+		if ( is_wp_error( $tags ) || empty( $tags ) ) {
+			return array();
+		}
 
-        return array_map( function ( $tag ) {
-            return [
-                'name'  => $tag->name,
-                'slug'  => $tag->slug,
-                'count' => $tag->count,
-            ];
-        }, $tags );
-    }
+		return array_map(
+			function ( $tag ) {
+				return array(
+					'name'  => $tag->name,
+					'slug'  => $tag->slug,
+					'count' => $tag->count,
+				);
+			},
+			$tags
+		);
+	}
 
-    /**
-     * Get overall content statistics.
-     */
-    public function get_content_stats(): array {
-        $post_count = wp_count_posts( 'post' );
-        $page_count = wp_count_posts( 'page' );
+	/**
+	 * Get overall content statistics.
+	 */
+	public function get_content_stats(): array {
+		$post_count = wp_count_posts( 'post' );
+		$page_count = wp_count_posts( 'page' );
 
-        return [
-            'published_posts' => (int) $post_count->publish,
-            'draft_posts'     => (int) $post_count->draft,
-            'published_pages' => (int) $page_count->publish,
-            'total_categories' => wp_count_terms( 'category' ),
-            'total_tags'       => wp_count_terms( 'post_tag' ),
-        ];
-    }
+		return array(
+			'published_posts'  => (int) $post_count->publish,
+			'draft_posts'      => (int) $post_count->draft,
+			'published_pages'  => (int) $page_count->publish,
+			'total_categories' => wp_count_terms( 'category' ),
+			'total_tags'       => wp_count_terms( 'post_tag' ),
+		);
+	}
 
-    /**
-     * Extract headings from post HTML content.
-     *
-     * @param string $content The post content HTML.
-     * @return array Array of headings [{level, text}].
-     */
-    public function extract_headings( string $content ): array {
-        $headings = [];
+	/**
+	 * Extract headings from post HTML content.
+	 *
+	 * @param string $content The post content HTML.
+	 * @return array Array of headings [{level, text}].
+	 */
+	public function extract_headings( string $content ): array {
+		$headings = array();
 
-        if ( preg_match_all( '/<h([1-6])[^>]*>(.*?)<\/h\1>/si', $content, $matches, PREG_SET_ORDER ) ) {
-            foreach ( $matches as $match ) {
-                $headings[] = [
-                    'level' => (int) $match[1],
-                    'text'  => wp_strip_all_tags( $match[2] ),
-                ];
-            }
-        }
+		if ( preg_match_all( '/<h([1-6])[^>]*>(.*?)<\/h\1>/si', $content, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				$headings[] = array(
+					'level' => (int) $match[1],
+					'text'  => wp_strip_all_tags( $match[2] ),
+				);
+			}
+		}
 
-        return $headings;
-    }
+		return $headings;
+	}
 
-    /**
-     * Build a condensed text representation of the site for Claude's context.
-     *
-     * @param int $max_posts Maximum posts to include in context.
-     * @return string Formatted site context string.
-     */
-    public function build_context_for_prompt( int $max_posts = 20 ): string {
-        $cache_key = 'context_prompt_' . $max_posts;
+	/**
+	 * Build a condensed text representation of the site for Claude's context.
+	 *
+	 * @param int $max_posts Maximum posts to include in context.
+	 * @return string Formatted site context string.
+	 */
+	public function build_context_for_prompt( int $max_posts = 20 ): string {
+		$cache_key = 'context_prompt_' . $max_posts;
 
-        if ( $this->cache ) {
-            $cached = $this->cache->get( $cache_key );
-            if ( false !== $cached ) {
-                return $cached;
-            }
-        }
+		if ( $this->cache ) {
+			$cached = $this->cache->get( $cache_key );
+			if ( false !== $cached ) {
+				return $cached;
+			}
+		}
 
-        $summary = $this->get_site_summary( $max_posts );
-        $info    = $summary['site_info'];
+		$summary = $this->get_site_summary( $max_posts );
+		$info    = $summary['site_info'];
 
-        $context = "=== SITE INFORMATION ===\n";
-        $context .= "Name: {$info['name']}\n";
-        $context .= "URL: {$info['url']}\n";
-        $context .= "Niche: {$info['niche']}\n";
-        $context .= "Description: {$info['site_desc']}\n\n";
+		$context  = "=== SITE INFORMATION ===\n";
+		$context .= "Name: {$info['name']}\n";
+		$context .= "URL: {$info['url']}\n";
+		$context .= "Niche: {$info['niche']}\n";
+		$context .= "Description: {$info['site_desc']}\n\n";
 
-        $context .= "=== EXISTING CONTENT ({$summary['content_stats']['published_posts']} published posts) ===\n";
+		$context .= "=== EXISTING CONTENT ({$summary['content_stats']['published_posts']} published posts) ===\n";
 
-        foreach ( $summary['posts'] as $post ) {
-            $cats = implode( ', ', $post['categories'] );
-            $context .= "- \"{$post['title']}\" ({$post['url']}) [{$cats}] {$post['word_count']} words\n";
-            if ( ! empty( $post['excerpt'] ) ) {
-                $short_excerpt = mb_substr( $post['excerpt'], 0, 150 );
-                $context .= "  Summary: {$short_excerpt}...\n";
-            }
-        }
+		foreach ( $summary['posts'] as $post ) {
+			$cats     = implode( ', ', $post['categories'] );
+			$context .= "- \"{$post['title']}\" ({$post['url']}) [{$cats}] {$post['word_count']} words\n";
+			if ( ! empty( $post['excerpt'] ) ) {
+				$short_excerpt = mb_substr( $post['excerpt'], 0, 150 );
+				$context      .= "  Summary: {$short_excerpt}...\n";
+			}
+		}
 
-        $context .= "\n=== CATEGORIES ===\n";
-        foreach ( $summary['categories'] as $cat ) {
-            $context .= "- {$cat['name']} ({$cat['count']} posts, {$cat['url']})\n";
-        }
+		$context .= "\n=== CATEGORIES ===\n";
+		foreach ( $summary['categories'] as $cat ) {
+			$context .= "- {$cat['name']} ({$cat['count']} posts, {$cat['url']})\n";
+		}
 
-        if ( ! empty( $summary['tags'] ) ) {
-            $tag_names = array_column( $summary['tags'], 'name' );
-            $context .= "\n=== POPULAR TAGS ===\n";
-            $context .= implode( ', ', $tag_names ) . "\n";
-        }
+		if ( ! empty( $summary['tags'] ) ) {
+			$tag_names = array_column( $summary['tags'], 'name' );
+			$context  .= "\n=== POPULAR TAGS ===\n";
+			$context  .= implode( ', ', $tag_names ) . "\n";
+		}
 
-        if ( $this->cache ) {
-            $this->cache->set( $cache_key, $context );
-        }
+		if ( $this->cache ) {
+			$this->cache->set( $cache_key, $context );
+		}
 
-        return $context;
-    }
+		return $context;
+	}
 
-    /**
-     * Get existing post titles and URLs for internal linking context.
-     *
-     * @return array Simplified list of [{title, url}].
-     */
-    public function get_linkable_posts(): array {
-        $posts = get_posts( [
-            'post_type'      => [ 'post', 'page' ],
-            'post_status'    => 'publish',
-            'posts_per_page' => 30,
-            'orderby'        => 'date',
-            'order'          => 'DESC',
-        ] );
+	/**
+	 * Get existing post titles and URLs for internal linking context.
+	 *
+	 * @return array Simplified list of [{title, url}].
+	 */
+	public function get_linkable_posts(): array {
+		$posts = get_posts(
+			array(
+				'post_type'      => array( 'post', 'page' ),
+				'post_status'    => 'publish',
+				'posts_per_page' => 30,
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			)
+		);
 
-        return array_map( function ( $post ) {
-            return [
-                'title' => $post->post_title,
-                'url'   => get_permalink( $post->ID ),
-            ];
-        }, $posts );
-    }
+		return array_map(
+			function ( $post ) {
+				return array(
+					'title' => $post->post_title,
+					'url'   => get_permalink( $post->ID ),
+				);
+			},
+			$posts
+		);
+	}
 }

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -6,7 +6,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_API extends SWPS_Anthropic_Provider {}

--- a/includes/class-audit-module.php
+++ b/includes/class-audit-module.php
@@ -45,7 +45,10 @@ abstract class SWPS_Audit_Module {
 	 * @return array { @type int $fixed Count of fixed issues. @type string[] $messages Log messages. }
 	 */
 	public function auto_fix( array $issues ): array {
-		return [ 'fixed' => 0, 'messages' => [] ];
+		return array(
+			'fixed'    => 0,
+			'messages' => array(),
+		);
 	}
 
 	/**
@@ -71,13 +74,15 @@ abstract class SWPS_Audit_Module {
 	 * @return WP_Post[]
 	 */
 	protected function get_public_posts( int $limit = 500 ): array {
-		return get_posts( [
-			'post_type'      => get_post_types( [ 'public' => true ] ),
-			'post_status'    => 'publish',
-			'posts_per_page' => $limit,
-			'orderby'        => 'date',
-			'order'          => 'DESC',
-			'no_found_rows'  => true,
-		] );
+		return get_posts(
+			array(
+				'post_type'      => get_post_types( array( 'public' => true ) ),
+				'post_status'    => 'publish',
+				'posts_per_page' => $limit,
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+				'no_found_rows'  => true,
+			)
+		);
 	}
 }

--- a/includes/class-auto-optimize.php
+++ b/includes/class-auto-optimize.php
@@ -15,255 +15,268 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Auto_Optimize {
 
-    public const META_PROPOSAL    = '_swps_optimize_proposal';
-    public const META_DISMISSED   = '_swps_optimize_dismissed';
-    public const META_PROPOSED_AT = '_swps_optimize_proposed_at';
-    public const META_APPLIED_AT  = '_swps_optimize_applied_at';
+	public const META_PROPOSAL    = '_swps_optimize_proposal';
+	public const META_DISMISSED   = '_swps_optimize_dismissed';
+	public const META_PROPOSED_AT = '_swps_optimize_proposed_at';
+	public const META_APPLIED_AT  = '_swps_optimize_applied_at';
 
-    public const OPTION_THRESHOLD = 'swps_optimize_threshold';
-    public const DEFAULT_THRESHOLD = 75;
+	public const OPTION_THRESHOLD  = 'swps_optimize_threshold';
+	public const DEFAULT_THRESHOLD = 75;
 
-    private SWPS_Content_Scorer $scorer;
+	private SWPS_Content_Scorer $scorer;
 
-    public function __construct( SWPS_Content_Scorer $scorer ) {
-        $this->scorer = $scorer;
+	public function __construct( SWPS_Content_Scorer $scorer ) {
+		$this->scorer = $scorer;
 
-        add_action( 'admin_menu',           [ $this, 'register_menu' ], 20 );
-        add_action( 'admin_enqueue_scripts',[ $this, 'enqueue_assets' ] );
+		add_action( 'admin_menu', array( $this, 'register_menu' ), 20 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
-        add_action( 'wp_ajax_swps_optimize_scan',       [ $this, 'ajax_scan' ] );
-        add_action( 'wp_ajax_swps_optimize_scan_chunk', [ $this, 'ajax_scan_chunk' ] );
-        add_action( 'wp_ajax_swps_optimize_propose',    [ $this, 'ajax_propose' ] );
-        add_action( 'wp_ajax_swps_optimize_apply',      [ $this, 'ajax_apply' ] );
-        add_action( 'wp_ajax_swps_optimize_dismiss',    [ $this, 'ajax_dismiss' ] );
-        add_action( 'wp_ajax_swps_optimize_undismiss',  [ $this, 'ajax_undismiss' ] );
-    }
+		add_action( 'wp_ajax_swps_optimize_scan', array( $this, 'ajax_scan' ) );
+		add_action( 'wp_ajax_swps_optimize_scan_chunk', array( $this, 'ajax_scan_chunk' ) );
+		add_action( 'wp_ajax_swps_optimize_propose', array( $this, 'ajax_propose' ) );
+		add_action( 'wp_ajax_swps_optimize_apply', array( $this, 'ajax_apply' ) );
+		add_action( 'wp_ajax_swps_optimize_dismiss', array( $this, 'ajax_dismiss' ) );
+		add_action( 'wp_ajax_swps_optimize_undismiss', array( $this, 'ajax_undismiss' ) );
+	}
 
-    public function register_menu(): void {
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Auto-Optimize', 'stratawp-seo' ),
-            __( 'Auto-Optimize', 'stratawp-seo' ),
-            'manage_options',
-            'swps-auto-optimize',
-            [ $this, 'render_page' ]
-        );
-    }
+	public function register_menu(): void {
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Auto-Optimize', 'stratawp-seo' ),
+			__( 'Auto-Optimize', 'stratawp-seo' ),
+			'manage_options',
+			'swps-auto-optimize',
+			array( $this, 'render_page' )
+		);
+	}
 
-    public function render_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
-        }
-        require SWPS_PLUGIN_DIR . 'templates/auto-optimize-page.php';
-    }
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
+		}
+		require SWPS_PLUGIN_DIR . 'templates/auto-optimize-page.php';
+	}
 
-    public function enqueue_assets( string $hook ): void {
-        if ( 'stratawp-seo_page_swps-auto-optimize' !== $hook ) {
-            return;
-        }
-        wp_enqueue_style(
-            'swps-page-auto-optimize',
-            SWPS_PLUGIN_URL . 'admin/css/pages/auto-optimize.css',
-            [ 'swps-tokens', 'swps-components', 'swps-templates' ],
-            SWPS_VERSION
-        );
-        wp_enqueue_script(
-            'swps-auto-optimize',
-            SWPS_PLUGIN_URL . 'admin/js/auto-optimize.js',
-            [ 'jquery' ],
-            SWPS_VERSION,
-            true
-        );
-        wp_localize_script( 'swps-auto-optimize', 'swpsOptimize', [
-            'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-            'nonce'   => wp_create_nonce( 'swps_nonce' ),
-            'i18n'    => [
-                'scoring'     => __( 'Re-scoring all posts...', 'stratawp-seo' ),
-                'loading'     => __( 'Loading queue...', 'stratawp-seo' ),
-                'proposing'   => __( 'Generating proposal — calling AI...', 'stratawp-seo' ),
-                'applying'    => __( 'Applying edits...', 'stratawp-seo' ),
-                'dismissing'  => __( 'Dismissing...', 'stratawp-seo' ),
-                'confirmDismiss' => __( 'Dismiss this post? It will be hidden from the queue.', 'stratawp-seo' ),
-                'noEdits'     => __( 'The AI did not return any actionable edits.', 'stratawp-seo' ),
-                'genericFail' => __( 'Request failed.', 'stratawp-seo' ),
-                'metaTitle'   => __( 'Meta title', 'stratawp-seo' ),
-                'metaDesc'    => __( 'Meta description', 'stratawp-seo' ),
-                'focusKw'     => __( 'Focus keyword', 'stratawp-seo' ),
-                'metaSection' => __( 'Metadata changes', 'stratawp-seo' ),
-                'editsSection'=> __( 'Content edits', 'stratawp-seo' ),
-                'estCost'     => __( 'est. cost', 'stratawp-seo' ),
-                'words'       => __( 'words', 'stratawp-seo' ),
-                'view'        => __( 'View', 'stratawp-seo' ),
-                'reGenerate'  => __( 'Re-generate', 'stratawp-seo' ),
-                'review'      => __( 'Review', 'stratawp-seo' ),
-                'generate'    => __( 'Generate proposal', 'stratawp-seo' ),
-                'dismiss'     => __( 'Dismiss', 'stratawp-seo' ),
-                'empty'       => __( 'Nothing to optimize. No published posts are below the threshold. Lower the threshold or re-scan.', 'stratawp-seo' ),
-                'countOne'    => __( '1 post below threshold', 'stratawp-seo' ),
-                'countMany'   => __( '%d posts below threshold', 'stratawp-seo' ),
-            ],
-        ] );
-    }
+	public function enqueue_assets( string $hook ): void {
+		if ( 'stratawp-seo_page_swps-auto-optimize' !== $hook ) {
+			return;
+		}
+		wp_enqueue_style(
+			'swps-page-auto-optimize',
+			SWPS_PLUGIN_URL . 'admin/css/pages/auto-optimize.css',
+			array( 'swps-tokens', 'swps-components', 'swps-templates' ),
+			SWPS_VERSION
+		);
+		wp_enqueue_script(
+			'swps-auto-optimize',
+			SWPS_PLUGIN_URL . 'admin/js/auto-optimize.js',
+			array( 'jquery' ),
+			SWPS_VERSION,
+			true
+		);
+		wp_localize_script(
+			'swps-auto-optimize',
+			'swpsOptimize',
+			array(
+				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'nonce'   => wp_create_nonce( 'swps_nonce' ),
+				'i18n'    => array(
+					'scoring'        => __( 'Re-scoring all posts...', 'stratawp-seo' ),
+					'loading'        => __( 'Loading queue...', 'stratawp-seo' ),
+					'proposing'      => __( 'Generating proposal — calling AI...', 'stratawp-seo' ),
+					'applying'       => __( 'Applying edits...', 'stratawp-seo' ),
+					'dismissing'     => __( 'Dismissing...', 'stratawp-seo' ),
+					'confirmDismiss' => __( 'Dismiss this post? It will be hidden from the queue.', 'stratawp-seo' ),
+					'noEdits'        => __( 'The AI did not return any actionable edits.', 'stratawp-seo' ),
+					'genericFail'    => __( 'Request failed.', 'stratawp-seo' ),
+					'metaTitle'      => __( 'Meta title', 'stratawp-seo' ),
+					'metaDesc'       => __( 'Meta description', 'stratawp-seo' ),
+					'focusKw'        => __( 'Focus keyword', 'stratawp-seo' ),
+					'metaSection'    => __( 'Metadata changes', 'stratawp-seo' ),
+					'editsSection'   => __( 'Content edits', 'stratawp-seo' ),
+					'estCost'        => __( 'est. cost', 'stratawp-seo' ),
+					'words'          => __( 'words', 'stratawp-seo' ),
+					'view'           => __( 'View', 'stratawp-seo' ),
+					'reGenerate'     => __( 'Re-generate', 'stratawp-seo' ),
+					'review'         => __( 'Review', 'stratawp-seo' ),
+					'generate'       => __( 'Generate proposal', 'stratawp-seo' ),
+					'dismiss'        => __( 'Dismiss', 'stratawp-seo' ),
+					'empty'          => __( 'Nothing to optimize. No published posts are below the threshold. Lower the threshold or re-scan.', 'stratawp-seo' ),
+					'countOne'       => __( '1 post below threshold', 'stratawp-seo' ),
+					'countMany'      => __( '%d posts below threshold', 'stratawp-seo' ),
+				),
+			)
+		);
+	}
 
-    /**
-     * Scan published posts, re-score, return queue sorted by lowest-score-first.
-     *
-     * @param int  $threshold         Skip posts at or above this score.
-     * @param int  $limit             Max posts to scan.
-     * @param bool $include_dismissed Whether to include dismissed posts.
-     * @return array<int, array>      Queue rows.
-     */
-    public function scan_candidates( int $threshold = self::DEFAULT_THRESHOLD, int $limit = 50, bool $include_dismissed = false ): array {
-        $posts = get_posts( [
-            'post_type'      => [ 'post', 'page' ],
-            'post_status'    => 'publish',
-            'posts_per_page' => max( 1, $limit ),
-            'orderby'        => 'date',
-            'order'          => 'DESC',
-        ] );
+	/**
+	 * Scan published posts, re-score, return queue sorted by lowest-score-first.
+	 *
+	 * @param int  $threshold         Skip posts at or above this score.
+	 * @param int  $limit             Max posts to scan.
+	 * @param bool $include_dismissed Whether to include dismissed posts.
+	 * @return array<int, array>      Queue rows.
+	 */
+	public function scan_candidates( int $threshold = self::DEFAULT_THRESHOLD, int $limit = 50, bool $include_dismissed = false ): array {
+		$posts = get_posts(
+			array(
+				'post_type'      => array( 'post', 'page' ),
+				'post_status'    => 'publish',
+				'posts_per_page' => max( 1, $limit ),
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			)
+		);
 
-        $rows = [];
+		$rows = array();
 
-        foreach ( $posts as $post ) {
-            if ( ! $include_dismissed && get_post_meta( $post->ID, self::META_DISMISSED, true ) ) {
-                continue;
-            }
+		foreach ( $posts as $post ) {
+			if ( ! $include_dismissed && get_post_meta( $post->ID, self::META_DISMISSED, true ) ) {
+				continue;
+			}
 
-            try {
-                $results = $this->score_existing_post( $post );
-            } catch ( \Throwable $e ) {
-                error_log( sprintf(
-                    '[StrataWP SEO] score failed for post %d: %s',
-                    $post->ID,
-                    $e->getMessage()
-                ) );
-                continue;
-            }
+			try {
+				$results = $this->score_existing_post( $post );
+			} catch ( \Throwable $e ) {
+				error_log(
+					sprintf(
+						'[StrataWP SEO] score failed for post %d: %s',
+						$post->ID,
+						$e->getMessage()
+					)
+				);
+				continue;
+			}
 
-            update_post_meta( $post->ID, '_swps_content_score', $results['overall_score'] );
-            update_post_meta( $post->ID, '_swps_score_details', $results['details'] );
-            update_post_meta( $post->ID, '_swps_score_recommendations', $results['recommendations'] );
+			update_post_meta( $post->ID, '_swps_content_score', $results['overall_score'] );
+			update_post_meta( $post->ID, '_swps_score_details', $results['details'] );
+			update_post_meta( $post->ID, '_swps_score_recommendations', $results['recommendations'] );
 
-            if ( $results['overall_score'] >= $threshold ) {
-                continue;
-            }
+			if ( $results['overall_score'] >= $threshold ) {
+				continue;
+			}
 
-            $rows[] = $this->build_queue_row( $post, $results );
-        }
+			$rows[] = $this->build_queue_row( $post, $results );
+		}
 
-        usort( $rows, fn( $a, $b ) => $a['current_score'] <=> $b['current_score'] );
-        return $rows;
-    }
+		usort( $rows, fn( $a, $b ) => $a['current_score'] <=> $b['current_score'] );
+		return $rows;
+	}
 
-    /**
-     * Get the current queue without re-scoring (uses cached scores).
-     */
-    public function get_queue( int $threshold = self::DEFAULT_THRESHOLD, int $limit = 50, bool $include_dismissed = false ): array {
-        $posts = get_posts( [
-            'post_type'      => [ 'post', 'page' ],
-            'post_status'    => 'publish',
-            'posts_per_page' => max( 1, $limit ),
-            'orderby'        => 'date',
-            'order'          => 'DESC',
-        ] );
+	/**
+	 * Get the current queue without re-scoring (uses cached scores).
+	 */
+	public function get_queue( int $threshold = self::DEFAULT_THRESHOLD, int $limit = 50, bool $include_dismissed = false ): array {
+		$posts = get_posts(
+			array(
+				'post_type'      => array( 'post', 'page' ),
+				'post_status'    => 'publish',
+				'posts_per_page' => max( 1, $limit ),
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			)
+		);
 
-        $rows = [];
+		$rows = array();
 
-        foreach ( $posts as $post ) {
-            if ( ! $include_dismissed && get_post_meta( $post->ID, self::META_DISMISSED, true ) ) {
-                continue;
-            }
+		foreach ( $posts as $post ) {
+			if ( ! $include_dismissed && get_post_meta( $post->ID, self::META_DISMISSED, true ) ) {
+				continue;
+			}
 
-            $cached = get_post_meta( $post->ID, '_swps_content_score', true );
-            if ( '' === $cached ) {
-                continue;
-            }
-            $score = (int) $cached;
-            if ( $score >= $threshold ) {
-                continue;
-            }
+			$cached = get_post_meta( $post->ID, '_swps_content_score', true );
+			if ( '' === $cached ) {
+				continue;
+			}
+			$score = (int) $cached;
+			if ( $score >= $threshold ) {
+				continue;
+			}
 
-            $details = get_post_meta( $post->ID, '_swps_score_details', true ) ?: [];
-            $recs    = get_post_meta( $post->ID, '_swps_score_recommendations', true ) ?: [];
+			$details = get_post_meta( $post->ID, '_swps_score_details', true ) ?: array();
+			$recs    = get_post_meta( $post->ID, '_swps_score_recommendations', true ) ?: array();
 
-            $rows[] = $this->build_queue_row( $post, [
-                'overall_score'   => $score,
-                'details'         => $details,
-                'recommendations' => $recs,
-            ] );
-        }
+			$rows[] = $this->build_queue_row(
+				$post,
+				array(
+					'overall_score'   => $score,
+					'details'         => $details,
+					'recommendations' => $recs,
+				)
+			);
+		}
 
-        usort( $rows, fn( $a, $b ) => $a['current_score'] <=> $b['current_score'] );
-        return $rows;
-    }
+		usort( $rows, fn( $a, $b ) => $a['current_score'] <=> $b['current_score'] );
+		return $rows;
+	}
 
-    /**
-     * Aggregate stats for the summary tile row.
-     *
-     * @param array $rows Queue rows from get_queue() / scan_candidates().
-     */
-    public function get_stats( array $rows ): array {
-        $with_proposal   = 0;
-        $proj_lift_total = 0;
-        $proj_lift_count = 0;
-        $est_cost_total  = 0.0;
+	/**
+	 * Aggregate stats for the summary tile row.
+	 *
+	 * @param array $rows Queue rows from get_queue() / scan_candidates().
+	 */
+	public function get_stats( array $rows ): array {
+		$with_proposal   = 0;
+		$proj_lift_total = 0;
+		$proj_lift_count = 0;
+		$est_cost_total  = 0.0;
 
-        foreach ( $rows as $row ) {
-            if ( ! empty( $row['has_proposal'] ) ) {
-                $with_proposal++;
-                $cur  = (int) ( $row['current_score'] ?? 0 );
-                $proj = (int) ( $row['proposal']['projected_score'] ?? 0 );
-                if ( $proj > $cur ) {
-                    $proj_lift_total += ( $proj - $cur );
-                    $proj_lift_count++;
-                }
-                $est_cost_total += (float) ( $row['proposal']['estimated_cost'] ?? 0 );
-            }
-        }
+		foreach ( $rows as $row ) {
+			if ( ! empty( $row['has_proposal'] ) ) {
+				++$with_proposal;
+				$cur  = (int) ( $row['current_score'] ?? 0 );
+				$proj = (int) ( $row['proposal']['projected_score'] ?? 0 );
+				if ( $proj > $cur ) {
+					$proj_lift_total += ( $proj - $cur );
+					++$proj_lift_count;
+				}
+				$est_cost_total += (float) ( $row['proposal']['estimated_cost'] ?? 0 );
+			}
+		}
 
-        return [
-            'count'         => count( $rows ),
-            'with_proposal' => $with_proposal,
-            'avg_lift'      => $proj_lift_count > 0 ? (int) round( $proj_lift_total / $proj_lift_count ) : 0,
-            'est_cost'      => round( $est_cost_total, 4 ),
-        ];
-    }
+		return array(
+			'count'         => count( $rows ),
+			'with_proposal' => $with_proposal,
+			'avg_lift'      => $proj_lift_count > 0 ? (int) round( $proj_lift_total / $proj_lift_count ) : 0,
+			'est_cost'      => round( $est_cost_total, 4 ),
+		);
+	}
 
-    /**
-     * Ask the AI for concrete edits + projected score.
-     *
-     * @return array|WP_Error Stored proposal payload.
-     */
-    public function propose_edits( int $post_id ): array|WP_Error {
-        $post = get_post( $post_id );
-        if ( ! $post ) {
-            return new WP_Error( 'swps_post_missing', __( 'Post not found.', 'stratawp-seo' ) );
-        }
+	/**
+	 * Ask the AI for concrete edits + projected score.
+	 *
+	 * @return array|WP_Error Stored proposal payload.
+	 */
+	public function propose_edits( int $post_id ): array|WP_Error {
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new WP_Error( 'swps_post_missing', __( 'Post not found.', 'stratawp-seo' ) );
+		}
 
-        $current = $this->score_existing_post( $post );
-        $recs    = $current['recommendations'] ?? [];
+		$current = $this->score_existing_post( $post );
+		$recs    = $current['recommendations'] ?? array();
 
-        $focus_keyword   = (string) get_post_meta( $post_id, '_swps_focus_keyword', true );
-        $secondary       = get_post_meta( $post_id, '_swps_secondary_keywords', true );
-        $secondary_list  = is_array( $secondary )
-            ? $secondary
-            : array_filter( array_map( 'trim', explode( ',', (string) $secondary ) ) );
-        $existing_meta_t = (string) get_post_meta( $post_id, '_swps_meta_title', true );
-        $existing_meta_d = (string) get_post_meta( $post_id, '_swps_meta_description', true );
+		$focus_keyword   = (string) get_post_meta( $post_id, '_swps_focus_keyword', true );
+		$secondary       = get_post_meta( $post_id, '_swps_secondary_keywords', true );
+		$secondary_list  = is_array( $secondary )
+			? $secondary
+			: array_filter( array_map( 'trim', explode( ',', (string) $secondary ) ) );
+		$existing_meta_t = (string) get_post_meta( $post_id, '_swps_meta_title', true );
+		$existing_meta_d = (string) get_post_meta( $post_id, '_swps_meta_description', true );
 
-        $body_excerpt = $this->extract_body_excerpt( $post->post_content, 6000 );
+		$body_excerpt = $this->extract_body_excerpt( $post->post_content, 6000 );
 
-        $system = 'You are an SEO editor. You return ONLY valid JSON conforming to the schema. '
-                . 'Edits must be safe, minimal, and grounded in the post content. '
-                . 'Each find_text MUST appear verbatim in the post content (case-sensitive). '
-                . 'Do not invent quotes, URLs, or claims.';
+		$system = 'You are an SEO editor. You return ONLY valid JSON conforming to the schema. '
+				. 'Edits must be safe, minimal, and grounded in the post content. '
+				. 'Each find_text MUST appear verbatim in the post content (case-sensitive). '
+				. 'Do not invent quotes, URLs, or claims.';
 
-        $schema = '{
+		$schema = '{
   "summary": "one-sentence rationale",
   "projected_score": 0-100 integer,
   "meta_title": "string or null",
@@ -279,502 +292,545 @@ class SWPS_Auto_Optimize {
   ]
 }';
 
-        $prompt = sprintf(
-            "Optimize this post for SEO. Current score: %d/100.\n\n"
-            . "POST TITLE: %s\n"
-            . "FOCUS KEYWORD: %s\n"
-            . "SECONDARY KEYWORDS: %s\n"
-            . "CURRENT META TITLE: %s\n"
-            . "CURRENT META DESCRIPTION: %s\n\n"
-            . "RECOMMENDATIONS FROM SCORER:\n- %s\n\n"
-            . "POST CONTENT (HTML, may be truncated):\n%s\n\n"
-            . "Return JSON only matching this schema:\n%s\n\n"
-            . "Rules:\n"
-            . "- Propose 2-6 concrete edits.\n"
-            . "- Prefer small targeted changes (one paragraph, one heading, the intro).\n"
-            . "- For replace_text edits: find_text MUST be a verbatim substring of the post content.\n"
-            . "- meta_title 50-60 chars; meta_description 140-160 chars.\n"
-            . "- projected_score should be a realistic estimate after applying ALL listed edits.",
-            $current['overall_score'],
-            $post->post_title,
-            $focus_keyword !== '' ? $focus_keyword : '(none set)',
-            ! empty( $secondary_list ) ? implode( ', ', $secondary_list ) : '(none set)',
-            $existing_meta_t !== '' ? $existing_meta_t : '(none set)',
-            $existing_meta_d !== '' ? $existing_meta_d : '(none set)',
-            ! empty( $recs ) ? implode( "\n- ", $recs ) : '(none)',
-            $body_excerpt,
-            $schema
-        );
-
-        $api      = SWPS_Provider_Factory::create_ai_provider();
-        $response = $api->chat_json( $system, $prompt, 4096 );
-
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
-
-        $proposal = $this->normalize_proposal( $response, $post );
-
-        $stored = [
-            'current_score'   => $current['overall_score'],
-            'projected_score' => $proposal['projected_score'],
-            'summary'         => $proposal['summary'],
-            'meta_title'      => $proposal['meta_title'],
-            'meta_description'=> $proposal['meta_description'],
-            'focus_keyword'   => $proposal['focus_keyword'],
-            'edits'           => $proposal['edits'],
-            'estimated_cost'  => $this->estimate_cost( $response['_usage'] ?? null ),
-            'usage'           => $response['_usage'] ?? null,
-        ];
-
-        update_post_meta( $post_id, self::META_PROPOSAL, $stored );
-        update_post_meta( $post_id, self::META_PROPOSED_AT, current_time( 'mysql' ) );
-        delete_post_meta( $post_id, self::META_DISMISSED );
-
-        return $stored;
-    }
-
-    /**
-     * Apply approved edits to the post.
-     *
-     * @param array $accepted {
-     *     @type bool   $meta_title
-     *     @type bool   $meta_description
-     *     @type bool   $focus_keyword
-     *     @type int[]  $edits  Indices into the proposal->edits array.
-     * }
-     */
-    public function apply_edits( int $post_id, array $accepted ): array|WP_Error {
-        $post = get_post( $post_id );
-        if ( ! $post ) {
-            return new WP_Error( 'swps_post_missing', __( 'Post not found.', 'stratawp-seo' ) );
-        }
-
-        $proposal = get_post_meta( $post_id, self::META_PROPOSAL, true );
-        if ( ! is_array( $proposal ) || empty( $proposal ) ) {
-            return new WP_Error( 'swps_no_proposal', __( 'No proposal found for this post. Generate one first.', 'stratawp-seo' ) );
-        }
-
-        $changed     = [];
-        $skipped     = [];
-        $new_content = $post->post_content;
-
-        if ( ! empty( $accepted['meta_title'] ) && ! empty( $proposal['meta_title'] ) ) {
-            update_post_meta( $post_id, '_swps_meta_title', sanitize_text_field( $proposal['meta_title'] ) );
-            $changed[] = 'meta_title';
-        }
-        if ( ! empty( $accepted['meta_description'] ) && ! empty( $proposal['meta_description'] ) ) {
-            update_post_meta( $post_id, '_swps_meta_description', sanitize_textarea_field( $proposal['meta_description'] ) );
-            $changed[] = 'meta_description';
-        }
-        if ( ! empty( $accepted['focus_keyword'] ) && ! empty( $proposal['focus_keyword'] ) ) {
-            update_post_meta( $post_id, '_swps_focus_keyword', sanitize_text_field( $proposal['focus_keyword'] ) );
-            $changed[] = 'focus_keyword';
-        }
-
-        $accepted_idx = isset( $accepted['edits'] ) && is_array( $accepted['edits'] )
-            ? array_map( 'intval', $accepted['edits'] )
-            : [];
-
-        foreach ( ( $proposal['edits'] ?? [] ) as $i => $edit ) {
-            if ( ! in_array( $i, $accepted_idx, true ) ) {
-                continue;
-            }
-            $applied = $this->apply_single_edit( $new_content, $edit );
-            if ( $applied['ok'] ) {
-                $new_content = $applied['content'];
-                $changed[]   = 'edit#' . $i;
-            } else {
-                $skipped[] = [ 'index' => $i, 'reason' => $applied['reason'] ];
-            }
-        }
-
-        if ( $new_content !== $post->post_content ) {
-            wp_update_post( [
-                'ID'           => $post_id,
-                'post_content' => $new_content,
-            ] );
-        }
-
-        $post_after = get_post( $post_id );
-        $rescored   = $this->score_existing_post( $post_after );
-        update_post_meta( $post_id, '_swps_content_score', $rescored['overall_score'] );
-        update_post_meta( $post_id, '_swps_score_details', $rescored['details'] );
-        update_post_meta( $post_id, '_swps_score_recommendations', $rescored['recommendations'] );
-
-        update_post_meta( $post_id, self::META_APPLIED_AT, current_time( 'mysql' ) );
-        delete_post_meta( $post_id, self::META_PROPOSAL );
-
-        return [
-            'changed'        => $changed,
-            'skipped'        => $skipped,
-            'new_score'      => $rescored['overall_score'],
-            'previous_score' => (int) ( $proposal['current_score'] ?? 0 ),
-        ];
-    }
-
-    public function dismiss( int $post_id ): void {
-        update_post_meta( $post_id, self::META_DISMISSED, 1 );
-        delete_post_meta( $post_id, self::META_PROPOSAL );
-    }
-
-    public function undismiss( int $post_id ): void {
-        delete_post_meta( $post_id, self::META_DISMISSED );
-    }
-
-    public function get_threshold(): int {
-        $val = (int) get_option( self::OPTION_THRESHOLD, self::DEFAULT_THRESHOLD );
-        return max( 0, min( 100, $val ) );
-    }
-
-    public function set_threshold( int $value ): void {
-        update_option( self::OPTION_THRESHOLD, max( 0, min( 100, $value ) ) );
-    }
-
-    // ---------- AJAX ----------
-
-    public function ajax_scan(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-
-        $threshold = isset( $_POST['threshold'] ) ? (int) $_POST['threshold'] : $this->get_threshold();
-        $limit     = isset( $_POST['limit'] ) ? max( 1, min( 200, (int) $_POST['limit'] ) ) : 50;
-        $rescore   = ! empty( $_POST['rescore'] );
-
-        $this->set_threshold( $threshold );
-
-        // Re-scoring 50 posts × 3 meta writes can easily exceed shared-host PHP
-        // timeouts. Give it room and don't fall over if a single post errors.
-        if ( $rescore ) {
-            if ( function_exists( 'set_time_limit' ) ) {
-                @set_time_limit( 180 );
-            }
-            if ( function_exists( 'wp_raise_memory_limit' ) ) {
-                wp_raise_memory_limit( 'admin' );
-            }
-            ignore_user_abort( true );
-        }
-
-        try {
-            $rows = $rescore
-                ? $this->scan_candidates( $threshold, $limit )
-                : $this->get_queue( $threshold, $limit );
-        } catch ( \Throwable $e ) {
-            error_log( '[StrataWP SEO] auto-optimize scan failed: ' . $e->getMessage() );
-            wp_send_json_error( [
-                'message' => sprintf(
-                    /* translators: %s: error message */
-                    __( 'Scan failed: %s', 'stratawp-seo' ),
-                    $e->getMessage()
-                ),
-            ] );
-        }
-
-        wp_send_json_success( [
-            'threshold' => $threshold,
-            'count'     => count( $rows ),
-            'rows'      => $rows,
-            'stats'     => $this->get_stats( $rows ),
-        ] );
-    }
-
-    /**
-     * Score a single chunk of posts. Used by JS to walk the published-posts
-     * list one batch at a time so a large site doesn't hit a 30/60s PHP
-     * timeout. Each chunk is its own AJAX request.
-     */
-    public function ajax_scan_chunk(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-
-        $offset     = isset( $_POST['offset'] )     ? max( 0, (int) $_POST['offset'] )                           : 0;
-        $chunk_size = isset( $_POST['chunk_size'] ) ? max( 1, min( 25, (int) $_POST['chunk_size'] ) )            : 10;
-
-        if ( function_exists( 'set_time_limit' ) ) {
-            @set_time_limit( 90 );
-        }
-        if ( function_exists( 'wp_raise_memory_limit' ) ) {
-            wp_raise_memory_limit( 'admin' );
-        }
-        ignore_user_abort( true );
-
-        try {
-            $result = $this->score_chunk( $offset, $chunk_size );
-        } catch ( \Throwable $e ) {
-            error_log( '[StrataWP SEO] auto-optimize chunk failed at offset ' . $offset . ': ' . $e->getMessage() );
-            wp_send_json_error( [
-                'message' => sprintf(
-                    /* translators: %s: error message */
-                    __( 'Chunk scan failed: %s', 'stratawp-seo' ),
-                    $e->getMessage()
-                ),
-            ] );
-        }
-
-        wp_send_json_success( $result );
-    }
-
-    /**
-     * Score one chunk of published posts. Stores the new score on each post's
-     * meta and returns counts for the JS progress UI.
-     *
-     * @return array { scanned, fetched, next_offset, has_more, total }
-     */
-    public function score_chunk( int $offset, int $chunk_size ): array {
-        $posts = get_posts( [
-            'post_type'      => [ 'post', 'page' ],
-            'post_status'    => 'publish',
-            'posts_per_page' => $chunk_size,
-            'offset'         => $offset,
-            'orderby'        => 'date',
-            'order'          => 'DESC',
-        ] );
-
-        $scanned = 0;
-        foreach ( $posts as $post ) {
-            try {
-                $results = $this->score_existing_post( $post );
-            } catch ( \Throwable $e ) {
-                error_log( sprintf(
-                    '[StrataWP SEO] score failed for post %d: %s',
-                    $post->ID,
-                    $e->getMessage()
-                ) );
-                continue;
-            }
-
-            update_post_meta( $post->ID, '_swps_content_score', $results['overall_score'] );
-            update_post_meta( $post->ID, '_swps_score_details', $results['details'] );
-            update_post_meta( $post->ID, '_swps_score_recommendations', $results['recommendations'] );
-            $scanned++;
-        }
-
-        $fetched = count( $posts );
-
-        return [
-            'scanned'     => $scanned,
-            'fetched'     => $fetched,
-            'next_offset' => $offset + $fetched,
-            'has_more'    => $fetched === $chunk_size,
-            'total'       => $this->count_published(),
-        ];
-    }
-
-    private function count_published(): int {
-        $post = wp_count_posts( 'post' );
-        $page = wp_count_posts( 'page' );
-        return (int) ( ( $post->publish ?? 0 ) + ( $page->publish ?? 0 ) );
-    }
-
-    public function ajax_propose(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-
-        $post_id = absint( $_POST['post_id'] ?? 0 );
-        if ( ! $post_id ) {
-            wp_send_json_error( [ 'message' => __( 'Invalid post ID.', 'stratawp-seo' ) ] );
-        }
-
-        $result = $this->propose_edits( $post_id );
-
-        if ( is_wp_error( $result ) ) {
-            wp_send_json_error( [ 'message' => $result->get_error_message() ] );
-        }
-
-        wp_send_json_success( $result );
-    }
-
-    public function ajax_apply(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-
-        $post_id  = absint( $_POST['post_id'] ?? 0 );
-        $accepted = isset( $_POST['accepted'] ) ? (array) $_POST['accepted'] : [];
-
-        $accepted_clean = [
-            'meta_title'       => ! empty( $accepted['meta_title'] ),
-            'meta_description' => ! empty( $accepted['meta_description'] ),
-            'focus_keyword'    => ! empty( $accepted['focus_keyword'] ),
-            'edits'            => isset( $accepted['edits'] ) ? array_map( 'intval', (array) $accepted['edits'] ) : [],
-        ];
-
-        $result = $this->apply_edits( $post_id, $accepted_clean );
-
-        if ( is_wp_error( $result ) ) {
-            wp_send_json_error( [ 'message' => $result->get_error_message() ] );
-        }
-
-        wp_send_json_success( $result );
-    }
-
-    public function ajax_dismiss(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-        $post_id = absint( $_POST['post_id'] ?? 0 );
-        if ( ! $post_id ) {
-            wp_send_json_error( [ 'message' => __( 'Invalid post ID.', 'stratawp-seo' ) ] );
-        }
-        $this->dismiss( $post_id );
-        wp_send_json_success();
-    }
-
-    public function ajax_undismiss(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-        $post_id = absint( $_POST['post_id'] ?? 0 );
-        if ( ! $post_id ) {
-            wp_send_json_error( [ 'message' => __( 'Invalid post ID.', 'stratawp-seo' ) ] );
-        }
-        $this->undismiss( $post_id );
-        wp_send_json_success();
-    }
-
-    // ---------- Internals ----------
-
-    private function score_existing_post( WP_Post $post ): array {
-        $ai_result = [
-            'title'                => $post->post_title,
-            'content_html'         => $post->post_content,
-            'meta_description'     => get_post_meta( $post->ID, '_swps_meta_description', true )
-                                   ?: get_post_meta( $post->ID, '_yoast_wpseo_metadesc', true )
-                                   ?: get_post_meta( $post->ID, 'rank_math_description', true )
-                                   ?: '',
-            'focus_keyword'        => get_post_meta( $post->ID, '_swps_focus_keyword', true )
-                                   ?: get_post_meta( $post->ID, '_yoast_wpseo_focuskw', true )
-                                   ?: get_post_meta( $post->ID, 'rank_math_focus_keyword', true )
-                                   ?: '',
-            'secondary_keywords'   => get_post_meta( $post->ID, '_swps_secondary_keywords', true ) ?: [],
-            'internal_links_used'  => get_post_meta( $post->ID, '_swps_internal_links', true ) ?: [],
-            'estimated_word_count' => str_word_count( wp_strip_all_tags( $post->post_content ) ),
-        ];
-        return $this->scorer->score( $post->ID, $ai_result );
-    }
-
-    private function build_queue_row( WP_Post $post, array $score ): array {
-        $proposal     = get_post_meta( $post->ID, self::META_PROPOSAL, true );
-        $has_proposal = is_array( $proposal ) && ! empty( $proposal );
-
-        return [
-            'post_id'       => $post->ID,
-            'title'         => $post->post_title,
-            'edit_url'      => get_edit_post_link( $post->ID, 'raw' ),
-            'permalink'     => get_permalink( $post->ID ),
-            'current_score' => (int) ( $score['overall_score'] ?? 0 ),
-            'top_recs'      => array_slice( (array) ( $score['recommendations'] ?? [] ), 0, 3 ),
-            'has_proposal'  => $has_proposal,
-            'proposal'      => $has_proposal ? $proposal : null,
-            'dismissed'     => (bool) get_post_meta( $post->ID, self::META_DISMISSED, true ),
-            'word_count'    => str_word_count( wp_strip_all_tags( $post->post_content ) ),
-        ];
-    }
-
-    private function extract_body_excerpt( string $content, int $max_chars ): string {
-        if ( strlen( $content ) <= $max_chars ) {
-            return $content;
-        }
-        $head_len = (int) floor( $max_chars * 0.7 );
-        $tail_len = $max_chars - $head_len - 32;
-        return mb_substr( $content, 0, $head_len )
-             . "\n\n[... content truncated ...]\n\n"
-             . mb_substr( $content, -$tail_len );
-    }
-
-    private function normalize_proposal( array $response, WP_Post $post ): array {
-        $edits     = [];
-        $raw_edits = $response['edits'] ?? [];
-        if ( is_array( $raw_edits ) ) {
-            foreach ( $raw_edits as $edit ) {
-                if ( ! is_array( $edit ) ) {
-                    continue;
-                }
-                $type = (string) ( $edit['type'] ?? '' );
-                if ( ! in_array( $type, [ 'replace_text', 'append_paragraph', 'prepend_paragraph' ], true ) ) {
-                    continue;
-                }
-                $find_text = isset( $edit['find_text'] ) ? (string) $edit['find_text'] : '';
-                $replace   = isset( $edit['replace_text'] ) ? (string) $edit['replace_text'] : '';
-                $reason    = isset( $edit['reason'] ) ? (string) $edit['reason'] : '';
-
-                // Block hallucinated finds.
-                if ( 'replace_text' === $type && '' !== $find_text ) {
-                    if ( strpos( $post->post_content, $find_text ) === false ) {
-                        continue;
-                    }
-                }
-
-                $edits[] = [
-                    'type'         => $type,
-                    'reason'       => $reason,
-                    'find_text'    => $find_text,
-                    'replace_text' => $replace,
-                ];
-            }
-        }
-
-        return [
-            'summary'          => (string) ( $response['summary'] ?? '' ),
-            'projected_score'  => max( 0, min( 100, (int) ( $response['projected_score'] ?? 0 ) ) ),
-            'meta_title'       => isset( $response['meta_title'] ) && '' !== trim( (string) $response['meta_title'] )
-                                    ? sanitize_text_field( $response['meta_title'] ) : null,
-            'meta_description' => isset( $response['meta_description'] ) && '' !== trim( (string) $response['meta_description'] )
-                                    ? sanitize_textarea_field( $response['meta_description'] ) : null,
-            'focus_keyword'    => isset( $response['focus_keyword'] ) && '' !== trim( (string) $response['focus_keyword'] )
-                                    ? sanitize_text_field( $response['focus_keyword'] ) : null,
-            'edits'            => $edits,
-        ];
-    }
-
-    /**
-     * @return array{ok: bool, content: string, reason: string}
-     */
-    private function apply_single_edit( string $content, array $edit ): array {
-        $type = $edit['type'] ?? '';
-        $repl = (string) ( $edit['replace_text'] ?? '' );
-
-        switch ( $type ) {
-            case 'replace_text':
-                $find = (string) ( $edit['find_text'] ?? '' );
-                if ( '' === $find || strpos( $content, $find ) === false ) {
-                    return [ 'ok' => false, 'content' => $content, 'reason' => 'find_text not found' ];
-                }
-                $pos = strpos( $content, $find );
-                $new = substr( $content, 0, $pos ) . $repl . substr( $content, $pos + strlen( $find ) );
-                return [ 'ok' => true, 'content' => $new, 'reason' => '' ];
-
-            case 'append_paragraph':
-                if ( '' === trim( $repl ) ) {
-                    return [ 'ok' => false, 'content' => $content, 'reason' => 'empty paragraph' ];
-                }
-                return [ 'ok' => true, 'content' => $content . "\n\n" . wp_kses_post( wpautop( $repl ) ), 'reason' => '' ];
-
-            case 'prepend_paragraph':
-                if ( '' === trim( $repl ) ) {
-                    return [ 'ok' => false, 'content' => $content, 'reason' => 'empty paragraph' ];
-                }
-                return [ 'ok' => true, 'content' => wp_kses_post( wpautop( $repl ) ) . "\n\n" . $content, 'reason' => '' ];
-        }
-
-        return [ 'ok' => false, 'content' => $content, 'reason' => 'unknown edit type' ];
-    }
-
-    private function estimate_cost( ?array $usage ): float {
-        if ( ! is_array( $usage ) ) {
-            return 0.0;
-        }
-        $in  = (int) ( $usage['input_tokens'] ?? 0 );
-        $out = (int) ( $usage['output_tokens'] ?? 0 );
-        return round( ( $in * 0.000003 ) + ( $out * 0.000015 ), 4 );
-    }
+		$prompt = sprintf(
+			"Optimize this post for SEO. Current score: %d/100.\n\n"
+			. "POST TITLE: %s\n"
+			. "FOCUS KEYWORD: %s\n"
+			. "SECONDARY KEYWORDS: %s\n"
+			. "CURRENT META TITLE: %s\n"
+			. "CURRENT META DESCRIPTION: %s\n\n"
+			. "RECOMMENDATIONS FROM SCORER:\n- %s\n\n"
+			. "POST CONTENT (HTML, may be truncated):\n%s\n\n"
+			. "Return JSON only matching this schema:\n%s\n\n"
+			. "Rules:\n"
+			. "- Propose 2-6 concrete edits.\n"
+			. "- Prefer small targeted changes (one paragraph, one heading, the intro).\n"
+			. "- For replace_text edits: find_text MUST be a verbatim substring of the post content.\n"
+			. "- meta_title 50-60 chars; meta_description 140-160 chars.\n"
+			. '- projected_score should be a realistic estimate after applying ALL listed edits.',
+			$current['overall_score'],
+			$post->post_title,
+			$focus_keyword !== '' ? $focus_keyword : '(none set)',
+			! empty( $secondary_list ) ? implode( ', ', $secondary_list ) : '(none set)',
+			$existing_meta_t !== '' ? $existing_meta_t : '(none set)',
+			$existing_meta_d !== '' ? $existing_meta_d : '(none set)',
+			! empty( $recs ) ? implode( "\n- ", $recs ) : '(none)',
+			$body_excerpt,
+			$schema
+		);
+
+		$api      = SWPS_Provider_Factory::create_ai_provider();
+		$response = $api->chat_json( $system, $prompt, 4096 );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$proposal = $this->normalize_proposal( $response, $post );
+
+		$stored = array(
+			'current_score'    => $current['overall_score'],
+			'projected_score'  => $proposal['projected_score'],
+			'summary'          => $proposal['summary'],
+			'meta_title'       => $proposal['meta_title'],
+			'meta_description' => $proposal['meta_description'],
+			'focus_keyword'    => $proposal['focus_keyword'],
+			'edits'            => $proposal['edits'],
+			'estimated_cost'   => $this->estimate_cost( $response['_usage'] ?? null ),
+			'usage'            => $response['_usage'] ?? null,
+		);
+
+		update_post_meta( $post_id, self::META_PROPOSAL, $stored );
+		update_post_meta( $post_id, self::META_PROPOSED_AT, current_time( 'mysql' ) );
+		delete_post_meta( $post_id, self::META_DISMISSED );
+
+		return $stored;
+	}
+
+	/**
+	 * Apply approved edits to the post.
+	 *
+	 * @param array $accepted {
+	 *     @type bool   $meta_title
+	 *     @type bool   $meta_description
+	 *     @type bool   $focus_keyword
+	 *     @type int[]  $edits  Indices into the proposal->edits array.
+	 * }
+	 */
+	public function apply_edits( int $post_id, array $accepted ): array|WP_Error {
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new WP_Error( 'swps_post_missing', __( 'Post not found.', 'stratawp-seo' ) );
+		}
+
+		$proposal = get_post_meta( $post_id, self::META_PROPOSAL, true );
+		if ( ! is_array( $proposal ) || empty( $proposal ) ) {
+			return new WP_Error( 'swps_no_proposal', __( 'No proposal found for this post. Generate one first.', 'stratawp-seo' ) );
+		}
+
+		$changed     = array();
+		$skipped     = array();
+		$new_content = $post->post_content;
+
+		if ( ! empty( $accepted['meta_title'] ) && ! empty( $proposal['meta_title'] ) ) {
+			update_post_meta( $post_id, '_swps_meta_title', sanitize_text_field( $proposal['meta_title'] ) );
+			$changed[] = 'meta_title';
+		}
+		if ( ! empty( $accepted['meta_description'] ) && ! empty( $proposal['meta_description'] ) ) {
+			update_post_meta( $post_id, '_swps_meta_description', sanitize_textarea_field( $proposal['meta_description'] ) );
+			$changed[] = 'meta_description';
+		}
+		if ( ! empty( $accepted['focus_keyword'] ) && ! empty( $proposal['focus_keyword'] ) ) {
+			update_post_meta( $post_id, '_swps_focus_keyword', sanitize_text_field( $proposal['focus_keyword'] ) );
+			$changed[] = 'focus_keyword';
+		}
+
+		$accepted_idx = isset( $accepted['edits'] ) && is_array( $accepted['edits'] )
+			? array_map( 'intval', $accepted['edits'] )
+			: array();
+
+		foreach ( ( $proposal['edits'] ?? array() ) as $i => $edit ) {
+			if ( ! in_array( $i, $accepted_idx, true ) ) {
+				continue;
+			}
+			$applied = $this->apply_single_edit( $new_content, $edit );
+			if ( $applied['ok'] ) {
+				$new_content = $applied['content'];
+				$changed[]   = 'edit#' . $i;
+			} else {
+				$skipped[] = array(
+					'index'  => $i,
+					'reason' => $applied['reason'],
+				);
+			}
+		}
+
+		if ( $new_content !== $post->post_content ) {
+			wp_update_post(
+				array(
+					'ID'           => $post_id,
+					'post_content' => $new_content,
+				)
+			);
+		}
+
+		$post_after = get_post( $post_id );
+		$rescored   = $this->score_existing_post( $post_after );
+		update_post_meta( $post_id, '_swps_content_score', $rescored['overall_score'] );
+		update_post_meta( $post_id, '_swps_score_details', $rescored['details'] );
+		update_post_meta( $post_id, '_swps_score_recommendations', $rescored['recommendations'] );
+
+		update_post_meta( $post_id, self::META_APPLIED_AT, current_time( 'mysql' ) );
+		delete_post_meta( $post_id, self::META_PROPOSAL );
+
+		return array(
+			'changed'        => $changed,
+			'skipped'        => $skipped,
+			'new_score'      => $rescored['overall_score'],
+			'previous_score' => (int) ( $proposal['current_score'] ?? 0 ),
+		);
+	}
+
+	public function dismiss( int $post_id ): void {
+		update_post_meta( $post_id, self::META_DISMISSED, 1 );
+		delete_post_meta( $post_id, self::META_PROPOSAL );
+	}
+
+	public function undismiss( int $post_id ): void {
+		delete_post_meta( $post_id, self::META_DISMISSED );
+	}
+
+	public function get_threshold(): int {
+		$val = (int) get_option( self::OPTION_THRESHOLD, self::DEFAULT_THRESHOLD );
+		return max( 0, min( 100, $val ) );
+	}
+
+	public function set_threshold( int $value ): void {
+		update_option( self::OPTION_THRESHOLD, max( 0, min( 100, $value ) ) );
+	}
+
+	// ---------- AJAX ----------
+
+	public function ajax_scan(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+
+		$threshold = isset( $_POST['threshold'] ) ? (int) $_POST['threshold'] : $this->get_threshold();
+		$limit     = isset( $_POST['limit'] ) ? max( 1, min( 200, (int) $_POST['limit'] ) ) : 50;
+		$rescore   = ! empty( $_POST['rescore'] );
+
+		$this->set_threshold( $threshold );
+
+		// Re-scoring 50 posts × 3 meta writes can easily exceed shared-host PHP
+		// timeouts. Give it room and don't fall over if a single post errors.
+		if ( $rescore ) {
+			if ( function_exists( 'set_time_limit' ) ) {
+				@set_time_limit( 180 );
+			}
+			if ( function_exists( 'wp_raise_memory_limit' ) ) {
+				wp_raise_memory_limit( 'admin' );
+			}
+			ignore_user_abort( true );
+		}
+
+		try {
+			$rows = $rescore
+				? $this->scan_candidates( $threshold, $limit )
+				: $this->get_queue( $threshold, $limit );
+		} catch ( \Throwable $e ) {
+			error_log( '[StrataWP SEO] auto-optimize scan failed: ' . $e->getMessage() );
+			wp_send_json_error(
+				array(
+					'message' => sprintf(
+					/* translators: %s: error message */
+						__( 'Scan failed: %s', 'stratawp-seo' ),
+						$e->getMessage()
+					),
+				)
+			);
+		}
+
+		wp_send_json_success(
+			array(
+				'threshold' => $threshold,
+				'count'     => count( $rows ),
+				'rows'      => $rows,
+				'stats'     => $this->get_stats( $rows ),
+			)
+		);
+	}
+
+	/**
+	 * Score a single chunk of posts. Used by JS to walk the published-posts
+	 * list one batch at a time so a large site doesn't hit a 30/60s PHP
+	 * timeout. Each chunk is its own AJAX request.
+	 */
+	public function ajax_scan_chunk(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+
+		$offset     = isset( $_POST['offset'] ) ? max( 0, (int) $_POST['offset'] ) : 0;
+		$chunk_size = isset( $_POST['chunk_size'] ) ? max( 1, min( 25, (int) $_POST['chunk_size'] ) ) : 10;
+
+		if ( function_exists( 'set_time_limit' ) ) {
+			@set_time_limit( 90 );
+		}
+		if ( function_exists( 'wp_raise_memory_limit' ) ) {
+			wp_raise_memory_limit( 'admin' );
+		}
+		ignore_user_abort( true );
+
+		try {
+			$result = $this->score_chunk( $offset, $chunk_size );
+		} catch ( \Throwable $e ) {
+			error_log( '[StrataWP SEO] auto-optimize chunk failed at offset ' . $offset . ': ' . $e->getMessage() );
+			wp_send_json_error(
+				array(
+					'message' => sprintf(
+					/* translators: %s: error message */
+						__( 'Chunk scan failed: %s', 'stratawp-seo' ),
+						$e->getMessage()
+					),
+				)
+			);
+		}
+
+		wp_send_json_success( $result );
+	}
+
+	/**
+	 * Score one chunk of published posts. Stores the new score on each post's
+	 * meta and returns counts for the JS progress UI.
+	 *
+	 * @return array { scanned, fetched, next_offset, has_more, total }
+	 */
+	public function score_chunk( int $offset, int $chunk_size ): array {
+		$posts = get_posts(
+			array(
+				'post_type'      => array( 'post', 'page' ),
+				'post_status'    => 'publish',
+				'posts_per_page' => $chunk_size,
+				'offset'         => $offset,
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			)
+		);
+
+		$scanned = 0;
+		foreach ( $posts as $post ) {
+			try {
+				$results = $this->score_existing_post( $post );
+			} catch ( \Throwable $e ) {
+				error_log(
+					sprintf(
+						'[StrataWP SEO] score failed for post %d: %s',
+						$post->ID,
+						$e->getMessage()
+					)
+				);
+				continue;
+			}
+
+			update_post_meta( $post->ID, '_swps_content_score', $results['overall_score'] );
+			update_post_meta( $post->ID, '_swps_score_details', $results['details'] );
+			update_post_meta( $post->ID, '_swps_score_recommendations', $results['recommendations'] );
+			++$scanned;
+		}
+
+		$fetched = count( $posts );
+
+		return array(
+			'scanned'     => $scanned,
+			'fetched'     => $fetched,
+			'next_offset' => $offset + $fetched,
+			'has_more'    => $fetched === $chunk_size,
+			'total'       => $this->count_published(),
+		);
+	}
+
+	private function count_published(): int {
+		$post = wp_count_posts( 'post' );
+		$page = wp_count_posts( 'page' );
+		return (int) ( ( $post->publish ?? 0 ) + ( $page->publish ?? 0 ) );
+	}
+
+	public function ajax_propose(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+
+		$post_id = absint( $_POST['post_id'] ?? 0 );
+		if ( ! $post_id ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid post ID.', 'stratawp-seo' ) ) );
+		}
+
+		$result = $this->propose_edits( $post_id );
+
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+		}
+
+		wp_send_json_success( $result );
+	}
+
+	public function ajax_apply(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+
+		$post_id  = absint( $_POST['post_id'] ?? 0 );
+		$accepted = isset( $_POST['accepted'] ) ? (array) $_POST['accepted'] : array();
+
+		$accepted_clean = array(
+			'meta_title'       => ! empty( $accepted['meta_title'] ),
+			'meta_description' => ! empty( $accepted['meta_description'] ),
+			'focus_keyword'    => ! empty( $accepted['focus_keyword'] ),
+			'edits'            => isset( $accepted['edits'] ) ? array_map( 'intval', (array) $accepted['edits'] ) : array(),
+		);
+
+		$result = $this->apply_edits( $post_id, $accepted_clean );
+
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+		}
+
+		wp_send_json_success( $result );
+	}
+
+	public function ajax_dismiss(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		$post_id = absint( $_POST['post_id'] ?? 0 );
+		if ( ! $post_id ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid post ID.', 'stratawp-seo' ) ) );
+		}
+		$this->dismiss( $post_id );
+		wp_send_json_success();
+	}
+
+	public function ajax_undismiss(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		$post_id = absint( $_POST['post_id'] ?? 0 );
+		if ( ! $post_id ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid post ID.', 'stratawp-seo' ) ) );
+		}
+		$this->undismiss( $post_id );
+		wp_send_json_success();
+	}
+
+	// ---------- Internals ----------
+
+	private function score_existing_post( WP_Post $post ): array {
+		$ai_result = array(
+			'title'                => $post->post_title,
+			'content_html'         => $post->post_content,
+			'meta_description'     => get_post_meta( $post->ID, '_swps_meta_description', true )
+									?: get_post_meta( $post->ID, '_yoast_wpseo_metadesc', true )
+									?: get_post_meta( $post->ID, 'rank_math_description', true )
+									?: '',
+			'focus_keyword'        => get_post_meta( $post->ID, '_swps_focus_keyword', true )
+									?: get_post_meta( $post->ID, '_yoast_wpseo_focuskw', true )
+									?: get_post_meta( $post->ID, 'rank_math_focus_keyword', true )
+									?: '',
+			'secondary_keywords'   => get_post_meta( $post->ID, '_swps_secondary_keywords', true ) ?: array(),
+			'internal_links_used'  => get_post_meta( $post->ID, '_swps_internal_links', true ) ?: array(),
+			'estimated_word_count' => str_word_count( wp_strip_all_tags( $post->post_content ) ),
+		);
+		return $this->scorer->score( $post->ID, $ai_result );
+	}
+
+	private function build_queue_row( WP_Post $post, array $score ): array {
+		$proposal     = get_post_meta( $post->ID, self::META_PROPOSAL, true );
+		$has_proposal = is_array( $proposal ) && ! empty( $proposal );
+
+		return array(
+			'post_id'       => $post->ID,
+			'title'         => $post->post_title,
+			'edit_url'      => get_edit_post_link( $post->ID, 'raw' ),
+			'permalink'     => get_permalink( $post->ID ),
+			'current_score' => (int) ( $score['overall_score'] ?? 0 ),
+			'top_recs'      => array_slice( (array) ( $score['recommendations'] ?? array() ), 0, 3 ),
+			'has_proposal'  => $has_proposal,
+			'proposal'      => $has_proposal ? $proposal : null,
+			'dismissed'     => (bool) get_post_meta( $post->ID, self::META_DISMISSED, true ),
+			'word_count'    => str_word_count( wp_strip_all_tags( $post->post_content ) ),
+		);
+	}
+
+	private function extract_body_excerpt( string $content, int $max_chars ): string {
+		if ( strlen( $content ) <= $max_chars ) {
+			return $content;
+		}
+		$head_len = (int) floor( $max_chars * 0.7 );
+		$tail_len = $max_chars - $head_len - 32;
+		return mb_substr( $content, 0, $head_len )
+			. "\n\n[... content truncated ...]\n\n"
+			. mb_substr( $content, -$tail_len );
+	}
+
+	private function normalize_proposal( array $response, WP_Post $post ): array {
+		$edits     = array();
+		$raw_edits = $response['edits'] ?? array();
+		if ( is_array( $raw_edits ) ) {
+			foreach ( $raw_edits as $edit ) {
+				if ( ! is_array( $edit ) ) {
+					continue;
+				}
+				$type = (string) ( $edit['type'] ?? '' );
+				if ( ! in_array( $type, array( 'replace_text', 'append_paragraph', 'prepend_paragraph' ), true ) ) {
+					continue;
+				}
+				$find_text = isset( $edit['find_text'] ) ? (string) $edit['find_text'] : '';
+				$replace   = isset( $edit['replace_text'] ) ? (string) $edit['replace_text'] : '';
+				$reason    = isset( $edit['reason'] ) ? (string) $edit['reason'] : '';
+
+				// Block hallucinated finds.
+				if ( 'replace_text' === $type && '' !== $find_text ) {
+					if ( strpos( $post->post_content, $find_text ) === false ) {
+						continue;
+					}
+				}
+
+				$edits[] = array(
+					'type'         => $type,
+					'reason'       => $reason,
+					'find_text'    => $find_text,
+					'replace_text' => $replace,
+				);
+			}
+		}
+
+		return array(
+			'summary'          => (string) ( $response['summary'] ?? '' ),
+			'projected_score'  => max( 0, min( 100, (int) ( $response['projected_score'] ?? 0 ) ) ),
+			'meta_title'       => isset( $response['meta_title'] ) && '' !== trim( (string) $response['meta_title'] )
+									? sanitize_text_field( $response['meta_title'] ) : null,
+			'meta_description' => isset( $response['meta_description'] ) && '' !== trim( (string) $response['meta_description'] )
+									? sanitize_textarea_field( $response['meta_description'] ) : null,
+			'focus_keyword'    => isset( $response['focus_keyword'] ) && '' !== trim( (string) $response['focus_keyword'] )
+									? sanitize_text_field( $response['focus_keyword'] ) : null,
+			'edits'            => $edits,
+		);
+	}
+
+	/**
+	 * @return array{ok: bool, content: string, reason: string}
+	 */
+	private function apply_single_edit( string $content, array $edit ): array {
+		$type = $edit['type'] ?? '';
+		$repl = (string) ( $edit['replace_text'] ?? '' );
+
+		switch ( $type ) {
+			case 'replace_text':
+				$find = (string) ( $edit['find_text'] ?? '' );
+				if ( '' === $find || strpos( $content, $find ) === false ) {
+					return array(
+						'ok'      => false,
+						'content' => $content,
+						'reason'  => 'find_text not found',
+					);
+				}
+				$pos = strpos( $content, $find );
+				$new = substr( $content, 0, $pos ) . $repl . substr( $content, $pos + strlen( $find ) );
+				return array(
+					'ok'      => true,
+					'content' => $new,
+					'reason'  => '',
+				);
+
+			case 'append_paragraph':
+				if ( '' === trim( $repl ) ) {
+					return array(
+						'ok'      => false,
+						'content' => $content,
+						'reason'  => 'empty paragraph',
+					);
+				}
+				return array(
+					'ok'      => true,
+					'content' => $content . "\n\n" . wp_kses_post( wpautop( $repl ) ),
+					'reason'  => '',
+				);
+
+			case 'prepend_paragraph':
+				if ( '' === trim( $repl ) ) {
+					return array(
+						'ok'      => false,
+						'content' => $content,
+						'reason'  => 'empty paragraph',
+					);
+				}
+				return array(
+					'ok'      => true,
+					'content' => wp_kses_post( wpautop( $repl ) ) . "\n\n" . $content,
+					'reason'  => '',
+				);
+		}
+
+		return array(
+			'ok'      => false,
+			'content' => $content,
+			'reason'  => 'unknown edit type',
+		);
+	}
+
+	private function estimate_cost( ?array $usage ): float {
+		if ( ! is_array( $usage ) ) {
+			return 0.0;
+		}
+		$in  = (int) ( $usage['input_tokens'] ?? 0 );
+		$out = (int) ( $usage['output_tokens'] ?? 0 );
+		return round( ( $in * 0.000003 ) + ( $out * 0.000015 ), 4 );
+	}
 }

--- a/includes/class-background-processor.php
+++ b/includes/class-background-processor.php
@@ -8,96 +8,98 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Background_Processor {
 
-    private const HOOK = 'swps_process_topic';
+	private const HOOK = 'swps_process_topic';
 
-    public function __construct() {
-        add_action( self::HOOK, [ $this, 'process_topic' ] );
-    }
+	public function __construct() {
+		add_action( self::HOOK, array( $this, 'process_topic' ) );
+	}
 
-    /**
-     * Schedule a topic for background generation.
-     *
-     * @param int $topic_id Topic post ID.
-     * @param int $delay    Delay in seconds from now.
-     */
-    public function schedule_generation( int $topic_id, int $delay = 0 ): void {
-        $timestamp = time() + $delay;
+	/**
+	 * Schedule a topic for background generation.
+	 *
+	 * @param int $topic_id Topic post ID.
+	 * @param int $delay    Delay in seconds from now.
+	 */
+	public function schedule_generation( int $topic_id, int $delay = 0 ): void {
+		$timestamp = time() + $delay;
 
-        if ( $this->has_action_scheduler() ) {
-            as_schedule_single_action( $timestamp, self::HOOK, [ 'topic_id' => $topic_id ] );
-        } else {
-            wp_schedule_single_event( $timestamp, self::HOOK, [ $topic_id ] );
-        }
-    }
+		if ( $this->has_action_scheduler() ) {
+			as_schedule_single_action( $timestamp, self::HOOK, array( 'topic_id' => $topic_id ) );
+		} else {
+			wp_schedule_single_event( $timestamp, self::HOOK, array( $topic_id ) );
+		}
+	}
 
-    /**
-     * Process a single topic (callback for scheduled action).
-     *
-     * @param int $topic_id Topic post ID.
-     */
-    public function process_topic( int $topic_id ): void {
-        $topic = get_post( $topic_id );
+	/**
+	 * Process a single topic (callback for scheduled action).
+	 *
+	 * @param int $topic_id Topic post ID.
+	 */
+	public function process_topic( int $topic_id ): void {
+		$topic = get_post( $topic_id );
 
-        if ( ! $topic || $topic->post_type !== SWPS_Topic_Queue::POST_TYPE ) {
-            return;
-        }
+		if ( ! $topic || $topic->post_type !== SWPS_Topic_Queue::POST_TYPE ) {
+			return;
+		}
 
-        $queue = new SWPS_Topic_Queue();
-        $queue->update_status( $topic_id, 'generating' );
+		$queue = new SWPS_Topic_Queue();
+		$queue->update_status( $topic_id, 'generating' );
 
-        // Get the plugin instance and generator.
-        $plugin   = stratawp_seo();
-        $template = get_post_meta( $topic_id, '_swps_template', true ) ?: 'auto';
+		// Get the plugin instance and generator.
+		$plugin   = stratawp_seo();
+		$template = get_post_meta( $topic_id, '_swps_template', true ) ?: 'auto';
 
-        $result = $plugin->generator->generate_post( $topic->post_title, $template );
+		$result = $plugin->generator->generate_post( $topic->post_title, $template );
 
-        if ( is_wp_error( $result ) ) {
-            $queue->update_status( $topic_id, 'failed', $result->get_error_message() );
-            return;
-        }
+		if ( is_wp_error( $result ) ) {
+			$queue->update_status( $topic_id, 'failed', $result->get_error_message() );
+			return;
+		}
 
-        $queue->update_status( $topic_id, 'published', '', $result['post_id'] );
-    }
+		$queue->update_status( $topic_id, 'published', '', $result['post_id'] );
+	}
 
-    /**
-     * Schedule multiple topics with staggered delays.
-     *
-     * @param array $topic_ids Array of topic post IDs.
-     * @param int   $interval  Seconds between each generation.
-     */
-    public function schedule_batch( array $topic_ids, int $interval = 5 ): void {
-        foreach ( $topic_ids as $index => $topic_id ) {
-            $this->schedule_generation( $topic_id, $index * $interval );
-        }
-    }
+	/**
+	 * Schedule multiple topics with staggered delays.
+	 *
+	 * @param array $topic_ids Array of topic post IDs.
+	 * @param int   $interval  Seconds between each generation.
+	 */
+	public function schedule_batch( array $topic_ids, int $interval = 5 ): void {
+		foreach ( $topic_ids as $index => $topic_id ) {
+			$this->schedule_generation( $topic_id, $index * $interval );
+		}
+	}
 
-    /**
-     * Check if any topics are currently being processed.
-     *
-     * @return bool True if processing.
-     */
-    public function is_processing(): bool {
-        $generating = get_posts( [
-            'post_type'      => SWPS_Topic_Queue::POST_TYPE,
-            'post_status'    => 'generating',
-            'posts_per_page' => 1,
-            'fields'         => 'ids',
-        ] );
+	/**
+	 * Check if any topics are currently being processed.
+	 *
+	 * @return bool True if processing.
+	 */
+	public function is_processing(): bool {
+		$generating = get_posts(
+			array(
+				'post_type'      => SWPS_Topic_Queue::POST_TYPE,
+				'post_status'    => 'generating',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+			)
+		);
 
-        return ! empty( $generating );
-    }
+		return ! empty( $generating );
+	}
 
-    /**
-     * Check if Action Scheduler is available.
-     *
-     * @return bool
-     */
-    private function has_action_scheduler(): bool {
-        return function_exists( 'as_schedule_single_action' );
-    }
+	/**
+	 * Check if Action Scheduler is available.
+	 *
+	 * @return bool
+	 */
+	private function has_action_scheduler(): bool {
+		return function_exists( 'as_schedule_single_action' );
+	}
 }

--- a/includes/class-backlinks.php
+++ b/includes/class-backlinks.php
@@ -18,52 +18,52 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Backlinks {
 
-    public const TABLE         = 'swps_backlinks';
-    public const CRON_HOOK     = 'swps_backlinks_daily_verify';
-    public const HTTP_TIMEOUT  = 12;
-    public const VERIFY_BATCH  = 25;
-    public const DB_VERSION    = '1';
-    public const OPT_DB_VER    = 'swps_backlinks_db_version';
+	public const TABLE        = 'swps_backlinks';
+	public const CRON_HOOK    = 'swps_backlinks_daily_verify';
+	public const HTTP_TIMEOUT = 12;
+	public const VERIFY_BATCH = 25;
+	public const DB_VERSION   = '1';
+	public const OPT_DB_VER   = 'swps_backlinks_db_version';
 
-    public function __construct() {
-        // Runtime upgrade: ensure the table exists on existing installs that
-        // didn't run the activation hook (i.e. plugin updated, not reactivated).
-        if ( self::DB_VERSION !== get_option( self::OPT_DB_VER ) ) {
-            self::create_tables();
-            update_option( self::OPT_DB_VER, self::DB_VERSION );
-        }
+	public function __construct() {
+		// Runtime upgrade: ensure the table exists on existing installs that
+		// didn't run the activation hook (i.e. plugin updated, not reactivated).
+		if ( self::DB_VERSION !== get_option( self::OPT_DB_VER ) ) {
+			self::create_tables();
+			update_option( self::OPT_DB_VER, self::DB_VERSION );
+		}
 
-        add_action( 'admin_menu',            [ $this, 'register_menu' ], 20 );
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
-        add_action( 'init',                  [ $this, 'maybe_schedule_cron' ] );
+		add_action( 'admin_menu', array( $this, 'register_menu' ), 20 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'init', array( $this, 'maybe_schedule_cron' ) );
 
-        add_action( 'wp_ajax_swps_backlink_save',     [ $this, 'ajax_save' ] );
-        add_action( 'wp_ajax_swps_backlink_delete',   [ $this, 'ajax_delete' ] );
-        add_action( 'wp_ajax_swps_backlink_verify',   [ $this, 'ajax_verify' ] );
-        add_action( 'wp_ajax_swps_backlink_import',   [ $this, 'ajax_import' ] );
-        add_action( 'wp_ajax_swps_backlink_export',   [ $this, 'ajax_export' ] );
+		add_action( 'wp_ajax_swps_backlink_save', array( $this, 'ajax_save' ) );
+		add_action( 'wp_ajax_swps_backlink_delete', array( $this, 'ajax_delete' ) );
+		add_action( 'wp_ajax_swps_backlink_verify', array( $this, 'ajax_verify' ) );
+		add_action( 'wp_ajax_swps_backlink_import', array( $this, 'ajax_import' ) );
+		add_action( 'wp_ajax_swps_backlink_export', array( $this, 'ajax_export' ) );
 
-        add_action( self::CRON_HOOK, [ $this, 'cron_verify_all' ] );
-    }
+		add_action( self::CRON_HOOK, array( $this, 'cron_verify_all' ) );
+	}
 
-    // ---------- Schema ----------
+	// ---------- Schema ----------
 
-    public static function table_name(): string {
-        global $wpdb;
-        return $wpdb->prefix . self::TABLE;
-    }
+	public static function table_name(): string {
+		global $wpdb;
+		return $wpdb->prefix . self::TABLE;
+	}
 
-    public static function create_tables(): void {
-        global $wpdb;
-        $table   = self::table_name();
-        $charset = $wpdb->get_charset_collate();
+	public static function create_tables(): void {
+		global $wpdb;
+		$table   = self::table_name();
+		$charset = $wpdb->get_charset_collate();
 
-        $sql = "CREATE TABLE {$table} (
+		$sql = "CREATE TABLE {$table} (
             id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
             source_url   VARCHAR(2048) NOT NULL,
             source_host  VARCHAR(255) NOT NULL DEFAULT '',
@@ -82,511 +82,568 @@ class SWPS_Backlinks {
             KEY last_checked (last_checked)
         ) {$charset};";
 
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        dbDelta( $sql );
-    }
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
 
-    public static function schedule_cron(): void {
-        if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-            wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', self::CRON_HOOK );
-        }
-    }
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', self::CRON_HOOK );
+		}
+	}
 
-    public static function unschedule_cron(): void {
-        $ts = wp_next_scheduled( self::CRON_HOOK );
-        if ( $ts ) {
-            wp_unschedule_event( $ts, self::CRON_HOOK );
-        }
-        wp_unschedule_hook( self::CRON_HOOK );
-    }
+	public static function unschedule_cron(): void {
+		$ts = wp_next_scheduled( self::CRON_HOOK );
+		if ( $ts ) {
+			wp_unschedule_event( $ts, self::CRON_HOOK );
+		}
+		wp_unschedule_hook( self::CRON_HOOK );
+	}
 
-    public function maybe_schedule_cron(): void {
-        self::schedule_cron();
-    }
+	public function maybe_schedule_cron(): void {
+		self::schedule_cron();
+	}
 
-    // ---------- Admin menu / assets ----------
+	// ---------- Admin menu / assets ----------
 
-    public function register_menu(): void {
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Backlinks', 'stratawp-seo' ),
-            __( 'Backlinks', 'stratawp-seo' ),
-            'manage_options',
-            'swps-backlinks',
-            [ $this, 'render_page' ]
-        );
-    }
+	public function register_menu(): void {
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Backlinks', 'stratawp-seo' ),
+			__( 'Backlinks', 'stratawp-seo' ),
+			'manage_options',
+			'swps-backlinks',
+			array( $this, 'render_page' )
+		);
+	}
 
-    public function render_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
-        }
-        require SWPS_PLUGIN_DIR . 'templates/backlinks-page.php';
-    }
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
+		}
+		require SWPS_PLUGIN_DIR . 'templates/backlinks-page.php';
+	}
 
-    public function enqueue_assets( string $hook ): void {
-        if ( 'stratawp-seo_page_swps-backlinks' !== $hook ) {
-            return;
-        }
-        wp_enqueue_style(
-            'swps-page-backlinks',
-            SWPS_PLUGIN_URL . 'admin/css/pages/backlinks.css',
-            [ 'swps-tokens', 'swps-components', 'swps-templates' ],
-            SWPS_VERSION
-        );
-        wp_enqueue_script(
-            'swps-backlinks',
-            SWPS_PLUGIN_URL . 'admin/js/backlinks.js',
-            [ 'jquery' ],
-            SWPS_VERSION,
-            true
-        );
-        wp_localize_script( 'swps-backlinks', 'swpsBacklinks', [
-            'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-            'nonce'   => wp_create_nonce( 'swps_nonce' ),
-            'i18n'    => [
-                'verifying'    => __( 'Verifying...', 'stratawp-seo' ),
-                'verifyingAll' => __( 'Verifying all backlinks...', 'stratawp-seo' ),
-                'saving'       => __( 'Saving...', 'stratawp-seo' ),
-                'importing'    => __( 'Importing...', 'stratawp-seo' ),
-                'failed'       => __( 'Request failed.', 'stratawp-seo' ),
-                'invalidUrl'   => __( 'Please enter a valid http(s) URL.', 'stratawp-seo' ),
-                'confirmDelete'=> __( 'Delete this backlink?', 'stratawp-seo' ),
-                'imported'     => __( 'Imported %d backlinks.', 'stratawp-seo' ),
-                'noNewLinks'   => __( 'No new links found in import.', 'stratawp-seo' ),
-            ],
-        ] );
-    }
+	public function enqueue_assets( string $hook ): void {
+		if ( 'stratawp-seo_page_swps-backlinks' !== $hook ) {
+			return;
+		}
+		wp_enqueue_style(
+			'swps-page-backlinks',
+			SWPS_PLUGIN_URL . 'admin/css/pages/backlinks.css',
+			array( 'swps-tokens', 'swps-components', 'swps-templates' ),
+			SWPS_VERSION
+		);
+		wp_enqueue_script(
+			'swps-backlinks',
+			SWPS_PLUGIN_URL . 'admin/js/backlinks.js',
+			array( 'jquery' ),
+			SWPS_VERSION,
+			true
+		);
+		wp_localize_script(
+			'swps-backlinks',
+			'swpsBacklinks',
+			array(
+				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'nonce'   => wp_create_nonce( 'swps_nonce' ),
+				'i18n'    => array(
+					'verifying'     => __( 'Verifying...', 'stratawp-seo' ),
+					'verifyingAll'  => __( 'Verifying all backlinks...', 'stratawp-seo' ),
+					'saving'        => __( 'Saving...', 'stratawp-seo' ),
+					'importing'     => __( 'Importing...', 'stratawp-seo' ),
+					'failed'        => __( 'Request failed.', 'stratawp-seo' ),
+					'invalidUrl'    => __( 'Please enter a valid http(s) URL.', 'stratawp-seo' ),
+					'confirmDelete' => __( 'Delete this backlink?', 'stratawp-seo' ),
+					'imported'      => __( 'Imported %d backlinks.', 'stratawp-seo' ),
+					'noNewLinks'    => __( 'No new links found in import.', 'stratawp-seo' ),
+				),
+			)
+		);
+	}
 
-    // ---------- AJAX ----------
+	// ---------- AJAX ----------
 
-    public function ajax_save(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
+	public function ajax_save(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
 
-        $id          = isset( $_POST['id'] )          ? (int) $_POST['id'] : 0;
-        $source      = isset( $_POST['source_url'] )  ? esc_url_raw( wp_unslash( $_POST['source_url'] ) ) : '';
-        $target      = isset( $_POST['target_url'] )  ? esc_url_raw( wp_unslash( $_POST['target_url'] ) ) : '';
-        $anchor      = isset( $_POST['anchor_text'] ) ? sanitize_text_field( wp_unslash( $_POST['anchor_text'] ) ) : '';
+		$id     = isset( $_POST['id'] ) ? (int) $_POST['id'] : 0;
+		$source = isset( $_POST['source_url'] ) ? esc_url_raw( wp_unslash( $_POST['source_url'] ) ) : '';
+		$target = isset( $_POST['target_url'] ) ? esc_url_raw( wp_unslash( $_POST['target_url'] ) ) : '';
+		$anchor = isset( $_POST['anchor_text'] ) ? sanitize_text_field( wp_unslash( $_POST['anchor_text'] ) ) : '';
 
-        if ( '' === $source || ! preg_match( '#^https?://#i', $source ) ) {
-            wp_send_json_error( [ 'message' => __( 'Please enter a valid http(s) URL.', 'stratawp-seo' ) ] );
-        }
+		if ( '' === $source || ! preg_match( '#^https?://#i', $source ) ) {
+			wp_send_json_error( array( 'message' => __( 'Please enter a valid http(s) URL.', 'stratawp-seo' ) ) );
+		}
 
-        if ( $id > 0 ) {
-            $this->update_row( $id, [
-                'source_url'  => $source,
-                'source_host' => $this->host_of( $source ),
-                'target_url'  => $target,
-                'anchor_text' => $anchor,
-            ] );
-        } else {
-            $id = $this->insert_row( [
-                'source_url'  => $source,
-                'source_host' => $this->host_of( $source ),
-                'target_url'  => $target,
-                'anchor_text' => $anchor,
-                'status'      => 'pending',
-                'created_at'  => current_time( 'mysql' ),
-            ] );
-            if ( ! $id ) {
-                wp_send_json_error( [ 'message' => __( 'Save failed.', 'stratawp-seo' ) ] );
-            }
-        }
+		if ( $id > 0 ) {
+			$this->update_row(
+				$id,
+				array(
+					'source_url'  => $source,
+					'source_host' => $this->host_of( $source ),
+					'target_url'  => $target,
+					'anchor_text' => $anchor,
+				)
+			);
+		} else {
+			$id = $this->insert_row(
+				array(
+					'source_url'  => $source,
+					'source_host' => $this->host_of( $source ),
+					'target_url'  => $target,
+					'anchor_text' => $anchor,
+					'status'      => 'pending',
+					'created_at'  => current_time( 'mysql' ),
+				)
+			);
+			if ( ! $id ) {
+				wp_send_json_error( array( 'message' => __( 'Save failed.', 'stratawp-seo' ) ) );
+			}
+		}
 
-        // Verify immediately so the row shows fresh data.
-        $this->verify_one( $id );
-        wp_send_json_success( [ 'row' => $this->get_row( $id ), 'stats' => $this->get_stats() ] );
-    }
+		// Verify immediately so the row shows fresh data.
+		$this->verify_one( $id );
+		wp_send_json_success(
+			array(
+				'row'   => $this->get_row( $id ),
+				'stats' => $this->get_stats(),
+			)
+		);
+	}
 
-    public function ajax_delete(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-        $id = isset( $_POST['id'] ) ? (int) $_POST['id'] : 0;
-        if ( $id <= 0 ) {
-            wp_send_json_error( [ 'message' => __( 'Invalid id.', 'stratawp-seo' ) ] );
-        }
-        global $wpdb;
-        $wpdb->delete( self::table_name(), [ 'id' => $id ], [ '%d' ] ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-        wp_send_json_success( [ 'stats' => $this->get_stats() ] );
-    }
+	public function ajax_delete(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		$id = isset( $_POST['id'] ) ? (int) $_POST['id'] : 0;
+		if ( $id <= 0 ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid id.', 'stratawp-seo' ) ) );
+		}
+		global $wpdb;
+		$wpdb->delete( self::table_name(), array( 'id' => $id ), array( '%d' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		wp_send_json_success( array( 'stats' => $this->get_stats() ) );
+	}
 
-    public function ajax_verify(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
+	public function ajax_verify(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
 
-        $id = isset( $_POST['id'] ) ? (int) $_POST['id'] : 0;
-        if ( $id > 0 ) {
-            $this->verify_one( $id );
-            wp_send_json_success( [ 'row' => $this->get_row( $id ), 'stats' => $this->get_stats() ] );
-        }
+		$id = isset( $_POST['id'] ) ? (int) $_POST['id'] : 0;
+		if ( $id > 0 ) {
+			$this->verify_one( $id );
+			wp_send_json_success(
+				array(
+					'row'   => $this->get_row( $id ),
+					'stats' => $this->get_stats(),
+				)
+			);
+		}
 
-        if ( function_exists( 'set_time_limit' ) ) {
-            @set_time_limit( 120 );
-        }
-        $offset = isset( $_POST['offset'] ) ? max( 0, (int) $_POST['offset'] ) : 0;
-        $batch  = $this->get_ids_for_verify( $offset, self::VERIFY_BATCH );
-        foreach ( $batch as $row_id ) {
-            $this->verify_one( (int) $row_id );
-        }
-        $remaining = max( 0, $this->count_total() - ( $offset + count( $batch ) ) );
-        wp_send_json_success( [
-            'processed' => count( $batch ),
-            'next'      => $offset + count( $batch ),
-            'remaining' => $remaining,
-            'stats'     => $this->get_stats(),
-        ] );
-    }
+		if ( function_exists( 'set_time_limit' ) ) {
+			@set_time_limit( 120 );
+		}
+		$offset = isset( $_POST['offset'] ) ? max( 0, (int) $_POST['offset'] ) : 0;
+		$batch  = $this->get_ids_for_verify( $offset, self::VERIFY_BATCH );
+		foreach ( $batch as $row_id ) {
+			$this->verify_one( (int) $row_id );
+		}
+		$remaining = max( 0, $this->count_total() - ( $offset + count( $batch ) ) );
+		wp_send_json_success(
+			array(
+				'processed' => count( $batch ),
+				'next'      => $offset + count( $batch ),
+				'remaining' => $remaining,
+				'stats'     => $this->get_stats(),
+			)
+		);
+	}
 
-    public function ajax_import(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-        $raw = isset( $_POST['csv'] ) ? (string) wp_unslash( $_POST['csv'] ) : '';
-        if ( '' === trim( $raw ) ) {
-            wp_send_json_error( [ 'message' => __( 'Nothing to import.', 'stratawp-seo' ) ] );
-        }
+	public function ajax_import(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		$raw = isset( $_POST['csv'] ) ? (string) wp_unslash( $_POST['csv'] ) : '';
+		if ( '' === trim( $raw ) ) {
+			wp_send_json_error( array( 'message' => __( 'Nothing to import.', 'stratawp-seo' ) ) );
+		}
 
-        $imported = $this->import_csv( $raw );
-        wp_send_json_success( [
-            'imported' => $imported,
-            'stats'    => $this->get_stats(),
-        ] );
-    }
+		$imported = $this->import_csv( $raw );
+		wp_send_json_success(
+			array(
+				'imported' => $imported,
+				'stats'    => $this->get_stats(),
+			)
+		);
+	}
 
-    public function ajax_export(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Insufficient permissions.', 'stratawp-seo' ) );
-        }
-        $rows = $this->get_all();
-        nocache_headers();
-        header( 'Content-Type: text/csv; charset=utf-8' );
-        header( 'Content-Disposition: attachment; filename="stratawp-backlinks-' . gmdate( 'Y-m-d' ) . '.csv"' );
+	public function ajax_export(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Insufficient permissions.', 'stratawp-seo' ) );
+		}
+		$rows = $this->get_all();
+		nocache_headers();
+		header( 'Content-Type: text/csv; charset=utf-8' );
+		header( 'Content-Disposition: attachment; filename="stratawp-backlinks-' . gmdate( 'Y-m-d' ) . '.csv"' );
 
-        $out = fopen( 'php://output', 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-        fputcsv( $out, [ 'source_url', 'target_url', 'anchor_text', 'status', 'http_status', 'first_seen', 'last_seen', 'last_checked' ] );
-        foreach ( $rows as $r ) {
-            fputcsv( $out, [
-                $r['source_url'],
-                $r['target_url'],
-                $r['anchor_text'],
-                $r['status'],
-                $r['http_status'],
-                $r['first_seen'],
-                $r['last_seen'],
-                $r['last_checked'],
-            ] );
-        }
-        fclose( $out ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
-        exit;
-    }
+		$out = fopen( 'php://output', 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
+		fputcsv( $out, array( 'source_url', 'target_url', 'anchor_text', 'status', 'http_status', 'first_seen', 'last_seen', 'last_checked' ) );
+		foreach ( $rows as $r ) {
+			fputcsv(
+				$out,
+				array(
+					$r['source_url'],
+					$r['target_url'],
+					$r['anchor_text'],
+					$r['status'],
+					$r['http_status'],
+					$r['first_seen'],
+					$r['last_seen'],
+					$r['last_checked'],
+				)
+			);
+		}
+		fclose( $out ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+		exit;
+	}
 
-    // ---------- CSV ----------
+	// ---------- CSV ----------
 
-    /**
-     * Import CSV. Accepts either:
-     *   - GSC "Top linking sites" export (single column of source domains)
-     *   - Generic source_url[,target_url[,anchor_text]] CSV
-     *   - One URL per line
-     *
-     * Returns count of newly inserted rows. Existing source_urls are skipped.
-     */
-    public function import_csv( string $raw ): int {
-        $raw   = str_replace( [ "\r\n", "\r" ], "\n", $raw );
-        $lines = array_filter( array_map( 'trim', explode( "\n", $raw ) ) );
+	/**
+	 * Import CSV. Accepts either:
+	 *   - GSC "Top linking sites" export (single column of source domains)
+	 *   - Generic source_url[,target_url[,anchor_text]] CSV
+	 *   - One URL per line
+	 *
+	 * Returns count of newly inserted rows. Existing source_urls are skipped.
+	 */
+	public function import_csv( string $raw ): int {
+		$raw   = str_replace( array( "\r\n", "\r" ), "\n", $raw );
+		$lines = array_filter( array_map( 'trim', explode( "\n", $raw ) ) );
 
-        $existing = array_flip( $this->get_all_source_urls() );
-        $count    = 0;
+		$existing = array_flip( $this->get_all_source_urls() );
+		$count    = 0;
 
-        foreach ( $lines as $i => $line ) {
-            // Skip header rows (first non-URL row).
-            if ( 0 === $i && false === stripos( $line, 'http' ) ) {
-                continue;
-            }
-            $cols = str_getcsv( $line );
-            if ( empty( $cols ) ) {
-                continue;
-            }
-            $source = trim( (string) $cols[0] );
-            if ( '' === $source ) {
-                continue;
-            }
-            // Bare-domain rows from GSC — promote to https://.
-            if ( ! preg_match( '#^https?://#i', $source ) ) {
-                if ( preg_match( '#^[a-z0-9.-]+\.[a-z]{2,}$#i', $source ) ) {
-                    $source = 'https://' . ltrim( $source, '/' );
-                } else {
-                    continue;
-                }
-            }
-            if ( isset( $existing[ $source ] ) ) {
-                continue;
-            }
-            $target = isset( $cols[1] ) ? trim( (string) $cols[1] ) : '';
-            $anchor = isset( $cols[2] ) ? trim( (string) $cols[2] ) : '';
+		foreach ( $lines as $i => $line ) {
+			// Skip header rows (first non-URL row).
+			if ( 0 === $i && false === stripos( $line, 'http' ) ) {
+				continue;
+			}
+			$cols = str_getcsv( $line );
+			if ( empty( $cols ) ) {
+				continue;
+			}
+			$source = trim( (string) $cols[0] );
+			if ( '' === $source ) {
+				continue;
+			}
+			// Bare-domain rows from GSC — promote to https://.
+			if ( ! preg_match( '#^https?://#i', $source ) ) {
+				if ( preg_match( '#^[a-z0-9.-]+\.[a-z]{2,}$#i', $source ) ) {
+					$source = 'https://' . ltrim( $source, '/' );
+				} else {
+					continue;
+				}
+			}
+			if ( isset( $existing[ $source ] ) ) {
+				continue;
+			}
+			$target = isset( $cols[1] ) ? trim( (string) $cols[1] ) : '';
+			$anchor = isset( $cols[2] ) ? trim( (string) $cols[2] ) : '';
 
-            $id = $this->insert_row( [
-                'source_url'  => esc_url_raw( $source ),
-                'source_host' => $this->host_of( $source ),
-                'target_url'  => $target ? esc_url_raw( $target ) : '',
-                'anchor_text' => sanitize_text_field( $anchor ),
-                'status'      => 'pending',
-                'created_at'  => current_time( 'mysql' ),
-            ] );
-            if ( $id ) {
-                $existing[ $source ] = true;
-                $count++;
-            }
-        }
-        return $count;
-    }
+			$id = $this->insert_row(
+				array(
+					'source_url'  => esc_url_raw( $source ),
+					'source_host' => $this->host_of( $source ),
+					'target_url'  => $target ? esc_url_raw( $target ) : '',
+					'anchor_text' => sanitize_text_field( $anchor ),
+					'status'      => 'pending',
+					'created_at'  => current_time( 'mysql' ),
+				)
+			);
+			if ( $id ) {
+				$existing[ $source ] = true;
+				++$count;
+			}
+		}
+		return $count;
+	}
 
-    // ---------- Cron ----------
+	// ---------- Cron ----------
 
-    public function cron_verify_all(): void {
-        if ( function_exists( 'set_time_limit' ) ) {
-            @set_time_limit( 0 );
-        }
-        $offset = 0;
-        do {
-            $batch = $this->get_ids_for_verify( $offset, self::VERIFY_BATCH );
-            foreach ( $batch as $id ) {
-                $this->verify_one( (int) $id );
-                usleep( 250000 ); // 0.25s — be polite.
-            }
-            $offset += count( $batch );
-        } while ( ! empty( $batch ) );
-    }
+	public function cron_verify_all(): void {
+		if ( function_exists( 'set_time_limit' ) ) {
+			@set_time_limit( 0 );
+		}
+		$offset = 0;
+		do {
+			$batch = $this->get_ids_for_verify( $offset, self::VERIFY_BATCH );
+			foreach ( $batch as $id ) {
+				$this->verify_one( (int) $id );
+				usleep( 250000 ); // 0.25s — be polite.
+			}
+			$offset += count( $batch );
+		} while ( ! empty( $batch ) );
+	}
 
-    // ---------- Verify ----------
+	// ---------- Verify ----------
 
-    public function verify_one( int $id ): array {
-        $row = $this->get_row( $id );
-        if ( ! $row ) {
-            return [];
-        }
+	public function verify_one( int $id ): array {
+		$row = $this->get_row( $id );
+		if ( ! $row ) {
+			return array();
+		}
 
-        $source = (string) $row['source_url'];
-        $now    = current_time( 'mysql' );
-        $resp   = wp_remote_get( $source, [
-            'timeout'     => self::HTTP_TIMEOUT,
-            'redirection' => 4,
-            'user-agent'  => 'StrataWP-SEO/' . SWPS_VERSION . ' (+https://stratawpseo.com; backlink verifier)',
-            'headers'     => [ 'Accept' => 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.8' ],
-        ] );
+		$source = (string) $row['source_url'];
+		$now    = current_time( 'mysql' );
+		$resp   = wp_remote_get(
+			$source,
+			array(
+				'timeout'     => self::HTTP_TIMEOUT,
+				'redirection' => 4,
+				'user-agent'  => 'StrataWP-SEO/' . SWPS_VERSION . ' (+https://stratawpseo.com; backlink verifier)',
+				'headers'     => array( 'Accept' => 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.8' ),
+			)
+		);
 
-        $update = [
-            'last_checked' => $now,
-            'http_status'  => 0,
-            'status'       => 'broken',
-            'anchor_text'  => $row['anchor_text'],
-            'target_url'   => $row['target_url'],
-        ];
+		$update = array(
+			'last_checked' => $now,
+			'http_status'  => 0,
+			'status'       => 'broken',
+			'anchor_text'  => $row['anchor_text'],
+			'target_url'   => $row['target_url'],
+		);
 
-        if ( is_wp_error( $resp ) ) {
-            $update['notes'] = mb_substr( (string) $resp->get_error_message(), 0, 200 );
-        } else {
-            $code = (int) wp_remote_retrieve_response_code( $resp );
-            $update['http_status'] = $code;
-            if ( $code < 200 || $code >= 400 ) {
-                $update['notes'] = sprintf( /* translators: %d HTTP status */ __( 'HTTP %d', 'stratawp-seo' ), $code );
-            } else {
-                $body  = (string) wp_remote_retrieve_body( $resp );
-                $found = $this->find_link( $body );
-                if ( $found ) {
-                    $update['status']      = 'live';
-                    $update['anchor_text'] = '' !== ( $found['anchor'] ?? '' ) ? $found['anchor'] : $row['anchor_text'];
-                    $update['target_url']  = '' !== ( $found['href'] ?? '' )   ? $found['href']   : $row['target_url'];
-                    $update['notes']       = '';
-                    if ( empty( $row['first_seen'] ) ) {
-                        $update['first_seen'] = $now;
-                    }
-                    $update['last_seen'] = $now;
-                } else {
-                    $update['status'] = 'lost';
-                    $update['notes']  = __( 'Page loaded but contained no link to this site.', 'stratawp-seo' );
-                }
-            }
-        }
+		if ( is_wp_error( $resp ) ) {
+			$update['notes'] = mb_substr( (string) $resp->get_error_message(), 0, 200 );
+		} else {
+			$code                  = (int) wp_remote_retrieve_response_code( $resp );
+			$update['http_status'] = $code;
+			if ( $code < 200 || $code >= 400 ) {
+				$update['notes'] = sprintf( /* translators: %d HTTP status */ __( 'HTTP %d', 'stratawp-seo' ), $code );
+			} else {
+				$body  = (string) wp_remote_retrieve_body( $resp );
+				$found = $this->find_link( $body );
+				if ( $found ) {
+					$update['status']      = 'live';
+					$update['anchor_text'] = '' !== ( $found['anchor'] ?? '' ) ? $found['anchor'] : $row['anchor_text'];
+					$update['target_url']  = '' !== ( $found['href'] ?? '' ) ? $found['href'] : $row['target_url'];
+					$update['notes']       = '';
+					if ( empty( $row['first_seen'] ) ) {
+						$update['first_seen'] = $now;
+					}
+					$update['last_seen'] = $now;
+				} else {
+					$update['status'] = 'lost';
+					$update['notes']  = __( 'Page loaded but contained no link to this site.', 'stratawp-seo' );
+				}
+			}
+		}
 
-        $this->update_row( $id, $update );
-        return $this->get_row( $id );
-    }
+		$this->update_row( $id, $update );
+		return $this->get_row( $id );
+	}
 
-    /**
-     * Look for any anchor in $html whose href contains the home host. Returns
-     * the first match's href + anchor text, or null.
-     *
-     * @return array{href:string, anchor:string}|null
-     */
-    private function find_link( string $html ): ?array {
-        $home_host = $this->home_host();
-        if ( '' === $home_host ) {
-            return null;
-        }
+	/**
+	 * Look for any anchor in $html whose href contains the home host. Returns
+	 * the first match's href + anchor text, or null.
+	 *
+	 * @return array{href:string, anchor:string}|null
+	 */
+	private function find_link( string $html ): ?array {
+		$home_host = $this->home_host();
+		if ( '' === $home_host ) {
+			return null;
+		}
 
-        if ( ! preg_match_all( '#<a\b([^>]*?)href\s*=\s*["\']([^"\']+)["\']([^>]*)>(.*?)</a>#is', $html, $m, PREG_SET_ORDER ) ) {
-            return null;
-        }
+		if ( ! preg_match_all( '#<a\b([^>]*?)href\s*=\s*["\']([^"\']+)["\']([^>]*)>(.*?)</a>#is', $html, $m, PREG_SET_ORDER ) ) {
+			return null;
+		}
 
-        foreach ( $m as $match ) {
-            $href = trim( $match[2] );
-            if ( '' === $href ) {
-                continue;
-            }
-            $href_host = $this->host_of( $href );
-            if ( '' !== $href_host && $this->hosts_match( $href_host, $home_host ) ) {
-                $anchor = trim( wp_strip_all_tags( $match[4] ) );
-                if ( mb_strlen( $anchor ) > 200 ) {
-                    $anchor = mb_substr( $anchor, 0, 200 );
-                }
-                return [ 'href' => $href, 'anchor' => $anchor ];
-            }
-        }
-        return null;
-    }
+		foreach ( $m as $match ) {
+			$href = trim( $match[2] );
+			if ( '' === $href ) {
+				continue;
+			}
+			$href_host = $this->host_of( $href );
+			if ( '' !== $href_host && $this->hosts_match( $href_host, $home_host ) ) {
+				$anchor = trim( wp_strip_all_tags( $match[4] ) );
+				if ( mb_strlen( $anchor ) > 200 ) {
+					$anchor = mb_substr( $anchor, 0, 200 );
+				}
+				return array(
+					'href'   => $href,
+					'anchor' => $anchor,
+				);
+			}
+		}
+		return null;
+	}
 
-    private function hosts_match( string $a, string $b ): bool {
-        $a = strtolower( preg_replace( '/^www\./i', '', $a ) ?: $a );
-        $b = strtolower( preg_replace( '/^www\./i', '', $b ) ?: $b );
-        return $a === $b;
-    }
+	private function hosts_match( string $a, string $b ): bool {
+		$a = strtolower( preg_replace( '/^www\./i', '', $a ) ?: $a );
+		$b = strtolower( preg_replace( '/^www\./i', '', $b ) ?: $b );
+		return $a === $b;
+	}
 
-    private function host_of( string $url ): string {
-        $h = wp_parse_url( $url, PHP_URL_HOST );
-        return is_string( $h ) ? strtolower( $h ) : '';
-    }
+	private function host_of( string $url ): string {
+		$h = wp_parse_url( $url, PHP_URL_HOST );
+		return is_string( $h ) ? strtolower( $h ) : '';
+	}
 
-    private function home_host(): string {
-        return $this->host_of( home_url() );
-    }
+	private function home_host(): string {
+		return $this->host_of( home_url() );
+	}
 
-    // ---------- Storage ----------
+	// ---------- Storage ----------
 
-    public function insert_row( array $data ): int {
-        global $wpdb;
+	public function insert_row( array $data ): int {
+		global $wpdb;
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-        $wpdb->insert( self::table_name(), $data );
-        return (int) $wpdb->insert_id;
-    }
+		$wpdb->insert( self::table_name(), $data );
+		return (int) $wpdb->insert_id;
+	}
 
-    public function update_row( int $id, array $data ): void {
-        if ( $id <= 0 || empty( $data ) ) {
-            return;
-        }
-        global $wpdb;
+	public function update_row( int $id, array $data ): void {
+		if ( $id <= 0 || empty( $data ) ) {
+			return;
+		}
+		global $wpdb;
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-        $wpdb->update( self::table_name(), $data, [ 'id' => $id ] );
-    }
+		$wpdb->update( self::table_name(), $data, array( 'id' => $id ) );
+	}
 
-    public function get_row( int $id ): ?array {
-        global $wpdb;
-        $table = self::table_name();
+	public function get_row( int $id ): ?array {
+		global $wpdb;
+		$table = self::table_name();
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
-        $row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $id ), ARRAY_A );
-        return $row ?: null;
-    }
+		$row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $id ), ARRAY_A );
+		return $row ?: null;
+	}
 
-    /**
-     * @return array<int, array<string, mixed>>
-     */
-    public function get_all( string $status_filter = '', string $order_by = 'last_checked DESC' ): array {
-        global $wpdb;
-        $table = self::table_name();
-        $allow = [ 'last_checked DESC', 'last_seen DESC', 'first_seen DESC', 'source_host ASC' ];
-        if ( ! in_array( $order_by, $allow, true ) ) {
-            $order_by = 'last_checked DESC';
-        }
-        if ( '' !== $status_filter ) {
+	/**
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function get_all( string $status_filter = '', string $order_by = 'last_checked DESC' ): array {
+		global $wpdb;
+		$table = self::table_name();
+		$allow = array( 'last_checked DESC', 'last_seen DESC', 'first_seen DESC', 'source_host ASC' );
+		if ( ! in_array( $order_by, $allow, true ) ) {
+			$order_by = 'last_checked DESC';
+		}
+		if ( '' !== $status_filter ) {
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
-            $rows = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE status = %s ORDER BY {$order_by}", $status_filter ), ARRAY_A );
-        } else {
+			$rows = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$table} WHERE status = %s ORDER BY {$order_by}", $status_filter ), ARRAY_A );
+		} else {
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
-            $rows = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY {$order_by}", ARRAY_A );
-        }
-        return is_array( $rows ) ? $rows : [];
-    }
+			$rows = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY {$order_by}", ARRAY_A );
+		}
+		return is_array( $rows ) ? $rows : array();
+	}
 
-    public function get_all_source_urls(): array {
-        global $wpdb;
-        $table = self::table_name();
+	public function get_all_source_urls(): array {
+		global $wpdb;
+		$table = self::table_name();
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
-        return array_map( 'strval', (array) $wpdb->get_col( "SELECT source_url FROM {$table}" ) );
-    }
+		return array_map( 'strval', (array) $wpdb->get_col( "SELECT source_url FROM {$table}" ) );
+	}
 
-    public function get_ids_for_verify( int $offset, int $limit ): array {
-        global $wpdb;
-        $table = self::table_name();
-        $offset = max( 0, $offset );
-        $limit  = max( 1, min( 100, $limit ) );
+	public function get_ids_for_verify( int $offset, int $limit ): array {
+		global $wpdb;
+		$table  = self::table_name();
+		$offset = max( 0, $offset );
+		$limit  = max( 1, min( 100, $limit ) );
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
-        return array_map( 'intval', (array) $wpdb->get_col( $wpdb->prepare(
-            "SELECT id FROM {$table} ORDER BY (last_checked IS NULL) DESC, last_checked ASC LIMIT %d, %d",
-            $offset,
-            $limit
-        ) ) );
-    }
+		return array_map(
+			'intval',
+			(array) $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT id FROM {$table} ORDER BY (last_checked IS NULL) DESC, last_checked ASC LIMIT %d, %d",
+					$offset,
+					$limit
+				)
+			)
+		);
+	}
 
-    public function count_total(): int {
-        global $wpdb;
-        $table = self::table_name();
+	public function count_total(): int {
+		global $wpdb;
+		$table = self::table_name();
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
-        return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table}" );
-    }
+		return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table}" );
+	}
 
-    public function get_stats(): array {
-        global $wpdb;
-        $table = self::table_name();
+	public function get_stats(): array {
+		global $wpdb;
+		$table = self::table_name();
         // phpcs:disable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
-        $by_status = $wpdb->get_results( "SELECT status, COUNT(*) AS c FROM {$table} GROUP BY status", ARRAY_A );
-        $stats = [ 'total' => 0, 'live' => 0, 'lost' => 0, 'broken' => 0, 'pending' => 0 ];
-        foreach ( $by_status as $r ) {
-            $key = (string) $r['status'];
-            $stats[ $key ] = (int) $r['c'];
-            $stats['total'] += (int) $r['c'];
-        }
+		$by_status = $wpdb->get_results( "SELECT status, COUNT(*) AS c FROM {$table} GROUP BY status", ARRAY_A );
+		$stats     = array(
+			'total'   => 0,
+			'live'    => 0,
+			'lost'    => 0,
+			'broken'  => 0,
+			'pending' => 0,
+		);
+		foreach ( $by_status as $r ) {
+			$key             = (string) $r['status'];
+			$stats[ $key ]   = (int) $r['c'];
+			$stats['total'] += (int) $r['c'];
+		}
 
-        $now30 = gmdate( 'Y-m-d H:i:s', strtotime( '-30 days' ) ?: time() );
-        $stats['new_30d']  = (int) $wpdb->get_var( $wpdb->prepare(
-            "SELECT COUNT(*) FROM {$table} WHERE first_seen IS NOT NULL AND first_seen >= %s", $now30
-        ) );
-        $stats['lost_30d'] = (int) $wpdb->get_var( $wpdb->prepare(
-            "SELECT COUNT(*) FROM {$table} WHERE status = 'lost' AND last_checked >= %s", $now30
-        ) );
-        $stats['unique_domains'] = (int) $wpdb->get_var( "SELECT COUNT(DISTINCT source_host) FROM {$table} WHERE source_host <> ''" );
+		$now30                   = gmdate( 'Y-m-d H:i:s', strtotime( '-30 days' ) ?: time() );
+		$stats['new_30d']        = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$table} WHERE first_seen IS NOT NULL AND first_seen >= %s",
+				$now30
+			)
+		);
+		$stats['lost_30d']       = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$table} WHERE status = 'lost' AND last_checked >= %s",
+				$now30
+			)
+		);
+		$stats['unique_domains'] = (int) $wpdb->get_var( "SELECT COUNT(DISTINCT source_host) FROM {$table} WHERE source_host <> ''" );
         // phpcs:enable
 
-        return $stats;
-    }
+		return $stats;
+	}
 
-    /**
-     * 3 most-recently-changed backlinks for the dashboard tile.
-     *
-     * @return array<int, array{label:string,url:string,status:string,when:string}>
-     */
-    public function get_dashboard_recent( int $limit = 3 ): array {
-        global $wpdb;
-        $table = self::table_name();
+	/**
+	 * 3 most-recently-changed backlinks for the dashboard tile.
+	 *
+	 * @return array<int, array{label:string,url:string,status:string,when:string}>
+	 */
+	public function get_dashboard_recent( int $limit = 3 ): array {
+		global $wpdb;
+		$table = self::table_name();
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
-        $rows = $wpdb->get_results( $wpdb->prepare(
-            "SELECT source_host, source_url, status, last_checked FROM {$table} WHERE last_checked IS NOT NULL ORDER BY last_checked DESC LIMIT %d",
-            max( 1, min( 10, $limit ) )
-        ), ARRAY_A );
-        return array_map( static function ( $r ) {
-            return [
-                'label'  => '' !== $r['source_host'] ? $r['source_host'] : $r['source_url'],
-                'url'    => $r['source_url'],
-                'status' => $r['status'],
-                'when'   => $r['last_checked'],
-            ];
-        }, is_array( $rows ) ? $rows : [] );
-    }
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT source_host, source_url, status, last_checked FROM {$table} WHERE last_checked IS NOT NULL ORDER BY last_checked DESC LIMIT %d",
+				max( 1, min( 10, $limit ) )
+			),
+			ARRAY_A
+		);
+		return array_map(
+			static function ( $r ) {
+				return array(
+					'label'  => '' !== $r['source_host'] ? $r['source_host'] : $r['source_url'],
+					'url'    => $r['source_url'],
+					'status' => $r['status'],
+					'when'   => $r['last_checked'],
+				);
+			},
+			is_array( $rows ) ? $rows : array()
+		);
+	}
 }

--- a/includes/class-bot-analytics-tracker.php
+++ b/includes/class-bot-analytics-tracker.php
@@ -14,39 +14,39 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Bot_Analytics_Tracker {
 
-    private const RAW_TABLE   = 'swps_bot_hits';
-    private const DAILY_TABLE = 'swps_bot_hits_daily';
-    private const CRON_HOOK   = 'swps_bot_analytics_aggregate';
+	private const RAW_TABLE   = 'swps_bot_hits';
+	private const DAILY_TABLE = 'swps_bot_hits_daily';
+	private const CRON_HOOK   = 'swps_bot_analytics_aggregate';
 
-    /**
-     * Max URI length stored — anything longer is truncated.
-     */
-    private const URI_MAX_LEN = 500;
+	/**
+	 * Max URI length stored — anything longer is truncated.
+	 */
+	private const URI_MAX_LEN = 500;
 
-    public function __construct() {
-        // Capture on shutdown so $wp_query, status code, and queried object are settled.
-        add_action( 'shutdown', [ $this, 'maybe_record' ], 999 );
+	public function __construct() {
+		// Capture on shutdown so $wp_query, status code, and queried object are settled.
+		add_action( 'shutdown', array( $this, 'maybe_record' ), 999 );
 
-        // Daily aggregation cron.
-        add_action( self::CRON_HOOK, [ $this, 'aggregate_and_prune' ] );
-    }
+		// Daily aggregation cron.
+		add_action( self::CRON_HOOK, array( $this, 'aggregate_and_prune' ) );
+	}
 
-    /**
-     * Create custom tables. Called on activation.
-     */
-    public static function create_tables(): void {
-        global $wpdb;
+	/**
+	 * Create custom tables. Called on activation.
+	 */
+	public static function create_tables(): void {
+		global $wpdb;
 
-        $charset = $wpdb->get_charset_collate();
-        $raw     = $wpdb->prefix . self::RAW_TABLE;
-        $daily   = $wpdb->prefix . self::DAILY_TABLE;
+		$charset = $wpdb->get_charset_collate();
+		$raw     = $wpdb->prefix . self::RAW_TABLE;
+		$daily   = $wpdb->prefix . self::DAILY_TABLE;
 
-        $sql_raw = "CREATE TABLE {$raw} (
+		$sql_raw = "CREATE TABLE {$raw} (
             id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
             bot_key VARCHAR(32) NOT NULL,
             post_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
@@ -60,7 +60,7 @@ class SWPS_Bot_Analytics_Tracker {
             KEY idx_status (status_code)
         ) {$charset};";
 
-        $sql_daily = "CREATE TABLE {$daily} (
+		$sql_daily = "CREATE TABLE {$daily} (
             id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
             bot_key VARCHAR(32) NOT NULL,
             post_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
@@ -73,223 +73,223 @@ class SWPS_Bot_Analytics_Tracker {
             KEY idx_date (date)
         ) {$charset};";
 
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        dbDelta( $sql_raw );
-        dbDelta( $sql_daily );
-    }
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql_raw );
+		dbDelta( $sql_daily );
+	}
 
-    /**
-     * Drop tables. Called on uninstall.
-     */
-    public static function drop_tables(): void {
-        global $wpdb;
+	/**
+	 * Drop tables. Called on uninstall.
+	 */
+	public static function drop_tables(): void {
+		global $wpdb;
         // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . self::RAW_TABLE );
-        $wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . self::DAILY_TABLE );
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . self::RAW_TABLE );
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}" . self::DAILY_TABLE );
         // phpcs:enable
-    }
+	}
 
-    public static function schedule_cron(): void {
-        if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-            wp_schedule_event( time(), 'daily', self::CRON_HOOK );
-        }
-    }
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+		}
+	}
 
-    public static function unschedule_cron(): void {
-        $ts = wp_next_scheduled( self::CRON_HOOK );
-        if ( $ts ) {
-            wp_unschedule_event( $ts, self::CRON_HOOK );
-        }
-    }
+	public static function unschedule_cron(): void {
+		$ts = wp_next_scheduled( self::CRON_HOOK );
+		if ( $ts ) {
+			wp_unschedule_event( $ts, self::CRON_HOOK );
+		}
+	}
 
-    /**
-     * Capture the current request if it came from a known AI bot.
-     */
-    public function maybe_record(): void {
-        if ( ! get_option( 'swps_bot_analytics_enabled', 1 ) ) {
-            return;
-        }
+	/**
+	 * Capture the current request if it came from a known AI bot.
+	 */
+	public function maybe_record(): void {
+		if ( ! get_option( 'swps_bot_analytics_enabled', 1 ) ) {
+			return;
+		}
 
-        // Skip admin, AJAX, cron, REST, CLI.
-        if ( is_admin() || wp_doing_ajax() || wp_doing_cron() ) {
-            return;
-        }
-        if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-            return;
-        }
-        if ( defined( 'WP_CLI' ) && WP_CLI ) {
-            return;
-        }
+		// Skip admin, AJAX, cron, REST, CLI.
+		if ( is_admin() || wp_doing_ajax() || wp_doing_cron() ) {
+			return;
+		}
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return;
+		}
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return;
+		}
 
-        $ua = isset( $_SERVER['HTTP_USER_AGENT'] ) ? (string) wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) : '';
-        if ( '' === $ua ) {
-            return;
-        }
+		$ua = isset( $_SERVER['HTTP_USER_AGENT'] ) ? (string) wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) : '';
+		if ( '' === $ua ) {
+			return;
+		}
 
-        $bot_key = $this->match_bot( $ua );
-        if ( null === $bot_key ) {
-            return;
-        }
+		$bot_key = $this->match_bot( $ua );
+		if ( null === $bot_key ) {
+			return;
+		}
 
-        // Method gate — GET/HEAD only.
-        $method = isset( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( (string) $_SERVER['REQUEST_METHOD'] ) : 'GET';
-        if ( ! in_array( $method, [ 'GET', 'HEAD' ], true ) ) {
-            return;
-        }
+		// Method gate — GET/HEAD only.
+		$method = isset( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( (string) $_SERVER['REQUEST_METHOD'] ) : 'GET';
+		if ( ! in_array( $method, array( 'GET', 'HEAD' ), true ) ) {
+			return;
+		}
 
-        $uri = $this->current_request_uri();
-        if ( '' === $uri ) {
-            return;
-        }
-        if ( $this->is_excluded_path( $uri ) ) {
-            return;
-        }
+		$uri = $this->current_request_uri();
+		if ( '' === $uri ) {
+			return;
+		}
+		if ( $this->is_excluded_path( $uri ) ) {
+			return;
+		}
 
-        // Sampling — `swps_bot_analytics_sample_rate` is a percent 0-100.
-        $sample = (int) get_option( 'swps_bot_analytics_sample_rate', 100 );
-        if ( $sample < 100 ) {
-            $sample = max( 0, min( 100, $sample ) );
-            if ( wp_rand( 1, 100 ) > $sample ) {
-                return;
-            }
-        }
+		// Sampling — `swps_bot_analytics_sample_rate` is a percent 0-100.
+		$sample = (int) get_option( 'swps_bot_analytics_sample_rate', 100 );
+		if ( $sample < 100 ) {
+			$sample = max( 0, min( 100, $sample ) );
+			if ( wp_rand( 1, 100 ) > $sample ) {
+				return;
+			}
+		}
 
-        $status = $this->current_status_code();
-        $post_id = ( function_exists( 'is_singular' ) && is_singular() ) ? (int) get_queried_object_id() : 0;
+		$status  = $this->current_status_code();
+		$post_id = ( function_exists( 'is_singular' ) && is_singular() ) ? (int) get_queried_object_id() : 0;
 
-        /**
-         * Filter: allow third parties to veto a captured hit.
-         *
-         * @param bool   $capture Default true.
-         * @param string $bot_key Bot key from SWPS_AI_Bots::get_bots().
-         * @param string $uri     Request URI.
-         * @param int    $status  HTTP status code.
-         */
-        $capture = (bool) apply_filters( 'swps_bot_analytics_capture', true, $bot_key, $uri, $status );
-        if ( ! $capture ) {
-            return;
-        }
+		/**
+		 * Filter: allow third parties to veto a captured hit.
+		 *
+		 * @param bool   $capture Default true.
+		 * @param string $bot_key Bot key from SWPS_AI_Bots::get_bots().
+		 * @param string $uri     Request URI.
+		 * @param int    $status  HTTP status code.
+		 */
+		$capture = (bool) apply_filters( 'swps_bot_analytics_capture', true, $bot_key, $uri, $status );
+		if ( ! $capture ) {
+			return;
+		}
 
-        $this->insert_hit( $bot_key, $post_id, $uri, $status, $ua );
+		$this->insert_hit( $bot_key, $post_id, $uri, $status, $ua );
 
-        /**
-         * Fires after a bot hit is recorded — useful for downstream notifications.
-         *
-         * @param string $bot_key Bot key.
-         * @param int    $post_id Post ID (0 if not singular).
-         * @param string $uri     Request URI.
-         * @param int    $status  HTTP status code.
-         */
-        do_action( 'swps_bot_analytics_hit', $bot_key, $post_id, $uri, $status );
-    }
+		/**
+		 * Fires after a bot hit is recorded — useful for downstream notifications.
+		 *
+		 * @param string $bot_key Bot key.
+		 * @param int    $post_id Post ID (0 if not singular).
+		 * @param string $uri     Request URI.
+		 * @param int    $status  HTTP status code.
+		 */
+		do_action( 'swps_bot_analytics_hit', $bot_key, $post_id, $uri, $status );
+	}
 
-    /**
-     * Look up the UA against the canonical bot list.
-     */
-    private function match_bot( string $ua ): ?string {
-        foreach ( SWPS_AI_Bots::get_bots() as $key => $token ) {
-            if ( stripos( $ua, $token ) !== false ) {
-                return $key;
-            }
-        }
-        return null;
-    }
+	/**
+	 * Look up the UA against the canonical bot list.
+	 */
+	private function match_bot( string $ua ): ?string {
+		foreach ( SWPS_AI_Bots::get_bots() as $key => $token ) {
+			if ( stripos( $ua, $token ) !== false ) {
+				return $key;
+			}
+		}
+		return null;
+	}
 
-    /**
-     * Normalize the current request URI to a clean path (no host, capped length).
-     */
-    private function current_request_uri(): string {
-        $raw = isset( $_SERVER['REQUEST_URI'] ) ? (string) wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
-        if ( '' === $raw ) {
-            return '';
-        }
-        // Strip host if present (some proxies prefix it).
-        $path = wp_parse_url( $raw, PHP_URL_PATH );
-        $query = wp_parse_url( $raw, PHP_URL_QUERY );
-        $uri = (string) $path . ( $query ? '?' . $query : '' );
+	/**
+	 * Normalize the current request URI to a clean path (no host, capped length).
+	 */
+	private function current_request_uri(): string {
+		$raw = isset( $_SERVER['REQUEST_URI'] ) ? (string) wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+		if ( '' === $raw ) {
+			return '';
+		}
+		// Strip host if present (some proxies prefix it).
+		$path  = wp_parse_url( $raw, PHP_URL_PATH );
+		$query = wp_parse_url( $raw, PHP_URL_QUERY );
+		$uri   = (string) $path . ( $query ? '?' . $query : '' );
 
-        /**
-         * Filter the normalized URI before bucketing into the analytics table.
-         * Useful for collapsing variants (e.g. paginated archives).
-         */
-        $uri = (string) apply_filters( 'swps_bot_analytics_normalize_uri', $uri );
+		/**
+		 * Filter the normalized URI before bucketing into the analytics table.
+		 * Useful for collapsing variants (e.g. paginated archives).
+		 */
+		$uri = (string) apply_filters( 'swps_bot_analytics_normalize_uri', $uri );
 
-        if ( strlen( $uri ) > self::URI_MAX_LEN ) {
-            $uri = substr( $uri, 0, self::URI_MAX_LEN );
-        }
-        return $uri;
-    }
+		if ( strlen( $uri ) > self::URI_MAX_LEN ) {
+			$uri = substr( $uri, 0, self::URI_MAX_LEN );
+		}
+		return $uri;
+	}
 
-    /**
-     * Match excluded path prefixes from settings.
-     */
-    private function is_excluded_path( string $uri ): bool {
-        $raw = (string) get_option(
-            'swps_bot_analytics_exclude_paths',
-            "/wp-admin\n/wp-json\n/wp-login\n/feed\n/xmlrpc.php"
-        );
-        $lines = preg_split( '/[\r\n,]+/', $raw ) ?: [];
-        foreach ( $lines as $prefix ) {
-            $prefix = trim( $prefix );
-            if ( '' === $prefix ) {
-                continue;
-            }
-            if ( str_starts_with( $uri, $prefix ) ) {
-                return true;
-            }
-        }
-        return false;
-    }
+	/**
+	 * Match excluded path prefixes from settings.
+	 */
+	private function is_excluded_path( string $uri ): bool {
+		$raw   = (string) get_option(
+			'swps_bot_analytics_exclude_paths',
+			"/wp-admin\n/wp-json\n/wp-login\n/feed\n/xmlrpc.php"
+		);
+		$lines = preg_split( '/[\r\n,]+/', $raw ) ?: array();
+		foreach ( $lines as $prefix ) {
+			$prefix = trim( $prefix );
+			if ( '' === $prefix ) {
+				continue;
+			}
+			if ( str_starts_with( $uri, $prefix ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
 
-    /**
-     * Best-effort current HTTP status code at shutdown.
-     */
-    private function current_status_code(): int {
-        $code = function_exists( 'http_response_code' ) ? (int) http_response_code() : 0;
-        if ( $code > 0 ) {
-            return $code;
-        }
-        if ( function_exists( 'is_404' ) && is_404() ) {
-            return 404;
-        }
-        return 200;
-    }
+	/**
+	 * Best-effort current HTTP status code at shutdown.
+	 */
+	private function current_status_code(): int {
+		$code = function_exists( 'http_response_code' ) ? (int) http_response_code() : 0;
+		if ( $code > 0 ) {
+			return $code;
+		}
+		if ( function_exists( 'is_404' ) && is_404() ) {
+			return 404;
+		}
+		return 200;
+	}
 
-    /**
-     * Single-row insert. One bot request → one row.
-     */
-    private function insert_hit( string $bot_key, int $post_id, string $uri, int $status, string $ua ): void {
-        global $wpdb;
-        $table = $wpdb->prefix . self::RAW_TABLE;
+	/**
+	 * Single-row insert. One bot request → one row.
+	 */
+	private function insert_hit( string $bot_key, int $post_id, string $uri, int $status, string $ua ): void {
+		global $wpdb;
+		$table = $wpdb->prefix . self::RAW_TABLE;
 
-        $wpdb->insert(
-            $table,
-            [
-                'bot_key'     => $bot_key,
-                'post_id'     => $post_id,
-                'request_uri' => $uri,
-                'status_code' => $status,
-                'user_agent'  => substr( $ua, 0, 255 ),
-            ],
-            [ '%s', '%d', '%s', '%d', '%s' ]
-        );
-    }
+		$wpdb->insert(
+			$table,
+			array(
+				'bot_key'     => $bot_key,
+				'post_id'     => $post_id,
+				'request_uri' => $uri,
+				'status_code' => $status,
+				'user_agent'  => substr( $ua, 0, 255 ),
+			),
+			array( '%s', '%d', '%s', '%d', '%s' )
+		);
+	}
 
-    /**
-     * Roll up raw rows older than 7 days into the daily table, then prune.
-     */
-    public function aggregate_and_prune(): void {
-        global $wpdb;
+	/**
+	 * Roll up raw rows older than 7 days into the daily table, then prune.
+	 */
+	public function aggregate_and_prune(): void {
+		global $wpdb;
 
-        $raw   = $wpdb->prefix . self::RAW_TABLE;
-        $daily = $wpdb->prefix . self::DAILY_TABLE;
+		$raw   = $wpdb->prefix . self::RAW_TABLE;
+		$daily = $wpdb->prefix . self::DAILY_TABLE;
 
-        $cutoff = gmdate( 'Y-m-d H:i:s', strtotime( '-7 days' ) );
+		$cutoff = gmdate( 'Y-m-d H:i:s', strtotime( '-7 days' ) );
 
         // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $wpdb->query(
-            $wpdb->prepare(
-                "INSERT INTO {$daily} (bot_key, post_id, date, hits, errors_404, errors_5xx)
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$daily} (bot_key, post_id, date, hits, errors_404, errors_5xx)
                  SELECT bot_key,
                         post_id,
                         DATE(created_at) AS date,
@@ -303,34 +303,34 @@ class SWPS_Bot_Analytics_Tracker {
                     hits = hits + VALUES(hits),
                     errors_404 = errors_404 + VALUES(errors_404),
                     errors_5xx = errors_5xx + VALUES(errors_5xx)",
-                $cutoff
-            )
-        );
+				$cutoff
+			)
+		);
 
-        $wpdb->query( $wpdb->prepare( "DELETE FROM {$raw} WHERE created_at < %s", $cutoff ) );
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$raw} WHERE created_at < %s", $cutoff ) );
 
-        $retention = (int) get_option( 'swps_bot_analytics_retention', 90 );
-        $retention = max( 7, $retention );
-        $prune     = gmdate( 'Y-m-d', strtotime( "-{$retention} days" ) );
-        $wpdb->query( $wpdb->prepare( "DELETE FROM {$daily} WHERE date < %s", $prune ) );
+		$retention = (int) get_option( 'swps_bot_analytics_retention', 90 );
+		$retention = max( 7, $retention );
+		$prune     = gmdate( 'Y-m-d', strtotime( "-{$retention} days" ) );
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$daily} WHERE date < %s", $prune ) );
         // phpcs:enable
-    }
+	}
 
-    /**
-     * Per-bot summary: hits, last seen, sparkline data.
-     *
-     * @return array<int, array{bot_key:string, label:string, hits:int, last_seen:?string, daily:array<int,array{date:string,hits:int}>}>
-     */
-    public function get_bot_summary( int $days = 30 ): array {
-        global $wpdb;
-        $raw   = $wpdb->prefix . self::RAW_TABLE;
-        $daily = $wpdb->prefix . self::DAILY_TABLE;
-        $since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+	/**
+	 * Per-bot summary: hits, last seen, sparkline data.
+	 *
+	 * @return array<int, array{bot_key:string, label:string, hits:int, last_seen:?string, daily:array<int,array{date:string,hits:int}>}>
+	 */
+	public function get_bot_summary( int $days = 30 ): array {
+		global $wpdb;
+		$raw   = $wpdb->prefix . self::RAW_TABLE;
+		$daily = $wpdb->prefix . self::DAILY_TABLE;
+		$since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
 
         // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $totals = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT bot_key, SUM(hits) AS hits, MAX(seen) AS last_seen
+		$totals = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT bot_key, SUM(hits) AS hits, MAX(seen) AS last_seen
                  FROM (
                      SELECT bot_key, 1 AS hits, created_at AS seen
                      FROM {$raw}
@@ -342,15 +342,15 @@ class SWPS_Bot_Analytics_Tracker {
                  ) c
                  GROUP BY bot_key
                  ORDER BY hits DESC",
-                $since,
-                $since
-            ),
-            ARRAY_A
-        );
+				$since,
+				$since
+			),
+			ARRAY_A
+		);
 
-        $per_bot_daily = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT bot_key, date, SUM(hits) AS hits FROM (
+		$per_bot_daily = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT bot_key, date, SUM(hits) AS hits FROM (
                     SELECT bot_key, DATE(created_at) AS date, 1 AS hits
                     FROM {$raw}
                     WHERE DATE(created_at) >= %s
@@ -361,54 +361,54 @@ class SWPS_Bot_Analytics_Tracker {
                 ) c
                 GROUP BY bot_key, date
                 ORDER BY date ASC",
-                $since,
-                $since
-            ),
-            ARRAY_A
-        );
+				$since,
+				$since
+			),
+			ARRAY_A
+		);
         // phpcs:enable
 
-        $daily_by_bot = [];
-        foreach ( $per_bot_daily as $row ) {
-            $daily_by_bot[ $row['bot_key'] ][] = [
-                'date' => $row['date'],
-                'hits' => (int) $row['hits'],
-            ];
-        }
+		$daily_by_bot = array();
+		foreach ( $per_bot_daily as $row ) {
+			$daily_by_bot[ $row['bot_key'] ][] = array(
+				'date' => $row['date'],
+				'hits' => (int) $row['hits'],
+			);
+		}
 
-        $bots = SWPS_AI_Bots::get_bots();
-        $out  = [];
-        foreach ( (array) $totals as $row ) {
-            $key       = (string) $row['bot_key'];
-            $label     = $bots[ $key ] ?? $key;
-            $last_seen = ! empty( $row['last_seen'] ) ? (string) $row['last_seen'] : null;
-            $out[] = [
-                'bot_key'   => $key,
-                'label'     => $label,
-                'hits'      => (int) $row['hits'],
-                'last_seen' => $last_seen,
-                'daily'     => $daily_by_bot[ $key ] ?? [],
-            ];
-        }
-        return $out;
-    }
+		$bots = SWPS_AI_Bots::get_bots();
+		$out  = array();
+		foreach ( (array) $totals as $row ) {
+			$key       = (string) $row['bot_key'];
+			$label     = $bots[ $key ] ?? $key;
+			$last_seen = ! empty( $row['last_seen'] ) ? (string) $row['last_seen'] : null;
+			$out[]     = array(
+				'bot_key'   => $key,
+				'label'     => $label,
+				'hits'      => (int) $row['hits'],
+				'last_seen' => $last_seen,
+				'daily'     => $daily_by_bot[ $key ] ?? array(),
+			);
+		}
+		return $out;
+	}
 
-    /**
-     * Get headline totals.
-     *
-     * @return array{total_hits:int, total_404:int, active_bots:int, prev_hits:int}
-     */
-    public function get_totals( int $days = 30 ): array {
-        global $wpdb;
-        $raw   = $wpdb->prefix . self::RAW_TABLE;
-        $daily = $wpdb->prefix . self::DAILY_TABLE;
-        $since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
-        $prev  = gmdate( 'Y-m-d', strtotime( '-' . ( $days * 2 ) . ' days' ) );
+	/**
+	 * Get headline totals.
+	 *
+	 * @return array{total_hits:int, total_404:int, active_bots:int, prev_hits:int}
+	 */
+	public function get_totals( int $days = 30 ): array {
+		global $wpdb;
+		$raw   = $wpdb->prefix . self::RAW_TABLE;
+		$daily = $wpdb->prefix . self::DAILY_TABLE;
+		$since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+		$prev  = gmdate( 'Y-m-d', strtotime( '-' . ( $days * 2 ) . ' days' ) );
 
         // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $row = $wpdb->get_row(
-            $wpdb->prepare(
-                "SELECT SUM(hits) AS hits,
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT SUM(hits) AS hits,
                         SUM(errors_404) AS errors_404,
                         COUNT(DISTINCT bot_key) AS active
                  FROM (
@@ -422,61 +422,61 @@ class SWPS_Bot_Analytics_Tracker {
                      FROM {$daily}
                      WHERE date >= %s
                  ) c",
-                $since,
-                $since
-            ),
-            ARRAY_A
-        );
+				$since,
+				$since
+			),
+			ARRAY_A
+		);
 
-        $prev_hits = (int) $wpdb->get_var(
-            $wpdb->prepare(
-                "SELECT SUM(hits) FROM (
+		$prev_hits = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT SUM(hits) FROM (
                     SELECT 1 AS hits FROM {$raw}
                     WHERE DATE(created_at) >= %s AND DATE(created_at) < %s
                     UNION ALL
                     SELECT hits FROM {$daily}
                     WHERE date >= %s AND date < %s
                 ) c",
-                $prev,
-                $since,
-                $prev,
-                $since
-            )
-        );
+				$prev,
+				$since,
+				$prev,
+				$since
+			)
+		);
         // phpcs:enable
 
-        return [
-            'total_hits'  => (int) ( $row['hits'] ?? 0 ),
-            'total_404'   => (int) ( $row['errors_404'] ?? 0 ),
-            'active_bots' => (int) ( $row['active'] ?? 0 ),
-            'prev_hits'   => $prev_hits,
-        ];
-    }
+		return array(
+			'total_hits'  => (int) ( $row['hits'] ?? 0 ),
+			'total_404'   => (int) ( $row['errors_404'] ?? 0 ),
+			'active_bots' => (int) ( $row['active'] ?? 0 ),
+			'prev_hits'   => $prev_hits,
+		);
+	}
 
-    /**
-     * Top crawled pages.
-     *
-     * @return array<int, array{post_id:int, request_uri:string, title:string, url:string, hits:int, errors_404:int}>
-     */
-    public function get_top_pages( int $days = 30, int $limit = 20, ?string $bot_key = null ): array {
-        global $wpdb;
-        $raw   = $wpdb->prefix . self::RAW_TABLE;
-        $daily = $wpdb->prefix . self::DAILY_TABLE;
-        $since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
-        $limit = max( 1, min( 100, $limit ) );
+	/**
+	 * Top crawled pages.
+	 *
+	 * @return array<int, array{post_id:int, request_uri:string, title:string, url:string, hits:int, errors_404:int}>
+	 */
+	public function get_top_pages( int $days = 30, int $limit = 20, ?string $bot_key = null ): array {
+		global $wpdb;
+		$raw   = $wpdb->prefix . self::RAW_TABLE;
+		$daily = $wpdb->prefix . self::DAILY_TABLE;
+		$since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+		$limit = max( 1, min( 100, $limit ) );
 
-        $bot_clause = '';
-        $params     = [ $since, $since ];
-        if ( $bot_key ) {
-            $bot_clause = ' WHERE bot_key = %s';
-            // We'll inject in both subqueries — handled via prepare placeholders below.
-        }
+		$bot_clause = '';
+		$params     = array( $since, $since );
+		if ( $bot_key ) {
+			$bot_clause = ' WHERE bot_key = %s';
+			// We'll inject in both subqueries — handled via prepare placeholders below.
+		}
 
         // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        if ( $bot_key ) {
-            $rows = $wpdb->get_results(
-                $wpdb->prepare(
-                    "SELECT post_id, MAX(request_uri) AS request_uri,
+		if ( $bot_key ) {
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT post_id, MAX(request_uri) AS request_uri,
                             SUM(hits) AS hits,
                             SUM(errors_404) AS errors_404
                      FROM (
@@ -493,18 +493,18 @@ class SWPS_Bot_Analytics_Tracker {
                      GROUP BY post_id
                      ORDER BY hits DESC
                      LIMIT %d",
-                    $since,
-                    $bot_key,
-                    $since,
-                    $bot_key,
-                    $limit
-                ),
-                ARRAY_A
-            );
-        } else {
-            $rows = $wpdb->get_results(
-                $wpdb->prepare(
-                    "SELECT post_id, MAX(request_uri) AS request_uri,
+					$since,
+					$bot_key,
+					$since,
+					$bot_key,
+					$limit
+				),
+				ARRAY_A
+			);
+		} else {
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT post_id, MAX(request_uri) AS request_uri,
                             SUM(hits) AS hits,
                             SUM(errors_404) AS errors_404
                      FROM (
@@ -521,190 +521,190 @@ class SWPS_Bot_Analytics_Tracker {
                      GROUP BY post_id
                      ORDER BY hits DESC
                      LIMIT %d",
-                    $since,
-                    $since,
-                    $limit
-                ),
-                ARRAY_A
-            );
-        }
+					$since,
+					$since,
+					$limit
+				),
+				ARRAY_A
+			);
+		}
         // phpcs:enable
 
-        $out = [];
-        foreach ( (array) $rows as $row ) {
-            $post_id = (int) $row['post_id'];
-            $title   = '';
-            $url     = '';
-            if ( $post_id > 0 ) {
-                $post = get_post( $post_id );
-                if ( $post ) {
-                    $title = (string) get_the_title( $post );
-                    $url   = (string) get_permalink( $post );
-                }
-            }
-            $out[] = [
-                'post_id'     => $post_id,
-                'request_uri' => (string) $row['request_uri'],
-                'title'       => $title,
-                'url'         => $url,
-                'hits'        => (int) $row['hits'],
-                'errors_404'  => (int) $row['errors_404'],
-            ];
-        }
-        return $out;
-    }
+		$out = array();
+		foreach ( (array) $rows as $row ) {
+			$post_id = (int) $row['post_id'];
+			$title   = '';
+			$url     = '';
+			if ( $post_id > 0 ) {
+				$post = get_post( $post_id );
+				if ( $post ) {
+					$title = (string) get_the_title( $post );
+					$url   = (string) get_permalink( $post );
+				}
+			}
+			$out[] = array(
+				'post_id'     => $post_id,
+				'request_uri' => (string) $row['request_uri'],
+				'title'       => $title,
+				'url'         => $url,
+				'hits'        => (int) $row['hits'],
+				'errors_404'  => (int) $row['errors_404'],
+			);
+		}
+		return $out;
+	}
 
-    /**
-     * Published posts with ZERO bot hits in the window — the AEO gap report.
-     *
-     * @return array<int, array{post_id:int, title:string, url:string, post_date:string}>
-     */
-    public function get_gap_posts( int $days = 30, int $limit = 25 ): array {
-        global $wpdb;
-        $raw   = $wpdb->prefix . self::RAW_TABLE;
-        $daily = $wpdb->prefix . self::DAILY_TABLE;
-        $since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
-        $limit = max( 1, min( 100, $limit ) );
+	/**
+	 * Published posts with ZERO bot hits in the window — the AEO gap report.
+	 *
+	 * @return array<int, array{post_id:int, title:string, url:string, post_date:string}>
+	 */
+	public function get_gap_posts( int $days = 30, int $limit = 25 ): array {
+		global $wpdb;
+		$raw   = $wpdb->prefix . self::RAW_TABLE;
+		$daily = $wpdb->prefix . self::DAILY_TABLE;
+		$since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+		$limit = max( 1, min( 100, $limit ) );
 
         // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $hit_ids = $wpdb->get_col(
-            $wpdb->prepare(
-                "SELECT DISTINCT post_id FROM (
+		$hit_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT DISTINCT post_id FROM (
                     SELECT post_id FROM {$raw} WHERE DATE(created_at) >= %s AND post_id > 0
                     UNION
                     SELECT post_id FROM {$daily} WHERE date >= %s AND post_id > 0
                 ) c",
-                $since,
-                $since
-            )
-        );
+				$since,
+				$since
+			)
+		);
         // phpcs:enable
 
-        $exclude = array_map( 'intval', (array) $hit_ids );
+		$exclude = array_map( 'intval', (array) $hit_ids );
 
-        $query = new WP_Query(
-            [
-                'post_type'      => [ 'post', 'page' ],
-                'post_status'    => 'publish',
-                'posts_per_page' => $limit,
-                'post__not_in'   => empty( $exclude ) ? [ 0 ] : $exclude,
-                'orderby'        => 'date',
-                'order'          => 'DESC',
-                'fields'         => 'ids',
-                'no_found_rows'  => true,
-            ]
-        );
+		$query = new WP_Query(
+			array(
+				'post_type'      => array( 'post', 'page' ),
+				'post_status'    => 'publish',
+				'posts_per_page' => $limit,
+				'post__not_in'   => empty( $exclude ) ? array( 0 ) : $exclude,
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+			)
+		);
 
-        $out = [];
-        foreach ( $query->posts as $pid ) {
-            $post = get_post( (int) $pid );
-            if ( ! $post ) {
-                continue;
-            }
-            $out[] = [
-                'post_id'   => (int) $post->ID,
-                'title'     => (string) get_the_title( $post ),
-                'url'       => (string) get_permalink( $post ),
-                'post_date' => (string) $post->post_date,
-            ];
-        }
-        return $out;
-    }
+		$out = array();
+		foreach ( $query->posts as $pid ) {
+			$post = get_post( (int) $pid );
+			if ( ! $post ) {
+				continue;
+			}
+			$out[] = array(
+				'post_id'   => (int) $post->ID,
+				'title'     => (string) get_the_title( $post ),
+				'url'       => (string) get_permalink( $post ),
+				'post_date' => (string) $post->post_date,
+			);
+		}
+		return $out;
+	}
 
-    /**
-     * Top URIs returning 404 to AI bots.
-     *
-     * @return array<int, array{request_uri:string, hits:int}>
-     */
-    public function get_top_404s( int $days = 30, int $limit = 10 ): array {
-        global $wpdb;
-        $raw   = $wpdb->prefix . self::RAW_TABLE;
-        $since = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
-        $limit = max( 1, min( 50, $limit ) );
+	/**
+	 * Top URIs returning 404 to AI bots.
+	 *
+	 * @return array<int, array{request_uri:string, hits:int}>
+	 */
+	public function get_top_404s( int $days = 30, int $limit = 10 ): array {
+		global $wpdb;
+		$raw   = $wpdb->prefix . self::RAW_TABLE;
+		$since = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+		$limit = max( 1, min( 50, $limit ) );
 
-        // 404s with full URI live in the raw table; the daily table aggregates by post_id
-        // which loses URI fidelity for not-found URLs (which have no post). That's fine —
-        // 404s are higher-signal in the recent (raw) window anyway.
+		// 404s with full URI live in the raw table; the daily table aggregates by post_id
+		// which loses URI fidelity for not-found URLs (which have no post). That's fine —
+		// 404s are higher-signal in the recent (raw) window anyway.
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $rows = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT request_uri, COUNT(*) AS hits
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT request_uri, COUNT(*) AS hits
                  FROM {$raw}
                  WHERE status_code = 404 AND created_at >= %s
                  GROUP BY request_uri
                  ORDER BY hits DESC
                  LIMIT %d",
-                $since,
-                $limit
-            ),
-            ARRAY_A
-        );
+				$since,
+				$limit
+			),
+			ARRAY_A
+		);
 
-        $out = [];
-        foreach ( (array) $rows as $row ) {
-            $out[] = [
-                'request_uri' => (string) $row['request_uri'],
-                'hits'        => (int) $row['hits'],
-            ];
-        }
-        return $out;
-    }
+		$out = array();
+		foreach ( (array) $rows as $row ) {
+			$out[] = array(
+				'request_uri' => (string) $row['request_uri'],
+				'hits'        => (int) $row['hits'],
+			);
+		}
+		return $out;
+	}
 
-    /**
-     * Per-post bot stats (for the post-edit metabox extension).
-     *
-     * @return array{hits_7d:int, hits_30d:int, last_seen:?string}
-     */
-    public function get_post_stats( int $post_id ): array {
-        global $wpdb;
-        $raw   = $wpdb->prefix . self::RAW_TABLE;
-        $daily = $wpdb->prefix . self::DAILY_TABLE;
+	/**
+	 * Per-post bot stats (for the post-edit metabox extension).
+	 *
+	 * @return array{hits_7d:int, hits_30d:int, last_seen:?string}
+	 */
+	public function get_post_stats( int $post_id ): array {
+		global $wpdb;
+		$raw   = $wpdb->prefix . self::RAW_TABLE;
+		$daily = $wpdb->prefix . self::DAILY_TABLE;
 
         // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $hits_7d = (int) $wpdb->get_var(
-            $wpdb->prepare(
-                "SELECT SUM(hits) FROM (
+		$hits_7d = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT SUM(hits) FROM (
                     SELECT 1 AS hits FROM {$raw}
                     WHERE post_id = %d AND DATE(created_at) >= %s
                     UNION ALL
                     SELECT hits FROM {$daily}
                     WHERE post_id = %d AND date >= %s
                 ) c",
-                $post_id,
-                gmdate( 'Y-m-d', strtotime( '-7 days' ) ),
-                $post_id,
-                gmdate( 'Y-m-d', strtotime( '-7 days' ) )
-            )
-        );
+				$post_id,
+				gmdate( 'Y-m-d', strtotime( '-7 days' ) ),
+				$post_id,
+				gmdate( 'Y-m-d', strtotime( '-7 days' ) )
+			)
+		);
 
-        $hits_30d = (int) $wpdb->get_var(
-            $wpdb->prepare(
-                "SELECT SUM(hits) FROM (
+		$hits_30d = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT SUM(hits) FROM (
                     SELECT 1 AS hits FROM {$raw}
                     WHERE post_id = %d AND DATE(created_at) >= %s
                     UNION ALL
                     SELECT hits FROM {$daily}
                     WHERE post_id = %d AND date >= %s
                 ) c",
-                $post_id,
-                gmdate( 'Y-m-d', strtotime( '-30 days' ) ),
-                $post_id,
-                gmdate( 'Y-m-d', strtotime( '-30 days' ) )
-            )
-        );
+				$post_id,
+				gmdate( 'Y-m-d', strtotime( '-30 days' ) ),
+				$post_id,
+				gmdate( 'Y-m-d', strtotime( '-30 days' ) )
+			)
+		);
 
-        $last = $wpdb->get_var(
-            $wpdb->prepare(
-                "SELECT MAX(created_at) FROM {$raw} WHERE post_id = %d",
-                $post_id
-            )
-        );
+		$last = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT MAX(created_at) FROM {$raw} WHERE post_id = %d",
+				$post_id
+			)
+		);
         // phpcs:enable
 
-        return [
-            'hits_7d'   => $hits_7d,
-            'hits_30d'  => $hits_30d,
-            'last_seen' => $last ? (string) $last : null,
-        ];
-    }
+		return array(
+			'hits_7d'   => $hits_7d,
+			'hits_30d'  => $hits_30d,
+			'last_seen' => $last ? (string) $last : null,
+		);
+	}
 }

--- a/includes/class-breadcrumbs.php
+++ b/includes/class-breadcrumbs.php
@@ -8,188 +8,234 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Breadcrumbs {
 
-    public function __construct() {
-        add_shortcode( 'swps_breadcrumbs', [ $this, 'shortcode' ] );
-    }
+	public function __construct() {
+		add_shortcode( 'swps_breadcrumbs', array( $this, 'shortcode' ) );
+	}
 
-    /**
-     * Shortcode handler.
-     */
-    public function shortcode(): string {
-        ob_start();
-        $this->render();
-        return ob_get_clean();
-    }
+	/**
+	 * Shortcode handler.
+	 */
+	public function shortcode(): string {
+		ob_start();
+		$this->render();
+		return ob_get_clean();
+	}
 
-    /**
-     * Render breadcrumbs HTML with schema markup.
-     */
-    public function render(): void {
-        if ( ! get_option( 'swps_breadcrumbs_enabled', 1 ) ) {
-            return;
-        }
+	/**
+	 * Render breadcrumbs HTML with schema markup.
+	 */
+	public function render(): void {
+		if ( ! get_option( 'swps_breadcrumbs_enabled', 1 ) ) {
+			return;
+		}
 
-        // Skip on front page.
-        if ( is_front_page() ) {
-            return;
-        }
+		// Skip on front page.
+		if ( is_front_page() ) {
+			return;
+		}
 
-        $crumbs    = $this->build_crumbs();
-        $separator = get_option( 'swps_breadcrumbs_separator', '&raquo;' );
-        $class     = get_option( 'swps_breadcrumbs_class', 'swps-breadcrumbs' );
+		$crumbs    = $this->build_crumbs();
+		$separator = get_option( 'swps_breadcrumbs_separator', '&raquo;' );
+		$class     = get_option( 'swps_breadcrumbs_class', 'swps-breadcrumbs' );
 
-        if ( empty( $crumbs ) ) {
-            return;
-        }
+		if ( empty( $crumbs ) ) {
+			return;
+		}
 
-        echo '<nav aria-label="Breadcrumb" class="' . esc_attr( $class ) . '">';
-        echo '<ol itemscope itemtype="https://schema.org/BreadcrumbList">';
+		echo '<nav aria-label="Breadcrumb" class="' . esc_attr( $class ) . '">';
+		echo '<ol itemscope itemtype="https://schema.org/BreadcrumbList">';
 
-        $position = 0;
-        $last     = count( $crumbs ) - 1;
+		$position = 0;
+		$last     = count( $crumbs ) - 1;
 
-        foreach ( $crumbs as $i => $crumb ) {
-            $position++;
-            echo '<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">';
+		foreach ( $crumbs as $i => $crumb ) {
+			++$position;
+			echo '<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">';
 
-            if ( $i < $last && ! empty( $crumb['url'] ) ) {
-                printf(
-                    '<a itemprop="item" href="%s"><span itemprop="name">%s</span></a>',
-                    esc_url( $crumb['url'] ),
-                    esc_html( $crumb['label'] )
-                );
-            } else {
-                printf( '<span itemprop="name">%s</span>', esc_html( $crumb['label'] ) );
-            }
+			if ( $i < $last && ! empty( $crumb['url'] ) ) {
+				printf(
+					'<a itemprop="item" href="%s"><span itemprop="name">%s</span></a>',
+					esc_url( $crumb['url'] ),
+					esc_html( $crumb['label'] )
+				);
+			} else {
+				printf( '<span itemprop="name">%s</span>', esc_html( $crumb['label'] ) );
+			}
 
-            printf( '<meta itemprop="position" content="%d">', $position );
-            echo '</li>';
+			printf( '<meta itemprop="position" content="%d">', $position );
+			echo '</li>';
 
-            if ( $i < $last ) {
-                printf( ' <span class="swps-breadcrumb-sep">%s</span> ', $separator );
-            }
-        }
+			if ( $i < $last ) {
+				printf( ' <span class="swps-breadcrumb-sep">%s</span> ', $separator );
+			}
+		}
 
-        echo '</ol>';
-        echo '</nav>';
-    }
+		echo '</ol>';
+		echo '</nav>';
+	}
 
-    /**
-     * Build the breadcrumb trail.
-     *
-     * @return array<array{label: string, url: string}>
-     */
-    private function build_crumbs(): array {
-        $home_label = get_option( 'swps_breadcrumbs_home_label', __( 'Home', 'stratawp-seo' ) );
-        $crumbs     = [ [ 'label' => $home_label, 'url' => home_url( '/' ) ] ];
+	/**
+	 * Build the breadcrumb trail.
+	 *
+	 * @return array<array{label: string, url: string}>
+	 */
+	private function build_crumbs(): array {
+		$home_label = get_option( 'swps_breadcrumbs_home_label', __( 'Home', 'stratawp-seo' ) );
+		$crumbs     = array(
+			array(
+				'label' => $home_label,
+				'url'   => home_url( '/' ),
+			),
+		);
 
-        if ( is_singular() ) {
-            $post = get_queried_object();
-            if ( ! $post ) {
-                return $crumbs;
-            }
+		if ( is_singular() ) {
+			$post = get_queried_object();
+			if ( ! $post ) {
+				return $crumbs;
+			}
 
-            // Hierarchical pages: add parent chain.
-            if ( is_page() && $post->post_parent ) {
-                $ancestors = array_reverse( get_post_ancestors( $post ) );
-                foreach ( $ancestors as $ancestor_id ) {
-                    $crumbs[] = [
-                        'label' => get_the_title( $ancestor_id ),
-                        'url'   => get_permalink( $ancestor_id ),
-                    ];
-                }
-            }
+			// Hierarchical pages: add parent chain.
+			if ( is_page() && $post->post_parent ) {
+				$ancestors = array_reverse( get_post_ancestors( $post ) );
+				foreach ( $ancestors as $ancestor_id ) {
+					$crumbs[] = array(
+						'label' => get_the_title( $ancestor_id ),
+						'url'   => get_permalink( $ancestor_id ),
+					);
+				}
+			}
 
-            // Posts: add primary category.
-            if ( 'post' === $post->post_type ) {
-                $categories = get_the_category( $post->ID );
-                if ( ! empty( $categories ) ) {
-                    // Use Yoast primary category if set, otherwise first.
-                    $primary = $categories[0];
-                    $crumbs[] = [
-                        'label' => $primary->name,
-                        'url'   => get_category_link( $primary->term_id ),
-                    ];
-                }
-            }
+			// Posts: add primary category.
+			if ( 'post' === $post->post_type ) {
+				$categories = get_the_category( $post->ID );
+				if ( ! empty( $categories ) ) {
+					// Use Yoast primary category if set, otherwise first.
+					$primary  = $categories[0];
+					$crumbs[] = array(
+						'label' => $primary->name,
+						'url'   => get_category_link( $primary->term_id ),
+					);
+				}
+			}
 
-            // CPTs: add post type archive.
-            $post_type = get_post_type_object( $post->post_type );
-            if ( $post_type && $post_type->has_archive && 'post' !== $post->post_type ) {
-                $crumbs[] = [
-                    'label' => $post_type->labels->name,
-                    'url'   => get_post_type_archive_link( $post->post_type ),
-                ];
-            }
+			// CPTs: add post type archive.
+			$post_type = get_post_type_object( $post->post_type );
+			if ( $post_type && $post_type->has_archive && 'post' !== $post->post_type ) {
+				$crumbs[] = array(
+					'label' => $post_type->labels->name,
+					'url'   => get_post_type_archive_link( $post->post_type ),
+				);
+			}
 
-            // Current post — use breadcrumb title override if set.
-            $breadcrumb_title = get_post_meta( $post->ID, '_swps_breadcrumb_title', true );
-            $crumbs[] = [
-                'label' => ! empty( $breadcrumb_title ) ? $breadcrumb_title : $post->post_title,
-                'url'   => '',
-            ];
+			// Current post — use breadcrumb title override if set.
+			$breadcrumb_title = get_post_meta( $post->ID, '_swps_breadcrumb_title', true );
+			$crumbs[]         = array(
+				'label' => ! empty( $breadcrumb_title ) ? $breadcrumb_title : $post->post_title,
+				'url'   => '',
+			);
 
-        } elseif ( is_category() ) {
-            $term = get_queried_object();
-            // Parent categories.
-            if ( $term->parent ) {
-                $ancestors = array_reverse( get_ancestors( $term->term_id, 'category' ) );
-                foreach ( $ancestors as $ancestor_id ) {
-                    $ancestor = get_term( $ancestor_id, 'category' );
-                    if ( $ancestor ) {
-                        $crumbs[] = [ 'label' => $ancestor->name, 'url' => get_category_link( $ancestor_id ) ];
-                    }
-                }
-            }
-            $crumbs[] = [ 'label' => $term->name, 'url' => '' ];
+		} elseif ( is_category() ) {
+			$term = get_queried_object();
+			// Parent categories.
+			if ( $term->parent ) {
+				$ancestors = array_reverse( get_ancestors( $term->term_id, 'category' ) );
+				foreach ( $ancestors as $ancestor_id ) {
+					$ancestor = get_term( $ancestor_id, 'category' );
+					if ( $ancestor ) {
+						$crumbs[] = array(
+							'label' => $ancestor->name,
+							'url'   => get_category_link( $ancestor_id ),
+						);
+					}
+				}
+			}
+			$crumbs[] = array(
+				'label' => $term->name,
+				'url'   => '',
+			);
 
-        } elseif ( is_tag() ) {
-            $crumbs[] = [ 'label' => single_tag_title( '', false ), 'url' => '' ];
+		} elseif ( is_tag() ) {
+			$crumbs[] = array(
+				'label' => single_tag_title( '', false ),
+				'url'   => '',
+			);
 
-        } elseif ( is_tax() ) {
-            $term = get_queried_object();
-            $crumbs[] = [ 'label' => $term->name, 'url' => '' ];
+		} elseif ( is_tax() ) {
+			$term     = get_queried_object();
+			$crumbs[] = array(
+				'label' => $term->name,
+				'url'   => '',
+			);
 
-        } elseif ( is_author() ) {
-            $crumbs[] = [ 'label' => get_the_author(), 'url' => '' ];
+		} elseif ( is_author() ) {
+			$crumbs[] = array(
+				'label' => get_the_author(),
+				'url'   => '',
+			);
 
-        } elseif ( is_date() ) {
-            if ( is_year() ) {
-                $crumbs[] = [ 'label' => get_the_date( 'Y' ), 'url' => '' ];
-            } elseif ( is_month() ) {
-                $crumbs[] = [ 'label' => get_the_date( 'Y' ), 'url' => get_year_link( get_the_date( 'Y' ) ) ];
-                $crumbs[] = [ 'label' => get_the_date( 'F' ), 'url' => '' ];
-            } elseif ( is_day() ) {
-                $crumbs[] = [ 'label' => get_the_date( 'Y' ), 'url' => get_year_link( get_the_date( 'Y' ) ) ];
-                $crumbs[] = [ 'label' => get_the_date( 'F' ), 'url' => get_month_link( get_the_date( 'Y' ), get_the_date( 'm' ) ) ];
-                $crumbs[] = [ 'label' => get_the_date( 'j' ), 'url' => '' ];
-            }
+		} elseif ( is_date() ) {
+			if ( is_year() ) {
+				$crumbs[] = array(
+					'label' => get_the_date( 'Y' ),
+					'url'   => '',
+				);
+			} elseif ( is_month() ) {
+				$crumbs[] = array(
+					'label' => get_the_date( 'Y' ),
+					'url'   => get_year_link( get_the_date( 'Y' ) ),
+				);
+				$crumbs[] = array(
+					'label' => get_the_date( 'F' ),
+					'url'   => '',
+				);
+			} elseif ( is_day() ) {
+				$crumbs[] = array(
+					'label' => get_the_date( 'Y' ),
+					'url'   => get_year_link( get_the_date( 'Y' ) ),
+				);
+				$crumbs[] = array(
+					'label' => get_the_date( 'F' ),
+					'url'   => get_month_link( get_the_date( 'Y' ), get_the_date( 'm' ) ),
+				);
+				$crumbs[] = array(
+					'label' => get_the_date( 'j' ),
+					'url'   => '',
+				);
+			}
+		} elseif ( is_search() ) {
+			$crumbs[] = array(
+				'label' => sprintf( __( 'Search: %s', 'stratawp-seo' ), get_search_query() ),
+				'url'   => '',
+			);
 
-        } elseif ( is_search() ) {
-            $crumbs[] = [ 'label' => sprintf( __( 'Search: %s', 'stratawp-seo' ), get_search_query() ), 'url' => '' ];
+		} elseif ( is_404() ) {
+			$crumbs[] = array(
+				'label' => __( 'Page Not Found', 'stratawp-seo' ),
+				'url'   => '',
+			);
 
-        } elseif ( is_404() ) {
-            $crumbs[] = [ 'label' => __( 'Page Not Found', 'stratawp-seo' ), 'url' => '' ];
+		} elseif ( is_post_type_archive() ) {
+			$crumbs[] = array(
+				'label' => post_type_archive_title( '', false ),
+				'url'   => '',
+			);
+		}
 
-        } elseif ( is_post_type_archive() ) {
-            $crumbs[] = [ 'label' => post_type_archive_title( '', false ), 'url' => '' ];
-        }
-
-        return $crumbs;
-    }
+		return $crumbs;
+	}
 }
 
 /**
  * Template function — call in theme templates.
  */
 function swps_breadcrumbs(): void {
-    $plugin = stratawp_seo();
-    if ( isset( $plugin->breadcrumbs ) ) {
-        $plugin->breadcrumbs->render();
-    }
+	$plugin = stratawp_seo();
+	if ( isset( $plugin->breadcrumbs ) ) {
+		$plugin->breadcrumbs->render();
+	}
 }

--- a/includes/class-cache-manager.php
+++ b/includes/class-cache-manager.php
@@ -6,78 +6,78 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Cache_Manager {
 
-    private const CACHE_PREFIX = 'swps_cache_';
-    private const DEFAULT_TTL  = HOUR_IN_SECONDS;
+	private const CACHE_PREFIX = 'swps_cache_';
+	private const DEFAULT_TTL  = HOUR_IN_SECONDS;
 
-    public function __construct() {
-        add_action( 'save_post', [ $this, 'invalidate_on_post_save' ], 10, 2 );
-        add_action( 'delete_post', [ $this, 'invalidate_all' ] );
-    }
+	public function __construct() {
+		add_action( 'save_post', array( $this, 'invalidate_on_post_save' ), 10, 2 );
+		add_action( 'delete_post', array( $this, 'invalidate_all' ) );
+	}
 
-    /**
-     * Get a cached value.
-     *
-     * @param string $key Cache key.
-     * @return mixed|false Cached value or false if not found.
-     */
-    public function get( string $key ): mixed {
-        return get_transient( self::CACHE_PREFIX . $key );
-    }
+	/**
+	 * Get a cached value.
+	 *
+	 * @param string $key Cache key.
+	 * @return mixed|false Cached value or false if not found.
+	 */
+	public function get( string $key ): mixed {
+		return get_transient( self::CACHE_PREFIX . $key );
+	}
 
-    /**
-     * Set a cached value.
-     *
-     * @param string $key   Cache key.
-     * @param mixed  $value Value to cache.
-     * @param int    $ttl   Time to live in seconds.
-     */
-    public function set( string $key, mixed $value, int $ttl = self::DEFAULT_TTL ): void {
-        set_transient( self::CACHE_PREFIX . $key, $value, $ttl );
-    }
+	/**
+	 * Set a cached value.
+	 *
+	 * @param string $key   Cache key.
+	 * @param mixed  $value Value to cache.
+	 * @param int    $ttl   Time to live in seconds.
+	 */
+	public function set( string $key, mixed $value, int $ttl = self::DEFAULT_TTL ): void {
+		set_transient( self::CACHE_PREFIX . $key, $value, $ttl );
+	}
 
-    /**
-     * Delete a cached value.
-     *
-     * @param string $key Cache key.
-     */
-    public function delete( string $key ): void {
-        delete_transient( self::CACHE_PREFIX . $key );
-    }
+	/**
+	 * Delete a cached value.
+	 *
+	 * @param string $key Cache key.
+	 */
+	public function delete( string $key ): void {
+		delete_transient( self::CACHE_PREFIX . $key );
+	}
 
-    /**
-     * Clear all plugin caches.
-     */
-    public function invalidate_all(): void {
-        global $wpdb;
+	/**
+	 * Clear all plugin caches.
+	 */
+	public function invalidate_all(): void {
+		global $wpdb;
 
-        // Delete all transients with our prefix.
-        $wpdb->query(
-            $wpdb->prepare(
-                "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
-                '_transient_' . self::CACHE_PREFIX . '%',
-                '_transient_timeout_' . self::CACHE_PREFIX . '%'
-            )
-        );
-    }
+		// Delete all transients with our prefix.
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
+				'_transient_' . self::CACHE_PREFIX . '%',
+				'_transient_timeout_' . self::CACHE_PREFIX . '%'
+			)
+		);
+	}
 
-    /**
-     * Invalidate caches when a post is saved (only for published posts).
-     *
-     * @param int     $post_id Post ID.
-     * @param WP_Post $post    Post object.
-     */
-    public function invalidate_on_post_save( int $post_id, WP_Post $post ): void {
-        if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
-            return;
-        }
+	/**
+	 * Invalidate caches when a post is saved (only for published posts).
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post    Post object.
+	 */
+	public function invalidate_on_post_save( int $post_id, WP_Post $post ): void {
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return;
+		}
 
-        if ( in_array( $post->post_type, [ 'post', 'page' ], true ) ) {
-            $this->invalidate_all();
-        }
-    }
+		if ( in_array( $post->post_type, array( 'post', 'page' ), true ) ) {
+			$this->invalidate_all();
+		}
+	}
 }

--- a/includes/class-calendar.php
+++ b/includes/class-calendar.php
@@ -6,183 +6,189 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Calendar {
 
-    private SWPS_Topic_Queue $queue;
+	private SWPS_Topic_Queue $queue;
 
-    public function __construct( SWPS_Topic_Queue $queue ) {
-        $this->queue = $queue;
+	public function __construct( SWPS_Topic_Queue $queue ) {
+		$this->queue = $queue;
 
-        add_action( 'admin_menu', [ $this, 'register_menu' ] );
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+		add_action( 'admin_menu', array( $this, 'register_menu' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
-        // AJAX handlers.
-        add_action( 'wp_ajax_swps_calendar_events', [ $this, 'ajax_get_events' ] );
-        add_action( 'wp_ajax_swps_calendar_create_topic', [ $this, 'ajax_create_topic' ] );
-        add_action( 'wp_ajax_swps_calendar_update_topic', [ $this, 'ajax_update_topic' ] );
-        add_action( 'wp_ajax_swps_calendar_delete_topic', [ $this, 'ajax_delete_topic' ] );
-    }
+		// AJAX handlers.
+		add_action( 'wp_ajax_swps_calendar_events', array( $this, 'ajax_get_events' ) );
+		add_action( 'wp_ajax_swps_calendar_create_topic', array( $this, 'ajax_create_topic' ) );
+		add_action( 'wp_ajax_swps_calendar_update_topic', array( $this, 'ajax_update_topic' ) );
+		add_action( 'wp_ajax_swps_calendar_delete_topic', array( $this, 'ajax_delete_topic' ) );
+	}
 
-    /**
-     * Register the calendar submenu page.
-     */
-    public function register_menu(): void {
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Content Calendar', 'stratawp-seo' ),
-            __( 'Content Calendar', 'stratawp-seo' ),
-            'edit_posts',
-            'swps-calendar',
-            [ $this, 'render_page' ]
-        );
-    }
+	/**
+	 * Register the calendar submenu page.
+	 */
+	public function register_menu(): void {
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Content Calendar', 'stratawp-seo' ),
+			__( 'Content Calendar', 'stratawp-seo' ),
+			'edit_posts',
+			'swps-calendar',
+			array( $this, 'render_page' )
+		);
+	}
 
-    /**
-     * Enqueue calendar assets.
-     */
-    public function enqueue_assets( string $hook ): void {
-        if ( ! str_contains( $hook, 'swps-calendar' ) ) {
-            return;
-        }
+	/**
+	 * Enqueue calendar assets.
+	 */
+	public function enqueue_assets( string $hook ): void {
+		if ( ! str_contains( $hook, 'swps-calendar' ) ) {
+			return;
+		}
 
-        // FullCalendar CDN.
-        wp_enqueue_script(
-            'fullcalendar',
-            'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js',
-            [],
-            '6.1.11',
-            true
-        );
+		// FullCalendar CDN.
+		wp_enqueue_script(
+			'fullcalendar',
+			'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js',
+			array(),
+			'6.1.11',
+			true
+		);
 
-        wp_enqueue_style(
-            'swps-calendar',
-            SWPS_PLUGIN_URL . 'admin/css/calendar.css',
-            [ 'swps-admin' ],
-            SWPS_VERSION
-        );
+		wp_enqueue_style(
+			'swps-calendar',
+			SWPS_PLUGIN_URL . 'admin/css/calendar.css',
+			array( 'swps-admin' ),
+			SWPS_VERSION
+		);
 
-        wp_enqueue_script(
-            'swps-calendar',
-            SWPS_PLUGIN_URL . 'admin/js/calendar.js',
-            [ 'fullcalendar', 'jquery' ],
-            SWPS_VERSION,
-            true
-        );
+		wp_enqueue_script(
+			'swps-calendar',
+			SWPS_PLUGIN_URL . 'admin/js/calendar.js',
+			array( 'fullcalendar', 'jquery' ),
+			SWPS_VERSION,
+			true
+		);
 
-        wp_localize_script( 'swps-calendar', 'swpsCalendar', [
-            'ajax_url'  => admin_url( 'admin-ajax.php' ),
-            'nonce'     => wp_create_nonce( 'swps_calendar_nonce' ),
-            'templates' => SWPS_Templates::get_options(),
-        ] );
-    }
+		wp_localize_script(
+			'swps-calendar',
+			'swpsCalendar',
+			array(
+				'ajax_url'  => admin_url( 'admin-ajax.php' ),
+				'nonce'     => wp_create_nonce( 'swps_calendar_nonce' ),
+				'templates' => SWPS_Templates::get_options(),
+			)
+		);
+	}
 
-    /**
-     * Render the calendar page.
-     */
-    public function render_page(): void {
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            return;
-        }
-        include SWPS_PLUGIN_DIR . 'templates/calendar-page.php';
-    }
+	/**
+	 * Render the calendar page.
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return;
+		}
+		include SWPS_PLUGIN_DIR . 'templates/calendar-page.php';
+	}
 
-    /**
-     * AJAX: Get calendar events.
-     */
-    public function ajax_get_events(): void {
-        check_ajax_referer( 'swps_calendar_nonce', 'nonce' );
+	/**
+	 * AJAX: Get calendar events.
+	 */
+	public function ajax_get_events(): void {
+		check_ajax_referer( 'swps_calendar_nonce', 'nonce' );
 
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $start = sanitize_text_field( $_GET['start'] ?? '' );
-        $end   = sanitize_text_field( $_GET['end'] ?? '' );
+		$start = sanitize_text_field( $_GET['start'] ?? '' );
+		$end   = sanitize_text_field( $_GET['end'] ?? '' );
 
-        if ( empty( $start ) || empty( $end ) ) {
-            wp_send_json_error( [ 'message' => 'Missing date range.' ] );
-        }
+		if ( empty( $start ) || empty( $end ) ) {
+			wp_send_json_error( array( 'message' => 'Missing date range.' ) );
+		}
 
-        $topic_events    = $this->queue->get_calendar_events( $start, $end );
-        $published_events = $this->queue->get_published_events( $start, $end );
+		$topic_events     = $this->queue->get_calendar_events( $start, $end );
+		$published_events = $this->queue->get_published_events( $start, $end );
 
-        wp_send_json_success( array_merge( $topic_events, $published_events ) );
-    }
+		wp_send_json_success( array_merge( $topic_events, $published_events ) );
+	}
 
-    /**
-     * AJAX: Create a new topic.
-     */
-    public function ajax_create_topic(): void {
-        check_ajax_referer( 'swps_calendar_nonce', 'nonce' );
+	/**
+	 * AJAX: Create a new topic.
+	 */
+	public function ajax_create_topic(): void {
+		check_ajax_referer( 'swps_calendar_nonce', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $title    = sanitize_text_field( $_POST['title'] ?? '' );
-        $date     = sanitize_text_field( $_POST['date'] ?? '' );
-        $template = sanitize_text_field( $_POST['template'] ?? 'auto' );
-        $notes    = sanitize_textarea_field( $_POST['notes'] ?? '' );
+		$title    = sanitize_text_field( $_POST['title'] ?? '' );
+		$date     = sanitize_text_field( $_POST['date'] ?? '' );
+		$template = sanitize_text_field( $_POST['template'] ?? 'auto' );
+		$notes    = sanitize_textarea_field( $_POST['notes'] ?? '' );
 
-        if ( empty( $title ) ) {
-            wp_send_json_error( [ 'message' => 'Topic title is required.' ] );
-        }
+		if ( empty( $title ) ) {
+			wp_send_json_error( array( 'message' => 'Topic title is required.' ) );
+		}
 
-        $result = $this->queue->create_topic( $title, $date, $template, $notes );
+		$result = $this->queue->create_topic( $title, $date, $template, $notes );
 
-        if ( is_wp_error( $result ) ) {
-            wp_send_json_error( [ 'message' => $result->get_error_message() ] );
-        }
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+		}
 
-        wp_send_json_success( [
-            'topic_id' => $result,
-            'message'  => 'Topic added to queue.',
-        ] );
-    }
+		wp_send_json_success(
+			array(
+				'topic_id' => $result,
+				'message'  => 'Topic added to queue.',
+			)
+		);
+	}
 
-    /**
-     * AJAX: Update a topic (date change via drag-and-drop).
-     */
-    public function ajax_update_topic(): void {
-        check_ajax_referer( 'swps_calendar_nonce', 'nonce' );
+	/**
+	 * AJAX: Update a topic (date change via drag-and-drop).
+	 */
+	public function ajax_update_topic(): void {
+		check_ajax_referer( 'swps_calendar_nonce', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $topic_id = (int) ( $_POST['topic_id'] ?? 0 );
-        $date     = sanitize_text_field( $_POST['date'] ?? '' );
+		$topic_id = (int) ( $_POST['topic_id'] ?? 0 );
+		$date     = sanitize_text_field( $_POST['date'] ?? '' );
 
-        if ( ! $topic_id || empty( $date ) ) {
-            wp_send_json_error( [ 'message' => 'Missing topic ID or date.' ] );
-        }
+		if ( ! $topic_id || empty( $date ) ) {
+			wp_send_json_error( array( 'message' => 'Missing topic ID or date.' ) );
+		}
 
-        $this->queue->update_date( $topic_id, $date );
+		$this->queue->update_date( $topic_id, $date );
 
-        wp_send_json_success( [ 'message' => 'Topic rescheduled.' ] );
-    }
+		wp_send_json_success( array( 'message' => 'Topic rescheduled.' ) );
+	}
 
-    /**
-     * AJAX: Delete a topic.
-     */
-    public function ajax_delete_topic(): void {
-        check_ajax_referer( 'swps_calendar_nonce', 'nonce' );
+	/**
+	 * AJAX: Delete a topic.
+	 */
+	public function ajax_delete_topic(): void {
+		check_ajax_referer( 'swps_calendar_nonce', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $topic_id = (int) ( $_POST['topic_id'] ?? 0 );
+		$topic_id = (int) ( $_POST['topic_id'] ?? 0 );
 
-        if ( ! $topic_id ) {
-            wp_send_json_error( [ 'message' => 'Missing topic ID.' ] );
-        }
+		if ( ! $topic_id ) {
+			wp_send_json_error( array( 'message' => 'Missing topic ID.' ) );
+		}
 
-        $this->queue->delete_topic( $topic_id );
+		$this->queue->delete_topic( $topic_id );
 
-        wp_send_json_success( [ 'message' => 'Topic deleted.' ] );
-    }
+		wp_send_json_success( array( 'message' => 'Topic deleted.' ) );
+	}
 }

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -6,342 +6,353 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_CLI {
 
-    /**
-     * Generate a blog post.
-     *
-     * ## OPTIONS
-     *
-     * [<topic>]
-     * : Optional topic for the post.
-     *
-     * [--template=<template>]
-     * : Content template to use (auto, listicle, how-to, comparison, case-study, news, tutorial).
-     * ---
-     * default: auto
-     * ---
-     *
-     * ## EXAMPLES
-     *
-     *     wp swps generate "Best practices for WordPress security"
-     *     wp swps generate --template=listicle
-     *
-     * @param array $args       Positional arguments.
-     * @param array $assoc_args Named arguments.
-     */
-    public function generate( array $args, array $assoc_args ): void {
-        $topic    = $args[0] ?? '';
-        $template = $assoc_args['template'] ?? 'auto';
+	/**
+	 * Generate a blog post.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<topic>]
+	 * : Optional topic for the post.
+	 *
+	 * [--template=<template>]
+	 * : Content template to use (auto, listicle, how-to, comparison, case-study, news, tutorial).
+	 * ---
+	 * default: auto
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp swps generate "Best practices for WordPress security"
+	 *     wp swps generate --template=listicle
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function generate( array $args, array $assoc_args ): void {
+		$topic    = $args[0] ?? '';
+		$template = $assoc_args['template'] ?? 'auto';
 
-        WP_CLI::log( 'Starting content generation...' );
+		WP_CLI::log( 'Starting content generation...' );
 
-        if ( ! empty( $topic ) ) {
-            WP_CLI::log( "Topic: {$topic}" );
-        }
+		if ( ! empty( $topic ) ) {
+			WP_CLI::log( "Topic: {$topic}" );
+		}
 
-        if ( $template !== 'auto' ) {
-            WP_CLI::log( "Template: {$template}" );
-        }
+		if ( $template !== 'auto' ) {
+			WP_CLI::log( "Template: {$template}" );
+		}
 
-        $plugin = stratawp_seo();
-        $result = $plugin->generator->generate_post( $topic, $template );
+		$plugin = stratawp_seo();
+		$result = $plugin->generator->generate_post( $topic, $template );
 
-        if ( is_wp_error( $result ) ) {
-            WP_CLI::error( $result->get_error_message() );
-        }
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+		}
 
-        WP_CLI::success( sprintf(
-            'Post #%d created: "%s" (%s)',
-            $result['post_id'],
-            $result['title'],
-            $result['status']
-        ) );
+		WP_CLI::success(
+			sprintf(
+				'Post #%d created: "%s" (%s)',
+				$result['post_id'],
+				$result['title'],
+				$result['status']
+			)
+		);
 
-        WP_CLI::log( "Edit: {$result['edit_url']}" );
-        WP_CLI::log( "Focus keyword: {$result['focus_keyword']}" );
-        WP_CLI::log( "Word count: ~{$result['word_count']}" );
-    }
+		WP_CLI::log( "Edit: {$result['edit_url']}" );
+		WP_CLI::log( "Focus keyword: {$result['focus_keyword']}" );
+		WP_CLI::log( "Word count: ~{$result['word_count']}" );
+	}
 
-    /**
-     * Analyze site content.
-     *
-     * ## OPTIONS
-     *
-     * [--format=<format>]
-     * : Output format.
-     * ---
-     * default: json
-     * options:
-     *   - json
-     *   - table
-     * ---
-     *
-     * ## EXAMPLES
-     *
-     *     wp swps analyze
-     *     wp swps analyze --format=table
-     *
-     * @param array $args       Positional arguments.
-     * @param array $assoc_args Named arguments.
-     */
-    public function analyze( array $args, array $assoc_args ): void {
-        $format = $assoc_args['format'] ?? 'json';
+	/**
+	 * Analyze site content.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: json
+	 * options:
+	 *   - json
+	 *   - table
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp swps analyze
+	 *     wp swps analyze --format=table
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function analyze( array $args, array $assoc_args ): void {
+		$format = $assoc_args['format'] ?? 'json';
 
-        WP_CLI::log( 'Analyzing site content...' );
+		WP_CLI::log( 'Analyzing site content...' );
 
-        $plugin  = stratawp_seo();
-        $summary = $plugin->analyzer->get_site_summary();
+		$plugin  = stratawp_seo();
+		$summary = $plugin->analyzer->get_site_summary();
 
-        if ( $format === 'table' ) {
-            $stats = $summary['content_stats'];
-            $items = [];
-            foreach ( $stats as $key => $value ) {
-                $items[] = [
-                    'metric' => str_replace( '_', ' ', ucfirst( $key ) ),
-                    'value'  => $value,
-                ];
-            }
-            WP_CLI\Utils\format_items( 'table', $items, [ 'metric', 'value' ] );
-        } else {
-            WP_CLI::log( wp_json_encode( $summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
-        }
-    }
+		if ( $format === 'table' ) {
+			$stats = $summary['content_stats'];
+			$items = array();
+			foreach ( $stats as $key => $value ) {
+				$items[] = array(
+					'metric' => str_replace( '_', ' ', ucfirst( $key ) ),
+					'value'  => $value,
+				);
+			}
+			WP_CLI\Utils\format_items( 'table', $items, array( 'metric', 'value' ) );
+		} else {
+			WP_CLI::log( wp_json_encode( $summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		}
+	}
 
-    /**
-     * Show plugin status.
-     *
-     * ## EXAMPLES
-     *
-     *     wp swps status
-     */
-    public function status(): void {
-        $ai_provider = get_option( 'swps_ai_provider', 'anthropic' );
-        $model       = get_option( 'swps_model', '' );
-        $schedule    = SWPS_Cron::get_schedule_info();
+	/**
+	 * Show plugin status.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp swps status
+	 */
+	public function status(): void {
+		$ai_provider = get_option( 'swps_ai_provider', 'anthropic' );
+		$model       = get_option( 'swps_model', '' );
+		$schedule    = SWPS_Cron::get_schedule_info();
 
-        WP_CLI::log( '--- StrataWP SEO Status ---' );
-        WP_CLI::log( "Version: " . SWPS_VERSION );
-        WP_CLI::log( "AI Provider: {$ai_provider}" );
-        WP_CLI::log( "Model: {$model}" );
-        WP_CLI::log( "Schedule: " . ( $schedule['enabled'] ? 'Active' : 'Inactive' ) );
+		WP_CLI::log( '--- StrataWP SEO Status ---' );
+		WP_CLI::log( 'Version: ' . SWPS_VERSION );
+		WP_CLI::log( "AI Provider: {$ai_provider}" );
+		WP_CLI::log( "Model: {$model}" );
+		WP_CLI::log( 'Schedule: ' . ( $schedule['enabled'] ? 'Active' : 'Inactive' ) );
 
-        if ( $schedule['enabled'] ) {
-            WP_CLI::log( "Next run: {$schedule['next_run']}" );
-            WP_CLI::log( "Last run: {$schedule['last_run']}" );
-        }
+		if ( $schedule['enabled'] ) {
+			WP_CLI::log( "Next run: {$schedule['next_run']}" );
+			WP_CLI::log( "Last run: {$schedule['last_run']}" );
+		}
 
-        // Cost stats.
-        if ( get_option( 'swps_cost_tracking', false ) ) {
-            $tracker = new SWPS_Cost_Tracker();
-            $monthly = $tracker->get_monthly_stats();
-            WP_CLI::log( sprintf(
-                'This month: %d generations, $%.4f cost',
-                $monthly['generation_count'],
-                $monthly['total_cost']
-            ) );
-        }
+		// Cost stats.
+		if ( get_option( 'swps_cost_tracking', false ) ) {
+			$tracker = new SWPS_Cost_Tracker();
+			$monthly = $tracker->get_monthly_stats();
+			WP_CLI::log(
+				sprintf(
+					'This month: %d generations, $%.4f cost',
+					$monthly['generation_count'],
+					$monthly['total_cost']
+				)
+			);
+		}
 
-        // Queue stats.
-        $queue_count = wp_count_posts( SWPS_Topic_Queue::POST_TYPE );
-        WP_CLI::log( "Queue: " . ( $queue_count->queued ?? 0 ) . " topics queued" );
-    }
+		// Queue stats.
+		$queue_count = wp_count_posts( SWPS_Topic_Queue::POST_TYPE );
+		WP_CLI::log( 'Queue: ' . ( $queue_count->queued ?? 0 ) . ' topics queued' );
+	}
 
-    /**
-     * Manage the topic queue.
-     *
-     * ## OPTIONS
-     *
-     * <action>
-     * : Queue action (list, add, remove, clear).
-     *
-     * [<value>]
-     * : Topic title (for add) or topic ID (for remove).
-     *
-     * [--date=<date>]
-     * : Scheduled date for the topic (Y-m-d H:i:s).
-     *
-     * [--template=<template>]
-     * : Content template for the topic.
-     * ---
-     * default: auto
-     * ---
-     *
-     * ## EXAMPLES
-     *
-     *     wp swps queue list
-     *     wp swps queue add "WordPress security best practices" --date="2026-03-01 09:00:00"
-     *     wp swps queue remove 123
-     *     wp swps queue clear
-     *
-     * @param array $args       Positional arguments.
-     * @param array $assoc_args Named arguments.
-     */
-    public function queue( array $args, array $assoc_args ): void {
-        $action = $args[0] ?? '';
-        $value  = $args[1] ?? '';
-        $queue  = new SWPS_Topic_Queue();
+	/**
+	 * Manage the topic queue.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <action>
+	 * : Queue action (list, add, remove, clear).
+	 *
+	 * [<value>]
+	 * : Topic title (for add) or topic ID (for remove).
+	 *
+	 * [--date=<date>]
+	 * : Scheduled date for the topic (Y-m-d H:i:s).
+	 *
+	 * [--template=<template>]
+	 * : Content template for the topic.
+	 * ---
+	 * default: auto
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp swps queue list
+	 *     wp swps queue add "WordPress security best practices" --date="2026-03-01 09:00:00"
+	 *     wp swps queue remove 123
+	 *     wp swps queue clear
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function queue( array $args, array $assoc_args ): void {
+		$action = $args[0] ?? '';
+		$value  = $args[1] ?? '';
+		$queue  = new SWPS_Topic_Queue();
 
-        switch ( $action ) {
-            case 'list':
-                $topics = $queue->get_queued_topics();
-                if ( empty( $topics ) ) {
-                    WP_CLI::log( 'Queue is empty.' );
-                    return;
-                }
-                $items = [];
-                foreach ( $topics as $topic ) {
-                    $items[] = [
-                        'ID'       => $topic->ID,
-                        'title'    => $topic->post_title,
-                        'date'     => $topic->post_date,
-                        'status'   => $topic->post_status,
-                        'template' => get_post_meta( $topic->ID, '_swps_template', true ) ?: 'auto',
-                    ];
-                }
-                WP_CLI\Utils\format_items( 'table', $items, [ 'ID', 'title', 'date', 'status', 'template' ] );
-                break;
+		switch ( $action ) {
+			case 'list':
+				$topics = $queue->get_queued_topics();
+				if ( empty( $topics ) ) {
+					WP_CLI::log( 'Queue is empty.' );
+					return;
+				}
+				$items = array();
+				foreach ( $topics as $topic ) {
+					$items[] = array(
+						'ID'       => $topic->ID,
+						'title'    => $topic->post_title,
+						'date'     => $topic->post_date,
+						'status'   => $topic->post_status,
+						'template' => get_post_meta( $topic->ID, '_swps_template', true ) ?: 'auto',
+					);
+				}
+				WP_CLI\Utils\format_items( 'table', $items, array( 'ID', 'title', 'date', 'status', 'template' ) );
+				break;
 
-            case 'add':
-                if ( empty( $value ) ) {
-                    WP_CLI::error( 'Topic title is required.' );
-                }
-                $date     = $assoc_args['date'] ?? '';
-                $template = $assoc_args['template'] ?? 'auto';
+			case 'add':
+				if ( empty( $value ) ) {
+					WP_CLI::error( 'Topic title is required.' );
+				}
+				$date     = $assoc_args['date'] ?? '';
+				$template = $assoc_args['template'] ?? 'auto';
 
-                $result = $queue->create_topic( $value, $date, $template );
-                if ( is_wp_error( $result ) ) {
-                    WP_CLI::error( $result->get_error_message() );
-                }
-                WP_CLI::success( "Topic #{$result} added to queue." );
-                break;
+				$result = $queue->create_topic( $value, $date, $template );
+				if ( is_wp_error( $result ) ) {
+					WP_CLI::error( $result->get_error_message() );
+				}
+				WP_CLI::success( "Topic #{$result} added to queue." );
+				break;
 
-            case 'remove':
-                if ( empty( $value ) ) {
-                    WP_CLI::error( 'Topic ID is required.' );
-                }
-                $queue->delete_topic( (int) $value );
-                WP_CLI::success( "Topic #{$value} removed." );
-                break;
+			case 'remove':
+				if ( empty( $value ) ) {
+					WP_CLI::error( 'Topic ID is required.' );
+				}
+				$queue->delete_topic( (int) $value );
+				WP_CLI::success( "Topic #{$value} removed." );
+				break;
 
-            case 'clear':
-                $topics = $queue->get_queued_topics( 500 );
-                $count  = count( $topics );
-                foreach ( $topics as $topic ) {
-                    $queue->delete_topic( $topic->ID );
-                }
-                WP_CLI::success( "{$count} topics cleared from queue." );
-                break;
+			case 'clear':
+				$topics = $queue->get_queued_topics( 500 );
+				$count  = count( $topics );
+				foreach ( $topics as $topic ) {
+					$queue->delete_topic( $topic->ID );
+				}
+				WP_CLI::success( "{$count} topics cleared from queue." );
+				break;
 
-            default:
-                WP_CLI::error( "Unknown action: {$action}. Use list, add, remove, or clear." );
-        }
-    }
+			default:
+				WP_CLI::error( "Unknown action: {$action}. Use list, add, remove, or clear." );
+		}
+	}
 
-    /**
-     * Show AI bot analytics summary.
-     *
-     * ## OPTIONS
-     *
-     * [--days=<days>]
-     * : Window in days.
-     * ---
-     * default: 30
-     * ---
-     *
-     * [--bot=<bot>]
-     * : Filter top-pages by bot key (e.g. gptbot, claudebot).
-     *
-     * [--format=<format>]
-     * : Output format.
-     * ---
-     * default: table
-     * options:
-     *   - table
-     *   - json
-     * ---
-     *
-     * ## EXAMPLES
-     *
-     *     wp swps bot-stats
-     *     wp swps bot-stats --days=7
-     *     wp swps bot-stats --bot=gptbot
-     *     wp swps bot-stats --format=json
-     *
-     * @param array $args       Positional arguments.
-     * @param array $assoc_args Named arguments.
-     */
-    public function bot_stats( array $args, array $assoc_args ): void {
-        $days   = (int) ( $assoc_args['days'] ?? 30 );
-        $bot    = (string) ( $assoc_args['bot'] ?? '' );
-        $format = (string) ( $assoc_args['format'] ?? 'table' );
+	/**
+	 * Show AI bot analytics summary.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--days=<days>]
+	 * : Window in days.
+	 * ---
+	 * default: 30
+	 * ---
+	 *
+	 * [--bot=<bot>]
+	 * : Filter top-pages by bot key (e.g. gptbot, claudebot).
+	 *
+	 * [--format=<format>]
+	 * : Output format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp swps bot-stats
+	 *     wp swps bot-stats --days=7
+	 *     wp swps bot-stats --bot=gptbot
+	 *     wp swps bot-stats --format=json
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function bot_stats( array $args, array $assoc_args ): void {
+		$days   = (int) ( $assoc_args['days'] ?? 30 );
+		$bot    = (string) ( $assoc_args['bot'] ?? '' );
+		$format = (string) ( $assoc_args['format'] ?? 'table' );
 
-        $tracker = stratawp_seo()->bot_analytics_tracker;
-        $totals  = $tracker->get_totals( $days );
-        $bots    = $tracker->get_bot_summary( $days );
-        $pages   = $tracker->get_top_pages( $days, 10, '' !== $bot ? $bot : null );
+		$tracker = stratawp_seo()->bot_analytics_tracker;
+		$totals  = $tracker->get_totals( $days );
+		$bots    = $tracker->get_bot_summary( $days );
+		$pages   = $tracker->get_top_pages( $days, 10, '' !== $bot ? $bot : null );
 
-        if ( 'json' === $format ) {
-            WP_CLI::log( wp_json_encode( [
-                'days'      => $days,
-                'totals'    => $totals,
-                'bots'      => $bots,
-                'top_pages' => $pages,
-            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
-            return;
-        }
+		if ( 'json' === $format ) {
+			WP_CLI::log(
+				wp_json_encode(
+					array(
+						'days'      => $days,
+						'totals'    => $totals,
+						'bots'      => $bots,
+						'top_pages' => $pages,
+					),
+					JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+				)
+			);
+			return;
+		}
 
-        WP_CLI::log( sprintf(
-            '--- AI Bot Analytics (last %d days) ---',
-            $days
-        ) );
-        WP_CLI::log( "Total hits:  {$totals['total_hits']}" );
-        WP_CLI::log( "404s to bots: {$totals['total_404']}" );
-        WP_CLI::log( "Active bots: {$totals['active_bots']}" );
-        WP_CLI::log( '' );
+		WP_CLI::log(
+			sprintf(
+				'--- AI Bot Analytics (last %d days) ---',
+				$days
+			)
+		);
+		WP_CLI::log( "Total hits:  {$totals['total_hits']}" );
+		WP_CLI::log( "404s to bots: {$totals['total_404']}" );
+		WP_CLI::log( "Active bots: {$totals['active_bots']}" );
+		WP_CLI::log( '' );
 
-        if ( empty( $bots ) ) {
-            WP_CLI::log( 'No bot activity recorded.' );
-            return;
-        }
+		if ( empty( $bots ) ) {
+			WP_CLI::log( 'No bot activity recorded.' );
+			return;
+		}
 
-        WP_CLI::log( 'By Crawler:' );
-        WP_CLI\Utils\format_items(
-            'table',
-            array_map(
-                static function ( $b ) {
-                    return [
-                        'bot'       => $b['label'],
-                        'key'       => $b['bot_key'],
-                        'hits'      => $b['hits'],
-                        'last_seen' => $b['last_seen'] ?? '—',
-                    ];
-                },
-                $bots
-            ),
-            [ 'bot', 'key', 'hits', 'last_seen' ]
-        );
+		WP_CLI::log( 'By Crawler:' );
+		WP_CLI\Utils\format_items(
+			'table',
+			array_map(
+				static function ( $b ) {
+					return array(
+						'bot'       => $b['label'],
+						'key'       => $b['bot_key'],
+						'hits'      => $b['hits'],
+						'last_seen' => $b['last_seen'] ?? '—',
+					);
+				},
+				$bots
+			),
+			array( 'bot', 'key', 'hits', 'last_seen' )
+		);
 
-        if ( ! empty( $pages ) ) {
-            WP_CLI::log( '' );
-            WP_CLI::log( 'Top Pages:' );
-            WP_CLI\Utils\format_items(
-                'table',
-                array_map(
-                    static function ( $p ) {
-                        return [
-                            'page'       => $p['title'] !== '' ? $p['title'] : $p['request_uri'],
-                            'hits'       => $p['hits'],
-                            'errors_404' => $p['errors_404'],
-                        ];
-                    },
-                    $pages
-                ),
-                [ 'page', 'hits', 'errors_404' ]
-            );
-        }
-    }
+		if ( ! empty( $pages ) ) {
+			WP_CLI::log( '' );
+			WP_CLI::log( 'Top Pages:' );
+			WP_CLI\Utils\format_items(
+				'table',
+				array_map(
+					static function ( $p ) {
+						return array(
+							'page'       => $p['title'] !== '' ? $p['title'] : $p['request_uri'],
+							'hits'       => $p['hits'],
+							'errors_404' => $p['errors_404'],
+						);
+					},
+					$pages
+				),
+				array( 'page', 'hits', 'errors_404' )
+			);
+		}
+	}
 }

--- a/includes/class-competitors.php
+++ b/includes/class-competitors.php
@@ -18,753 +18,813 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Competitors {
 
-    public const OPTION_LIST       = 'swps_competitors';
-    public const CRON_HOOK         = 'swps_competitors_daily_scan';
-    public const MAX_COMPETITORS   = 10;
-    public const MAX_SNAPSHOTS     = 12;
-    public const MAX_RECENT_POSTS  = 20;
-    public const HTTP_TIMEOUT      = 12;
-
-    public function __construct() {
-        add_action( 'admin_menu',           [ $this, 'register_menu' ], 20 );
-        add_action( 'admin_enqueue_scripts',[ $this, 'enqueue_assets' ] );
-        add_action( 'init',                 [ $this, 'maybe_schedule_cron' ] );
-
-        add_action( 'wp_ajax_swps_competitor_save',     [ $this, 'ajax_save' ] );
-        add_action( 'wp_ajax_swps_competitor_delete',   [ $this, 'ajax_delete' ] );
-        add_action( 'wp_ajax_swps_competitor_scan',     [ $this, 'ajax_scan' ] );
-        add_action( 'wp_ajax_swps_competitor_scan_all', [ $this, 'ajax_scan_all' ] );
-
-        add_action( self::CRON_HOOK, [ $this, 'cron_scan_all' ] );
-    }
-
-    public function register_menu(): void {
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Competitors', 'stratawp-seo' ),
-            __( 'Competitors', 'stratawp-seo' ),
-            'manage_options',
-            'swps-competitors',
-            [ $this, 'render_page' ]
-        );
-    }
-
-    public function render_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
-        }
-        require SWPS_PLUGIN_DIR . 'templates/competitors-page.php';
-    }
-
-    public function enqueue_assets( string $hook ): void {
-        if ( 'stratawp-seo_page_swps-competitors' !== $hook ) {
-            return;
-        }
-        wp_enqueue_style(
-            'swps-page-competitors',
-            SWPS_PLUGIN_URL . 'admin/css/pages/competitors.css',
-            [ 'swps-tokens', 'swps-components', 'swps-templates' ],
-            SWPS_VERSION
-        );
-        wp_enqueue_script(
-            'swps-competitors',
-            SWPS_PLUGIN_URL . 'admin/js/competitors.js',
-            [ 'jquery' ],
-            SWPS_VERSION,
-            true
-        );
-        wp_localize_script( 'swps-competitors', 'swpsCompetitors', [
-            'ajaxUrl'        => admin_url( 'admin-ajax.php' ),
-            'nonce'          => wp_create_nonce( 'swps_nonce' ),
-            'maxCompetitors' => self::MAX_COMPETITORS,
-            'i18n'           => [
-                'scanning'       => __( 'Scanning...', 'stratawp-seo' ),
-                'scanningAll'    => __( 'Scanning all competitors...', 'stratawp-seo' ),
-                'saving'         => __( 'Saving...', 'stratawp-seo' ),
-                'deleting'       => __( 'Deleting...', 'stratawp-seo' ),
-                'genericFail'    => __( 'Request failed.', 'stratawp-seo' ),
-                'invalidUrl'     => __( 'Please enter a valid URL (https://example.com).', 'stratawp-seo' ),
-                'confirmDelete'  => __( 'Stop tracking this competitor? Snapshot history will be deleted.', 'stratawp-seo' ),
-                'limitReached'   => sprintf( /* translators: %d: max competitors */ __( 'You can track up to %d competitors.', 'stratawp-seo' ), self::MAX_COMPETITORS ),
-                'noChanges'      => __( 'No changes since last scan.', 'stratawp-seo' ),
-                'newPosts'       => __( 'new posts', 'stratawp-seo' ),
-                'newPost'        => __( 'new post', 'stratawp-seo' ),
-                'newSchema'      => __( 'New schema:', 'stratawp-seo' ),
-                'titleChanged'   => __( 'Homepage title changed.', 'stratawp-seo' ),
-                'h1Changed'      => __( 'Homepage H1 changed.', 'stratawp-seo' ),
-                'never'          => __( 'never', 'stratawp-seo' ),
-                'noScanYet'      => __( 'Not scanned yet — click "Scan now".', 'stratawp-seo' ),
-                'addCompetitor'  => __( 'Add competitor', 'stratawp-seo' ),
-                'editCompetitor' => __( 'Edit', 'stratawp-seo' ),
-                'cancel'         => __( 'Cancel', 'stratawp-seo' ),
-                'save'           => __( 'Save', 'stratawp-seo' ),
-                'scanNow'        => __( 'Scan now', 'stratawp-seo' ),
-                'delete'         => __( 'Delete', 'stratawp-seo' ),
-                'urlPlaceholder' => __( 'https://competitor.com', 'stratawp-seo' ),
-                'labelPlaceholder' => __( 'Optional label (defaults to domain)', 'stratawp-seo' ),
-                'sourceRss'      => __( 'RSS', 'stratawp-seo' ),
-                'sourceSitemap'  => __( 'Sitemap', 'stratawp-seo' ),
-                'sourceNone'     => __( 'No data source found', 'stratawp-seo' ),
-                'velocity'       => __( 'posts/wk', 'stratawp-seo' ),
-                'noNewPosts'     => __( 'No new posts since last scan', 'stratawp-seo' ),
-                'recentPosts'    => __( 'Recent posts', 'stratawp-seo' ),
-                'schemaTypes'    => __( 'Schema types', 'stratawp-seo' ),
-                'lastScan'       => __( 'Last scan', 'stratawp-seo' ),
-                'empty'          => __( 'No competitors tracked yet. Click "Add competitor" to start.', 'stratawp-seo' ),
-            ],
-        ] );
-    }
-
-    // ---------- Cron ----------
-
-    public function maybe_schedule_cron(): void {
-        if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-            wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', self::CRON_HOOK );
-        }
-    }
-
-    public static function unschedule_cron(): void {
-        $timestamp = wp_next_scheduled( self::CRON_HOOK );
-        if ( $timestamp ) {
-            wp_unschedule_event( $timestamp, self::CRON_HOOK );
-        }
-        wp_unschedule_hook( self::CRON_HOOK );
-    }
-
-    public function cron_scan_all(): void {
-        $list = $this->get_list();
-        $n    = count( $list );
-        foreach ( $list as $i => $c ) {
-            $list[ $i ] = $this->scan_one( $c );
-            if ( $i < $n - 1 ) {
-                usleep( 500000 ); // 0.5s — be polite between competitors.
-            }
-        }
-        $this->save_list( $list );
-    }
-
-    // ---------- AJAX ----------
-
-    public function ajax_save(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-
-        $url   = isset( $_POST['url'] )   ? esc_url_raw( wp_unslash( $_POST['url'] ) )         : '';
-        $label = isset( $_POST['label'] ) ? sanitize_text_field( wp_unslash( $_POST['label'] ) ) : '';
-        $id    = isset( $_POST['id'] )    ? sanitize_key( wp_unslash( $_POST['id'] ) )           : '';
-
-        if ( '' === $url || ! preg_match( '#^https?://#i', $url ) ) {
-            wp_send_json_error( [ 'message' => __( 'Please enter a valid URL (https://example.com).', 'stratawp-seo' ) ] );
-        }
-
-        $url = $this->normalize_url( $url );
-        if ( '' === $label ) {
-            $label = $this->derive_label( $url );
-        }
-
-        $list = $this->get_list();
-
-        if ( '' !== $id ) {
-            foreach ( $list as $i => $c ) {
-                if ( $c['id'] === $id ) {
-                    $list[ $i ]['url']   = $url;
-                    $list[ $i ]['label'] = $label;
-                    $this->save_list( $list );
-                    wp_send_json_success( [ 'list' => $list, 'summary' => $this->get_summary( $list ) ] );
-                }
-            }
-        }
-
-        if ( count( $list ) >= self::MAX_COMPETITORS ) {
-            wp_send_json_error( [ 'message' => sprintf( /* translators: %d: max */ __( 'You can track up to %d competitors.', 'stratawp-seo' ), self::MAX_COMPETITORS ) ] );
-        }
-
-        $list[] = [
-            'id'           => $this->make_id( $url ),
-            'url'          => $url,
-            'label'        => $label,
-            'feed_url'     => '',
-            'data_source'  => '',
-            'last_scanned' => '',
-            'last_error'   => '',
-            'snapshots'    => [],
-        ];
-        $this->save_list( $list );
-        wp_send_json_success( [ 'list' => $list, 'summary' => $this->get_summary( $list ) ] );
-    }
-
-    public function ajax_delete(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-        $id = isset( $_POST['id'] ) ? sanitize_key( wp_unslash( $_POST['id'] ) ) : '';
-        if ( '' === $id ) {
-            wp_send_json_error( [ 'message' => __( 'Invalid id.', 'stratawp-seo' ) ] );
-        }
-        $list = array_values( array_filter( $this->get_list(), fn( $c ) => $c['id'] !== $id ) );
-        $this->save_list( $list );
-        wp_send_json_success( [ 'list' => $list, 'summary' => $this->get_summary( $list ) ] );
-    }
-
-    public function ajax_scan(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-        $id   = isset( $_POST['id'] ) ? sanitize_key( wp_unslash( $_POST['id'] ) ) : '';
-        $list = $this->get_list();
-        foreach ( $list as $i => $c ) {
-            if ( $c['id'] === $id ) {
-                $list[ $i ] = $this->scan_one( $c );
-                $this->save_list( $list );
-                wp_send_json_success( [ 'list' => $list, 'summary' => $this->get_summary( $list ) ] );
-            }
-        }
-        wp_send_json_error( [ 'message' => __( 'Competitor not found.', 'stratawp-seo' ) ] );
-    }
-
-    public function ajax_scan_all(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-        // Allow a slightly longer execution window for the bulk scan.
-        if ( function_exists( 'set_time_limit' ) ) {
-            @set_time_limit( 120 );
-        }
-        $list = $this->get_list();
-        foreach ( $list as $i => $c ) {
-            $list[ $i ] = $this->scan_one( $c );
-        }
-        $this->save_list( $list );
-        wp_send_json_success( [ 'list' => $list, 'summary' => $this->get_summary( $list ) ] );
-    }
-
-    // ---------- Public API ----------
-
-    public function get_list(): array {
-        $list = get_option( self::OPTION_LIST, [] );
-        if ( ! is_array( $list ) ) {
-            return [];
-        }
-        $defaults = [
-            'id'           => '',
-            'url'          => '',
-            'label'        => '',
-            'feed_url'     => '',
-            'data_source'  => '',
-            'last_scanned' => '',
-            'last_error'   => '',
-            'snapshots'    => [],
-        ];
-        foreach ( $list as $i => $c ) {
-            $list[ $i ] = wp_parse_args( is_array( $c ) ? $c : [], $defaults );
-        }
-        return $list;
-    }
-
-    public function save_list( array $list ): void {
-        update_option( self::OPTION_LIST, $list, false );
-    }
-
-    /**
-     * Public for dashboard widget (3 most-recently-changed competitors with one-line summaries).
-     */
-    public function get_dashboard_summary( int $limit = 3 ): array {
-        $list = $this->get_list();
-        $rows = [];
-        foreach ( $list as $c ) {
-            $diff = $this->latest_diff( $c );
-            if ( empty( $diff['has_data'] ) ) { continue; }
-
-            $summary_parts = [];
-            if ( $diff['new_post_count'] > 0 ) {
-                $summary_parts[] = sprintf(
-                    /* translators: %d: count */
-                    _n( '%d new post', '%d new posts', $diff['new_post_count'], 'stratawp-seo' ),
-                    $diff['new_post_count']
-                );
-            }
-            if ( ! empty( $diff['new_schema_types'] ) ) {
-                $summary_parts[] = sprintf(
-                    /* translators: %s: schema list */
-                    __( 'new schema: %s', 'stratawp-seo' ),
-                    implode( ', ', $diff['new_schema_types'] )
-                );
-            }
-            if ( ! empty( $diff['homepage_title_changed'] ) ) {
-                $summary_parts[] = __( 'title changed', 'stratawp-seo' );
-            }
-            if ( ! empty( $summary_parts ) || ! empty( $c['last_scanned'] ) ) {
-                $rows[] = [
-                    'label'        => $c['label'],
-                    'url'          => $c['url'],
-                    'summary'      => empty( $summary_parts )
-                        ? __( 'No changes since last scan.', 'stratawp-seo' )
-                        : implode( ' · ', $summary_parts ),
-                    'last_scanned' => $c['last_scanned'],
-                    'has_changes'  => ! empty( $summary_parts ),
-                ];
-            }
-        }
-        usort( $rows, fn( $a, $b ) => strcmp( $b['last_scanned'], $a['last_scanned'] ) );
-        return array_slice( $rows, 0, $limit );
-    }
-
-    public function get_summary( ?array $list = null ): array {
-        $list           = $list ?? $this->get_list();
-        $new_posts_week = 0;
-        $changes        = 0;
-        $latest_scan    = '';
-        foreach ( $list as $c ) {
-            $diff = $this->latest_diff( $c );
-            if ( empty( $diff['has_data'] ) ) { continue; }
-            $new_posts_week += (int) $diff['new_post_count'];
-            if ( ! empty( $diff['new_schema_types'] ) )       { $changes++; }
-            if ( ! empty( $diff['removed_schema_types'] ) )   { $changes++; }
-            if ( ! empty( $diff['homepage_title_changed'] ) ) { $changes++; }
-            if ( ! empty( $diff['homepage_h1_changed'] ) )    { $changes++; }
-            if ( ! empty( $c['last_scanned'] ) && $c['last_scanned'] > $latest_scan ) {
-                $latest_scan = $c['last_scanned'];
-            }
-        }
-        return [
-            'count'          => count( $list ),
-            'new_posts_week' => $new_posts_week,
-            'changes'        => $changes,
-            'latest_scan'    => $latest_scan,
-        ];
-    }
-
-    /**
-     * Diff the latest snapshot against the previous one.
-     *
-     * @return array { has_data, post_count, new_post_count, new_posts[],
-     *                new_schema_types[], removed_schema_types[],
-     *                homepage_title, homepage_h1, homepage_title_changed, homepage_h1_changed,
-     *                velocity_per_week }
-     */
-    public function latest_diff( array $competitor ): array {
-        $snaps = $competitor['snapshots'] ?? [];
-        $count = count( $snaps );
-        if ( 0 === $count ) {
-            return [ 'has_data' => false ];
-        }
-        $cur  = $snaps[ $count - 1 ];
-        $prev = $count > 1 ? $snaps[ $count - 2 ] : null;
-
-        $diff = [
-            'has_data'               => true,
-            'post_count'             => (int) ( $cur['post_count'] ?? 0 ),
-            'new_post_count'         => 0,
-            'new_posts'              => [],
-            'new_schema_types'       => [],
-            'removed_schema_types'   => [],
-            'homepage_title'         => (string) ( $cur['homepage_title'] ?? '' ),
-            'homepage_h1'            => (string) ( $cur['homepage_h1'] ?? '' ),
-            'homepage_title_changed' => false,
-            'homepage_h1_changed'    => false,
-            'velocity_per_week'      => $this->compute_velocity( $snaps ),
-        ];
-
-        if ( $prev ) {
-            $prev_urls = array_map( fn( $p ) => $p['url'] ?? '', $prev['recent_posts'] ?? [] );
-            foreach ( $cur['recent_posts'] ?? [] as $post ) {
-                if ( ! in_array( $post['url'] ?? '', $prev_urls, true ) ) {
-                    $diff['new_posts'][] = $post;
-                }
-            }
-            $diff['new_post_count'] = count( $diff['new_posts'] );
-
-            $cur_schema  = $cur['schema_types']  ?? [];
-            $prev_schema = $prev['schema_types'] ?? [];
-            $diff['new_schema_types']     = array_values( array_diff( $cur_schema, $prev_schema ) );
-            $diff['removed_schema_types'] = array_values( array_diff( $prev_schema, $cur_schema ) );
-
-            $diff['homepage_title_changed'] = ( $cur['homepage_title'] ?? '' ) !== ( $prev['homepage_title'] ?? '' );
-            $diff['homepage_h1_changed']    = ( $cur['homepage_h1']    ?? '' ) !== ( $prev['homepage_h1']    ?? '' );
-        }
-
-        return $diff;
-    }
-
-    // ---------- Scan ----------
-
-    /**
-     * Fetch + parse one competitor and append a fresh snapshot. Always returns the
-     * (possibly updated) competitor array — errors are stored in $c['last_error'].
-     */
-    public function scan_one( array $c ): array {
-        $url = (string) ( $c['url'] ?? '' );
-        if ( '' === $url ) {
-            $c['last_error']   = __( 'Missing URL.', 'stratawp-seo' );
-            $c['last_scanned'] = current_time( 'mysql' );
-            return $c;
-        }
-
-        $homepage = $this->fetch( $url );
-        if ( is_wp_error( $homepage ) ) {
-            $c['last_scanned'] = current_time( 'mysql' );
-            $c['last_error']   = $homepage->get_error_message();
-            return $c;
-        }
-
-        $homepage_data = $this->parse_homepage( $homepage, $url );
-
-        $feed_url = '' !== ( $c['feed_url'] ?? '' ) ? $c['feed_url'] : $homepage_data['feed_url'];
-        $posts    = [];
-        $source   = '';
-
-        if ( '' !== $feed_url ) {
-            $feed_posts = $this->fetch_and_parse_feed( $feed_url );
-            if ( ! is_wp_error( $feed_posts ) && ! empty( $feed_posts ) ) {
-                $posts  = $feed_posts;
-                $source = 'rss';
-            }
-        }
-
-        if ( empty( $posts ) ) {
-            foreach ( [ '/feed/', '/feed', '/feed/atom/', '/?feed=rss2', '/rss', '/rss.xml' ] as $path ) {
-                $candidate  = $this->join_url( $url, $path );
-                $feed_posts = $this->fetch_and_parse_feed( $candidate );
-                if ( ! is_wp_error( $feed_posts ) && ! empty( $feed_posts ) ) {
-                    $posts    = $feed_posts;
-                    $source   = 'rss';
-                    $feed_url = $candidate;
-                    break;
-                }
-            }
-        }
-
-        if ( empty( $posts ) ) {
-            $sitemap_posts = $this->try_sitemap( $url );
-            if ( ! is_wp_error( $sitemap_posts ) && ! empty( $sitemap_posts ) ) {
-                $posts  = $sitemap_posts;
-                $source = 'sitemap';
-            }
-        }
-
-        $snapshot = [
-            'ts'             => current_time( 'mysql' ),
-            'post_count'     => count( $posts ),
-            'recent_posts'   => array_slice( $posts, 0, self::MAX_RECENT_POSTS ),
-            'schema_types'   => $homepage_data['schema_types'],
-            'homepage_title' => $homepage_data['title'],
-            'homepage_h1'    => $homepage_data['h1'],
-        ];
-
-        $snapshots   = $c['snapshots'] ?? [];
-        $snapshots[] = $snapshot;
-        if ( count( $snapshots ) > self::MAX_SNAPSHOTS ) {
-            $snapshots = array_slice( $snapshots, -self::MAX_SNAPSHOTS );
-        }
-
-        $c['snapshots']    = $snapshots;
-        $c['feed_url']     = $feed_url;
-        $c['data_source']  = '' !== $source ? $source : 'none';
-        $c['last_scanned'] = current_time( 'mysql' );
-        $c['last_error']   = ( '' === $source )
-            ? __( 'No RSS feed or sitemap found — only homepage data captured.', 'stratawp-seo' )
-            : '';
-
-        return $c;
-    }
-
-    // ---------- Fetchers ----------
-
-    /**
-     * @return string|WP_Error Body on success.
-     */
-    private function fetch( string $url ) {
-        $resp = wp_remote_get( $url, [
-            'timeout'     => self::HTTP_TIMEOUT,
-            'user-agent'  => $this->user_agent(),
-            'redirection' => 4,
-            'headers'     => [ 'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' ],
-        ] );
-        if ( is_wp_error( $resp ) ) {
-            return $resp;
-        }
-        $code = wp_remote_retrieve_response_code( $resp );
-        if ( $code < 200 || $code >= 400 ) {
-            return new WP_Error( 'swps_http', sprintf( /* translators: %d: HTTP status */ __( 'HTTP %d when fetching the site.', 'stratawp-seo' ), $code ) );
-        }
-        return (string) wp_remote_retrieve_body( $resp );
-    }
-
-    private function fetch_and_parse_feed( string $url ) {
-        $body = $this->fetch( $url );
-        if ( is_wp_error( $body ) ) {
-            return $body;
-        }
-        if ( '' === trim( $body ) ) {
-            return [];
-        }
-        return $this->parse_feed( $body );
-    }
-
-    private function parse_feed( string $body ): array {
-        libxml_use_internal_errors( true );
-        $xml = @simplexml_load_string( $body );
-        libxml_clear_errors();
-        if ( ! $xml ) {
-            return [];
-        }
-
-        $posts = [];
-
-        if ( isset( $xml->channel->item ) ) {
-            foreach ( $xml->channel->item as $item ) {
-                $title = trim( (string) $item->title );
-                $link  = trim( (string) $item->link );
-                $date  = trim( (string) $item->pubDate );
-                if ( '' === $link ) { continue; }
-                $posts[] = [
-                    'title' => $title,
-                    'url'   => $link,
-                    'date'  => '' !== $date ? gmdate( 'Y-m-d', strtotime( $date ) ?: time() ) : '',
-                ];
-            }
-        } elseif ( isset( $xml->entry ) ) {
-            foreach ( $xml->entry as $entry ) {
-                $title = trim( (string) $entry->title );
-                $link  = '';
-                if ( isset( $entry->link ) ) {
-                    foreach ( $entry->link as $l ) {
-                        $rel = isset( $l['rel'] ) ? (string) $l['rel'] : '';
-                        if ( '' === $rel || 'alternate' === $rel ) {
-                            $link = (string) $l['href'];
-                            break;
-                        }
-                    }
-                }
-                $date = (string) ( $entry->published ?? $entry->updated ?? '' );
-                if ( '' === $link ) { continue; }
-                $posts[] = [
-                    'title' => $title,
-                    'url'   => $link,
-                    'date'  => '' !== $date ? gmdate( 'Y-m-d', strtotime( $date ) ?: time() ) : '',
-                ];
-            }
-        }
-
-        return $posts;
-    }
-
-    private function parse_homepage( string $html, string $base_url ): array {
-        $title        = '';
-        $h1           = '';
-        $feed_url     = '';
-        $schema_types = [];
-
-        if ( '' === trim( $html ) ) {
-            return compact( 'title', 'h1', 'feed_url', 'schema_types' );
-        }
-
-        if ( preg_match( '#<title[^>]*>(.*?)</title>#is', $html, $m ) ) {
-            $title = trim( html_entity_decode( wp_strip_all_tags( $m[1] ), ENT_QUOTES, 'UTF-8' ) );
-        }
-
-        if ( preg_match( '#<h1[^>]*>(.*?)</h1>#is', $html, $m ) ) {
-            $h1 = trim( html_entity_decode( wp_strip_all_tags( $m[1] ), ENT_QUOTES, 'UTF-8' ) );
-        }
-
-        if ( preg_match_all( '#<link\b[^>]*>#i', $html, $matches ) ) {
-            foreach ( $matches[0] as $link_tag ) {
-                if ( ! preg_match( '#rel\s*=\s*["\']alternate["\']#i', $link_tag ) ) { continue; }
-                if ( ! preg_match( '#type\s*=\s*["\']application/(?:rss|atom)\+xml["\']#i', $link_tag ) ) { continue; }
-                if ( preg_match( '#href\s*=\s*["\']([^"\']+)["\']#i', $link_tag, $href ) ) {
-                    $feed_url = $this->absolutize( $href[1], $base_url );
-                    break;
-                }
-            }
-        }
-
-        if ( preg_match_all( '#<script[^>]+type\s*=\s*["\']application/ld\+json["\'][^>]*>(.*?)</script>#is', $html, $blocks ) ) {
-            foreach ( $blocks[1] as $json ) {
-                $decoded = json_decode( trim( $json ), true );
-                if ( ! $decoded ) { continue; }
-                $this->collect_schema_types( $decoded, $schema_types );
-            }
-        }
-
-        $schema_types = array_values( array_unique( array_filter( $schema_types ) ) );
-        sort( $schema_types );
-
-        return compact( 'title', 'h1', 'feed_url', 'schema_types' );
-    }
-
-    private function collect_schema_types( $node, array &$bag ): void {
-        if ( ! is_array( $node ) ) { return; }
-        if ( isset( $node['@type'] ) ) {
-            $type = $node['@type'];
-            if ( is_array( $type ) ) {
-                foreach ( $type as $t ) {
-                    if ( is_string( $t ) ) { $bag[] = $t; }
-                }
-            } elseif ( is_string( $type ) ) {
-                $bag[] = $type;
-            }
-        }
-        if ( isset( $node['@graph'] ) && is_array( $node['@graph'] ) ) {
-            foreach ( $node['@graph'] as $sub ) {
-                $this->collect_schema_types( $sub, $bag );
-            }
-        }
-        foreach ( $node as $k => $v ) {
-            if ( '@graph' === $k || '@type' === $k ) { continue; }
-            if ( is_array( $v ) ) {
-                $this->collect_schema_types( $v, $bag );
-            }
-        }
-    }
-
-    /**
-     * @return array|WP_Error Posts on success.
-     */
-    private function try_sitemap( string $base_url ) {
-        foreach ( [ '/sitemap.xml', '/sitemap_index.xml', '/wp-sitemap.xml', '/sitemap-index.xml' ] as $path ) {
-            $url     = $this->join_url( $base_url, $path );
-            $body    = $this->fetch( $url );
-            if ( is_wp_error( $body ) ) { continue; }
-            $entries = $this->parse_sitemap( $body );
-            if ( ! empty( $entries ) ) {
-                return $entries;
-            }
-        }
-        return new WP_Error( 'swps_no_sitemap', __( 'No sitemap found.', 'stratawp-seo' ) );
-    }
-
-    private function parse_sitemap( string $body ): array {
-        libxml_use_internal_errors( true );
-        $xml = @simplexml_load_string( $body );
-        libxml_clear_errors();
-        if ( ! $xml ) { return []; }
-
-        // Sitemap index → follow first non-image sub-sitemap.
-        if ( isset( $xml->sitemap ) ) {
-            foreach ( $xml->sitemap as $s ) {
-                $loc = trim( (string) $s->loc );
-                if ( '' === $loc ) { continue; }
-                if ( preg_match( '#(image|video|news)#i', $loc ) ) { continue; }
-                $sub_body = $this->fetch( $loc );
-                if ( is_wp_error( $sub_body ) ) { continue; }
-                $entries = $this->parse_sitemap( $sub_body );
-                if ( ! empty( $entries ) ) {
-                    return $entries;
-                }
-            }
-            return [];
-        }
-
-        $entries = [];
-        if ( isset( $xml->url ) ) {
-            foreach ( $xml->url as $u ) {
-                $loc = trim( (string) $u->loc );
-                if ( '' === $loc ) { continue; }
-                $lastmod = trim( (string) ( $u->lastmod ?? '' ) );
-                $entries[] = [
-                    'title' => $this->slug_to_title( $loc ),
-                    'url'   => $loc,
-                    'date'  => '' !== $lastmod ? gmdate( 'Y-m-d', strtotime( $lastmod ) ?: time() ) : '',
-                ];
-            }
-        }
-
-        // Drop obvious non-post URLs to keep counts comparable across competitors.
-        $entries = array_values( array_filter( $entries, function ( $e ) {
-            $u = $e['url'];
-            if ( preg_match( '#/(category|tag|author|page|product-category|wp-content|wp-includes)/#i', $u ) ) { return false; }
-            if ( preg_match( '#\.(jpg|jpeg|png|gif|webp|svg|css|js|pdf)$#i', $u ) ) { return false; }
-            return true;
-        } ) );
-
-        usort( $entries, fn( $a, $b ) => strcmp( $b['date'], $a['date'] ) );
-        return $entries;
-    }
-
-    // ---------- Helpers ----------
-
-    private function slug_to_title( string $url ): string {
-        $path = wp_parse_url( $url, PHP_URL_PATH ) ?: '';
-        $path = trim( $path, '/' );
-        if ( '' === $path ) { return $url; }
-        $segments = explode( '/', $path );
-        $slug     = end( $segments );
-        return ucwords( str_replace( [ '-', '_' ], ' ', $slug ) );
-    }
-
-    private function absolutize( string $href, string $base ): string {
-        if ( preg_match( '#^https?://#i', $href ) ) {
-            return $href;
-        }
-        $parts = wp_parse_url( $base );
-        if ( ! $parts || empty( $parts['host'] ) ) {
-            return $href;
-        }
-        $scheme = $parts['scheme'] ?? 'https';
-        $host   = $parts['host'];
-        if ( str_starts_with( $href, '//' ) ) {
-            return $scheme . ':' . $href;
-        }
-        if ( str_starts_with( $href, '/' ) ) {
-            return $scheme . '://' . $host . $href;
-        }
-        return $scheme . '://' . $host . '/' . ltrim( $href, '/' );
-    }
-
-    private function join_url( string $base, string $path ): string {
-        return rtrim( $base, '/' ) . '/' . ltrim( $path, '/' );
-    }
-
-    private function user_agent(): string {
-        return 'StrataWP-SEO/' . SWPS_VERSION . ' (+https://stratawpseo.com)';
-    }
-
-    private function compute_velocity( array $snapshots ): float {
-        $count = count( $snapshots );
-        if ( $count < 2 ) {
-            return 0.0;
-        }
-        $first = $snapshots[0];
-        $last  = $snapshots[ $count - 1 ];
-        $first_ts = strtotime( $first['ts'] ?? '' );
-        $last_ts  = strtotime( $last['ts'] ?? '' );
-        if ( ! $first_ts || ! $last_ts || $last_ts <= $first_ts ) {
-            return 0.0;
-        }
-        $days  = max( 1, (int) round( ( $last_ts - $first_ts ) / DAY_IN_SECONDS ) );
-        $delta = max( 0, (int) ( $last['post_count'] ?? 0 ) - (int) ( $first['post_count'] ?? 0 ) );
-        return round( ( $delta / $days ) * 7, 1 );
-    }
-
-    private function normalize_url( string $url ): string {
-        $url   = trim( $url );
-        $parts = wp_parse_url( $url );
-        if ( ! $parts || empty( $parts['host'] ) ) {
-            return rtrim( $url, '/' );
-        }
-        $scheme = strtolower( $parts['scheme'] ?? 'https' );
-        $host   = strtolower( $parts['host'] );
-        $path   = isset( $parts['path'] ) ? rtrim( $parts['path'], '/' ) : '';
-        return $scheme . '://' . $host . $path;
-    }
-
-    private function derive_label( string $url ): string {
-        $host = wp_parse_url( $url, PHP_URL_HOST ) ?: '';
-        $host = preg_replace( '#^www\.#i', '', $host );
-        return '' !== $host ? $host : $url;
-    }
-
-    private function make_id( string $url ): string {
-        return substr( md5( $url . microtime() ), 0, 8 );
-    }
+	public const OPTION_LIST      = 'swps_competitors';
+	public const CRON_HOOK        = 'swps_competitors_daily_scan';
+	public const MAX_COMPETITORS  = 10;
+	public const MAX_SNAPSHOTS    = 12;
+	public const MAX_RECENT_POSTS = 20;
+	public const HTTP_TIMEOUT     = 12;
+
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'register_menu' ), 20 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'init', array( $this, 'maybe_schedule_cron' ) );
+
+		add_action( 'wp_ajax_swps_competitor_save', array( $this, 'ajax_save' ) );
+		add_action( 'wp_ajax_swps_competitor_delete', array( $this, 'ajax_delete' ) );
+		add_action( 'wp_ajax_swps_competitor_scan', array( $this, 'ajax_scan' ) );
+		add_action( 'wp_ajax_swps_competitor_scan_all', array( $this, 'ajax_scan_all' ) );
+
+		add_action( self::CRON_HOOK, array( $this, 'cron_scan_all' ) );
+	}
+
+	public function register_menu(): void {
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Competitors', 'stratawp-seo' ),
+			__( 'Competitors', 'stratawp-seo' ),
+			'manage_options',
+			'swps-competitors',
+			array( $this, 'render_page' )
+		);
+	}
+
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
+		}
+		require SWPS_PLUGIN_DIR . 'templates/competitors-page.php';
+	}
+
+	public function enqueue_assets( string $hook ): void {
+		if ( 'stratawp-seo_page_swps-competitors' !== $hook ) {
+			return;
+		}
+		wp_enqueue_style(
+			'swps-page-competitors',
+			SWPS_PLUGIN_URL . 'admin/css/pages/competitors.css',
+			array( 'swps-tokens', 'swps-components', 'swps-templates' ),
+			SWPS_VERSION
+		);
+		wp_enqueue_script(
+			'swps-competitors',
+			SWPS_PLUGIN_URL . 'admin/js/competitors.js',
+			array( 'jquery' ),
+			SWPS_VERSION,
+			true
+		);
+		wp_localize_script(
+			'swps-competitors',
+			'swpsCompetitors',
+			array(
+				'ajaxUrl'        => admin_url( 'admin-ajax.php' ),
+				'nonce'          => wp_create_nonce( 'swps_nonce' ),
+				'maxCompetitors' => self::MAX_COMPETITORS,
+				'i18n'           => array(
+					'scanning'         => __( 'Scanning...', 'stratawp-seo' ),
+					'scanningAll'      => __( 'Scanning all competitors...', 'stratawp-seo' ),
+					'saving'           => __( 'Saving...', 'stratawp-seo' ),
+					'deleting'         => __( 'Deleting...', 'stratawp-seo' ),
+					'genericFail'      => __( 'Request failed.', 'stratawp-seo' ),
+					'invalidUrl'       => __( 'Please enter a valid URL (https://example.com).', 'stratawp-seo' ),
+					'confirmDelete'    => __( 'Stop tracking this competitor? Snapshot history will be deleted.', 'stratawp-seo' ),
+					'limitReached'     => sprintf( /* translators: %d: max competitors */ __( 'You can track up to %d competitors.', 'stratawp-seo' ), self::MAX_COMPETITORS ),
+					'noChanges'        => __( 'No changes since last scan.', 'stratawp-seo' ),
+					'newPosts'         => __( 'new posts', 'stratawp-seo' ),
+					'newPost'          => __( 'new post', 'stratawp-seo' ),
+					'newSchema'        => __( 'New schema:', 'stratawp-seo' ),
+					'titleChanged'     => __( 'Homepage title changed.', 'stratawp-seo' ),
+					'h1Changed'        => __( 'Homepage H1 changed.', 'stratawp-seo' ),
+					'never'            => __( 'never', 'stratawp-seo' ),
+					'noScanYet'        => __( 'Not scanned yet — click "Scan now".', 'stratawp-seo' ),
+					'addCompetitor'    => __( 'Add competitor', 'stratawp-seo' ),
+					'editCompetitor'   => __( 'Edit', 'stratawp-seo' ),
+					'cancel'           => __( 'Cancel', 'stratawp-seo' ),
+					'save'             => __( 'Save', 'stratawp-seo' ),
+					'scanNow'          => __( 'Scan now', 'stratawp-seo' ),
+					'delete'           => __( 'Delete', 'stratawp-seo' ),
+					'urlPlaceholder'   => __( 'https://competitor.com', 'stratawp-seo' ),
+					'labelPlaceholder' => __( 'Optional label (defaults to domain)', 'stratawp-seo' ),
+					'sourceRss'        => __( 'RSS', 'stratawp-seo' ),
+					'sourceSitemap'    => __( 'Sitemap', 'stratawp-seo' ),
+					'sourceNone'       => __( 'No data source found', 'stratawp-seo' ),
+					'velocity'         => __( 'posts/wk', 'stratawp-seo' ),
+					'noNewPosts'       => __( 'No new posts since last scan', 'stratawp-seo' ),
+					'recentPosts'      => __( 'Recent posts', 'stratawp-seo' ),
+					'schemaTypes'      => __( 'Schema types', 'stratawp-seo' ),
+					'lastScan'         => __( 'Last scan', 'stratawp-seo' ),
+					'empty'            => __( 'No competitors tracked yet. Click "Add competitor" to start.', 'stratawp-seo' ),
+				),
+			)
+		);
+	}
+
+	// ---------- Cron ----------
+
+	public function maybe_schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', self::CRON_HOOK );
+		}
+	}
+
+	public static function unschedule_cron(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+		wp_unschedule_hook( self::CRON_HOOK );
+	}
+
+	public function cron_scan_all(): void {
+		$list = $this->get_list();
+		$n    = count( $list );
+		foreach ( $list as $i => $c ) {
+			$list[ $i ] = $this->scan_one( $c );
+			if ( $i < $n - 1 ) {
+				usleep( 500000 ); // 0.5s — be polite between competitors.
+			}
+		}
+		$this->save_list( $list );
+	}
+
+	// ---------- AJAX ----------
+
+	public function ajax_save(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+
+		$url   = isset( $_POST['url'] ) ? esc_url_raw( wp_unslash( $_POST['url'] ) ) : '';
+		$label = isset( $_POST['label'] ) ? sanitize_text_field( wp_unslash( $_POST['label'] ) ) : '';
+		$id    = isset( $_POST['id'] ) ? sanitize_key( wp_unslash( $_POST['id'] ) ) : '';
+
+		if ( '' === $url || ! preg_match( '#^https?://#i', $url ) ) {
+			wp_send_json_error( array( 'message' => __( 'Please enter a valid URL (https://example.com).', 'stratawp-seo' ) ) );
+		}
+
+		$url = $this->normalize_url( $url );
+		if ( '' === $label ) {
+			$label = $this->derive_label( $url );
+		}
+
+		$list = $this->get_list();
+
+		if ( '' !== $id ) {
+			foreach ( $list as $i => $c ) {
+				if ( $c['id'] === $id ) {
+					$list[ $i ]['url']   = $url;
+					$list[ $i ]['label'] = $label;
+					$this->save_list( $list );
+					wp_send_json_success(
+						array(
+							'list'    => $list,
+							'summary' => $this->get_summary( $list ),
+						)
+					);
+				}
+			}
+		}
+
+		if ( count( $list ) >= self::MAX_COMPETITORS ) {
+			wp_send_json_error( array( 'message' => sprintf( /* translators: %d: max */ __( 'You can track up to %d competitors.', 'stratawp-seo' ), self::MAX_COMPETITORS ) ) );
+		}
+
+		$list[] = array(
+			'id'           => $this->make_id( $url ),
+			'url'          => $url,
+			'label'        => $label,
+			'feed_url'     => '',
+			'data_source'  => '',
+			'last_scanned' => '',
+			'last_error'   => '',
+			'snapshots'    => array(),
+		);
+		$this->save_list( $list );
+		wp_send_json_success(
+			array(
+				'list'    => $list,
+				'summary' => $this->get_summary( $list ),
+			)
+		);
+	}
+
+	public function ajax_delete(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		$id = isset( $_POST['id'] ) ? sanitize_key( wp_unslash( $_POST['id'] ) ) : '';
+		if ( '' === $id ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid id.', 'stratawp-seo' ) ) );
+		}
+		$list = array_values( array_filter( $this->get_list(), fn( $c ) => $c['id'] !== $id ) );
+		$this->save_list( $list );
+		wp_send_json_success(
+			array(
+				'list'    => $list,
+				'summary' => $this->get_summary( $list ),
+			)
+		);
+	}
+
+	public function ajax_scan(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		$id   = isset( $_POST['id'] ) ? sanitize_key( wp_unslash( $_POST['id'] ) ) : '';
+		$list = $this->get_list();
+		foreach ( $list as $i => $c ) {
+			if ( $c['id'] === $id ) {
+				$list[ $i ] = $this->scan_one( $c );
+				$this->save_list( $list );
+				wp_send_json_success(
+					array(
+						'list'    => $list,
+						'summary' => $this->get_summary( $list ),
+					)
+				);
+			}
+		}
+		wp_send_json_error( array( 'message' => __( 'Competitor not found.', 'stratawp-seo' ) ) );
+	}
+
+	public function ajax_scan_all(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		// Allow a slightly longer execution window for the bulk scan.
+		if ( function_exists( 'set_time_limit' ) ) {
+			@set_time_limit( 120 );
+		}
+		$list = $this->get_list();
+		foreach ( $list as $i => $c ) {
+			$list[ $i ] = $this->scan_one( $c );
+		}
+		$this->save_list( $list );
+		wp_send_json_success(
+			array(
+				'list'    => $list,
+				'summary' => $this->get_summary( $list ),
+			)
+		);
+	}
+
+	// ---------- Public API ----------
+
+	public function get_list(): array {
+		$list = get_option( self::OPTION_LIST, array() );
+		if ( ! is_array( $list ) ) {
+			return array();
+		}
+		$defaults = array(
+			'id'           => '',
+			'url'          => '',
+			'label'        => '',
+			'feed_url'     => '',
+			'data_source'  => '',
+			'last_scanned' => '',
+			'last_error'   => '',
+			'snapshots'    => array(),
+		);
+		foreach ( $list as $i => $c ) {
+			$list[ $i ] = wp_parse_args( is_array( $c ) ? $c : array(), $defaults );
+		}
+		return $list;
+	}
+
+	public function save_list( array $list ): void {
+		update_option( self::OPTION_LIST, $list, false );
+	}
+
+	/**
+	 * Public for dashboard widget (3 most-recently-changed competitors with one-line summaries).
+	 */
+	public function get_dashboard_summary( int $limit = 3 ): array {
+		$list = $this->get_list();
+		$rows = array();
+		foreach ( $list as $c ) {
+			$diff = $this->latest_diff( $c );
+			if ( empty( $diff['has_data'] ) ) {
+				continue; }
+
+			$summary_parts = array();
+			if ( $diff['new_post_count'] > 0 ) {
+				$summary_parts[] = sprintf(
+					/* translators: %d: count */
+					_n( '%d new post', '%d new posts', $diff['new_post_count'], 'stratawp-seo' ),
+					$diff['new_post_count']
+				);
+			}
+			if ( ! empty( $diff['new_schema_types'] ) ) {
+				$summary_parts[] = sprintf(
+					/* translators: %s: schema list */
+					__( 'new schema: %s', 'stratawp-seo' ),
+					implode( ', ', $diff['new_schema_types'] )
+				);
+			}
+			if ( ! empty( $diff['homepage_title_changed'] ) ) {
+				$summary_parts[] = __( 'title changed', 'stratawp-seo' );
+			}
+			if ( ! empty( $summary_parts ) || ! empty( $c['last_scanned'] ) ) {
+				$rows[] = array(
+					'label'        => $c['label'],
+					'url'          => $c['url'],
+					'summary'      => empty( $summary_parts )
+						? __( 'No changes since last scan.', 'stratawp-seo' )
+						: implode( ' · ', $summary_parts ),
+					'last_scanned' => $c['last_scanned'],
+					'has_changes'  => ! empty( $summary_parts ),
+				);
+			}
+		}
+		usort( $rows, fn( $a, $b ) => strcmp( $b['last_scanned'], $a['last_scanned'] ) );
+		return array_slice( $rows, 0, $limit );
+	}
+
+	public function get_summary( ?array $list = null ): array {
+		$list           = $list ?? $this->get_list();
+		$new_posts_week = 0;
+		$changes        = 0;
+		$latest_scan    = '';
+		foreach ( $list as $c ) {
+			$diff = $this->latest_diff( $c );
+			if ( empty( $diff['has_data'] ) ) {
+				continue; }
+			$new_posts_week += (int) $diff['new_post_count'];
+			if ( ! empty( $diff['new_schema_types'] ) ) {
+				++$changes; }
+			if ( ! empty( $diff['removed_schema_types'] ) ) {
+				++$changes; }
+			if ( ! empty( $diff['homepage_title_changed'] ) ) {
+				++$changes; }
+			if ( ! empty( $diff['homepage_h1_changed'] ) ) {
+				++$changes; }
+			if ( ! empty( $c['last_scanned'] ) && $c['last_scanned'] > $latest_scan ) {
+				$latest_scan = $c['last_scanned'];
+			}
+		}
+		return array(
+			'count'          => count( $list ),
+			'new_posts_week' => $new_posts_week,
+			'changes'        => $changes,
+			'latest_scan'    => $latest_scan,
+		);
+	}
+
+	/**
+	 * Diff the latest snapshot against the previous one.
+	 *
+	 * @return array { has_data, post_count, new_post_count, new_posts[],
+	 *                new_schema_types[], removed_schema_types[],
+	 *                homepage_title, homepage_h1, homepage_title_changed, homepage_h1_changed,
+	 *                velocity_per_week }
+	 */
+	public function latest_diff( array $competitor ): array {
+		$snaps = $competitor['snapshots'] ?? array();
+		$count = count( $snaps );
+		if ( 0 === $count ) {
+			return array( 'has_data' => false );
+		}
+		$cur  = $snaps[ $count - 1 ];
+		$prev = $count > 1 ? $snaps[ $count - 2 ] : null;
+
+		$diff = array(
+			'has_data'               => true,
+			'post_count'             => (int) ( $cur['post_count'] ?? 0 ),
+			'new_post_count'         => 0,
+			'new_posts'              => array(),
+			'new_schema_types'       => array(),
+			'removed_schema_types'   => array(),
+			'homepage_title'         => (string) ( $cur['homepage_title'] ?? '' ),
+			'homepage_h1'            => (string) ( $cur['homepage_h1'] ?? '' ),
+			'homepage_title_changed' => false,
+			'homepage_h1_changed'    => false,
+			'velocity_per_week'      => $this->compute_velocity( $snaps ),
+		);
+
+		if ( $prev ) {
+			$prev_urls = array_map( fn( $p ) => $p['url'] ?? '', $prev['recent_posts'] ?? array() );
+			foreach ( $cur['recent_posts'] ?? array() as $post ) {
+				if ( ! in_array( $post['url'] ?? '', $prev_urls, true ) ) {
+					$diff['new_posts'][] = $post;
+				}
+			}
+			$diff['new_post_count'] = count( $diff['new_posts'] );
+
+			$cur_schema                   = $cur['schema_types'] ?? array();
+			$prev_schema                  = $prev['schema_types'] ?? array();
+			$diff['new_schema_types']     = array_values( array_diff( $cur_schema, $prev_schema ) );
+			$diff['removed_schema_types'] = array_values( array_diff( $prev_schema, $cur_schema ) );
+
+			$diff['homepage_title_changed'] = ( $cur['homepage_title'] ?? '' ) !== ( $prev['homepage_title'] ?? '' );
+			$diff['homepage_h1_changed']    = ( $cur['homepage_h1'] ?? '' ) !== ( $prev['homepage_h1'] ?? '' );
+		}
+
+		return $diff;
+	}
+
+	// ---------- Scan ----------
+
+	/**
+	 * Fetch + parse one competitor and append a fresh snapshot. Always returns the
+	 * (possibly updated) competitor array — errors are stored in $c['last_error'].
+	 */
+	public function scan_one( array $c ): array {
+		$url = (string) ( $c['url'] ?? '' );
+		if ( '' === $url ) {
+			$c['last_error']   = __( 'Missing URL.', 'stratawp-seo' );
+			$c['last_scanned'] = current_time( 'mysql' );
+			return $c;
+		}
+
+		$homepage = $this->fetch( $url );
+		if ( is_wp_error( $homepage ) ) {
+			$c['last_scanned'] = current_time( 'mysql' );
+			$c['last_error']   = $homepage->get_error_message();
+			return $c;
+		}
+
+		$homepage_data = $this->parse_homepage( $homepage, $url );
+
+		$feed_url = '' !== ( $c['feed_url'] ?? '' ) ? $c['feed_url'] : $homepage_data['feed_url'];
+		$posts    = array();
+		$source   = '';
+
+		if ( '' !== $feed_url ) {
+			$feed_posts = $this->fetch_and_parse_feed( $feed_url );
+			if ( ! is_wp_error( $feed_posts ) && ! empty( $feed_posts ) ) {
+				$posts  = $feed_posts;
+				$source = 'rss';
+			}
+		}
+
+		if ( empty( $posts ) ) {
+			foreach ( array( '/feed/', '/feed', '/feed/atom/', '/?feed=rss2', '/rss', '/rss.xml' ) as $path ) {
+				$candidate  = $this->join_url( $url, $path );
+				$feed_posts = $this->fetch_and_parse_feed( $candidate );
+				if ( ! is_wp_error( $feed_posts ) && ! empty( $feed_posts ) ) {
+					$posts    = $feed_posts;
+					$source   = 'rss';
+					$feed_url = $candidate;
+					break;
+				}
+			}
+		}
+
+		if ( empty( $posts ) ) {
+			$sitemap_posts = $this->try_sitemap( $url );
+			if ( ! is_wp_error( $sitemap_posts ) && ! empty( $sitemap_posts ) ) {
+				$posts  = $sitemap_posts;
+				$source = 'sitemap';
+			}
+		}
+
+		$snapshot = array(
+			'ts'             => current_time( 'mysql' ),
+			'post_count'     => count( $posts ),
+			'recent_posts'   => array_slice( $posts, 0, self::MAX_RECENT_POSTS ),
+			'schema_types'   => $homepage_data['schema_types'],
+			'homepage_title' => $homepage_data['title'],
+			'homepage_h1'    => $homepage_data['h1'],
+		);
+
+		$snapshots   = $c['snapshots'] ?? array();
+		$snapshots[] = $snapshot;
+		if ( count( $snapshots ) > self::MAX_SNAPSHOTS ) {
+			$snapshots = array_slice( $snapshots, -self::MAX_SNAPSHOTS );
+		}
+
+		$c['snapshots']    = $snapshots;
+		$c['feed_url']     = $feed_url;
+		$c['data_source']  = '' !== $source ? $source : 'none';
+		$c['last_scanned'] = current_time( 'mysql' );
+		$c['last_error']   = ( '' === $source )
+			? __( 'No RSS feed or sitemap found — only homepage data captured.', 'stratawp-seo' )
+			: '';
+
+		return $c;
+	}
+
+	// ---------- Fetchers ----------
+
+	/**
+	 * @return string|WP_Error Body on success.
+	 */
+	private function fetch( string $url ) {
+		$resp = wp_remote_get(
+			$url,
+			array(
+				'timeout'     => self::HTTP_TIMEOUT,
+				'user-agent'  => $this->user_agent(),
+				'redirection' => 4,
+				'headers'     => array( 'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' ),
+			)
+		);
+		if ( is_wp_error( $resp ) ) {
+			return $resp;
+		}
+		$code = wp_remote_retrieve_response_code( $resp );
+		if ( $code < 200 || $code >= 400 ) {
+			return new WP_Error( 'swps_http', sprintf( /* translators: %d: HTTP status */ __( 'HTTP %d when fetching the site.', 'stratawp-seo' ), $code ) );
+		}
+		return (string) wp_remote_retrieve_body( $resp );
+	}
+
+	private function fetch_and_parse_feed( string $url ) {
+		$body = $this->fetch( $url );
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+		if ( '' === trim( $body ) ) {
+			return array();
+		}
+		return $this->parse_feed( $body );
+	}
+
+	private function parse_feed( string $body ): array {
+		libxml_use_internal_errors( true );
+		$xml = @simplexml_load_string( $body );
+		libxml_clear_errors();
+		if ( ! $xml ) {
+			return array();
+		}
+
+		$posts = array();
+
+		if ( isset( $xml->channel->item ) ) {
+			foreach ( $xml->channel->item as $item ) {
+				$title = trim( (string) $item->title );
+				$link  = trim( (string) $item->link );
+				$date  = trim( (string) $item->pubDate );
+				if ( '' === $link ) {
+					continue; }
+				$posts[] = array(
+					'title' => $title,
+					'url'   => $link,
+					'date'  => '' !== $date ? gmdate( 'Y-m-d', strtotime( $date ) ?: time() ) : '',
+				);
+			}
+		} elseif ( isset( $xml->entry ) ) {
+			foreach ( $xml->entry as $entry ) {
+				$title = trim( (string) $entry->title );
+				$link  = '';
+				if ( isset( $entry->link ) ) {
+					foreach ( $entry->link as $l ) {
+						$rel = isset( $l['rel'] ) ? (string) $l['rel'] : '';
+						if ( '' === $rel || 'alternate' === $rel ) {
+							$link = (string) $l['href'];
+							break;
+						}
+					}
+				}
+				$date = (string) ( $entry->published ?? $entry->updated ?? '' );
+				if ( '' === $link ) {
+					continue; }
+				$posts[] = array(
+					'title' => $title,
+					'url'   => $link,
+					'date'  => '' !== $date ? gmdate( 'Y-m-d', strtotime( $date ) ?: time() ) : '',
+				);
+			}
+		}
+
+		return $posts;
+	}
+
+	private function parse_homepage( string $html, string $base_url ): array {
+		$title        = '';
+		$h1           = '';
+		$feed_url     = '';
+		$schema_types = array();
+
+		if ( '' === trim( $html ) ) {
+			return compact( 'title', 'h1', 'feed_url', 'schema_types' );
+		}
+
+		if ( preg_match( '#<title[^>]*>(.*?)</title>#is', $html, $m ) ) {
+			$title = trim( html_entity_decode( wp_strip_all_tags( $m[1] ), ENT_QUOTES, 'UTF-8' ) );
+		}
+
+		if ( preg_match( '#<h1[^>]*>(.*?)</h1>#is', $html, $m ) ) {
+			$h1 = trim( html_entity_decode( wp_strip_all_tags( $m[1] ), ENT_QUOTES, 'UTF-8' ) );
+		}
+
+		if ( preg_match_all( '#<link\b[^>]*>#i', $html, $matches ) ) {
+			foreach ( $matches[0] as $link_tag ) {
+				if ( ! preg_match( '#rel\s*=\s*["\']alternate["\']#i', $link_tag ) ) {
+					continue; }
+				if ( ! preg_match( '#type\s*=\s*["\']application/(?:rss|atom)\+xml["\']#i', $link_tag ) ) {
+					continue; }
+				if ( preg_match( '#href\s*=\s*["\']([^"\']+)["\']#i', $link_tag, $href ) ) {
+					$feed_url = $this->absolutize( $href[1], $base_url );
+					break;
+				}
+			}
+		}
+
+		if ( preg_match_all( '#<script[^>]+type\s*=\s*["\']application/ld\+json["\'][^>]*>(.*?)</script>#is', $html, $blocks ) ) {
+			foreach ( $blocks[1] as $json ) {
+				$decoded = json_decode( trim( $json ), true );
+				if ( ! $decoded ) {
+					continue; }
+				$this->collect_schema_types( $decoded, $schema_types );
+			}
+		}
+
+		$schema_types = array_values( array_unique( array_filter( $schema_types ) ) );
+		sort( $schema_types );
+
+		return compact( 'title', 'h1', 'feed_url', 'schema_types' );
+	}
+
+	private function collect_schema_types( $node, array &$bag ): void {
+		if ( ! is_array( $node ) ) {
+			return; }
+		if ( isset( $node['@type'] ) ) {
+			$type = $node['@type'];
+			if ( is_array( $type ) ) {
+				foreach ( $type as $t ) {
+					if ( is_string( $t ) ) {
+						$bag[] = $t; }
+				}
+			} elseif ( is_string( $type ) ) {
+				$bag[] = $type;
+			}
+		}
+		if ( isset( $node['@graph'] ) && is_array( $node['@graph'] ) ) {
+			foreach ( $node['@graph'] as $sub ) {
+				$this->collect_schema_types( $sub, $bag );
+			}
+		}
+		foreach ( $node as $k => $v ) {
+			if ( '@graph' === $k || '@type' === $k ) {
+				continue; }
+			if ( is_array( $v ) ) {
+				$this->collect_schema_types( $v, $bag );
+			}
+		}
+	}
+
+	/**
+	 * @return array|WP_Error Posts on success.
+	 */
+	private function try_sitemap( string $base_url ) {
+		foreach ( array( '/sitemap.xml', '/sitemap_index.xml', '/wp-sitemap.xml', '/sitemap-index.xml' ) as $path ) {
+			$url  = $this->join_url( $base_url, $path );
+			$body = $this->fetch( $url );
+			if ( is_wp_error( $body ) ) {
+				continue; }
+			$entries = $this->parse_sitemap( $body );
+			if ( ! empty( $entries ) ) {
+				return $entries;
+			}
+		}
+		return new WP_Error( 'swps_no_sitemap', __( 'No sitemap found.', 'stratawp-seo' ) );
+	}
+
+	private function parse_sitemap( string $body ): array {
+		libxml_use_internal_errors( true );
+		$xml = @simplexml_load_string( $body );
+		libxml_clear_errors();
+		if ( ! $xml ) {
+			return array(); }
+
+		// Sitemap index → follow first non-image sub-sitemap.
+		if ( isset( $xml->sitemap ) ) {
+			foreach ( $xml->sitemap as $s ) {
+				$loc = trim( (string) $s->loc );
+				if ( '' === $loc ) {
+					continue; }
+				if ( preg_match( '#(image|video|news)#i', $loc ) ) {
+					continue; }
+				$sub_body = $this->fetch( $loc );
+				if ( is_wp_error( $sub_body ) ) {
+					continue; }
+				$entries = $this->parse_sitemap( $sub_body );
+				if ( ! empty( $entries ) ) {
+					return $entries;
+				}
+			}
+			return array();
+		}
+
+		$entries = array();
+		if ( isset( $xml->url ) ) {
+			foreach ( $xml->url as $u ) {
+				$loc = trim( (string) $u->loc );
+				if ( '' === $loc ) {
+					continue; }
+				$lastmod   = trim( (string) ( $u->lastmod ?? '' ) );
+				$entries[] = array(
+					'title' => $this->slug_to_title( $loc ),
+					'url'   => $loc,
+					'date'  => '' !== $lastmod ? gmdate( 'Y-m-d', strtotime( $lastmod ) ?: time() ) : '',
+				);
+			}
+		}
+
+		// Drop obvious non-post URLs to keep counts comparable across competitors.
+		$entries = array_values(
+			array_filter(
+				$entries,
+				function ( $e ) {
+					$u = $e['url'];
+					if ( preg_match( '#/(category|tag|author|page|product-category|wp-content|wp-includes)/#i', $u ) ) {
+						return false; }
+					if ( preg_match( '#\.(jpg|jpeg|png|gif|webp|svg|css|js|pdf)$#i', $u ) ) {
+						return false; }
+					return true;
+				}
+			)
+		);
+
+		usort( $entries, fn( $a, $b ) => strcmp( $b['date'], $a['date'] ) );
+		return $entries;
+	}
+
+	// ---------- Helpers ----------
+
+	private function slug_to_title( string $url ): string {
+		$path = wp_parse_url( $url, PHP_URL_PATH ) ?: '';
+		$path = trim( $path, '/' );
+		if ( '' === $path ) {
+			return $url; }
+		$segments = explode( '/', $path );
+		$slug     = end( $segments );
+		return ucwords( str_replace( array( '-', '_' ), ' ', $slug ) );
+	}
+
+	private function absolutize( string $href, string $base ): string {
+		if ( preg_match( '#^https?://#i', $href ) ) {
+			return $href;
+		}
+		$parts = wp_parse_url( $base );
+		if ( ! $parts || empty( $parts['host'] ) ) {
+			return $href;
+		}
+		$scheme = $parts['scheme'] ?? 'https';
+		$host   = $parts['host'];
+		if ( str_starts_with( $href, '//' ) ) {
+			return $scheme . ':' . $href;
+		}
+		if ( str_starts_with( $href, '/' ) ) {
+			return $scheme . '://' . $host . $href;
+		}
+		return $scheme . '://' . $host . '/' . ltrim( $href, '/' );
+	}
+
+	private function join_url( string $base, string $path ): string {
+		return rtrim( $base, '/' ) . '/' . ltrim( $path, '/' );
+	}
+
+	private function user_agent(): string {
+		return 'StrataWP-SEO/' . SWPS_VERSION . ' (+https://stratawpseo.com)';
+	}
+
+	private function compute_velocity( array $snapshots ): float {
+		$count = count( $snapshots );
+		if ( $count < 2 ) {
+			return 0.0;
+		}
+		$first    = $snapshots[0];
+		$last     = $snapshots[ $count - 1 ];
+		$first_ts = strtotime( $first['ts'] ?? '' );
+		$last_ts  = strtotime( $last['ts'] ?? '' );
+		if ( ! $first_ts || ! $last_ts || $last_ts <= $first_ts ) {
+			return 0.0;
+		}
+		$days  = max( 1, (int) round( ( $last_ts - $first_ts ) / DAY_IN_SECONDS ) );
+		$delta = max( 0, (int) ( $last['post_count'] ?? 0 ) - (int) ( $first['post_count'] ?? 0 ) );
+		return round( ( $delta / $days ) * 7, 1 );
+	}
+
+	private function normalize_url( string $url ): string {
+		$url   = trim( $url );
+		$parts = wp_parse_url( $url );
+		if ( ! $parts || empty( $parts['host'] ) ) {
+			return rtrim( $url, '/' );
+		}
+		$scheme = strtolower( $parts['scheme'] ?? 'https' );
+		$host   = strtolower( $parts['host'] );
+		$path   = isset( $parts['path'] ) ? rtrim( $parts['path'], '/' ) : '';
+		return $scheme . '://' . $host . $path;
+	}
+
+	private function derive_label( string $url ): string {
+		$host = wp_parse_url( $url, PHP_URL_HOST ) ?: '';
+		$host = preg_replace( '#^www\.#i', '', $host );
+		return '' !== $host ? $host : $url;
+	}
+
+	private function make_id( string $url ): string {
+		return substr( md5( $url . microtime() ), 0, 8 );
+	}
 }

--- a/includes/class-content-scorer.php
+++ b/includes/class-content-scorer.php
@@ -18,7 +18,7 @@ class SWPS_Content_Scorer {
 	/**
 	 * Default weights for each scoring dimension (must sum to 100).
 	 */
-	public const DEFAULT_WEIGHTS = [
+	public const DEFAULT_WEIGHTS = array(
 		'keyword_density'   => 15,
 		'readability'       => 20,
 		'heading_structure' => 15,
@@ -26,7 +26,7 @@ class SWPS_Content_Scorer {
 		'internal_links'    => 10,
 		'content_depth'     => 15,
 		'engagement'        => 10,
-	];
+	);
 
 	/**
 	 * Score a generated post across all quality dimensions.
@@ -44,18 +44,18 @@ class SWPS_Content_Scorer {
 		$title              = $ai_result['title'] ?? '';
 		$meta_description   = $ai_result['meta_description'] ?? '';
 		$focus_keyword      = $ai_result['focus_keyword'] ?? '';
-		$secondary_keywords = $ai_result['secondary_keywords'] ?? [];
-		$internal_links     = $ai_result['internal_links_used'] ?? [];
+		$secondary_keywords = $ai_result['secondary_keywords'] ?? array();
+		$internal_links     = $ai_result['internal_links_used'] ?? array();
 		$estimated_words    = (int) ( $ai_result['estimated_word_count'] ?? 0 );
 		$post_type          = get_post_type( $post_id );
 
 		// Note: passes $post_id as extra arg beyond the design doc's ($weights, $post_type) for per-post customization.
 		$weights = apply_filters( 'swps_score_weights', self::DEFAULT_WEIGHTS, $post_id, $post_type );
 
-		$recommendations = [];
+		$recommendations = array();
 		$plain_text      = wp_strip_all_tags( $content_html );
 
-		$details = [
+		$details = array(
 			'keyword_density'   => $this->analyze_keyword_density( $plain_text, $focus_keyword, $secondary_keywords, $recommendations ),
 			'readability'       => $this->analyze_readability( $plain_text, $recommendations ),
 			'heading_structure' => $this->analyze_heading_structure( $content_html, $focus_keyword, $recommendations ),
@@ -63,13 +63,13 @@ class SWPS_Content_Scorer {
 			'internal_links'    => $this->analyze_internal_links( $content_html, $recommendations ),
 			'content_depth'     => $this->analyze_content_depth( $plain_text, $content_html, $estimated_words, $recommendations ),
 			'engagement'        => $this->analyze_engagement( $content_html, $plain_text, $recommendations ),
-		];
+		);
 
-		$weighted_sum   = 0;
-		$weight_total   = 0;
+		$weighted_sum = 0;
+		$weight_total = 0;
 
 		foreach ( $details as $dimension => $dimension_score ) {
-			$weight       = $weights[ $dimension ] ?? 0;
+			$weight        = $weights[ $dimension ] ?? 0;
 			$weighted_sum += $dimension_score * $weight;
 			$weight_total += $weight;
 		}
@@ -77,11 +77,11 @@ class SWPS_Content_Scorer {
 		$overall_score = ( $weight_total > 0 ) ? (int) round( $weighted_sum / $weight_total ) : 0;
 		$overall_score = max( 0, min( 100, $overall_score ) );
 
-		return [
+		return array(
 			'overall_score'   => $overall_score,
 			'details'         => $details,
 			'recommendations' => $recommendations,
-		];
+		);
 	}
 
 	/**
@@ -134,7 +134,7 @@ class SWPS_Content_Scorer {
 		}
 
 		// Check secondary keywords.
-		$missing_secondary = [];
+		$missing_secondary = array();
 		foreach ( $secondary_keywords as $secondary ) {
 			if ( ! is_string( $secondary ) || empty( $secondary ) ) {
 				continue;
@@ -247,9 +247,14 @@ class SWPS_Content_Scorer {
 		$score = 100;
 
 		// Penalize H1 in content body (-20).
-		$h1_count = count( array_filter( $levels, function ( $level ) {
-			return 1 === $level;
-		} ) );
+		$h1_count = count(
+			array_filter(
+				$levels,
+				function ( $level ) {
+					return 1 === $level;
+				}
+			)
+		);
 
 		if ( $h1_count > 0 ) {
 			$score -= 20;
@@ -257,9 +262,14 @@ class SWPS_Content_Scorer {
 		}
 
 		// Count H2s, penalize if fewer than 2 (-20).
-		$h2_count = count( array_filter( $levels, function ( $level ) {
-			return 2 === $level;
-		} ) );
+		$h2_count = count(
+			array_filter(
+				$levels,
+				function ( $level ) {
+					return 2 === $level;
+				}
+			)
+		);
 
 		if ( $h2_count < 2 ) {
 			$score -= 20;
@@ -270,9 +280,14 @@ class SWPS_Content_Scorer {
 		}
 
 		// Check for skipped heading levels (-10).
-		$non_h1_levels = array_values( array_filter( $levels, function ( $level ) {
-			return $level > 1;
-		} ) );
+		$non_h1_levels = array_values(
+			array_filter(
+				$levels,
+				function ( $level ) {
+					return $level > 1;
+				}
+			)
+		);
 
 		$has_skipped = false;
 		for ( $i = 0; $i < count( $non_h1_levels ) - 1; $i++ ) {
@@ -291,7 +306,7 @@ class SWPS_Content_Scorer {
 
 		// Check focus keyword in headings (-15).
 		if ( ! empty( $focus_keyword ) ) {
-			$keyword_lower     = mb_strtolower( $focus_keyword );
+			$keyword_lower      = mb_strtolower( $focus_keyword );
 			$keyword_in_heading = false;
 
 			foreach ( $texts as $heading_text ) {
@@ -397,8 +412,8 @@ class SWPS_Content_Scorer {
 		preg_match_all( '/<a\s[^>]*href=["\']([^"\']*)["\'][^>]*>(.*?)<\/a>/is', $content_html, $matches );
 
 		$site_url       = home_url();
-		$internal_hrefs = [];
-		$internal_texts = [];
+		$internal_hrefs = array();
+		$internal_texts = array();
 
 		foreach ( $matches[1] as $index => $href ) {
 			$href_trimmed = trim( $href );
@@ -442,13 +457,13 @@ class SWPS_Content_Scorer {
 		}
 
 		// Check for generic anchor text on internal links.
-		$generic_anchors = [ 'click here', 'read more', 'here', 'this', 'link', 'this link', 'learn more', 'more' ];
+		$generic_anchors = array( 'click here', 'read more', 'here', 'this', 'link', 'this link', 'learn more', 'more' );
 		$generic_count   = 0;
 
 		foreach ( $internal_texts as $anchor_text ) {
 			$anchor_clean = mb_strtolower( trim( wp_strip_all_tags( $anchor_text ) ) );
 			if ( in_array( $anchor_clean, $generic_anchors, true ) ) {
-				$generic_count++;
+				++$generic_count;
 			}
 		}
 
@@ -572,7 +587,7 @@ class SWPS_Content_Scorer {
 		foreach ( $link_matches[1] as $href ) {
 			// External if it starts with http and does not start with site URL.
 			if ( preg_match( '/^https?:\/\//i', $href ) && 0 !== mb_strpos( $href, $site_url ) ) {
-				$external_count++;
+				++$external_count;
 			}
 		}
 
@@ -597,8 +612,8 @@ class SWPS_Content_Scorer {
 	 * @return int Total syllable count.
 	 */
 	private function count_syllables( string $text ): int {
-		$words  = preg_split( '/\s+/', $text, -1, PREG_SPLIT_NO_EMPTY );
-		$total  = 0;
+		$words = preg_split( '/\s+/', $text, -1, PREG_SPLIT_NO_EMPTY );
+		$total = 0;
 
 		foreach ( $words as $word ) {
 			$word = mb_strtolower( trim( $word ) );
@@ -646,69 +661,69 @@ class SWPS_Content_Scorer {
 		$post = get_post( $post_id );
 
 		if ( ! $post ) {
-			return [
+			return array(
 				'score'  => 0,
 				'status' => 'poor',
-				'checks' => [],
-			];
+				'checks' => array(),
+			);
 		}
 
-		$focus_keyword   = get_post_meta( $post_id, '_swps_focus_keyword', true );
-		$meta_title      = get_post_meta( $post_id, '_swps_meta_title', true );
-		$meta_desc       = get_post_meta( $post_id, '_swps_meta_description', true );
-		$social_image    = get_post_meta( $post_id, '_swps_social_image', true );
-		$content_html    = $post->post_content;
-		$plain_text      = wp_strip_all_tags( $content_html );
-		$keyword_lower   = mb_strtolower( trim( $focus_keyword ) );
-		$min_words       = (int) get_option( 'swps_seo_score_content_min', 300 );
+		$focus_keyword = get_post_meta( $post_id, '_swps_focus_keyword', true );
+		$meta_title    = get_post_meta( $post_id, '_swps_meta_title', true );
+		$meta_desc     = get_post_meta( $post_id, '_swps_meta_description', true );
+		$social_image  = get_post_meta( $post_id, '_swps_social_image', true );
+		$content_html  = $post->post_content;
+		$plain_text    = wp_strip_all_tags( $content_html );
+		$keyword_lower = mb_strtolower( trim( $focus_keyword ) );
+		$min_words     = (int) get_option( 'swps_seo_score_content_min', 300 );
 
 		// Check 1: Focus keyword set.
 		$has_keyword = ! empty( $keyword_lower );
-		$checks = [];
+		$checks      = array();
 
-		$checks['focus_keyword_set'] = [
+		$checks['focus_keyword_set'] = array(
 			'pass'  => $has_keyword,
 			'label' => __( 'Focus keyword set', 'stratawp-seo' ),
-		];
+		);
 
 		if ( ! $has_keyword ) {
-			$result = [
+			$result = array(
 				'score'  => 0,
 				'status' => 'no_keyword',
 				'checks' => $checks,
-			];
+			);
 			update_post_meta( $post_id, '_swps_seo_score', $result );
 			update_post_meta( $post_id, '_swps_seo_score_value', 0 );
 			return $result;
 		}
 
 		// Check 2: Keyword in meta title.
-		$checks['keyword_in_title'] = [
+		$checks['keyword_in_title'] = array(
 			'pass'  => ! empty( $meta_title ) && false !== mb_strpos( mb_strtolower( $meta_title ), $keyword_lower ),
 			'label' => __( 'Keyword in meta title', 'stratawp-seo' ),
-		];
+		);
 
 		// Check 3: Keyword in meta description.
-		$checks['keyword_in_desc'] = [
+		$checks['keyword_in_desc'] = array(
 			'pass'  => ! empty( $meta_desc ) && false !== mb_strpos( mb_strtolower( $meta_desc ), $keyword_lower ),
 			'label' => __( 'Keyword in meta description', 'stratawp-seo' ),
-		];
+		);
 
 		// Check 4: Title length (50-60 chars).
-		$title_len = mb_strlen( $meta_title );
-		$checks['title_length'] = [
+		$title_len              = mb_strlen( $meta_title );
+		$checks['title_length'] = array(
 			'pass'  => $title_len >= 50 && $title_len <= 60,
 			'label' => __( 'Meta title length (50-60 chars)', 'stratawp-seo' ),
 			'value' => sprintf( '%d chars', $title_len ),
-		];
+		);
 
 		// Check 5: Description length (150-160 chars).
-		$desc_len = mb_strlen( $meta_desc );
-		$checks['desc_length'] = [
+		$desc_len              = mb_strlen( $meta_desc );
+		$checks['desc_length'] = array(
 			'pass'  => $desc_len >= 147 && $desc_len <= 160,
 			'label' => __( 'Meta description length (147-160 chars)', 'stratawp-seo' ),
 			'value' => sprintf( '%d chars', $desc_len ),
-		];
+		);
 
 		// Check 6: Keyword in first paragraph.
 		// Strip TOC, key takeaways, and other structural blocks before finding the first real <p>.
@@ -727,10 +742,10 @@ class SWPS_Content_Scorer {
 			$first_para_text = mb_strtolower( wp_strip_all_tags( $p_match[1] ) );
 			$first_para_pass = false !== mb_strpos( $first_para_text, $keyword_lower );
 		}
-		$checks['keyword_first_para'] = [
+		$checks['keyword_first_para'] = array(
 			'pass'  => $first_para_pass,
 			'label' => __( 'Keyword in first paragraph', 'stratawp-seo' ),
-		];
+		);
 
 		// Check 7: Keyword in at least one H2.
 		$h2_pass = false;
@@ -742,24 +757,24 @@ class SWPS_Content_Scorer {
 				}
 			}
 		}
-		$checks['keyword_in_h2'] = [
+		$checks['keyword_in_h2'] = array(
 			'pass'  => $h2_pass,
 			'label' => __( 'Keyword in an H2 heading', 'stratawp-seo' ),
-		];
+		);
 
 		// Check 8: Content length.
-		$word_count = str_word_count( $plain_text );
-		$checks['content_length'] = [
+		$word_count               = str_word_count( $plain_text );
+		$checks['content_length'] = array(
 			'pass'  => $word_count >= $min_words,
 			'label' => sprintf( __( 'Content length (min %d words)', 'stratawp-seo' ), $min_words ),
 			'value' => sprintf( '%s words', number_format_i18n( $word_count ) ),
-		];
+		);
 
 		// Check 9: Internal links present.
 		$site_url        = home_url();
-		$has_internal     = false;
-		$has_external     = false;
-		$has_alt_keyword  = false;
+		$has_internal    = false;
+		$has_external    = false;
+		$has_alt_keyword = false;
 
 		if ( preg_match_all( '/<a\s[^>]*href=["\']([^"\']*)["\'][^>]*>/is', $content_html, $link_matches ) ) {
 			foreach ( $link_matches[1] as $href ) {
@@ -776,16 +791,16 @@ class SWPS_Content_Scorer {
 			}
 		}
 
-		$checks['internal_links'] = [
+		$checks['internal_links'] = array(
 			'pass'  => $has_internal,
 			'label' => __( 'Internal link present', 'stratawp-seo' ),
-		];
+		);
 
 		// Check 10: External links present.
-		$checks['external_links'] = [
+		$checks['external_links'] = array(
 			'pass'  => $has_external,
 			'label' => __( 'External link present', 'stratawp-seo' ),
-		];
+		);
 
 		// Check 11: Image alt text contains keyword.
 		if ( preg_match_all( '/<img\s[^>]*alt=["\']([^"\']*)["\'][^>]*>/is', $content_html, $img_matches ) ) {
@@ -796,15 +811,15 @@ class SWPS_Content_Scorer {
 				}
 			}
 		}
-		$checks['image_alt_keyword'] = [
+		$checks['image_alt_keyword'] = array(
 			'pass'  => $has_alt_keyword,
 			'label' => __( 'Image alt text contains keyword', 'stratawp-seo' ),
-		];
+		);
 
 		// Check 12: Slug contains keyword.
-		$slug_words   = explode( ' ', $keyword_lower );
-		$slug         = $post->post_name;
-		$slug_pass    = true;
+		$slug_words = explode( ' ', $keyword_lower );
+		$slug       = $post->post_name;
+		$slug_pass  = true;
 		foreach ( $slug_words as $word ) {
 			$word = trim( $word );
 			if ( ! empty( $word ) && false === mb_strpos( $slug, sanitize_title( $word ) ) ) {
@@ -812,42 +827,42 @@ class SWPS_Content_Scorer {
 				break;
 			}
 		}
-		$checks['slug_keyword'] = [
+		$checks['slug_keyword'] = array(
 			'pass'  => $slug_pass,
 			'label' => __( 'Slug contains keyword', 'stratawp-seo' ),
-		];
+		);
 
 		// Check 13: OG image set.
-		$checks['og_image_set'] = [
+		$checks['og_image_set'] = array(
 			'pass'  => ! empty( $social_image ),
 			'label' => __( 'OG image is set', 'stratawp-seo' ),
-		];
+		);
 
 		// Check 14: Readability (Flesch-Kincaid grade 6-10).
 		$readability_pass = false;
 		$grade_value      = '';
 		if ( str_word_count( $plain_text ) >= 10 ) {
-			$recs = [];
+			$recs              = array();
 			$readability_score = $this->analyze_readability( $plain_text, $recs );
-			$sentences      = preg_split( '/[.!?]+/', $plain_text, -1, PREG_SPLIT_NO_EMPTY );
-			$sentence_count = max( count( $sentences ), 1 );
-			$wc             = str_word_count( $plain_text );
-			$syllables      = $this->count_syllables( $plain_text );
-			$grade          = max( 0, ( 0.39 * ( $wc / $sentence_count ) ) + ( 11.8 * ( $syllables / $wc ) ) - 15.59 );
-			$readability_pass = ( $grade >= 6 && $grade <= 10 );
-			$grade_value      = sprintf( 'Grade %.0f', $grade );
+			$sentences         = preg_split( '/[.!?]+/', $plain_text, -1, PREG_SPLIT_NO_EMPTY );
+			$sentence_count    = max( count( $sentences ), 1 );
+			$wc                = str_word_count( $plain_text );
+			$syllables         = $this->count_syllables( $plain_text );
+			$grade             = max( 0, ( 0.39 * ( $wc / $sentence_count ) ) + ( 11.8 * ( $syllables / $wc ) ) - 15.59 );
+			$readability_pass  = ( $grade >= 6 && $grade <= 10 );
+			$grade_value       = sprintf( 'Grade %.0f', $grade );
 		}
-		$checks['readability'] = [
+		$checks['readability'] = array(
 			'pass'  => $readability_pass,
 			'label' => __( 'Readability score OK', 'stratawp-seo' ),
 			'value' => $grade_value,
-		];
+		);
 
 		// Calculate score: each check worth equal weight.
 		$passed = 0;
 		foreach ( $checks as $check ) {
 			if ( $check['pass'] ) {
-				$passed++;
+				++$passed;
 			}
 		}
 		$total_checks = count( $checks );
@@ -862,11 +877,11 @@ class SWPS_Content_Scorer {
 			$status = 'poor';
 		}
 
-		$result = [
+		$result = array(
 			'score'  => $score,
 			'status' => $status,
 			'checks' => $checks,
-		];
+		);
 
 		// Cache the result.
 		update_post_meta( $post_id, '_swps_seo_score', $result );

--- a/includes/class-cost-tracker.php
+++ b/includes/class-cost-tracker.php
@@ -8,136 +8,203 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Cost_Tracker {
 
-    /**
-     * Pricing per 1M tokens [model => [input, output]].
-     * Prices in USD.
-     */
-    private const PRICING = [
-        // Anthropic
-        'claude-opus-4-7'              => [ 'input' => 15.00, 'output' => 75.00 ],
-        'claude-opus-4-6'              => [ 'input' => 15.00, 'output' => 75.00 ],
-        'claude-sonnet-4-6'            => [ 'input' => 3.00, 'output' => 15.00 ],
-        'claude-sonnet-4-5-20250929'   => [ 'input' => 3.00, 'output' => 15.00 ],
-        'claude-haiku-4-5-20251001'    => [ 'input' => 0.80, 'output' => 4.00 ],
-        // OpenAI
-        'gpt-4.1'                      => [ 'input' => 2.00, 'output' => 8.00 ],
-        'gpt-4.1-mini'                 => [ 'input' => 0.40, 'output' => 1.60 ],
-        'gpt-4.1-nano'                 => [ 'input' => 0.10, 'output' => 0.40 ],
-        'gpt-4o'                       => [ 'input' => 2.50, 'output' => 10.00 ],
-        'gpt-4o-mini'                  => [ 'input' => 0.15, 'output' => 0.60 ],
-        'o3-mini'                      => [ 'input' => 1.10, 'output' => 4.40 ],
-        // Google
-        'gemini-2.5-pro'               => [ 'input' => 1.25, 'output' => 10.00 ],
-        'gemini-2.5-flash'             => [ 'input' => 0.15, 'output' => 0.60 ],
-        'gemini-2.0-flash'             => [ 'input' => 0.10, 'output' => 0.40 ],
-        'gemini-2.0-flash-lite'        => [ 'input' => 0.075, 'output' => 0.30 ],
-        // xAI
-        'grok-3'                       => [ 'input' => 3.00, 'output' => 15.00 ],
-        'grok-3-mini'                  => [ 'input' => 0.30, 'output' => 0.50 ],
-        'grok-3-fast'                  => [ 'input' => 5.00, 'output' => 25.00 ],
-    ];
+	/**
+	 * Pricing per 1M tokens [model => [input, output]].
+	 * Prices in USD.
+	 */
+	private const PRICING = array(
+		// Anthropic
+		'claude-opus-4-7'            => array(
+			'input'  => 15.00,
+			'output' => 75.00,
+		),
+		'claude-opus-4-6'            => array(
+			'input'  => 15.00,
+			'output' => 75.00,
+		),
+		'claude-sonnet-4-6'          => array(
+			'input'  => 3.00,
+			'output' => 15.00,
+		),
+		'claude-sonnet-4-5-20250929' => array(
+			'input'  => 3.00,
+			'output' => 15.00,
+		),
+		'claude-haiku-4-5-20251001'  => array(
+			'input'  => 0.80,
+			'output' => 4.00,
+		),
+		// OpenAI
+		'gpt-4.1'                    => array(
+			'input'  => 2.00,
+			'output' => 8.00,
+		),
+		'gpt-4.1-mini'               => array(
+			'input'  => 0.40,
+			'output' => 1.60,
+		),
+		'gpt-4.1-nano'               => array(
+			'input'  => 0.10,
+			'output' => 0.40,
+		),
+		'gpt-4o'                     => array(
+			'input'  => 2.50,
+			'output' => 10.00,
+		),
+		'gpt-4o-mini'                => array(
+			'input'  => 0.15,
+			'output' => 0.60,
+		),
+		'o3-mini'                    => array(
+			'input'  => 1.10,
+			'output' => 4.40,
+		),
+		// Google
+		'gemini-2.5-pro'             => array(
+			'input'  => 1.25,
+			'output' => 10.00,
+		),
+		'gemini-2.5-flash'           => array(
+			'input'  => 0.15,
+			'output' => 0.60,
+		),
+		'gemini-2.0-flash'           => array(
+			'input'  => 0.10,
+			'output' => 0.40,
+		),
+		'gemini-2.0-flash-lite'      => array(
+			'input'  => 0.075,
+			'output' => 0.30,
+		),
+		// xAI
+		'grok-3'                     => array(
+			'input'  => 3.00,
+			'output' => 15.00,
+		),
+		'grok-3-mini'                => array(
+			'input'  => 0.30,
+			'output' => 0.50,
+		),
+		'grok-3-fast'                => array(
+			'input'  => 5.00,
+			'output' => 25.00,
+		),
+	);
 
-    /**
-     * Track token usage for a generation.
-     *
-     * @param string $model         Model identifier.
-     * @param int    $input_tokens  Input token count.
-     * @param int    $output_tokens Output token count.
-     * @param int    $post_id       Optional post ID to store per-post data.
-     */
-    public function track( string $model, int $input_tokens, int $output_tokens, int $post_id = 0 ): void {
-        if ( ! get_option( 'swps_cost_tracking', false ) ) {
-            return;
-        }
+	/**
+	 * Track token usage for a generation.
+	 *
+	 * @param string $model         Model identifier.
+	 * @param int    $input_tokens  Input token count.
+	 * @param int    $output_tokens Output token count.
+	 * @param int    $post_id       Optional post ID to store per-post data.
+	 */
+	public function track( string $model, int $input_tokens, int $output_tokens, int $post_id = 0 ): void {
+		if ( ! get_option( 'swps_cost_tracking', false ) ) {
+			return;
+		}
 
-        $cost = $this->calculate_cost( $model, $input_tokens, $output_tokens );
+		$cost = $this->calculate_cost( $model, $input_tokens, $output_tokens );
 
-        // Update monthly aggregate.
-        $month_key = 'swps_cost_' . gmdate( 'Y_m' );
-        $monthly   = get_option( $month_key, [
-            'total_cost'          => 0,
-            'total_input_tokens'  => 0,
-            'total_output_tokens' => 0,
-            'generation_count'    => 0,
-        ] );
+		// Update monthly aggregate.
+		$month_key = 'swps_cost_' . gmdate( 'Y_m' );
+		$monthly   = get_option(
+			$month_key,
+			array(
+				'total_cost'          => 0,
+				'total_input_tokens'  => 0,
+				'total_output_tokens' => 0,
+				'generation_count'    => 0,
+			)
+		);
 
-        $monthly['total_cost']          += $cost;
-        $monthly['total_input_tokens']  += $input_tokens;
-        $monthly['total_output_tokens'] += $output_tokens;
-        $monthly['generation_count']    += 1;
+		$monthly['total_cost']          += $cost;
+		$monthly['total_input_tokens']  += $input_tokens;
+		$monthly['total_output_tokens'] += $output_tokens;
+		$monthly['generation_count']    += 1;
 
-        update_option( $month_key, $monthly );
+		update_option( $month_key, $monthly );
 
-        // Store per-post if applicable.
-        if ( $post_id > 0 ) {
-            update_post_meta( $post_id, '_swps_cost', round( $cost, 6 ) );
-            update_post_meta( $post_id, '_swps_tokens', [
-                'input'  => $input_tokens,
-                'output' => $output_tokens,
-                'model'  => $model,
-            ] );
-        }
-    }
+		// Store per-post if applicable.
+		if ( $post_id > 0 ) {
+			update_post_meta( $post_id, '_swps_cost', round( $cost, 6 ) );
+			update_post_meta(
+				$post_id,
+				'_swps_tokens',
+				array(
+					'input'  => $input_tokens,
+					'output' => $output_tokens,
+					'model'  => $model,
+				)
+			);
+		}
+	}
 
-    /**
-     * Calculate cost for given token usage.
-     *
-     * @param string $model         Model identifier.
-     * @param int    $input_tokens  Input token count.
-     * @param int    $output_tokens Output token count.
-     * @return float Cost in USD.
-     */
-    public function calculate_cost( string $model, int $input_tokens, int $output_tokens ): float {
-        $pricing = self::PRICING[ $model ] ?? [ 'input' => 3.00, 'output' => 15.00 ];
+	/**
+	 * Calculate cost for given token usage.
+	 *
+	 * @param string $model         Model identifier.
+	 * @param int    $input_tokens  Input token count.
+	 * @param int    $output_tokens Output token count.
+	 * @return float Cost in USD.
+	 */
+	public function calculate_cost( string $model, int $input_tokens, int $output_tokens ): float {
+		$pricing = self::PRICING[ $model ] ?? array(
+			'input'  => 3.00,
+			'output' => 15.00,
+		);
 
-        $input_cost  = ( $input_tokens / 1_000_000 ) * $pricing['input'];
-        $output_cost = ( $output_tokens / 1_000_000 ) * $pricing['output'];
+		$input_cost  = ( $input_tokens / 1_000_000 ) * $pricing['input'];
+		$output_cost = ( $output_tokens / 1_000_000 ) * $pricing['output'];
 
-        return $input_cost + $output_cost;
-    }
+		return $input_cost + $output_cost;
+	}
 
-    /**
-     * Get monthly stats.
-     *
-     * @param string $year_month Format: Y_m (e.g., 2026_02). Defaults to current month.
-     * @return array Monthly stats.
-     */
-    public function get_monthly_stats( string $year_month = '' ): array {
-        if ( empty( $year_month ) ) {
-            $year_month = gmdate( 'Y_m' );
-        }
+	/**
+	 * Get monthly stats.
+	 *
+	 * @param string $year_month Format: Y_m (e.g., 2026_02). Defaults to current month.
+	 * @return array Monthly stats.
+	 */
+	public function get_monthly_stats( string $year_month = '' ): array {
+		if ( empty( $year_month ) ) {
+			$year_month = gmdate( 'Y_m' );
+		}
 
-        return get_option( 'swps_cost_' . $year_month, [
-            'total_cost'          => 0,
-            'total_input_tokens'  => 0,
-            'total_output_tokens' => 0,
-            'generation_count'    => 0,
-        ] );
-    }
+		return get_option(
+			'swps_cost_' . $year_month,
+			array(
+				'total_cost'          => 0,
+				'total_input_tokens'  => 0,
+				'total_output_tokens' => 0,
+				'generation_count'    => 0,
+			)
+		);
+	}
 
-    /**
-     * Get total cost across all months.
-     *
-     * @return float Total cost in USD.
-     */
-    public function get_total_cost(): float {
-        global $wpdb;
+	/**
+	 * Get total cost across all months.
+	 *
+	 * @return float Total cost in USD.
+	 */
+	public function get_total_cost(): float {
+		global $wpdb;
 
-        $results = $wpdb->get_col(
-            "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE 'swps_cost_20%'"
-        );
+		$results = $wpdb->get_col(
+			"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE 'swps_cost_20%'"
+		);
 
-        $total = 0;
-        foreach ( $results as $option_name ) {
-            $data = get_option( $option_name, [] );
-            $total += $data['total_cost'] ?? 0;
-        }
+		$total = 0;
+		foreach ( $results as $option_name ) {
+			$data   = get_option( $option_name, array() );
+			$total += $data['total_cost'] ?? 0;
+		}
 
-        return $total;
-    }
+		return $total;
+	}
 }

--- a/includes/class-crawl-files.php
+++ b/includes/class-crawl-files.php
@@ -15,190 +15,206 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Crawl_Files {
 
-    public const OPT_LLMS_MODE     = 'swps_llms_txt_mode';
-    public const OPT_LLMS_CUSTOM   = 'swps_llms_txt_custom';
-    public const OPT_ROBOTS_MODE   = 'swps_robots_txt_mode';
-    public const OPT_ROBOTS_CUSTOM = 'swps_robots_txt_custom';
+	public const OPT_LLMS_MODE     = 'swps_llms_txt_mode';
+	public const OPT_LLMS_CUSTOM   = 'swps_llms_txt_custom';
+	public const OPT_ROBOTS_MODE   = 'swps_robots_txt_mode';
+	public const OPT_ROBOTS_CUSTOM = 'swps_robots_txt_custom';
 
-    public const MODE_AUTO    = 'auto';
-    public const MODE_CUSTOM  = 'custom';
-    public const MODE_APPEND  = 'append';
-    public const MODE_REPLACE = 'replace';
+	public const MODE_AUTO    = 'auto';
+	public const MODE_CUSTOM  = 'custom';
+	public const MODE_APPEND  = 'append';
+	public const MODE_REPLACE = 'replace';
 
-    public function __construct() {
-        add_action( 'admin_menu',            [ $this, 'register_menu' ], 21 );
-        add_action( 'admin_init',            [ $this, 'register_settings' ] );
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'register_menu' ), 21 );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
-        // Edit-on-frontend hooks.
-        add_filter( 'swps_llms_txt_content', [ $this, 'filter_llms_content' ], 100 );
-        add_filter( 'robots_txt',            [ $this, 'filter_robots_txt' ], 200, 2 );
-    }
+		// Edit-on-frontend hooks.
+		add_filter( 'swps_llms_txt_content', array( $this, 'filter_llms_content' ), 100 );
+		add_filter( 'robots_txt', array( $this, 'filter_robots_txt' ), 200, 2 );
+	}
 
-    public function register_menu(): void {
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Crawlers & Files', 'stratawp-seo' ),
-            __( 'Crawlers & Files', 'stratawp-seo' ),
-            'manage_options',
-            'swps-crawl-files',
-            [ $this, 'render_page' ]
-        );
-    }
+	public function register_menu(): void {
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Crawlers & Files', 'stratawp-seo' ),
+			__( 'Crawlers & Files', 'stratawp-seo' ),
+			'manage_options',
+			'swps-crawl-files',
+			array( $this, 'render_page' )
+		);
+	}
 
-    public function render_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
-        }
-        require SWPS_PLUGIN_DIR . 'templates/crawl-files-page.php';
-    }
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
+		}
+		require SWPS_PLUGIN_DIR . 'templates/crawl-files-page.php';
+	}
 
-    public function enqueue_assets( string $hook ): void {
-        if ( 'stratawp-seo_page_swps-crawl-files' !== $hook ) {
-            return;
-        }
-        wp_enqueue_style(
-            'swps-page-crawl-files',
-            SWPS_PLUGIN_URL . 'admin/css/pages/crawl-files.css',
-            [ 'swps-tokens', 'swps-components', 'swps-templates' ],
-            SWPS_VERSION
-        );
-    }
+	public function enqueue_assets( string $hook ): void {
+		if ( 'stratawp-seo_page_swps-crawl-files' !== $hook ) {
+			return;
+		}
+		wp_enqueue_style(
+			'swps-page-crawl-files',
+			SWPS_PLUGIN_URL . 'admin/css/pages/crawl-files.css',
+			array( 'swps-tokens', 'swps-components', 'swps-templates' ),
+			SWPS_VERSION
+		);
+	}
 
-    public function register_settings(): void {
-        register_setting( 'swps_crawl_files_group', self::OPT_LLMS_MODE, [
-            'type'              => 'string',
-            'sanitize_callback' => [ $this, 'sanitize_llms_mode' ],
-            'default'           => self::MODE_AUTO,
-        ] );
-        register_setting( 'swps_crawl_files_group', self::OPT_LLMS_CUSTOM, [
-            'type'              => 'string',
-            'sanitize_callback' => [ $this, 'sanitize_textfile' ],
-            'default'           => '',
-        ] );
-        register_setting( 'swps_crawl_files_group', self::OPT_ROBOTS_MODE, [
-            'type'              => 'string',
-            'sanitize_callback' => [ $this, 'sanitize_robots_mode' ],
-            'default'           => self::MODE_AUTO,
-        ] );
-        register_setting( 'swps_crawl_files_group', self::OPT_ROBOTS_CUSTOM, [
-            'type'              => 'string',
-            'sanitize_callback' => [ $this, 'sanitize_textfile' ],
-            'default'           => '',
-        ] );
-    }
+	public function register_settings(): void {
+		register_setting(
+			'swps_crawl_files_group',
+			self::OPT_LLMS_MODE,
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => array( $this, 'sanitize_llms_mode' ),
+				'default'           => self::MODE_AUTO,
+			)
+		);
+		register_setting(
+			'swps_crawl_files_group',
+			self::OPT_LLMS_CUSTOM,
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => array( $this, 'sanitize_textfile' ),
+				'default'           => '',
+			)
+		);
+		register_setting(
+			'swps_crawl_files_group',
+			self::OPT_ROBOTS_MODE,
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => array( $this, 'sanitize_robots_mode' ),
+				'default'           => self::MODE_AUTO,
+			)
+		);
+		register_setting(
+			'swps_crawl_files_group',
+			self::OPT_ROBOTS_CUSTOM,
+			array(
+				'type'              => 'string',
+				'sanitize_callback' => array( $this, 'sanitize_textfile' ),
+				'default'           => '',
+			)
+		);
+	}
 
-    public function sanitize_llms_mode( $value ): string {
-        return self::MODE_CUSTOM === $value ? self::MODE_CUSTOM : self::MODE_AUTO;
-    }
+	public function sanitize_llms_mode( $value ): string {
+		return self::MODE_CUSTOM === $value ? self::MODE_CUSTOM : self::MODE_AUTO;
+	}
 
-    public function sanitize_robots_mode( $value ): string {
-        $value = is_string( $value ) ? $value : '';
-        if ( in_array( $value, [ self::MODE_APPEND, self::MODE_REPLACE ], true ) ) {
-            return $value;
-        }
-        return self::MODE_AUTO;
-    }
+	public function sanitize_robots_mode( $value ): string {
+		$value = is_string( $value ) ? $value : '';
+		if ( in_array( $value, array( self::MODE_APPEND, self::MODE_REPLACE ), true ) ) {
+			return $value;
+		}
+		return self::MODE_AUTO;
+	}
 
-    /**
-     * Strip control chars except tab/newline/CR. Capped at 64KB to keep rows sane.
-     */
-    public function sanitize_textfile( $value ): string {
-        if ( ! is_string( $value ) ) {
-            return '';
-        }
-        $value = wp_check_invalid_utf8( $value );
-        $value = preg_replace( "/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/u", '', $value ) ?? '';
-        // Normalize line endings.
-        $value = str_replace( [ "\r\n", "\r" ], "\n", $value );
-        if ( strlen( $value ) > 65536 ) {
-            $value = substr( $value, 0, 65536 );
-        }
-        return $value;
-    }
+	/**
+	 * Strip control chars except tab/newline/CR. Capped at 64KB to keep rows sane.
+	 */
+	public function sanitize_textfile( $value ): string {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+		$value = wp_check_invalid_utf8( $value );
+		$value = preg_replace( "/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/u", '', $value ) ?? '';
+		// Normalize line endings.
+		$value = str_replace( array( "\r\n", "\r" ), "\n", $value );
+		if ( strlen( $value ) > 65536 ) {
+			$value = substr( $value, 0, 65536 );
+		}
+		return $value;
+	}
 
-    // ---------- Public mode/value helpers (used by the template) ----------
+	// ---------- Public mode/value helpers (used by the template) ----------
 
-    public function get_llms_mode(): string {
-        return self::MODE_CUSTOM === get_option( self::OPT_LLMS_MODE, self::MODE_AUTO ) ? self::MODE_CUSTOM : self::MODE_AUTO;
-    }
+	public function get_llms_mode(): string {
+		return self::MODE_CUSTOM === get_option( self::OPT_LLMS_MODE, self::MODE_AUTO ) ? self::MODE_CUSTOM : self::MODE_AUTO;
+	}
 
-    public function get_robots_mode(): string {
-        $mode = (string) get_option( self::OPT_ROBOTS_MODE, self::MODE_AUTO );
-        return in_array( $mode, [ self::MODE_AUTO, self::MODE_APPEND, self::MODE_REPLACE ], true ) ? $mode : self::MODE_AUTO;
-    }
+	public function get_robots_mode(): string {
+		$mode = (string) get_option( self::OPT_ROBOTS_MODE, self::MODE_AUTO );
+		return in_array( $mode, array( self::MODE_AUTO, self::MODE_APPEND, self::MODE_REPLACE ), true ) ? $mode : self::MODE_AUTO;
+	}
 
-    public function get_llms_custom(): string {
-        return (string) get_option( self::OPT_LLMS_CUSTOM, '' );
-    }
+	public function get_llms_custom(): string {
+		return (string) get_option( self::OPT_LLMS_CUSTOM, '' );
+	}
 
-    public function get_robots_custom(): string {
-        return (string) get_option( self::OPT_ROBOTS_CUSTOM, '' );
-    }
+	public function get_robots_custom(): string {
+		return (string) get_option( self::OPT_ROBOTS_CUSTOM, '' );
+	}
 
-    /**
-     * Render the auto llms.txt the way the public endpoint would.
-     */
-    public function render_auto_llms( SWPS_AI_Bots $bots ): string {
-        // Run the bots class generator, but bypass our own custom-mode filter.
-        remove_filter( 'swps_llms_txt_content', [ $this, 'filter_llms_content' ], 100 );
-        $out = $bots->generate_llms_txt();
-        add_filter( 'swps_llms_txt_content', [ $this, 'filter_llms_content' ], 100 );
-        return $out;
-    }
+	/**
+	 * Render the auto llms.txt the way the public endpoint would.
+	 */
+	public function render_auto_llms( SWPS_AI_Bots $bots ): string {
+		// Run the bots class generator, but bypass our own custom-mode filter.
+		remove_filter( 'swps_llms_txt_content', array( $this, 'filter_llms_content' ), 100 );
+		$out = $bots->generate_llms_txt();
+		add_filter( 'swps_llms_txt_content', array( $this, 'filter_llms_content' ), 100 );
+		return $out;
+	}
 
-    /**
-     * Render the auto robots.txt by re-running the chain WordPress would,
-     * but skipping our own filter so users see the raw "auto" baseline.
-     */
-    public function render_auto_robots(): string {
-        remove_filter( 'robots_txt', [ $this, 'filter_robots_txt' ], 200 );
-        $public = (int) get_option( 'blog_public' );
-        // Mimic WP core default body, then run filters as core would.
-        if ( 0 === $public ) {
-            $output = "User-agent: *\nDisallow: /\n";
-        } else {
-            $site_url = wp_parse_url( site_url() );
-            $path     = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
-            $output   = "User-agent: *\nDisallow: {$path}/wp-admin/\nAllow: {$path}/wp-admin/admin-ajax.php\n";
-        }
-        $output = (string) apply_filters( 'robots_txt', $output, $public );
-        add_filter( 'robots_txt', [ $this, 'filter_robots_txt' ], 200, 2 );
-        return $output;
-    }
+	/**
+	 * Render the auto robots.txt by re-running the chain WordPress would,
+	 * but skipping our own filter so users see the raw "auto" baseline.
+	 */
+	public function render_auto_robots(): string {
+		remove_filter( 'robots_txt', array( $this, 'filter_robots_txt' ), 200 );
+		$public = (int) get_option( 'blog_public' );
+		// Mimic WP core default body, then run filters as core would.
+		if ( 0 === $public ) {
+			$output = "User-agent: *\nDisallow: /\n";
+		} else {
+			$site_url = wp_parse_url( site_url() );
+			$path     = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
+			$output   = "User-agent: *\nDisallow: {$path}/wp-admin/\nAllow: {$path}/wp-admin/admin-ajax.php\n";
+		}
+		$output = (string) apply_filters( 'robots_txt', $output, $public );
+		add_filter( 'robots_txt', array( $this, 'filter_robots_txt' ), 200, 2 );
+		return $output;
+	}
 
-    // ---------- Filters ----------
+	// ---------- Filters ----------
 
-    public function filter_llms_content( string $content ): string {
-        if ( self::MODE_CUSTOM !== $this->get_llms_mode() ) {
-            return $content;
-        }
-        $custom = trim( $this->get_llms_custom() );
-        if ( '' === $custom ) {
-            return $content;
-        }
-        return rtrim( $custom ) . "\n";
-    }
+	public function filter_llms_content( string $content ): string {
+		if ( self::MODE_CUSTOM !== $this->get_llms_mode() ) {
+			return $content;
+		}
+		$custom = trim( $this->get_llms_custom() );
+		if ( '' === $custom ) {
+			return $content;
+		}
+		return rtrim( $custom ) . "\n";
+	}
 
-    public function filter_robots_txt( string $output, $public ): string {
-        if ( ! $public ) {
-            return $output;
-        }
-        $mode   = $this->get_robots_mode();
-        $custom = trim( $this->get_robots_custom() );
-        if ( '' === $custom || self::MODE_AUTO === $mode ) {
-            return $output;
-        }
+	public function filter_robots_txt( string $output, $public ): string {
+		if ( ! $public ) {
+			return $output;
+		}
+		$mode   = $this->get_robots_mode();
+		$custom = trim( $this->get_robots_custom() );
+		if ( '' === $custom || self::MODE_AUTO === $mode ) {
+			return $output;
+		}
 
-        if ( self::MODE_REPLACE === $mode ) {
-            return rtrim( $custom ) . "\n";
-        }
-        // append
-        return rtrim( $output ) . "\n\n# Custom — managed by StrataWP SEO\n" . rtrim( $custom ) . "\n";
-    }
+		if ( self::MODE_REPLACE === $mode ) {
+			return rtrim( $custom ) . "\n";
+		}
+		// append
+		return rtrim( $output ) . "\n\n# Custom — managed by StrataWP SEO\n" . rtrim( $custom ) . "\n";
+	}
 }

--- a/includes/class-cron.php
+++ b/includes/class-cron.php
@@ -6,193 +6,193 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Cron {
 
-    private const HOOK = 'swps_generate_scheduled_post';
+	private const HOOK = 'swps_generate_scheduled_post';
 
-    private SWPS_Generator $generator;
-    private ?SWPS_Topic_Queue $queue;
+	private SWPS_Generator $generator;
+	private ?SWPS_Topic_Queue $queue;
 
-    public function __construct( SWPS_Generator $generator, ?SWPS_Topic_Queue $queue = null ) {
-        $this->generator = $generator;
-        $this->queue     = $queue;
+	public function __construct( SWPS_Generator $generator, ?SWPS_Topic_Queue $queue = null ) {
+		$this->generator = $generator;
+		$this->queue     = $queue;
 
-        add_action( self::HOOK, [ $this, 'run_scheduled_generation' ] );
-        add_filter( 'cron_schedules', [ $this, 'add_custom_schedules' ] );
-    }
+		add_action( self::HOOK, array( $this, 'run_scheduled_generation' ) );
+		add_filter( 'cron_schedules', array( $this, 'add_custom_schedules' ) );
+	}
 
-    /**
-     * Add custom cron schedules.
-     */
-    public function add_custom_schedules( array $schedules ): array {
-        $schedules['swps_twice_weekly'] = [
-            'interval' => 3.5 * DAY_IN_SECONDS,
-            'display'  => __( 'Twice Weekly', 'stratawp-seo' ),
-        ];
+	/**
+	 * Add custom cron schedules.
+	 */
+	public function add_custom_schedules( array $schedules ): array {
+		$schedules['swps_twice_weekly'] = array(
+			'interval' => 3.5 * DAY_IN_SECONDS,
+			'display'  => __( 'Twice Weekly', 'stratawp-seo' ),
+		);
 
-        $schedules['swps_three_weekly'] = [
-            'interval' => 2.33 * DAY_IN_SECONDS,
-            'display'  => __( 'Three Times Weekly', 'stratawp-seo' ),
-        ];
+		$schedules['swps_three_weekly'] = array(
+			'interval' => 2.33 * DAY_IN_SECONDS,
+			'display'  => __( 'Three Times Weekly', 'stratawp-seo' ),
+		);
 
-        $schedules['swps_biweekly'] = [
-            'interval' => 14 * DAY_IN_SECONDS,
-            'display'  => __( 'Every Two Weeks', 'stratawp-seo' ),
-        ];
+		$schedules['swps_biweekly'] = array(
+			'interval' => 14 * DAY_IN_SECONDS,
+			'display'  => __( 'Every Two Weeks', 'stratawp-seo' ),
+		);
 
-        $schedules['swps_monthly'] = [
-            'interval' => 30 * DAY_IN_SECONDS,
-            'display'  => __( 'Monthly', 'stratawp-seo' ),
-        ];
+		$schedules['swps_monthly'] = array(
+			'interval' => 30 * DAY_IN_SECONDS,
+			'display'  => __( 'Monthly', 'stratawp-seo' ),
+		);
 
-        return $schedules;
-    }
+		return $schedules;
+	}
 
-    /**
-     * The cron callback — generates posts from queue or randomly.
-     */
-    public function run_scheduled_generation(): void {
-        $enabled = get_option( 'swps_cron_enabled', false );
+	/**
+	 * The cron callback — generates posts from queue or randomly.
+	 */
+	public function run_scheduled_generation(): void {
+		$enabled = get_option( 'swps_cron_enabled', false );
 
-        if ( ! $enabled ) {
-            return;
-        }
+		if ( ! $enabled ) {
+			return;
+		}
 
-        $posts_per_run = (int) get_option( 'swps_cron_posts_per_run', 1 );
-        $posts_per_run = min( $posts_per_run, 5 );
+		$posts_per_run = (int) get_option( 'swps_cron_posts_per_run', 1 );
+		$posts_per_run = min( $posts_per_run, 5 );
 
-        for ( $i = 0; $i < $posts_per_run; $i++ ) {
-            $topic    = '';
-            $template = get_option( 'swps_default_template', 'auto' );
-            $topic_id = 0;
+		for ( $i = 0; $i < $posts_per_run; $i++ ) {
+			$topic    = '';
+			$template = get_option( 'swps_default_template', 'auto' );
+			$topic_id = 0;
 
-            // Check queue for next topic.
-            if ( $this->queue ) {
-                $next_topic = $this->queue->get_next_topic();
-                if ( $next_topic ) {
-                    $topic    = $next_topic->post_title;
-                    $template = get_post_meta( $next_topic->ID, '_swps_template', true ) ?: $template;
-                    $topic_id = $next_topic->ID;
-                    $this->queue->update_status( $topic_id, 'generating' );
-                }
-            }
+			// Check queue for next topic.
+			if ( $this->queue ) {
+				$next_topic = $this->queue->get_next_topic();
+				if ( $next_topic ) {
+					$topic    = $next_topic->post_title;
+					$template = get_post_meta( $next_topic->ID, '_swps_template', true ) ?: $template;
+					$topic_id = $next_topic->ID;
+					$this->queue->update_status( $topic_id, 'generating' );
+				}
+			}
 
-            $result = $this->generator->generate_post( $topic, $template );
+			$result = $this->generator->generate_post( $topic, $template );
 
-            if ( is_wp_error( $result ) ) {
-                error_log( '[StrataWP SEO Cron] Generation failed: ' . $result->get_error_message() );
+			if ( is_wp_error( $result ) ) {
+				error_log( '[StrataWP SEO Cron] Generation failed: ' . $result->get_error_message() );
 
-                if ( $topic_id && $this->queue ) {
-                    $this->queue->update_status( $topic_id, 'failed', $result->get_error_message() );
-                }
+				if ( $topic_id && $this->queue ) {
+					$this->queue->update_status( $topic_id, 'failed', $result->get_error_message() );
+				}
 
-                break;
-            }
+				break;
+			}
 
-            // Update topic status if from queue.
-            if ( $topic_id && $this->queue ) {
-                $this->queue->update_status( $topic_id, 'published', '', $result['post_id'] );
-            }
+			// Update topic status if from queue.
+			if ( $topic_id && $this->queue ) {
+				$this->queue->update_status( $topic_id, 'published', '', $result['post_id'] );
+			}
 
-            if ( $i < $posts_per_run - 1 ) {
-                sleep( 5 );
-            }
-        }
+			if ( $i < $posts_per_run - 1 ) {
+				sleep( 5 );
+			}
+		}
 
-        update_option( 'swps_cron_last_run', current_time( 'mysql' ) );
-    }
+		update_option( 'swps_cron_last_run', current_time( 'mysql' ) );
+	}
 
-    /**
-     * Schedule the cron event.
-     */
-    public static function schedule(): void {
-        self::unschedule();
+	/**
+	 * Schedule the cron event.
+	 */
+	public static function schedule(): void {
+		self::unschedule();
 
-        $frequency = get_option( 'swps_cron_frequency', 'weekly' );
-        $day       = get_option( 'swps_cron_day', 'monday' );
-        $time      = get_option( 'swps_cron_time', '09:00' );
+		$frequency = get_option( 'swps_cron_frequency', 'weekly' );
+		$day       = get_option( 'swps_cron_day', 'monday' );
+		$time      = get_option( 'swps_cron_time', '09:00' );
 
-        $recurrence_map = [
-            'daily'        => 'daily',
-            'twice_weekly' => 'swps_twice_weekly',
-            'three_weekly' => 'swps_three_weekly',
-            'weekly'       => 'weekly',
-            'biweekly'     => 'swps_biweekly',
-            'monthly'      => 'swps_monthly',
-        ];
+		$recurrence_map = array(
+			'daily'        => 'daily',
+			'twice_weekly' => 'swps_twice_weekly',
+			'three_weekly' => 'swps_three_weekly',
+			'weekly'       => 'weekly',
+			'biweekly'     => 'swps_biweekly',
+			'monthly'      => 'swps_monthly',
+		);
 
-        $recurrence = $recurrence_map[ $frequency ] ?? 'weekly';
-        $next_run = self::calculate_next_run( $day, $time );
+		$recurrence = $recurrence_map[ $frequency ] ?? 'weekly';
+		$next_run   = self::calculate_next_run( $day, $time );
 
-        wp_schedule_event( $next_run, $recurrence, self::HOOK );
-    }
+		wp_schedule_event( $next_run, $recurrence, self::HOOK );
+	}
 
-    /**
-     * Unschedule the cron event.
-     */
-    public static function unschedule(): void {
-        $timestamp = wp_next_scheduled( self::HOOK );
-        if ( $timestamp ) {
-            wp_unschedule_event( $timestamp, self::HOOK );
-        }
-        wp_unschedule_hook( self::HOOK );
-    }
+	/**
+	 * Unschedule the cron event.
+	 */
+	public static function unschedule(): void {
+		$timestamp = wp_next_scheduled( self::HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::HOOK );
+		}
+		wp_unschedule_hook( self::HOOK );
+	}
 
-    /**
-     * Calculate the next run timestamp based on desired day and time.
-     *
-     * For daily frequency, schedules the next occurrence of the time
-     * (today if it hasn't passed, otherwise tomorrow). For weekly+
-     * frequencies, schedules the next occurrence of the specified day.
-     */
-    private static function calculate_next_run( string $day, string $time ): int {
-        $timezone  = wp_timezone();
-        $now       = new DateTime( 'now', $timezone );
-        $frequency = get_option( 'swps_cron_frequency', 'weekly' );
+	/**
+	 * Calculate the next run timestamp based on desired day and time.
+	 *
+	 * For daily frequency, schedules the next occurrence of the time
+	 * (today if it hasn't passed, otherwise tomorrow). For weekly+
+	 * frequencies, schedules the next occurrence of the specified day.
+	 */
+	private static function calculate_next_run( string $day, string $time ): int {
+		$timezone  = wp_timezone();
+		$now       = new DateTime( 'now', $timezone );
+		$frequency = get_option( 'swps_cron_frequency', 'weekly' );
 
-        list( $hour, $minute ) = explode( ':', $time );
+		list( $hour, $minute ) = explode( ':', $time );
 
-        if ( 'daily' === $frequency ) {
-            // For daily: use today's date at the specified time, or tomorrow if past.
-            $next = clone $now;
-            $next->setTime( (int) $hour, (int) $minute, 0 );
-            if ( $next <= $now ) {
-                $next->modify( '+1 day' );
-            }
-            return $next->getTimestamp();
-        }
+		if ( 'daily' === $frequency ) {
+			// For daily: use today's date at the specified time, or tomorrow if past.
+			$next = clone $now;
+			$next->setTime( (int) $hour, (int) $minute, 0 );
+			if ( $next <= $now ) {
+				$next->modify( '+1 day' );
+			}
+			return $next->getTimestamp();
+		}
 
-        // For weekly+ frequencies: schedule on the specified day.
-        $next = new DateTime( "next {$day}", $timezone );
-        $next->setTime( (int) $hour, (int) $minute, 0 );
+		// For weekly+ frequencies: schedule on the specified day.
+		$next = new DateTime( "next {$day}", $timezone );
+		$next->setTime( (int) $hour, (int) $minute, 0 );
 
-        // If "next $day" overshoots (e.g. today is that day but time hasn't passed).
-        $today_at_time = clone $now;
-        $today_at_time->setTime( (int) $hour, (int) $minute, 0 );
-        if ( strtolower( $now->format( 'l' ) ) === strtolower( $day ) && $today_at_time > $now ) {
-            return $today_at_time->getTimestamp();
-        }
+		// If "next $day" overshoots (e.g. today is that day but time hasn't passed).
+		$today_at_time = clone $now;
+		$today_at_time->setTime( (int) $hour, (int) $minute, 0 );
+		if ( strtolower( $now->format( 'l' ) ) === strtolower( $day ) && $today_at_time > $now ) {
+			return $today_at_time->getTimestamp();
+		}
 
-        return $next->getTimestamp();
-    }
+		return $next->getTimestamp();
+	}
 
-    /**
-     * Get info about the current schedule for display.
-     */
-    public static function get_schedule_info(): array {
-        $next = wp_next_scheduled( self::HOOK );
+	/**
+	 * Get info about the current schedule for display.
+	 */
+	public static function get_schedule_info(): array {
+		$next = wp_next_scheduled( self::HOOK );
 
-        return [
-            'enabled'    => (bool) get_option( 'swps_cron_enabled', false ),
-            'frequency'  => get_option( 'swps_cron_frequency', 'weekly' ),
-            'day'        => get_option( 'swps_cron_day', 'monday' ),
-            'time'       => get_option( 'swps_cron_time', '09:00' ),
-            'posts_per'  => (int) get_option( 'swps_cron_posts_per_run', 1 ),
-            'next_run'   => $next ? wp_date( 'F j, Y \a\t g:i A', $next ) : __( 'Not scheduled', 'stratawp-seo' ),
-            'last_run'   => get_option( 'swps_cron_last_run', __( 'Never', 'stratawp-seo' ) ),
-        ];
-    }
+		return array(
+			'enabled'   => (bool) get_option( 'swps_cron_enabled', false ),
+			'frequency' => get_option( 'swps_cron_frequency', 'weekly' ),
+			'day'       => get_option( 'swps_cron_day', 'monday' ),
+			'time'      => get_option( 'swps_cron_time', '09:00' ),
+			'posts_per' => (int) get_option( 'swps_cron_posts_per_run', 1 ),
+			'next_run'  => $next ? wp_date( 'F j, Y \a\t g:i A', $next ) : __( 'Not scheduled', 'stratawp-seo' ),
+			'last_run'  => get_option( 'swps_cron_last_run', __( 'Never', 'stratawp-seo' ) ),
+		);
+	}
 }

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -10,296 +10,321 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Dashboard {
 
-    public function __construct() {
-        // Hook earlier than SWPS_Settings (priority 10) so we register the
-        // top-level menu first. Settings::register_menu() now skips the
-        // top-level add_menu_page and only registers submenus.
-        add_action( 'admin_menu', [ $this, 'register_menu' ], 5 );
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
-    }
+	public function __construct() {
+		// Hook earlier than SWPS_Settings (priority 10) so we register the
+		// top-level menu first. Settings::register_menu() now skips the
+		// top-level add_menu_page and only registers submenus.
+		add_action( 'admin_menu', array( $this, 'register_menu' ), 5 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+	}
 
-    /**
-     * Page-specific CSS/JS for the dashboard.
-     */
-    public function enqueue_assets( string $hook ): void {
-        if ( 'toplevel_page_stratawp-seo' !== $hook ) {
-            return;
-        }
-        wp_enqueue_style(
-            'swps-dashboard',
-            SWPS_PLUGIN_URL . 'admin/css/pages/dashboard.css',
-            [ 'swps-tokens', 'swps-shell', 'swps-components' ],
-            SWPS_VERSION
-        );
-        wp_enqueue_script(
-            'swps-dashboard',
-            SWPS_PLUGIN_URL . 'admin/js/dashboard.js',
-            [ 'swps-shell' ],
-            SWPS_VERSION,
-            true
-        );
-    }
+	/**
+	 * Page-specific CSS/JS for the dashboard.
+	 */
+	public function enqueue_assets( string $hook ): void {
+		if ( 'toplevel_page_stratawp-seo' !== $hook ) {
+			return;
+		}
+		wp_enqueue_style(
+			'swps-dashboard',
+			SWPS_PLUGIN_URL . 'admin/css/pages/dashboard.css',
+			array( 'swps-tokens', 'swps-shell', 'swps-components' ),
+			SWPS_VERSION
+		);
+		wp_enqueue_script(
+			'swps-dashboard',
+			SWPS_PLUGIN_URL . 'admin/js/dashboard.js',
+			array( 'swps-shell' ),
+			SWPS_VERSION,
+			true
+		);
+	}
 
-    /**
-     * Register the top-level menu and Dashboard submenu.
-     */
-    public function register_menu(): void {
-        add_menu_page(
-            __( 'StrataWP SEO', 'stratawp-seo' ),
-            __( 'StrataWP SEO', 'stratawp-seo' ),
-            'manage_options',
-            'stratawp-seo',
-            [ $this, 'render' ],
-            'dashicons-superhero-alt',
-            30
-        );
+	/**
+	 * Register the top-level menu and Dashboard submenu.
+	 */
+	public function register_menu(): void {
+		add_menu_page(
+			__( 'StrataWP SEO', 'stratawp-seo' ),
+			__( 'StrataWP SEO', 'stratawp-seo' ),
+			'manage_options',
+			'stratawp-seo',
+			array( $this, 'render' ),
+			'dashicons-superhero-alt',
+			30
+		);
 
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Dashboard', 'stratawp-seo' ),
-            __( 'Dashboard', 'stratawp-seo' ),
-            'manage_options',
-            'stratawp-seo',
-            [ $this, 'render' ]
-        );
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Dashboard', 'stratawp-seo' ),
+			__( 'Dashboard', 'stratawp-seo' ),
+			'manage_options',
+			'stratawp-seo',
+			array( $this, 'render' )
+		);
 
-        // Auto-Optimize and Competitors register their own submenus
-        // (SWPS_Auto_Optimize, SWPS_Competitors).
-    }
+		// Auto-Optimize and Competitors register their own submenus
+		// (SWPS_Auto_Optimize, SWPS_Competitors).
+	}
 
-    /**
-     * Render the dashboard page.
-     */
-    public function render(): void {
-        $data = $this->get_summary_data();
-        require SWPS_PLUGIN_DIR . 'templates/dashboard-page.php';
-    }
+	/**
+	 * Render the dashboard page.
+	 */
+	public function render(): void {
+		$data = $this->get_summary_data();
+		require SWPS_PLUGIN_DIR . 'templates/dashboard-page.php';
+	}
 
-    /**
-     * Build everything the dashboard template needs.
-     *
-     * Each piece is wrapped in try/catch so a single subsystem error
-     * doesn't blank the whole page.
-     *
-     * @return array
-     */
-    public function get_summary_data(): array {
-        $current_user = wp_get_current_user();
+	/**
+	 * Build everything the dashboard template needs.
+	 *
+	 * Each piece is wrapped in try/catch so a single subsystem error
+	 * doesn't blank the whole page.
+	 *
+	 * @return array
+	 */
+	public function get_summary_data(): array {
+		$current_user = wp_get_current_user();
 
-        return [
-            'first_name'         => $current_user->first_name ?: $current_user->display_name,
-            'site_health'        => $this->safe_get_health(),
-            'recent_generations' => $this->safe_get_recent_generations(),
-            'ai_cost_30d'        => $this->safe_get_ai_cost(),
-            'posts_30d'          => $this->safe_get_post_views(),
-            'top_issues'         => $this->safe_get_top_issues(),
-            'top_queries'        => $this->safe_get_top_gsc_queries(),
-            'auto_optimize_queue' => [], // Phase 7 fills in.
-            'competitors'        => $this->safe_get_competitor_summary(),
-            'backlinks'          => $this->safe_get_backlinks_summary(),
-            'modules'            => $this->get_modules_for_grid(),
-        ];
-    }
+		return array(
+			'first_name'          => $current_user->first_name ?: $current_user->display_name,
+			'site_health'         => $this->safe_get_health(),
+			'recent_generations'  => $this->safe_get_recent_generations(),
+			'ai_cost_30d'         => $this->safe_get_ai_cost(),
+			'posts_30d'           => $this->safe_get_post_views(),
+			'top_issues'          => $this->safe_get_top_issues(),
+			'top_queries'         => $this->safe_get_top_gsc_queries(),
+			'auto_optimize_queue' => array(), // Phase 7 fills in.
+			'competitors'         => $this->safe_get_competitor_summary(),
+			'backlinks'           => $this->safe_get_backlinks_summary(),
+			'modules'             => $this->get_modules_for_grid(),
+		);
+	}
 
-    private function safe_get_health(): array {
-        try {
-            $audit    = stratawp_seo()->seo_audit;
-            $results  = $audit->get_cached_results();
-            $last_run = $audit->get_last_run();
-            $score    = (int) ( $results['overall_score'] ?? 0 );
+	private function safe_get_health(): array {
+		try {
+			$audit    = stratawp_seo()->seo_audit;
+			$results  = $audit->get_cached_results();
+			$last_run = $audit->get_last_run();
+			$score    = (int) ( $results['overall_score'] ?? 0 );
 
-            $crit_count = 0;
-            $warn_count = 0;
-            $pass_count = 0;
-            foreach ( ( $results['modules'] ?? [] ) as $mod ) {
-                $status = $mod['status'] ?? '';
-                if ( 'critical' === $status ) {
-                    $crit_count++;
-                } elseif ( 'warning' === $status ) {
-                    $warn_count++;
-                } else {
-                    $pass_count++;
-                }
-            }
+			$crit_count = 0;
+			$warn_count = 0;
+			$pass_count = 0;
+			foreach ( ( $results['modules'] ?? array() ) as $mod ) {
+				$status = $mod['status'] ?? '';
+				if ( 'critical' === $status ) {
+					++$crit_count;
+				} elseif ( 'warning' === $status ) {
+					++$warn_count;
+				} else {
+					++$pass_count;
+				}
+			}
 
-            $label = 'Needs work';
-            if ( $score >= 80 ) {
-                $label = 'Healthy';
-            } elseif ( $score >= 50 ) {
-                $label = 'Fair';
-            }
+			$label = 'Needs work';
+			if ( $score >= 80 ) {
+				$label = 'Healthy';
+			} elseif ( $score >= 50 ) {
+				$label = 'Fair';
+			}
 
-            return [
-                'score'      => $score,
-                'label'      => $label,
-                'crit_count' => $crit_count,
-                'warn_count' => $warn_count,
-                'pass_count' => $pass_count,
-                'last_run'   => $last_run,
-            ];
-        } catch ( \Throwable $e ) {
-            return [
-                'score' => 0, 'label' => '—',
-                'crit_count' => 0, 'warn_count' => 0, 'pass_count' => 0,
-                'last_run' => 0,
-            ];
-        }
-    }
+			return array(
+				'score'      => $score,
+				'label'      => $label,
+				'crit_count' => $crit_count,
+				'warn_count' => $warn_count,
+				'pass_count' => $pass_count,
+				'last_run'   => $last_run,
+			);
+		} catch ( \Throwable $e ) {
+			return array(
+				'score'      => 0,
+				'label'      => '—',
+				'crit_count' => 0,
+				'warn_count' => 0,
+				'pass_count' => 0,
+				'last_run'   => 0,
+			);
+		}
+	}
 
-    private function safe_get_recent_generations(): array {
-        try {
-            $posts = get_posts( [
-                'numberposts' => 3,
-                'post_status' => [ 'publish', 'draft', 'future', 'pending' ],
-                'meta_key'    => '_swps_generated_at',
-                'orderby'     => 'meta_value',
-                'order'       => 'DESC',
-            ] );
-            $out = [];
-            foreach ( $posts as $p ) {
-                $out[] = [
-                    'id'           => $p->ID,
-                    'title'        => $p->post_title,
-                    'template'     => get_post_meta( $p->ID, '_swps_template', true ) ?: 'auto',
-                    'word_count'   => str_word_count( wp_strip_all_tags( $p->post_content ) ),
-                    'model'        => get_post_meta( $p->ID, '_swps_model', true ) ?: '',
-                    'score'        => (int) get_post_meta( $p->ID, '_swps_content_score', true ),
-                    'status'       => $p->post_status,
-                    'edit_link'    => get_edit_post_link( $p->ID ),
-                    'time_ago'     => human_time_diff( strtotime( $p->post_date_gmt ), time() ) . ' ago',
-                ];
-            }
-            return $out;
-        } catch ( \Throwable $e ) {
-            return [];
-        }
-    }
+	private function safe_get_recent_generations(): array {
+		try {
+			$posts = get_posts(
+				array(
+					'numberposts' => 3,
+					'post_status' => array( 'publish', 'draft', 'future', 'pending' ),
+					'meta_key'    => '_swps_generated_at',
+					'orderby'     => 'meta_value',
+					'order'       => 'DESC',
+				)
+			);
+			$out   = array();
+			foreach ( $posts as $p ) {
+				$out[] = array(
+					'id'         => $p->ID,
+					'title'      => $p->post_title,
+					'template'   => get_post_meta( $p->ID, '_swps_template', true ) ?: 'auto',
+					'word_count' => str_word_count( wp_strip_all_tags( $p->post_content ) ),
+					'model'      => get_post_meta( $p->ID, '_swps_model', true ) ?: '',
+					'score'      => (int) get_post_meta( $p->ID, '_swps_content_score', true ),
+					'status'     => $p->post_status,
+					'edit_link'  => get_edit_post_link( $p->ID ),
+					'time_ago'   => human_time_diff( strtotime( $p->post_date_gmt ), time() ) . ' ago',
+				);
+			}
+			return $out;
+		} catch ( \Throwable $e ) {
+			return array();
+		}
+	}
 
-    private function safe_get_ai_cost(): array {
-        try {
-            $tracker = stratawp_seo()->cost_tracker;
-            $stats   = $tracker->get_monthly_stats();
-            return [
-                'usd'  => (float) ( $stats['total_cost'] ?? 0 ),
-                'gens' => (int) ( $stats['total_generations'] ?? 0 ),
-            ];
-        } catch ( \Throwable $e ) {
-            return [ 'usd' => 0.0, 'gens' => 0 ];
-        }
-    }
+	private function safe_get_ai_cost(): array {
+		try {
+			$tracker = stratawp_seo()->cost_tracker;
+			$stats   = $tracker->get_monthly_stats();
+			return array(
+				'usd'  => (float) ( $stats['total_cost'] ?? 0 ),
+				'gens' => (int) ( $stats['total_generations'] ?? 0 ),
+			);
+		} catch ( \Throwable $e ) {
+			return array(
+				'usd'  => 0.0,
+				'gens' => 0,
+			);
+		}
+	}
 
-    private function safe_get_post_views(): array {
-        try {
-            global $wpdb;
-            $table = $wpdb->prefix . 'swps_analytics';
+	private function safe_get_post_views(): array {
+		try {
+			global $wpdb;
+			$table = $wpdb->prefix . 'swps_analytics';
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-            $exists = (string) $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
-            if ( $exists !== $table ) {
-                return [ 'views' => 0, 'delta_pct' => null ];
-            }
+			$exists = (string) $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+			if ( $exists !== $table ) {
+				return array(
+					'views'     => 0,
+					'delta_pct' => null,
+				);
+			}
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-            $views_30  = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table} WHERE viewed_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)" );
+			$views_30 = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table} WHERE viewed_at >= DATE_SUB(NOW(), INTERVAL 30 DAY)" );
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-            $views_60  = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table} WHERE viewed_at >= DATE_SUB(NOW(), INTERVAL 60 DAY) AND viewed_at < DATE_SUB(NOW(), INTERVAL 30 DAY)" );
-            $delta = ( $views_60 > 0 ) ? round( ( ( $views_30 - $views_60 ) / $views_60 ) * 100, 1 ) : null;
-            return [ 'views' => $views_30, 'delta_pct' => $delta ];
-        } catch ( \Throwable $e ) {
-            return [ 'views' => 0, 'delta_pct' => null ];
-        }
-    }
+			$views_60 = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$table} WHERE viewed_at >= DATE_SUB(NOW(), INTERVAL 60 DAY) AND viewed_at < DATE_SUB(NOW(), INTERVAL 30 DAY)" );
+			$delta    = ( $views_60 > 0 ) ? round( ( ( $views_30 - $views_60 ) / $views_60 ) * 100, 1 ) : null;
+			return array(
+				'views'     => $views_30,
+				'delta_pct' => $delta,
+			);
+		} catch ( \Throwable $e ) {
+			return array(
+				'views'     => 0,
+				'delta_pct' => null,
+			);
+		}
+	}
 
-    private function safe_get_top_issues(): array {
-        try {
-            $audit   = stratawp_seo()->seo_audit;
-            $results = $audit->get_cached_results();
-            $issues  = [];
-            foreach ( ( $results['modules'] ?? [] ) as $mod ) {
-                $status = $mod['status'] ?? '';
-                if ( 'critical' === $status || 'warning' === $status ) {
-                    $issues[] = [
-                        'level'    => $status === 'critical' ? 'crit' : 'warn',
-                        'name'     => $mod['name'] ?? '',
-                        'message'  => $mod['message'] ?? '',
-                        'fixable'  => ! empty( $mod['fixable'] ),
-                        'page_url' => admin_url( 'admin.php?page=swps-seo-audit' ),
-                    ];
-                }
-                if ( count( $issues ) >= 3 ) {
-                    break;
-                }
-            }
-            return $issues;
-        } catch ( \Throwable $e ) {
-            return [];
-        }
-    }
+	private function safe_get_top_issues(): array {
+		try {
+			$audit   = stratawp_seo()->seo_audit;
+			$results = $audit->get_cached_results();
+			$issues  = array();
+			foreach ( ( $results['modules'] ?? array() ) as $mod ) {
+				$status = $mod['status'] ?? '';
+				if ( 'critical' === $status || 'warning' === $status ) {
+					$issues[] = array(
+						'level'    => $status === 'critical' ? 'crit' : 'warn',
+						'name'     => $mod['name'] ?? '',
+						'message'  => $mod['message'] ?? '',
+						'fixable'  => ! empty( $mod['fixable'] ),
+						'page_url' => admin_url( 'admin.php?page=swps-seo-audit' ),
+					);
+				}
+				if ( count( $issues ) >= 3 ) {
+					break;
+				}
+			}
+			return $issues;
+		} catch ( \Throwable $e ) {
+			return array();
+		}
+	}
 
-    private function safe_get_top_gsc_queries(): array {
-        try {
-            $gsc = stratawp_seo()->search_console;
-            if ( ! method_exists( $gsc, 'get_top_queries' ) ) {
-                return [];
-            }
-            $rows = $gsc->get_top_queries( 7, 3 );
-            return is_array( $rows ) ? $rows : [];
-        } catch ( \Throwable $e ) {
-            return [];
-        }
-    }
+	private function safe_get_top_gsc_queries(): array {
+		try {
+			$gsc = stratawp_seo()->search_console;
+			if ( ! method_exists( $gsc, 'get_top_queries' ) ) {
+				return array();
+			}
+			$rows = $gsc->get_top_queries( 7, 3 );
+			return is_array( $rows ) ? $rows : array();
+		} catch ( \Throwable $e ) {
+			return array();
+		}
+	}
 
-    private function safe_get_competitor_summary(): array {
-        try {
-            $competitors = stratawp_seo()->competitors;
-            if ( ! method_exists( $competitors, 'get_dashboard_summary' ) ) {
-                return [];
-            }
-            return $competitors->get_dashboard_summary( 3 );
-        } catch ( \Throwable $e ) {
-            return [];
-        }
-    }
+	private function safe_get_competitor_summary(): array {
+		try {
+			$competitors = stratawp_seo()->competitors;
+			if ( ! method_exists( $competitors, 'get_dashboard_summary' ) ) {
+				return array();
+			}
+			return $competitors->get_dashboard_summary( 3 );
+		} catch ( \Throwable $e ) {
+			return array();
+		}
+	}
 
-    private function safe_get_backlinks_summary(): array {
-        try {
-            $bl = stratawp_seo()->backlinks;
-            return [
-                'stats'  => $bl->get_stats(),
-                'recent' => $bl->get_dashboard_recent( 3 ),
-            ];
-        } catch ( \Throwable $e ) {
-            return [
-                'stats'  => [ 'total' => 0, 'live' => 0, 'lost' => 0, 'broken' => 0, 'new_30d' => 0, 'lost_30d' => 0, 'unique_domains' => 0 ],
-                'recent' => [],
-            ];
-        }
-    }
+	private function safe_get_backlinks_summary(): array {
+		try {
+			$bl = stratawp_seo()->backlinks;
+			return array(
+				'stats'  => $bl->get_stats(),
+				'recent' => $bl->get_dashboard_recent( 3 ),
+			);
+		} catch ( \Throwable $e ) {
+			return array(
+				'stats'  => array(
+					'total'          => 0,
+					'live'           => 0,
+					'lost'           => 0,
+					'broken'         => 0,
+					'new_30d'        => 0,
+					'lost_30d'       => 0,
+					'unique_domains' => 0,
+				),
+				'recent' => array(),
+			);
+		}
+	}
 
-    /**
-     * Build the modules grid array for the dashboard template.
-     *
-     * Reads from SWPS_Modules registry — each entry includes the
-     * persisted on/off state.
-     */
-    private function get_modules_for_grid(): array {
-        $modules = stratawp_seo()->modules->get_all();
-        $out     = [];
-        foreach ( $modules as $slug => $mod ) {
-            $out[] = [
-                'slug'         => $slug,
-                'icon'         => $mod['icon'],
-                'title'        => $mod['name'],
-                'desc'         => $mod['desc'],
-                'badge'        => $mod['badge'],
-                'enabled'      => (bool) $mod['enabled'],
-                'locked'       => ! empty( $mod['locked'] ),
-                'settings_url' => $mod['settings_url'],
-            ];
-        }
-        return $out;
-    }
+	/**
+	 * Build the modules grid array for the dashboard template.
+	 *
+	 * Reads from SWPS_Modules registry — each entry includes the
+	 * persisted on/off state.
+	 */
+	private function get_modules_for_grid(): array {
+		$modules = stratawp_seo()->modules->get_all();
+		$out     = array();
+		foreach ( $modules as $slug => $mod ) {
+			$out[] = array(
+				'slug'         => $slug,
+				'icon'         => $mod['icon'],
+				'title'        => $mod['name'],
+				'desc'         => $mod['desc'],
+				'badge'        => $mod['badge'],
+				'enabled'      => (bool) $mod['enabled'],
+				'locked'       => ! empty( $mod['locked'] ),
+				'settings_url' => $mod['settings_url'],
+			);
+		}
+		return $out;
+	}
 }

--- a/includes/class-duplicate-checker.php
+++ b/includes/class-duplicate-checker.php
@@ -10,131 +10,136 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Duplicate_Checker {
 
-    private const SIMILARITY_THRESHOLD = 85;
+	private const SIMILARITY_THRESHOLD = 85;
 
-    /**
-     * Check if a title is a duplicate.
-     *
-     * @param string $title The proposed title.
-     * @return string|false False if not a duplicate, or the matching title string.
-     */
-    public function is_duplicate( string $title ): string|false {
-        if ( ! get_option( 'swps_duplicate_check', false ) ) {
-            return false;
-        }
+	/**
+	 * Check if a title is a duplicate.
+	 *
+	 * @param string $title The proposed title.
+	 * @return string|false False if not a duplicate, or the matching title string.
+	 */
+	public function is_duplicate( string $title ): string|false {
+		if ( ! get_option( 'swps_duplicate_check', false ) ) {
+			return false;
+		}
 
-        // Phase 1: Local database check.
-        $local_match = $this->check_local( $title );
-        if ( false !== $local_match ) {
-            return $local_match;
-        }
+		// Phase 1: Local database check.
+		$local_match = $this->check_local( $title );
+		if ( false !== $local_match ) {
+			return $local_match;
+		}
 
-        // Phase 2: Remote endpoint check.
-        $remote_match = $this->check_remote( $title );
-        if ( false !== $remote_match ) {
-            return $remote_match;
-        }
+		// Phase 2: Remote endpoint check.
+		$remote_match = $this->check_remote( $title );
+		if ( false !== $remote_match ) {
+			return $remote_match;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Check against local WordPress posts.
-     *
-     * @param string $title Title to check.
-     * @return string|false Matching title or false.
-     */
-    private function check_local( string $title ): string|false {
-        $posts = get_posts( [
-            'post_type'      => 'post',
-            'post_status'    => [ 'publish', 'draft', 'pending' ],
-            'posts_per_page' => 200,
-            'fields'         => 'ids',
-        ] );
+	/**
+	 * Check against local WordPress posts.
+	 *
+	 * @param string $title Title to check.
+	 * @return string|false Matching title or false.
+	 */
+	private function check_local( string $title ): string|false {
+		$posts = get_posts(
+			array(
+				'post_type'      => 'post',
+				'post_status'    => array( 'publish', 'draft', 'pending' ),
+				'posts_per_page' => 200,
+				'fields'         => 'ids',
+			)
+		);
 
-        foreach ( $posts as $post_id ) {
-            $existing_title = get_the_title( $post_id );
-            $similarity     = 0;
+		foreach ( $posts as $post_id ) {
+			$existing_title = get_the_title( $post_id );
+			$similarity     = 0;
 
-            similar_text(
-                strtolower( $title ),
-                strtolower( $existing_title ),
-                $similarity
-            );
+			similar_text(
+				strtolower( $title ),
+				strtolower( $existing_title ),
+				$similarity
+			);
 
-            if ( $similarity >= self::SIMILARITY_THRESHOLD ) {
-                return $existing_title;
-            }
-        }
+			if ( $similarity >= self::SIMILARITY_THRESHOLD ) {
+				return $existing_title;
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Check against remote jonimms-ai-writer endpoint.
-     *
-     * @param string $title Title to check.
-     * @return string|false Matching title or false.
-     */
-    private function check_remote( string $title ): string|false {
-        $endpoint = get_option( 'swps_jon_ai_endpoint', '' );
-        $secret   = get_option( 'swps_jon_ai_secret', '' );
+	/**
+	 * Check against remote jonimms-ai-writer endpoint.
+	 *
+	 * @param string $title Title to check.
+	 * @return string|false Matching title or false.
+	 */
+	private function check_remote( string $title ): string|false {
+		$endpoint = get_option( 'swps_jon_ai_endpoint', '' );
+		$secret   = get_option( 'swps_jon_ai_secret', '' );
 
-        if ( empty( $endpoint ) || empty( $secret ) ) {
-            return false;
-        }
+		if ( empty( $endpoint ) || empty( $secret ) ) {
+			return false;
+		}
 
-        // Decrypt the secret if encrypted.
-        if ( class_exists( 'SWPS_Encryption' ) ) {
-            $secret = SWPS_Encryption::decrypt( $secret );
-        }
+		// Decrypt the secret if encrypted.
+		if ( class_exists( 'SWPS_Encryption' ) ) {
+			$secret = SWPS_Encryption::decrypt( $secret );
+		}
 
-        // Build the recent-titles URL from the base endpoint.
-        $base_url   = dirname( $endpoint );
-        $titles_url = trailingslashit( $base_url ) . 'recent-titles';
+		// Build the recent-titles URL from the base endpoint.
+		$base_url   = dirname( $endpoint );
+		$titles_url = trailingslashit( $base_url ) . 'recent-titles';
 
-        $response = wp_remote_get( $titles_url, [
-            'headers' => [
-                'X-Jon-AI-Secret' => $secret,
-            ],
-            'timeout' => 10,
-        ] );
+		$response = wp_remote_get(
+			$titles_url,
+			array(
+				'headers' => array(
+					'X-Jon-AI-Secret' => $secret,
+				),
+				'timeout' => 10,
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return false;
-        }
+		if ( is_wp_error( $response ) ) {
+			return false;
+		}
 
-        $body = json_decode( wp_remote_retrieve_body( $response ), true );
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
 
-        if ( ! is_array( $body ) ) {
-            return false;
-        }
+		if ( ! is_array( $body ) ) {
+			return false;
+		}
 
-        // Check the titles array for similarity.
-        $titles = $body['titles'] ?? $body;
+		// Check the titles array for similarity.
+		$titles = $body['titles'] ?? $body;
 
-        foreach ( $titles as $remote_title ) {
-            if ( ! is_string( $remote_title ) ) {
-                continue;
-            }
+		foreach ( $titles as $remote_title ) {
+			if ( ! is_string( $remote_title ) ) {
+				continue;
+			}
 
-            $similarity = 0;
-            similar_text(
-                strtolower( $title ),
-                strtolower( $remote_title ),
-                $similarity
-            );
+			$similarity = 0;
+			similar_text(
+				strtolower( $title ),
+				strtolower( $remote_title ),
+				$similarity
+			);
 
-            if ( $similarity >= self::SIMILARITY_THRESHOLD ) {
-                return $remote_title;
-            }
-        }
+			if ( $similarity >= self::SIMILARITY_THRESHOLD ) {
+				return $remote_title;
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 }

--- a/includes/class-encryption.php
+++ b/includes/class-encryption.php
@@ -6,79 +6,79 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Encryption {
 
-    private const METHOD = 'aes-256-cbc';
-    private const PREFIX = 'encrypted:';
+	private const METHOD = 'aes-256-cbc';
+	private const PREFIX = 'encrypted:';
 
-    /**
-     * Encrypt a value.
-     *
-     * @param string $value Plain text value.
-     * @return string Encrypted string as "encrypted:iv:ciphertext".
-     */
-    public static function encrypt( string $value ): string {
-        if ( empty( $value ) || self::is_encrypted( $value ) ) {
-            return $value;
-        }
+	/**
+	 * Encrypt a value.
+	 *
+	 * @param string $value Plain text value.
+	 * @return string Encrypted string as "encrypted:iv:ciphertext".
+	 */
+	public static function encrypt( string $value ): string {
+		if ( empty( $value ) || self::is_encrypted( $value ) ) {
+			return $value;
+		}
 
-        $key = self::get_key();
-        $iv  = openssl_random_pseudo_bytes( openssl_cipher_iv_length( self::METHOD ) );
+		$key = self::get_key();
+		$iv  = openssl_random_pseudo_bytes( openssl_cipher_iv_length( self::METHOD ) );
 
-        $encrypted = openssl_encrypt( $value, self::METHOD, $key, 0, $iv );
+		$encrypted = openssl_encrypt( $value, self::METHOD, $key, 0, $iv );
 
-        if ( false === $encrypted ) {
-            return $value;
-        }
+		if ( false === $encrypted ) {
+			return $value;
+		}
 
-        return self::PREFIX . base64_encode( $iv ) . ':' . $encrypted;
-    }
+		return self::PREFIX . base64_encode( $iv ) . ':' . $encrypted;
+	}
 
-    /**
-     * Decrypt a value.
-     *
-     * @param string $value Encrypted string.
-     * @return string Decrypted plain text.
-     */
-    public static function decrypt( string $value ): string {
-        if ( empty( $value ) || ! self::is_encrypted( $value ) ) {
-            return $value;
-        }
+	/**
+	 * Decrypt a value.
+	 *
+	 * @param string $value Encrypted string.
+	 * @return string Decrypted plain text.
+	 */
+	public static function decrypt( string $value ): string {
+		if ( empty( $value ) || ! self::is_encrypted( $value ) ) {
+			return $value;
+		}
 
-        $parts = explode( ':', substr( $value, strlen( self::PREFIX ) ), 2 );
+		$parts = explode( ':', substr( $value, strlen( self::PREFIX ) ), 2 );
 
-        if ( count( $parts ) !== 2 ) {
-            return $value;
-        }
+		if ( count( $parts ) !== 2 ) {
+			return $value;
+		}
 
-        $iv         = base64_decode( $parts[0] );
-        $ciphertext = $parts[1];
-        $key        = self::get_key();
+		$iv         = base64_decode( $parts[0] );
+		$ciphertext = $parts[1];
+		$key        = self::get_key();
 
-        $decrypted = openssl_decrypt( $ciphertext, self::METHOD, $key, 0, $iv );
+		$decrypted = openssl_decrypt( $ciphertext, self::METHOD, $key, 0, $iv );
 
-        return false === $decrypted ? $value : $decrypted;
-    }
+		return false === $decrypted ? $value : $decrypted;
+	}
 
-    /**
-     * Check if a value is already encrypted.
-     *
-     * @param string $value Value to check.
-     * @return bool
-     */
-    public static function is_encrypted( string $value ): bool {
-        return str_starts_with( $value, self::PREFIX );
-    }
+	/**
+	 * Check if a value is already encrypted.
+	 *
+	 * @param string $value Value to check.
+	 * @return bool
+	 */
+	public static function is_encrypted( string $value ): bool {
+		return str_starts_with( $value, self::PREFIX );
+	}
 
-    /**
-     * Get the encryption key derived from WordPress salts.
-     *
-     * @return string 32-byte key.
-     */
-    private static function get_key(): string {
-        return hash( 'sha256', wp_salt( 'auth' ), true );
-    }
+	/**
+	 * Get the encryption key derived from WordPress salts.
+	 *
+	 * @return string 32-byte key.
+	 */
+	private static function get_key(): string {
+		return hash( 'sha256', wp_salt( 'auth' ), true );
+	}
 }

--- a/includes/class-generator.php
+++ b/includes/class-generator.php
@@ -8,221 +8,231 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Generator {
 
-    private SWPS_AI_Provider $api;
-    private SWPS_Analyzer $analyzer;
-    private SWPS_Image_Provider $images;
-    private SWPS_Duplicate_Checker $duplicate_checker;
-    private SWPS_Rate_Limiter $rate_limiter;
-    private SWPS_Cost_Tracker $cost_tracker;
+	private SWPS_AI_Provider $api;
+	private SWPS_Analyzer $analyzer;
+	private SWPS_Image_Provider $images;
+	private SWPS_Duplicate_Checker $duplicate_checker;
+	private SWPS_Rate_Limiter $rate_limiter;
+	private SWPS_Cost_Tracker $cost_tracker;
 
-    public function __construct(
-        SWPS_AI_Provider $api,
-        SWPS_Analyzer $analyzer,
-        SWPS_Image_Provider $images,
-        SWPS_Duplicate_Checker $duplicate_checker,
-        SWPS_Rate_Limiter $rate_limiter,
-        SWPS_Cost_Tracker $cost_tracker
-    ) {
-        $this->api               = $api;
-        $this->analyzer          = $analyzer;
-        $this->images            = $images;
-        $this->duplicate_checker = $duplicate_checker;
-        $this->rate_limiter      = $rate_limiter;
-        $this->cost_tracker      = $cost_tracker;
-    }
+	public function __construct(
+		SWPS_AI_Provider $api,
+		SWPS_Analyzer $analyzer,
+		SWPS_Image_Provider $images,
+		SWPS_Duplicate_Checker $duplicate_checker,
+		SWPS_Rate_Limiter $rate_limiter,
+		SWPS_Cost_Tracker $cost_tracker
+	) {
+		$this->api               = $api;
+		$this->analyzer          = $analyzer;
+		$this->images            = $images;
+		$this->duplicate_checker = $duplicate_checker;
+		$this->rate_limiter      = $rate_limiter;
+		$this->cost_tracker      = $cost_tracker;
+	}
 
-    /**
-     * Generate a complete blog post and save it as a WP draft.
-     *
-     * @param string $topic    Optional specific topic. If empty, AI picks one.
-     * @param string $template Content template slug.
-     * @return array|WP_Error Post data on success, error on failure.
-     */
-    public function generate_post( string $topic = '', string $template = 'auto' ): array|WP_Error {
-        // Image generation (especially Gemini) can take several minutes per post.
-        // Lift PHP execution caps so cron/background jobs don't die mid-download,
-        // leaving posts with no images and an empty debug.log.
-        if ( function_exists( 'set_time_limit' ) ) {
-            @set_time_limit( 0 );
-        }
-        if ( function_exists( 'wp_raise_memory_limit' ) ) {
-            wp_raise_memory_limit( 'admin' );
-        }
-        ignore_user_abort( true );
+	/**
+	 * Generate a complete blog post and save it as a WP draft.
+	 *
+	 * @param string $topic    Optional specific topic. If empty, AI picks one.
+	 * @param string $template Content template slug.
+	 * @return array|WP_Error Post data on success, error on failure.
+	 */
+	public function generate_post( string $topic = '', string $template = 'auto' ): array|WP_Error {
+		// Image generation (especially Gemini) can take several minutes per post.
+		// Lift PHP execution caps so cron/background jobs don't die mid-download,
+		// leaving posts with no images and an empty debug.log.
+		if ( function_exists( 'set_time_limit' ) ) {
+			@set_time_limit( 0 );
+		}
+		if ( function_exists( 'wp_raise_memory_limit' ) ) {
+			wp_raise_memory_limit( 'admin' );
+		}
+		ignore_user_abort( true );
 
-        // Fire before_generate action.
-        SWPS_Hooks::do_before_generate( $topic, $template );
+		// Fire before_generate action.
+		SWPS_Hooks::do_before_generate( $topic, $template );
 
-        // Check rate limit.
-        if ( ! $this->rate_limiter->can_generate() ) {
-            $remaining = $this->rate_limiter->get_remaining_seconds();
-            $error = new WP_Error(
-                'swps_rate_limited',
-                sprintf( __( 'Rate limited. Please wait %d seconds before generating again.', 'stratawp-seo' ), $remaining )
-            );
-            SWPS_Hooks::do_generation_failed( $error, $topic, $template );
-            return $error;
-        }
+		// Check rate limit.
+		if ( ! $this->rate_limiter->can_generate() ) {
+			$remaining = $this->rate_limiter->get_remaining_seconds();
+			$error     = new WP_Error(
+				'swps_rate_limited',
+				sprintf( __( 'Rate limited. Please wait %d seconds before generating again.', 'stratawp-seo' ), $remaining )
+			);
+			SWPS_Hooks::do_generation_failed( $error, $topic, $template );
+			return $error;
+		}
 
-        // Build prompts and call AI.
-        $ai_result = $this->call_ai( $topic, $template );
+		// Build prompts and call AI.
+		$ai_result = $this->call_ai( $topic, $template );
 
-        if ( is_wp_error( $ai_result ) ) {
-            $this->log( 'Generation failed: ' . $ai_result->get_error_message() );
-            SWPS_Hooks::do_generation_failed( $ai_result, $topic, $template );
-            return $ai_result;
-        }
+		if ( is_wp_error( $ai_result ) ) {
+			$this->log( 'Generation failed: ' . $ai_result->get_error_message() );
+			SWPS_Hooks::do_generation_failed( $ai_result, $topic, $template );
+			return $ai_result;
+		}
 
-        // Apply AI response filter.
-        $ai_result = SWPS_Hooks::filter_ai_response( $ai_result, $topic );
+		// Apply AI response filter.
+		$ai_result = SWPS_Hooks::filter_ai_response( $ai_result, $topic );
 
-        // Check for duplicates.
-        if ( ! empty( $ai_result['title'] ) ) {
-            $duplicate = $this->duplicate_checker->is_duplicate( $ai_result['title'] );
-            if ( false !== $duplicate ) {
-                $error = new WP_Error(
-                    'swps_duplicate',
-                    sprintf( __( 'Duplicate detected: "%s" is too similar to existing title "%s"', 'stratawp-seo' ), $ai_result['title'], $duplicate )
-                );
-                SWPS_Hooks::do_generation_failed( $error, $topic, $template );
-                return $error;
-            }
-        }
+		// Check for duplicates.
+		if ( ! empty( $ai_result['title'] ) ) {
+			$duplicate = $this->duplicate_checker->is_duplicate( $ai_result['title'] );
+			if ( false !== $duplicate ) {
+				$error = new WP_Error(
+					'swps_duplicate',
+					sprintf( __( 'Duplicate detected: "%1$s" is too similar to existing title "%2$s"', 'stratawp-seo' ), $ai_result['title'], $duplicate )
+				);
+				SWPS_Hooks::do_generation_failed( $error, $topic, $template );
+				return $error;
+			}
+		}
 
-        // Lock rate limiter.
-        $this->rate_limiter->lock();
+		// Lock rate limiter.
+		$this->rate_limiter->lock();
 
-        // Validate required fields.
-        $required = [ 'title', 'content_html', 'meta_description', 'slug' ];
-        foreach ( $required as $field ) {
-            if ( empty( $ai_result[ $field ] ) ) {
-                $error = new WP_Error(
-                    'swps_missing_field',
-                    sprintf( __( 'AI response missing required field: %s', 'stratawp-seo' ), $field )
-                );
-                SWPS_Hooks::do_generation_failed( $error, $topic, $template );
-                return $error;
-            }
-        }
+		// Validate required fields.
+		$required = array( 'title', 'content_html', 'meta_description', 'slug' );
+		foreach ( $required as $field ) {
+			if ( empty( $ai_result[ $field ] ) ) {
+				$error = new WP_Error(
+					'swps_missing_field',
+					sprintf( __( 'AI response missing required field: %s', 'stratawp-seo' ), $field )
+				);
+				SWPS_Hooks::do_generation_failed( $error, $topic, $template );
+				return $error;
+			}
+		}
 
-        // Create the WordPress post.
-        $post_data = $this->create_wp_post( $ai_result, $template );
+		// Create the WordPress post.
+		$post_data = $this->create_wp_post( $ai_result, $template );
 
-        if ( is_wp_error( $post_data ) ) {
-            SWPS_Hooks::do_generation_failed( $post_data, $topic, $template );
-            return $post_data;
-        }
+		if ( is_wp_error( $post_data ) ) {
+			SWPS_Hooks::do_generation_failed( $post_data, $topic, $template );
+			return $post_data;
+		}
 
-        // Fire after_generate action.
-        SWPS_Hooks::do_after_generate( $post_data, $topic, $template );
+		// Fire after_generate action.
+		SWPS_Hooks::do_after_generate( $post_data, $topic, $template );
 
-        return $post_data;
-    }
+		return $post_data;
+	}
 
-    /**
-     * Preview content without creating a post.
-     *
-     * @param string $topic    Optional topic.
-     * @param string $template Content template slug.
-     * @return array|WP_Error AI result data or error.
-     */
-    public function preview_content( string $topic = '', string $template = 'auto' ): array|WP_Error {
-        // Check rate limit.
-        if ( ! $this->rate_limiter->can_generate() ) {
-            $remaining = $this->rate_limiter->get_remaining_seconds();
-            return new WP_Error(
-                'swps_rate_limited',
-                sprintf( __( 'Rate limited. Please wait %d seconds.', 'stratawp-seo' ), $remaining )
-            );
-        }
+	/**
+	 * Preview content without creating a post.
+	 *
+	 * @param string $topic    Optional topic.
+	 * @param string $template Content template slug.
+	 * @return array|WP_Error AI result data or error.
+	 */
+	public function preview_content( string $topic = '', string $template = 'auto' ): array|WP_Error {
+		// Check rate limit.
+		if ( ! $this->rate_limiter->can_generate() ) {
+			$remaining = $this->rate_limiter->get_remaining_seconds();
+			return new WP_Error(
+				'swps_rate_limited',
+				sprintf( __( 'Rate limited. Please wait %d seconds.', 'stratawp-seo' ), $remaining )
+			);
+		}
 
-        $ai_result = $this->call_ai( $topic, $template );
+		$ai_result = $this->call_ai( $topic, $template );
 
-        if ( is_wp_error( $ai_result ) ) {
-            return $ai_result;
-        }
+		if ( is_wp_error( $ai_result ) ) {
+			return $ai_result;
+		}
 
-        // Lock rate limiter.
-        $this->rate_limiter->lock();
+		// Lock rate limiter.
+		$this->rate_limiter->lock();
 
-        return $ai_result;
-    }
+		return $ai_result;
+	}
 
-    /**
-     * Call the AI provider with built prompts.
-     *
-     * @param string $topic    Topic.
-     * @param string $template Template slug.
-     * @return array|WP_Error Parsed AI response or error.
-     */
-    private function call_ai( string $topic, string $template ): array|WP_Error {
-        // Gather site context (limit posts to keep prompt under timeout threshold).
-        $site_context   = $this->analyzer->build_context_for_prompt( 20 );
-        $linkable_posts = $this->analyzer->get_linkable_posts();
+	/**
+	 * Call the AI provider with built prompts.
+	 *
+	 * @param string $topic    Topic.
+	 * @param string $template Template slug.
+	 * @return array|WP_Error Parsed AI response or error.
+	 */
+	private function call_ai( string $topic, string $template ): array|WP_Error {
+		// Gather site context (limit posts to keep prompt under timeout threshold).
+		$site_context   = $this->analyzer->build_context_for_prompt( 20 );
+		$linkable_posts = $this->analyzer->get_linkable_posts();
 
-        // Get user preferences.
-        $niche       = get_option( 'swps_site_niche', '' );
-        $tone        = get_option( 'swps_tone', 'professional' );
-        $style       = get_option( 'swps_writing_style', '' );
-        $keywords    = get_option( 'swps_target_keywords', '' );
-        $min_words   = (int) get_option( 'swps_word_count_min', 1200 );
-        $max_words   = (int) get_option( 'swps_word_count_max', 2000 );
-        $min_links   = (int) get_option( 'swps_internal_links_min', 3 );
-        $max_links   = (int) get_option( 'swps_internal_links_max', 6 );
-        $include_faq = (bool) get_option( 'swps_include_faq_schema', true );
-        $include_toc = (bool) get_option( 'swps_include_toc', true );
-        $include_takeaways = (bool) get_option( 'swps_include_takeaways', false );
-        $takeaways_count   = (int) get_option( 'swps_takeaways_count', 5 );
+		// Get user preferences.
+		$niche             = get_option( 'swps_site_niche', '' );
+		$tone              = get_option( 'swps_tone', 'professional' );
+		$style             = get_option( 'swps_writing_style', '' );
+		$keywords          = get_option( 'swps_target_keywords', '' );
+		$min_words         = (int) get_option( 'swps_word_count_min', 1200 );
+		$max_words         = (int) get_option( 'swps_word_count_max', 2000 );
+		$min_links         = (int) get_option( 'swps_internal_links_min', 3 );
+		$max_links         = (int) get_option( 'swps_internal_links_max', 6 );
+		$include_faq       = (bool) get_option( 'swps_include_faq_schema', true );
+		$include_toc       = (bool) get_option( 'swps_include_toc', true );
+		$include_takeaways = (bool) get_option( 'swps_include_takeaways', false );
+		$takeaways_count   = (int) get_option( 'swps_takeaways_count', 5 );
 
-        // Build the system prompt.
-        $system_prompt = $this->build_system_prompt( $tone, $style );
+		// Build the system prompt.
+		$system_prompt = $this->build_system_prompt( $tone, $style );
 
-        // Build linkable posts reference.
-        $links_context = "=== EXISTING PAGES FOR INTERNAL LINKING ===\n";
-        $links_context .= "You MUST include natural internal links to these pages where relevant:\n";
-        foreach ( $linkable_posts as $link ) {
-            $links_context .= "- \"{$link['title']}\" → {$link['url']}\n";
-        }
+		// Build linkable posts reference.
+		$links_context  = "=== EXISTING PAGES FOR INTERNAL LINKING ===\n";
+		$links_context .= "You MUST include natural internal links to these pages where relevant:\n";
+		foreach ( $linkable_posts as $link ) {
+			$links_context .= "- \"{$link['title']}\" → {$link['url']}\n";
+		}
 
-        // Build the user prompt.
-        $user_prompt = $this->build_user_prompt(
-            $topic, $site_context, $links_context, $niche, $keywords,
-            $min_words, $max_words, $min_links, $max_links, $include_faq, $include_toc,
-            $include_takeaways, $takeaways_count
-        );
+		// Build the user prompt.
+		$user_prompt = $this->build_user_prompt(
+			$topic,
+			$site_context,
+			$links_context,
+			$niche,
+			$keywords,
+			$min_words,
+			$max_words,
+			$min_links,
+			$max_links,
+			$include_faq,
+			$include_toc,
+			$include_takeaways,
+			$takeaways_count
+		);
 
-        // Apply template modifiers.
-        if ( $template === 'auto' ) {
-            $template = get_option( 'swps_default_template', 'auto' );
-        }
-        [ $system_prompt, $user_prompt ] = SWPS_Templates::apply( $system_prompt, $user_prompt, $template );
+		// Apply template modifiers.
+		if ( $template === 'auto' ) {
+			$template = get_option( 'swps_default_template', 'auto' );
+		}
+		[ $system_prompt, $user_prompt ] = SWPS_Templates::apply( $system_prompt, $user_prompt, $template );
 
-        // Apply hook filters.
-        $system_prompt = SWPS_Hooks::filter_system_prompt( $system_prompt, $tone, $style );
-        $user_prompt   = SWPS_Hooks::filter_user_prompt( $user_prompt, $topic, $site_context );
+		// Apply hook filters.
+		$system_prompt = SWPS_Hooks::filter_system_prompt( $system_prompt, $tone, $style );
+		$user_prompt   = SWPS_Hooks::filter_user_prompt( $user_prompt, $topic, $site_context );
 
-        // Call AI with 16384 tokens for complete posts with full JSON structure.
-        // 8192 was causing truncation for longer posts (1900-3000 words + metadata).
-        // Input is kept lean (20 posts, 30 linkable) to stay within timeout.
-        $result = $this->api->chat_json( $system_prompt, $user_prompt, 16384 );
+		// Call AI with 16384 tokens for complete posts with full JSON structure.
+		// 8192 was causing truncation for longer posts (1900-3000 words + metadata).
+		// Input is kept lean (20 posts, 30 linkable) to stay within timeout.
+		$result = $this->api->chat_json( $system_prompt, $user_prompt, 16384 );
 
-        if ( is_wp_error( $result ) ) {
-            return $result;
-        }
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
 
-        return $result;
-    }
+		return $result;
+	}
 
-    /**
-     * Build the system prompt for Claude.
-     */
-    private function build_system_prompt( string $tone, string $style ): string {
-        $prompt = <<<PROMPT
+	/**
+	 * Build the system prompt for Claude.
+	 */
+	private function build_system_prompt( string $tone, string $style ): string {
+		$prompt = <<<PROMPT
 You are an expert SEO content writer and WordPress specialist. You create blog posts that are:
 
 1. SEO-optimized with proper heading hierarchy (H2, H3 — never H1, as WordPress uses the post title as H1)
@@ -233,11 +243,11 @@ You are an expert SEO content writer and WordPress specialist. You create blog p
 TONE: {$tone}
 PROMPT;
 
-        if ( ! empty( $style ) ) {
-            $prompt .= "\nWRITING STYLE: {$style}";
-        }
+		if ( ! empty( $style ) ) {
+			$prompt .= "\nWRITING STYLE: {$style}";
+		}
 
-        $prompt .= <<<'PROMPT'
+		$prompt .= <<<'PROMPT'
 
 
 RESPONSE FORMAT: Respond ONLY with a single, strictly valid RFC 8259 JSON object. No markdown fences, no prose, no explanation.
@@ -286,442 +296,440 @@ CRITICAL RULES:
 - Every <img> tag in content_html MUST have an alt attribute that contains the focus_keyword
 PROMPT;
 
-        return $prompt;
-    }
-
-    /**
-     * Build the user prompt with site context and preferences.
-     */
-    private function build_user_prompt(
-        string $topic,
-        string $site_context,
-        string $links_context,
-        string $niche,
-        string $keywords,
-        int $min_words,
-        int $max_words,
-        int $min_links,
-        int $max_links,
-        bool $include_faq,
-        bool $include_toc,
-        bool $include_takeaways = false,
-        int $takeaways_count = 5
-    ): string {
-        $prompt = $site_context . "\n" . $links_context . "\n";
-
-        if ( ! empty( $topic ) ) {
-            $prompt .= "TOPIC: Write a blog post about: {$topic}\n\n";
-        } else {
-            $prompt .= "TOPIC: Based on the site's niche ({$niche}) and existing content above, choose a topic that:\n";
-            $prompt .= "- Fills a content gap (something the site hasn't covered yet)\n";
-            $prompt .= "- Is relevant to the site's niche and audience\n";
-            $prompt .= "- Has good search potential\n";
-            $prompt .= "- Can naturally link to existing content\n\n";
-        }
-
-        if ( ! empty( $keywords ) ) {
-            $prompt .= "TARGET KEYWORDS: {$keywords}\n";
-            $prompt .= "KEYWORD PLACEMENT RULES (mandatory for SEO):\n";
-            $prompt .= "- Include the primary keyword in the meta_title\n";
-            $prompt .= "- Include the primary keyword in the meta_description\n";
-            $prompt .= "- Include the primary keyword in the FIRST paragraph of the content\n";
-            $prompt .= "- Include the primary keyword in at least ONE H2 heading\n";
-            $prompt .= "- Include the primary keyword in the slug\n";
-            $prompt .= "- Use keywords naturally throughout the rest of the content — do not stuff\n\n";
-        }
-
-        $prompt .= "REQUIREMENTS:\n";
-        $prompt .= "- Word count: {$min_words}-{$max_words} words\n";
-        $prompt .= "- Include {$min_links}-{$max_links} internal links to existing pages listed above\n";
-        $prompt .= "- Include 2-4 external links to authoritative sources (real websites, documentation, or industry publications)\n";
-
-        if ( $include_toc ) {
-            $prompt .= "- Include a table of contents (HTML list with anchor links to each H2) at the beginning\n";
-        }
-
-        if ( $include_faq ) {
-            $prompt .= "- Include a FAQ section at the end with 3-5 questions (also populate the faq_schema field for structured data)\n";
-        }
-
-        if ( $include_takeaways ) {
-            $prompt .= "- Include {$takeaways_count} key takeaways — concise, actionable bullet points summarizing the post's most important insights (also populate the key_takeaways JSON field)\n";
-        }
-
-        $prompt .= "- Use proper heading hierarchy (H2 for main sections, H3 for subsections)\n";
-        $prompt .= "- Suggest the best existing category for this post, or suggest a new one\n";
-        $prompt .= "- Write a compelling meta description (147-160 characters) that includes the primary target keyword\n\n";
-        $prompt .= "Generate the blog post now. Respond with JSON only.";
-
-        return $prompt;
-    }
-
-    /**
-     * Create a WordPress post from the AI-generated data.
-     *
-     * @param array  $ai_result The parsed JSON from Claude.
-     * @param string $template  The template used.
-     * @return array|WP_Error Post data or error.
-     */
-    private function create_wp_post( array $ai_result, string $template = 'auto' ): array|WP_Error {
-        $post_status = get_option( 'swps_post_status', 'draft' );
-        $post_author = (int) get_option( 'swps_post_author', get_current_user_id() );
-        $category_id = (int) get_option( 'swps_post_category', 0 );
-
-        // Handle category.
-        if ( ! empty( $ai_result['suggested_category'] ) ) {
-            $cat = get_cat_ID( $ai_result['suggested_category'] );
-            if ( $cat > 0 ) {
-                $category_id = $cat;
-            } elseif ( $category_id === 0 ) {
-                $new_cat = wp_create_category( $ai_result['suggested_category'] );
-                if ( ! is_wp_error( $new_cat ) ) {
-                    $category_id = $new_cat;
-                }
-            }
-        }
-
-        $content = $ai_result['content_html'];
-
-        // Inject key takeaways block if enabled.
-        if ( get_option( 'swps_include_takeaways', false ) && ! empty( $ai_result['key_takeaways'] ) ) {
-            $content = $this->inject_takeaways( $content, $ai_result['key_takeaways'] );
-        }
-
-
-
-        $post_data = [
-            'post_title'    => sanitize_text_field( $ai_result['title'] ),
-            'post_content'  => wp_kses_post( $content ),
-            'post_excerpt'  => sanitize_text_field( $ai_result['excerpt'] ?? '' ),
-            'post_status'   => $post_status,
-            'post_author'   => $post_author,
-            'post_name'     => sanitize_title( $ai_result['slug'] ),
-            'post_category' => $category_id ? [ $category_id ] : [],
-            'post_type'     => 'post',
-        ];
-
-        // Apply post data filter.
-        $post_data = SWPS_Hooks::filter_post_data( $post_data, $ai_result );
-
-        // Flag that the generator is creating this post (prevents redundant AI calls from hooks).
-        if ( ! defined( 'SWPS_GENERATING' ) ) {
-            define( 'SWPS_GENERATING', true );
-        }
-
-        $post_id = wp_insert_post( $post_data, true );
-
-        if ( is_wp_error( $post_id ) ) {
-            return $post_id;
-        }
-
-        // Log the post creation immediately so we have a record even if a
-        // later step (featured image, hooks) fails or times out mid-cron.
-        $this->log( sprintf( 'Generated post #%d: "%s"', $post_id, $ai_result['title'] ) );
-
-        // Set tags.
-        if ( ! empty( $ai_result['suggested_tags'] ) ) {
-            wp_set_post_tags( $post_id, array_map( 'sanitize_text_field', $ai_result['suggested_tags'] ) );
-        }
-
-        // Store SEO meta (compatible with Yoast and RankMath).
-        $meta_desc     = sanitize_text_field( $ai_result['meta_description'] ?? '' );
-        $focus_keyword = sanitize_text_field( $ai_result['focus_keyword'] ?? '' );
-
-        update_post_meta( $post_id, '_yoast_wpseo_metadesc', $meta_desc );
-        update_post_meta( $post_id, '_yoast_wpseo_focuskw', $focus_keyword );
-        update_post_meta( $post_id, 'rank_math_description', $meta_desc );
-        update_post_meta( $post_id, 'rank_math_focus_keyword', $focus_keyword );
-
-        // Store StrataWP SEO metadata.
-        update_post_meta( $post_id, '_swps_generated', true );
-        update_post_meta( $post_id, '_swps_generated_at', current_time( 'mysql' ) );
-        update_post_meta( $post_id, '_swps_meta_description', $meta_desc );
-        update_post_meta( $post_id, '_swps_focus_keyword', $focus_keyword );
-
-        // Generate meta title (shortened post title if AI didn't provide one).
-        $meta_title = sanitize_text_field( $ai_result['meta_title'] ?? '' );
-        if ( empty( $meta_title ) ) {
-            $meta_title = mb_substr( $ai_result['title'], 0, 60 );
-        }
-        update_post_meta( $post_id, '_swps_meta_title', $meta_title );
-        $secondary = $ai_result['secondary_keywords'] ?? [];
-        $secondary_str = is_array( $secondary ) ? implode( ', ', array_map( 'sanitize_text_field', $secondary ) ) : sanitize_text_field( $secondary );
-        update_post_meta( $post_id, '_swps_secondary_keywords', $secondary_str );
-        update_post_meta( $post_id, '_swps_internal_links', $ai_result['internal_links_used'] ?? [] );
-        update_post_meta( $post_id, '_swps_external_links', $ai_result['external_links'] ?? [] );
-        update_post_meta( $post_id, '_swps_template', $template );
-
-        // Store key takeaways for schema output.
-        if ( ! empty( $ai_result['key_takeaways'] ) ) {
-            update_post_meta( $post_id, '_swps_key_takeaways', array_map( 'sanitize_text_field', $ai_result['key_takeaways'] ) );
-        }
-
-        // Store FAQ schema as post meta.
-        if ( ! empty( $ai_result['faq_schema'] ) ) {
-            $schema_data = $this->build_faq_schema_data( $ai_result['title'], $ai_result['faq_schema'] );
-            $schema_data = SWPS_Hooks::filter_faq_schema( $schema_data, $ai_result['title'], $ai_result['faq_schema'] );
-            update_post_meta( $post_id, '_swps_faq_schema', $schema_data );
-        }
-
-        // Track cost per post.
-        $cost = null;
-        $model = get_option( 'swps_model', '' );
-        if ( ! empty( $ai_result['_usage'] ) ) {
-            $input_tokens  = $ai_result['_usage']['input_tokens'] ?? 0;
-            $output_tokens = $ai_result['_usage']['output_tokens'] ?? 0;
-            $this->cost_tracker->track( $model, $input_tokens, $output_tokens, $post_id );
-            $cost = $this->cost_tracker->calculate_cost( $model, $input_tokens, $output_tokens );
-        }
-
-        // Set featured image.
-        if ( get_option( 'swps_featured_images', 1 ) ) {
-            $image_query = $focus_keyword ?: $ai_result['title'];
-            $image_query = SWPS_Hooks::filter_image_query( $image_query, $post_id );
-
-            $image_result = $this->images->set_featured_image( $post_id, $image_query );
-
-            if ( is_wp_error( $image_result ) ) {
-                $this->log( 'Featured image failed: ' . $image_result->get_error_message() );
-            } else {
-                $attachment_id = $image_result;
-
-                // Update alt text to include the focus keyword for SEO.
-                if ( ! empty( $focus_keyword ) ) {
-                    $existing_alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
-                    if ( empty( $existing_alt ) || false === mb_stripos( $existing_alt, $focus_keyword ) ) {
-                        $seo_alt = ! empty( $existing_alt )
-                            ? $existing_alt . ' - ' . $focus_keyword
-                            : ucfirst( $focus_keyword );
-                        update_post_meta( $attachment_id, '_wp_attachment_image_alt', sanitize_text_field( $seo_alt ) );
-                    }
-                }
-
-                // Set OG image from featured image so the social_image check passes.
-                $image_url = wp_get_attachment_url( $attachment_id );
-                if ( $image_url ) {
-                    update_post_meta( $post_id, '_swps_social_image', esc_url_raw( $image_url ) );
-                }
-            }
-        }
-
-        // Fire post_created action.
-        SWPS_Hooks::do_post_created( $post_id, $ai_result, $post_data );
-
-        // Read back content score (set by swps_post_created hook).
-        $content_score = get_post_meta( $post_id, '_swps_content_score', true );
-
-        return [
-            'post_id'          => $post_id,
-            'title'            => $ai_result['title'],
-            'edit_url'         => get_edit_post_link( $post_id, 'raw' ),
-            'preview_url'      => get_preview_post_link( $post_id ),
-            'status'           => $post_status,
-            'focus_keyword'    => $focus_keyword,
-            'meta_description' => $meta_desc,
-            'internal_links'   => $ai_result['internal_links_used'] ?? [],
-            'external_links'   => $ai_result['external_links'] ?? [],
-            'word_count'       => $ai_result['estimated_word_count'] ?? 0,
-            'template'         => $template,
-            'cost'             => $cost,
-            'content_score'    => $content_score ?: null,
-        ];
-    }
-
-    /**
-     * Inject a key takeaways block into content HTML.
-     *
-     * Inserts before the first <h2> tag (after intro paragraphs).
-     *
-     * @param string $content   The post content HTML.
-     * @param array  $takeaways Array of takeaway strings.
-     * @return string Modified content with takeaways injected.
-     */
-    private function inject_takeaways( string $content, array $takeaways ): string {
-        $takeaways_html = $this->build_takeaways_html( $takeaways );
-
-        // Find the first <h2> tag — insert before it.
-        $h2_pos = stripos( $content, '<h2' );
-        if ( $h2_pos === false ) {
-            // No H2 found — prepend to content.
-            return $takeaways_html . $content;
-        }
-
-        return substr( $content, 0, $h2_pos ) . $takeaways_html . substr( $content, $h2_pos );
-    }
-
-    /**
-     * Build the key takeaways HTML block.
-     *
-     * @param array $takeaways Array of takeaway strings.
-     * @return string HTML markup.
-     */
-    private function build_takeaways_html( array $takeaways ): string {
-        $items = '';
-        foreach ( $takeaways as $takeaway ) {
-            $items .= '<li>' . esc_html( $takeaway ) . '</li>';
-        }
-
-        return '<div class="swps-key-takeaways">'
-             . '<h3>' . esc_html__( 'Key Takeaways', 'stratawp-seo' ) . '</h3>'
-             . '<ul>' . $items . '</ul>'
-             . '</div>';
-    }
-
-    /**
-     * Convert classic HTML content into Gutenberg block markup.
-     *
-     * Wraps each top-level HTML element with the appropriate
-     * Gutenberg block comment delimiters so WordPress treats
-     * the content as native blocks instead of a classic block.
-     *
-     * @param string $html Raw HTML content.
-     * @return string Block-formatted content.
-     */
-    private function convert_to_blocks( string $html ): string {
-        // Normalize line breaks and trim.
-        $html = trim( $html );
-        if ( empty( $html ) ) {
-            return '';
-        }
-
-        $output = '';
-
-        // Split HTML into top-level elements using a regex that captures tags and text between them.
-        // Match any top-level HTML tag with its content.
-        $pattern = '/(<(h[1-6]|p|ul|ol|blockquote|pre|table|figure|div|nav|hr|img)[^>]*>.*?<\/\2>|<(hr|img)[^>]*\/?>)/is';
-
-        $last_pos = 0;
-        if ( preg_match_all( $pattern, $html, $matches, PREG_OFFSET_CAPTURE ) ) {
-            foreach ( $matches[0] as $match ) {
-                $tag_html = $match[0];
-                $tag_pos  = $match[1];
-
-                // Skip any text between tags (whitespace).
-                $last_pos = $tag_pos + strlen( $tag_html );
-
-                // Detect the tag type.
-                if ( preg_match( '/^<(h[1-6]|p|ul|ol|blockquote|pre|table|figure|div|nav|hr|img)/i', $tag_html, $tag_match ) ) {
-                    $tag = strtolower( $tag_match[1] );
-                    $output .= $this->wrap_block( $tag, $tag_html );
-                } else {
-                    $output .= $tag_html . "\n\n";
-                }
-            }
-        }
-
-        return $output;
-    }
-
-    /**
-     * Wrap a single HTML element with Gutenberg block comment delimiters.
-     *
-     * @param string $tag  The HTML tag name (e.g., 'p', 'h2', 'ul').
-     * @param string $html The full HTML element.
-     * @return string Block-wrapped HTML.
-     */
-    private function wrap_block( string $tag, string $html ): string {
-        switch ( $tag ) {
-            case 'h1':
-            case 'h2':
-            case 'h3':
-            case 'h4':
-            case 'h5':
-            case 'h6':
-                $level = (int) substr( $tag, 1 );
-                $attrs = $level !== 2 ? ' {"level":' . $level . '}' : '';
-                return "<!-- wp:heading{$attrs} -->\n{$html}\n<!-- /wp:heading -->\n\n";
-
-            case 'p':
-                return "<!-- wp:paragraph -->\n{$html}\n<!-- /wp:paragraph -->\n\n";
-
-            case 'ul':
-                return "<!-- wp:list -->\n{$html}\n<!-- /wp:list -->\n\n";
-
-            case 'ol':
-                return "<!-- wp:list {\"ordered\":true} -->\n{$html}\n<!-- /wp:list -->\n\n";
-
-            case 'blockquote':
-                return "<!-- wp:quote -->\n{$html}\n<!-- /wp:quote -->\n\n";
-
-            case 'pre':
-                return "<!-- wp:code -->\n{$html}\n<!-- /wp:code -->\n\n";
-
-            case 'table':
-                return "<!-- wp:table -->\n<figure class=\"wp-block-table\">{$html}</figure>\n<!-- /wp:table -->\n\n";
-
-            case 'figure':
-                return "<!-- wp:image -->\n{$html}\n<!-- /wp:image -->\n\n";
-
-            case 'hr':
-                return "<!-- wp:separator -->\n<hr class=\"wp-block-separator has-alpha-channel-opacity\"/>\n<!-- /wp:separator -->\n\n";
-
-            case 'img':
-                return "<!-- wp:image -->\n<figure class=\"wp-block-image\">{$html}</figure>\n<!-- /wp:image -->\n\n";
-
-            case 'nav':
-            case 'div':
-                return "<!-- wp:html -->\n{$html}\n<!-- /wp:html -->\n\n";
-
-            default:
-                return $html . "\n\n";
-        }
-    }
-
-    /**
-     * Build FAQ schema data array.
-     *
-     * @param string $title     Post title.
-     * @param array  $faq_items Array of [{question, answer}].
-     * @return array Schema data.
-     */
-    private function build_faq_schema_data( string $title, array $faq_items ): array {
-        $schema = [
-            '@context'   => 'https://schema.org',
-            '@type'      => 'FAQPage',
-            'name'       => sanitize_text_field( wp_strip_all_tags( $title ) ),
-            'mainEntity' => [],
-        ];
-
-        foreach ( $faq_items as $item ) {
-            if ( ! is_array( $item ) ) {
-                continue;
-            }
-
-            $question = sanitize_text_field( wp_strip_all_tags( (string) ( $item['question'] ?? '' ) ) );
-            $answer   = sanitize_textarea_field( wp_strip_all_tags( (string) ( $item['answer'] ?? '' ) ) );
-
-            if ( '' === $question || '' === $answer ) {
-                continue;
-            }
-
-            $schema['mainEntity'][] = [
-                '@type'          => 'Question',
-                'name'           => $question,
-                'acceptedAnswer' => [
-                    '@type' => 'Answer',
-                    'text'  => $answer,
-                ],
-            ];
-        }
-
-        return $schema;
-    }
-
-    /**
-     * Log a message.
-     */
-    private function log( string $message ): void {
-        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-            error_log( '[StrataWP SEO] ' . $message );
-        }
-
-        $log   = get_option( 'swps_generation_log', [] );
-        $log[] = [
-            'time'    => current_time( 'mysql' ),
-            'message' => $message,
-        ];
-
-        $log = array_slice( $log, -50 );
-        update_option( 'swps_generation_log', $log );
-    }
+		return $prompt;
+	}
+
+	/**
+	 * Build the user prompt with site context and preferences.
+	 */
+	private function build_user_prompt(
+		string $topic,
+		string $site_context,
+		string $links_context,
+		string $niche,
+		string $keywords,
+		int $min_words,
+		int $max_words,
+		int $min_links,
+		int $max_links,
+		bool $include_faq,
+		bool $include_toc,
+		bool $include_takeaways = false,
+		int $takeaways_count = 5
+	): string {
+		$prompt = $site_context . "\n" . $links_context . "\n";
+
+		if ( ! empty( $topic ) ) {
+			$prompt .= "TOPIC: Write a blog post about: {$topic}\n\n";
+		} else {
+			$prompt .= "TOPIC: Based on the site's niche ({$niche}) and existing content above, choose a topic that:\n";
+			$prompt .= "- Fills a content gap (something the site hasn't covered yet)\n";
+			$prompt .= "- Is relevant to the site's niche and audience\n";
+			$prompt .= "- Has good search potential\n";
+			$prompt .= "- Can naturally link to existing content\n\n";
+		}
+
+		if ( ! empty( $keywords ) ) {
+			$prompt .= "TARGET KEYWORDS: {$keywords}\n";
+			$prompt .= "KEYWORD PLACEMENT RULES (mandatory for SEO):\n";
+			$prompt .= "- Include the primary keyword in the meta_title\n";
+			$prompt .= "- Include the primary keyword in the meta_description\n";
+			$prompt .= "- Include the primary keyword in the FIRST paragraph of the content\n";
+			$prompt .= "- Include the primary keyword in at least ONE H2 heading\n";
+			$prompt .= "- Include the primary keyword in the slug\n";
+			$prompt .= "- Use keywords naturally throughout the rest of the content — do not stuff\n\n";
+		}
+
+		$prompt .= "REQUIREMENTS:\n";
+		$prompt .= "- Word count: {$min_words}-{$max_words} words\n";
+		$prompt .= "- Include {$min_links}-{$max_links} internal links to existing pages listed above\n";
+		$prompt .= "- Include 2-4 external links to authoritative sources (real websites, documentation, or industry publications)\n";
+
+		if ( $include_toc ) {
+			$prompt .= "- Include a table of contents (HTML list with anchor links to each H2) at the beginning\n";
+		}
+
+		if ( $include_faq ) {
+			$prompt .= "- Include a FAQ section at the end with 3-5 questions (also populate the faq_schema field for structured data)\n";
+		}
+
+		if ( $include_takeaways ) {
+			$prompt .= "- Include {$takeaways_count} key takeaways — concise, actionable bullet points summarizing the post's most important insights (also populate the key_takeaways JSON field)\n";
+		}
+
+		$prompt .= "- Use proper heading hierarchy (H2 for main sections, H3 for subsections)\n";
+		$prompt .= "- Suggest the best existing category for this post, or suggest a new one\n";
+		$prompt .= "- Write a compelling meta description (147-160 characters) that includes the primary target keyword\n\n";
+		$prompt .= 'Generate the blog post now. Respond with JSON only.';
+
+		return $prompt;
+	}
+
+	/**
+	 * Create a WordPress post from the AI-generated data.
+	 *
+	 * @param array  $ai_result The parsed JSON from Claude.
+	 * @param string $template  The template used.
+	 * @return array|WP_Error Post data or error.
+	 */
+	private function create_wp_post( array $ai_result, string $template = 'auto' ): array|WP_Error {
+		$post_status = get_option( 'swps_post_status', 'draft' );
+		$post_author = (int) get_option( 'swps_post_author', get_current_user_id() );
+		$category_id = (int) get_option( 'swps_post_category', 0 );
+
+		// Handle category.
+		if ( ! empty( $ai_result['suggested_category'] ) ) {
+			$cat = get_cat_ID( $ai_result['suggested_category'] );
+			if ( $cat > 0 ) {
+				$category_id = $cat;
+			} elseif ( $category_id === 0 ) {
+				$new_cat = wp_create_category( $ai_result['suggested_category'] );
+				if ( ! is_wp_error( $new_cat ) ) {
+					$category_id = $new_cat;
+				}
+			}
+		}
+
+		$content = $ai_result['content_html'];
+
+		// Inject key takeaways block if enabled.
+		if ( get_option( 'swps_include_takeaways', false ) && ! empty( $ai_result['key_takeaways'] ) ) {
+			$content = $this->inject_takeaways( $content, $ai_result['key_takeaways'] );
+		}
+
+		$post_data = array(
+			'post_title'    => sanitize_text_field( $ai_result['title'] ),
+			'post_content'  => wp_kses_post( $content ),
+			'post_excerpt'  => sanitize_text_field( $ai_result['excerpt'] ?? '' ),
+			'post_status'   => $post_status,
+			'post_author'   => $post_author,
+			'post_name'     => sanitize_title( $ai_result['slug'] ),
+			'post_category' => $category_id ? array( $category_id ) : array(),
+			'post_type'     => 'post',
+		);
+
+		// Apply post data filter.
+		$post_data = SWPS_Hooks::filter_post_data( $post_data, $ai_result );
+
+		// Flag that the generator is creating this post (prevents redundant AI calls from hooks).
+		if ( ! defined( 'SWPS_GENERATING' ) ) {
+			define( 'SWPS_GENERATING', true );
+		}
+
+		$post_id = wp_insert_post( $post_data, true );
+
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		// Log the post creation immediately so we have a record even if a
+		// later step (featured image, hooks) fails or times out mid-cron.
+		$this->log( sprintf( 'Generated post #%d: "%s"', $post_id, $ai_result['title'] ) );
+
+		// Set tags.
+		if ( ! empty( $ai_result['suggested_tags'] ) ) {
+			wp_set_post_tags( $post_id, array_map( 'sanitize_text_field', $ai_result['suggested_tags'] ) );
+		}
+
+		// Store SEO meta (compatible with Yoast and RankMath).
+		$meta_desc     = sanitize_text_field( $ai_result['meta_description'] ?? '' );
+		$focus_keyword = sanitize_text_field( $ai_result['focus_keyword'] ?? '' );
+
+		update_post_meta( $post_id, '_yoast_wpseo_metadesc', $meta_desc );
+		update_post_meta( $post_id, '_yoast_wpseo_focuskw', $focus_keyword );
+		update_post_meta( $post_id, 'rank_math_description', $meta_desc );
+		update_post_meta( $post_id, 'rank_math_focus_keyword', $focus_keyword );
+
+		// Store StrataWP SEO metadata.
+		update_post_meta( $post_id, '_swps_generated', true );
+		update_post_meta( $post_id, '_swps_generated_at', current_time( 'mysql' ) );
+		update_post_meta( $post_id, '_swps_meta_description', $meta_desc );
+		update_post_meta( $post_id, '_swps_focus_keyword', $focus_keyword );
+
+		// Generate meta title (shortened post title if AI didn't provide one).
+		$meta_title = sanitize_text_field( $ai_result['meta_title'] ?? '' );
+		if ( empty( $meta_title ) ) {
+			$meta_title = mb_substr( $ai_result['title'], 0, 60 );
+		}
+		update_post_meta( $post_id, '_swps_meta_title', $meta_title );
+		$secondary     = $ai_result['secondary_keywords'] ?? array();
+		$secondary_str = is_array( $secondary ) ? implode( ', ', array_map( 'sanitize_text_field', $secondary ) ) : sanitize_text_field( $secondary );
+		update_post_meta( $post_id, '_swps_secondary_keywords', $secondary_str );
+		update_post_meta( $post_id, '_swps_internal_links', $ai_result['internal_links_used'] ?? array() );
+		update_post_meta( $post_id, '_swps_external_links', $ai_result['external_links'] ?? array() );
+		update_post_meta( $post_id, '_swps_template', $template );
+
+		// Store key takeaways for schema output.
+		if ( ! empty( $ai_result['key_takeaways'] ) ) {
+			update_post_meta( $post_id, '_swps_key_takeaways', array_map( 'sanitize_text_field', $ai_result['key_takeaways'] ) );
+		}
+
+		// Store FAQ schema as post meta.
+		if ( ! empty( $ai_result['faq_schema'] ) ) {
+			$schema_data = $this->build_faq_schema_data( $ai_result['title'], $ai_result['faq_schema'] );
+			$schema_data = SWPS_Hooks::filter_faq_schema( $schema_data, $ai_result['title'], $ai_result['faq_schema'] );
+			update_post_meta( $post_id, '_swps_faq_schema', $schema_data );
+		}
+
+		// Track cost per post.
+		$cost  = null;
+		$model = get_option( 'swps_model', '' );
+		if ( ! empty( $ai_result['_usage'] ) ) {
+			$input_tokens  = $ai_result['_usage']['input_tokens'] ?? 0;
+			$output_tokens = $ai_result['_usage']['output_tokens'] ?? 0;
+			$this->cost_tracker->track( $model, $input_tokens, $output_tokens, $post_id );
+			$cost = $this->cost_tracker->calculate_cost( $model, $input_tokens, $output_tokens );
+		}
+
+		// Set featured image.
+		if ( get_option( 'swps_featured_images', 1 ) ) {
+			$image_query = $focus_keyword ?: $ai_result['title'];
+			$image_query = SWPS_Hooks::filter_image_query( $image_query, $post_id );
+
+			$image_result = $this->images->set_featured_image( $post_id, $image_query );
+
+			if ( is_wp_error( $image_result ) ) {
+				$this->log( 'Featured image failed: ' . $image_result->get_error_message() );
+			} else {
+				$attachment_id = $image_result;
+
+				// Update alt text to include the focus keyword for SEO.
+				if ( ! empty( $focus_keyword ) ) {
+					$existing_alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+					if ( empty( $existing_alt ) || false === mb_stripos( $existing_alt, $focus_keyword ) ) {
+						$seo_alt = ! empty( $existing_alt )
+							? $existing_alt . ' - ' . $focus_keyword
+							: ucfirst( $focus_keyword );
+						update_post_meta( $attachment_id, '_wp_attachment_image_alt', sanitize_text_field( $seo_alt ) );
+					}
+				}
+
+				// Set OG image from featured image so the social_image check passes.
+				$image_url = wp_get_attachment_url( $attachment_id );
+				if ( $image_url ) {
+					update_post_meta( $post_id, '_swps_social_image', esc_url_raw( $image_url ) );
+				}
+			}
+		}
+
+		// Fire post_created action.
+		SWPS_Hooks::do_post_created( $post_id, $ai_result, $post_data );
+
+		// Read back content score (set by swps_post_created hook).
+		$content_score = get_post_meta( $post_id, '_swps_content_score', true );
+
+		return array(
+			'post_id'          => $post_id,
+			'title'            => $ai_result['title'],
+			'edit_url'         => get_edit_post_link( $post_id, 'raw' ),
+			'preview_url'      => get_preview_post_link( $post_id ),
+			'status'           => $post_status,
+			'focus_keyword'    => $focus_keyword,
+			'meta_description' => $meta_desc,
+			'internal_links'   => $ai_result['internal_links_used'] ?? array(),
+			'external_links'   => $ai_result['external_links'] ?? array(),
+			'word_count'       => $ai_result['estimated_word_count'] ?? 0,
+			'template'         => $template,
+			'cost'             => $cost,
+			'content_score'    => $content_score ?: null,
+		);
+	}
+
+	/**
+	 * Inject a key takeaways block into content HTML.
+	 *
+	 * Inserts before the first <h2> tag (after intro paragraphs).
+	 *
+	 * @param string $content   The post content HTML.
+	 * @param array  $takeaways Array of takeaway strings.
+	 * @return string Modified content with takeaways injected.
+	 */
+	private function inject_takeaways( string $content, array $takeaways ): string {
+		$takeaways_html = $this->build_takeaways_html( $takeaways );
+
+		// Find the first <h2> tag — insert before it.
+		$h2_pos = stripos( $content, '<h2' );
+		if ( $h2_pos === false ) {
+			// No H2 found — prepend to content.
+			return $takeaways_html . $content;
+		}
+
+		return substr( $content, 0, $h2_pos ) . $takeaways_html . substr( $content, $h2_pos );
+	}
+
+	/**
+	 * Build the key takeaways HTML block.
+	 *
+	 * @param array $takeaways Array of takeaway strings.
+	 * @return string HTML markup.
+	 */
+	private function build_takeaways_html( array $takeaways ): string {
+		$items = '';
+		foreach ( $takeaways as $takeaway ) {
+			$items .= '<li>' . esc_html( $takeaway ) . '</li>';
+		}
+
+		return '<div class="swps-key-takeaways">'
+			. '<h3>' . esc_html__( 'Key Takeaways', 'stratawp-seo' ) . '</h3>'
+			. '<ul>' . $items . '</ul>'
+			. '</div>';
+	}
+
+	/**
+	 * Convert classic HTML content into Gutenberg block markup.
+	 *
+	 * Wraps each top-level HTML element with the appropriate
+	 * Gutenberg block comment delimiters so WordPress treats
+	 * the content as native blocks instead of a classic block.
+	 *
+	 * @param string $html Raw HTML content.
+	 * @return string Block-formatted content.
+	 */
+	private function convert_to_blocks( string $html ): string {
+		// Normalize line breaks and trim.
+		$html = trim( $html );
+		if ( empty( $html ) ) {
+			return '';
+		}
+
+		$output = '';
+
+		// Split HTML into top-level elements using a regex that captures tags and text between them.
+		// Match any top-level HTML tag with its content.
+		$pattern = '/(<(h[1-6]|p|ul|ol|blockquote|pre|table|figure|div|nav|hr|img)[^>]*>.*?<\/\2>|<(hr|img)[^>]*\/?>)/is';
+
+		$last_pos = 0;
+		if ( preg_match_all( $pattern, $html, $matches, PREG_OFFSET_CAPTURE ) ) {
+			foreach ( $matches[0] as $match ) {
+				$tag_html = $match[0];
+				$tag_pos  = $match[1];
+
+				// Skip any text between tags (whitespace).
+				$last_pos = $tag_pos + strlen( $tag_html );
+
+				// Detect the tag type.
+				if ( preg_match( '/^<(h[1-6]|p|ul|ol|blockquote|pre|table|figure|div|nav|hr|img)/i', $tag_html, $tag_match ) ) {
+					$tag     = strtolower( $tag_match[1] );
+					$output .= $this->wrap_block( $tag, $tag_html );
+				} else {
+					$output .= $tag_html . "\n\n";
+				}
+			}
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Wrap a single HTML element with Gutenberg block comment delimiters.
+	 *
+	 * @param string $tag  The HTML tag name (e.g., 'p', 'h2', 'ul').
+	 * @param string $html The full HTML element.
+	 * @return string Block-wrapped HTML.
+	 */
+	private function wrap_block( string $tag, string $html ): string {
+		switch ( $tag ) {
+			case 'h1':
+			case 'h2':
+			case 'h3':
+			case 'h4':
+			case 'h5':
+			case 'h6':
+				$level = (int) substr( $tag, 1 );
+				$attrs = $level !== 2 ? ' {"level":' . $level . '}' : '';
+				return "<!-- wp:heading{$attrs} -->\n{$html}\n<!-- /wp:heading -->\n\n";
+
+			case 'p':
+				return "<!-- wp:paragraph -->\n{$html}\n<!-- /wp:paragraph -->\n\n";
+
+			case 'ul':
+				return "<!-- wp:list -->\n{$html}\n<!-- /wp:list -->\n\n";
+
+			case 'ol':
+				return "<!-- wp:list {\"ordered\":true} -->\n{$html}\n<!-- /wp:list -->\n\n";
+
+			case 'blockquote':
+				return "<!-- wp:quote -->\n{$html}\n<!-- /wp:quote -->\n\n";
+
+			case 'pre':
+				return "<!-- wp:code -->\n{$html}\n<!-- /wp:code -->\n\n";
+
+			case 'table':
+				return "<!-- wp:table -->\n<figure class=\"wp-block-table\">{$html}</figure>\n<!-- /wp:table -->\n\n";
+
+			case 'figure':
+				return "<!-- wp:image -->\n{$html}\n<!-- /wp:image -->\n\n";
+
+			case 'hr':
+				return "<!-- wp:separator -->\n<hr class=\"wp-block-separator has-alpha-channel-opacity\"/>\n<!-- /wp:separator -->\n\n";
+
+			case 'img':
+				return "<!-- wp:image -->\n<figure class=\"wp-block-image\">{$html}</figure>\n<!-- /wp:image -->\n\n";
+
+			case 'nav':
+			case 'div':
+				return "<!-- wp:html -->\n{$html}\n<!-- /wp:html -->\n\n";
+
+			default:
+				return $html . "\n\n";
+		}
+	}
+
+	/**
+	 * Build FAQ schema data array.
+	 *
+	 * @param string $title     Post title.
+	 * @param array  $faq_items Array of [{question, answer}].
+	 * @return array Schema data.
+	 */
+	private function build_faq_schema_data( string $title, array $faq_items ): array {
+		$schema = array(
+			'@context'   => 'https://schema.org',
+			'@type'      => 'FAQPage',
+			'name'       => sanitize_text_field( wp_strip_all_tags( $title ) ),
+			'mainEntity' => array(),
+		);
+
+		foreach ( $faq_items as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			$question = sanitize_text_field( wp_strip_all_tags( (string) ( $item['question'] ?? '' ) ) );
+			$answer   = sanitize_textarea_field( wp_strip_all_tags( (string) ( $item['answer'] ?? '' ) ) );
+
+			if ( '' === $question || '' === $answer ) {
+				continue;
+			}
+
+			$schema['mainEntity'][] = array(
+				'@type'          => 'Question',
+				'name'           => $question,
+				'acceptedAnswer' => array(
+					'@type' => 'Answer',
+					'text'  => $answer,
+				),
+			);
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Log a message.
+	 */
+	private function log( string $message ): void {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			error_log( '[StrataWP SEO] ' . $message );
+		}
+
+		$log   = get_option( 'swps_generation_log', array() );
+		$log[] = array(
+			'time'    => current_time( 'mysql' ),
+			'message' => $message,
+		);
+
+		$log = array_slice( $log, -50 );
+		update_option( 'swps_generation_log', $log );
+	}
 }

--- a/includes/class-github-updater.php
+++ b/includes/class-github-updater.php
@@ -19,10 +19,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class SWPS_GitHub_Updater {
 
-	private const REPO            = 'JonImmsWordpressDev/stratawp-seo';
-	private const ASSET_NAME      = 'stratawp-seo.zip';
-	private const TRANSIENT_KEY   = 'swps_github_release_v1';
-	private const TRANSIENT_TTL   = 12 * HOUR_IN_SECONDS;
+	private const REPO          = 'JonImmsWordpressDev/stratawp-seo';
+	private const ASSET_NAME    = 'stratawp-seo.zip';
+	private const TRANSIENT_KEY = 'swps_github_release_v1';
+	private const TRANSIENT_TTL = 12 * HOUR_IN_SECONDS;
 
 	private string $plugin_file;
 	private string $plugin_basename;
@@ -35,10 +35,10 @@ class SWPS_GitHub_Updater {
 		$this->plugin_slug     = dirname( $this->plugin_basename );
 		$this->current_version = $current_version;
 
-		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'inject_update' ] );
-		add_filter( 'plugins_api', [ $this, 'plugin_info' ], 10, 3 );
-		add_filter( 'upgrader_source_selection', [ $this, 'rename_source_dir' ], 10, 4 );
-		add_action( 'upgrader_process_complete', [ $this, 'flush_cache_after_update' ], 10, 2 );
+		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'inject_update' ) );
+		add_filter( 'plugins_api', array( $this, 'plugin_info' ), 10, 3 );
+		add_filter( 'upgrader_source_selection', array( $this, 'rename_source_dir' ), 10, 4 );
+		add_action( 'upgrader_process_complete', array( $this, 'flush_cache_after_update' ), 10, 2 );
 	}
 
 	/**
@@ -52,10 +52,10 @@ class SWPS_GitHub_Updater {
 			$transient = new stdClass();
 		}
 		if ( ! isset( $transient->response ) || ! is_array( $transient->response ) ) {
-			$transient->response = [];
+			$transient->response = array();
 		}
 		if ( ! isset( $transient->no_update ) || ! is_array( $transient->no_update ) ) {
-			$transient->no_update = [];
+			$transient->no_update = array();
 		}
 
 		$release = $this->get_latest_release();
@@ -70,20 +70,20 @@ class SWPS_GitHub_Updater {
 			return $transient;
 		}
 
-		$item = (object) [
+		$item = (object) array(
 			'id'            => $this->plugin_basename,
 			'slug'          => $this->plugin_slug,
 			'plugin'        => $this->plugin_basename,
 			'new_version'   => $remote_version,
 			'url'           => 'https://github.com/' . self::REPO,
 			'package'       => $package_url,
-			'icons'         => [],
-			'banners'       => [],
-			'banners_rtl'   => [],
+			'icons'         => array(),
+			'banners'       => array(),
+			'banners_rtl'   => array(),
 			'tested'        => '',
 			'requires_php'  => '8.0',
 			'compatibility' => new stdClass(),
-		];
+		);
 
 		if ( version_compare( $remote_version, $this->current_version, '>' ) ) {
 			$transient->response[ $this->plugin_basename ] = $item;
@@ -122,20 +122,20 @@ class SWPS_GitHub_Updater {
 		$package_url    = (string) ( $release['package_url'] ?? '' );
 		$published      = (string) ( $release['published_at'] ?? '' );
 
-		$info               = new stdClass();
-		$info->name         = 'StrataWP SEO';
-		$info->slug         = $this->plugin_slug;
-		$info->version      = $remote_version;
-		$info->author       = '<a href="https://jonimms.com">Jon Imms</a>';
-		$info->homepage     = 'https://github.com/' . self::REPO;
-		$info->requires     = '6.0';
-		$info->requires_php = '8.0';
+		$info                = new stdClass();
+		$info->name          = 'StrataWP SEO';
+		$info->slug          = $this->plugin_slug;
+		$info->version       = $remote_version;
+		$info->author        = '<a href="https://jonimms.com">Jon Imms</a>';
+		$info->homepage      = 'https://github.com/' . self::REPO;
+		$info->requires      = '6.0';
+		$info->requires_php  = '8.0';
 		$info->download_link = $package_url;
-		$info->last_updated = $published ? gmdate( 'Y-m-d H:i:s', strtotime( $published ) ) : '';
-		$info->sections     = [
+		$info->last_updated  = $published ? gmdate( 'Y-m-d H:i:s', strtotime( $published ) ) : '';
+		$info->sections      = array(
 			'description' => 'AI-powered SEO content generator for WordPress. Updates are delivered directly from the official GitHub repository.',
 			'changelog'   => '<pre style="white-space:pre-wrap;">' . esc_html( $body ) . '</pre>',
-		];
+		);
 
 		return $info;
 	}
@@ -153,7 +153,7 @@ class SWPS_GitHub_Updater {
 	 * @param array       $hook_extra    Extra args.
 	 * @return string|WP_Error
 	 */
-	public function rename_source_dir( $source, $remote_source, $upgrader, $hook_extra = [] ) {
+	public function rename_source_dir( $source, $remote_source, $upgrader, $hook_extra = array() ) {
 		if ( empty( $hook_extra['plugin'] ) || $hook_extra['plugin'] !== $this->plugin_basename ) {
 			return $source;
 		}
@@ -202,24 +202,24 @@ class SWPS_GitHub_Updater {
 
 		$response = wp_remote_get(
 			'https://api.github.com/repos/' . self::REPO . '/releases/latest',
-			[
+			array(
 				'timeout' => 10,
-				'headers' => [
+				'headers' => array(
 					'Accept'     => 'application/vnd.github+json',
 					'User-Agent' => 'StrataWP-SEO-Updater',
-				],
-			]
+				),
+			)
 		);
 
 		if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
 			// Cache a short empty result so we don't hammer the API on transient failures.
-			set_transient( self::TRANSIENT_KEY, [], 15 * MINUTE_IN_SECONDS );
+			set_transient( self::TRANSIENT_KEY, array(), 15 * MINUTE_IN_SECONDS );
 			return null;
 		}
 
 		$data = json_decode( wp_remote_retrieve_body( $response ), true );
 		if ( ! is_array( $data ) ) {
-			set_transient( self::TRANSIENT_KEY, [], 15 * MINUTE_IN_SECONDS );
+			set_transient( self::TRANSIENT_KEY, array(), 15 * MINUTE_IN_SECONDS );
 			return null;
 		}
 
@@ -239,12 +239,12 @@ class SWPS_GitHub_Updater {
 			$package_url = 'https://github.com/' . self::REPO . '/releases/latest/download/' . self::ASSET_NAME;
 		}
 
-		$release = [
+		$release = array(
 			'tag_name'     => (string) ( $data['tag_name'] ?? '' ),
 			'body'         => (string) ( $data['body'] ?? '' ),
 			'package_url'  => $package_url,
 			'published_at' => (string) ( $data['published_at'] ?? '' ),
-		];
+		);
 
 		set_transient( self::TRANSIENT_KEY, $release, self::TRANSIENT_TTL );
 		return $release;

--- a/includes/class-head-cleanup.php
+++ b/includes/class-head-cleanup.php
@@ -6,39 +6,39 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Head_Cleanup {
 
-    private const CLEANUP_MAP = [
-        'swps_cleanup_generator' => [ 'wp_generator' ],
-        'swps_cleanup_rsd'       => [ 'rsd_link' ],
-        'swps_cleanup_wlw'       => [ 'wlwmanifest_link' ],
-        'swps_cleanup_shortlink' => [ 'wp_shortlink_wp_head' ],
-        'swps_cleanup_rest_api'  => [ 'rest_output_link_wp_head', 'wp_oembed_add_discovery_links' ],
-        'swps_cleanup_oembed'    => [ 'wp_oembed_add_host_js' ],
-    ];
+	private const CLEANUP_MAP = array(
+		'swps_cleanup_generator' => array( 'wp_generator' ),
+		'swps_cleanup_rsd'       => array( 'rsd_link' ),
+		'swps_cleanup_wlw'       => array( 'wlwmanifest_link' ),
+		'swps_cleanup_shortlink' => array( 'wp_shortlink_wp_head' ),
+		'swps_cleanup_rest_api'  => array( 'rest_output_link_wp_head', 'wp_oembed_add_discovery_links' ),
+		'swps_cleanup_oembed'    => array( 'wp_oembed_add_host_js' ),
+	);
 
-    public function __construct() {
-        if ( is_admin() ) {
-            return;
-        }
+	public function __construct() {
+		if ( is_admin() ) {
+			return;
+		}
 
-        foreach ( self::CLEANUP_MAP as $option => $hooks ) {
-            if ( get_option( $option, 0 ) ) {
-                foreach ( $hooks as $hook ) {
-                    remove_action( 'wp_head', $hook );
-                }
-            }
-        }
+		foreach ( self::CLEANUP_MAP as $option => $hooks ) {
+			if ( get_option( $option, 0 ) ) {
+				foreach ( $hooks as $hook ) {
+					remove_action( 'wp_head', $hook );
+				}
+			}
+		}
 
-        if ( get_option( 'swps_cleanup_emoji', 0 ) ) {
-            remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
-            remove_action( 'wp_print_styles', 'print_emoji_styles' );
-            remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
-            remove_action( 'admin_print_styles', 'print_emoji_styles' );
-            add_filter( 'emoji_svg_url', '__return_false' );
-        }
-    }
+		if ( get_option( 'swps_cleanup_emoji', 0 ) ) {
+			remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+			remove_action( 'wp_print_styles', 'print_emoji_styles' );
+			remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+			remove_action( 'admin_print_styles', 'print_emoji_styles' );
+			add_filter( 'emoji_svg_url', '__return_false' );
+		}
+	}
 }

--- a/includes/class-hooks.php
+++ b/includes/class-hooks.php
@@ -6,318 +6,318 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Hooks {
 
-    /**
-     * Apply the system prompt filter.
-     *
-     * @param string $prompt  The system prompt text.
-     * @param string $tone    The selected tone.
-     * @param string $style   Custom style notes.
-     * @return string Filtered prompt.
-     */
-    public static function filter_system_prompt( string $prompt, string $tone, string $style ): string {
-        return apply_filters( 'swps_system_prompt', $prompt, $tone, $style );
-    }
+	/**
+	 * Apply the system prompt filter.
+	 *
+	 * @param string $prompt  The system prompt text.
+	 * @param string $tone    The selected tone.
+	 * @param string $style   Custom style notes.
+	 * @return string Filtered prompt.
+	 */
+	public static function filter_system_prompt( string $prompt, string $tone, string $style ): string {
+		return apply_filters( 'swps_system_prompt', $prompt, $tone, $style );
+	}
 
-    /**
-     * Apply the user prompt filter.
-     *
-     * @param string $prompt       The user prompt text.
-     * @param string $topic        The requested topic.
-     * @param string $site_context Site context string.
-     * @return string Filtered prompt.
-     */
-    public static function filter_user_prompt( string $prompt, string $topic, string $site_context ): string {
-        return apply_filters( 'swps_user_prompt', $prompt, $topic, $site_context );
-    }
+	/**
+	 * Apply the user prompt filter.
+	 *
+	 * @param string $prompt       The user prompt text.
+	 * @param string $topic        The requested topic.
+	 * @param string $site_context Site context string.
+	 * @return string Filtered prompt.
+	 */
+	public static function filter_user_prompt( string $prompt, string $topic, string $site_context ): string {
+		return apply_filters( 'swps_user_prompt', $prompt, $topic, $site_context );
+	}
 
-    /**
-     * Apply the post data filter before inserting.
-     *
-     * @param array $post_data WordPress post data array.
-     * @param array $ai_result The AI response data.
-     * @return array Filtered post data.
-     */
-    public static function filter_post_data( array $post_data, array $ai_result ): array {
-        return apply_filters( 'swps_post_data', $post_data, $ai_result );
-    }
+	/**
+	 * Apply the post data filter before inserting.
+	 *
+	 * @param array $post_data WordPress post data array.
+	 * @param array $ai_result The AI response data.
+	 * @return array Filtered post data.
+	 */
+	public static function filter_post_data( array $post_data, array $ai_result ): array {
+		return apply_filters( 'swps_post_data', $post_data, $ai_result );
+	}
 
-    /**
-     * Apply the image query filter.
-     *
-     * @param string $query   The image search query.
-     * @param int    $post_id The post ID.
-     * @return string Filtered query.
-     */
-    public static function filter_image_query( string $query, int $post_id ): string {
-        return apply_filters( 'swps_image_query', $query, $post_id );
-    }
+	/**
+	 * Apply the image query filter.
+	 *
+	 * @param string $query   The image search query.
+	 * @param int    $post_id The post ID.
+	 * @return string Filtered query.
+	 */
+	public static function filter_image_query( string $query, int $post_id ): string {
+		return apply_filters( 'swps_image_query', $query, $post_id );
+	}
 
-    /**
-     * Apply the FAQ schema filter.
-     *
-     * @param array  $schema    The FAQ schema array.
-     * @param string $title     Post title.
-     * @param array  $faq_items Raw FAQ items from AI.
-     * @return array Filtered schema.
-     */
-    public static function filter_faq_schema( array $schema, string $title, array $faq_items ): array {
-        return apply_filters( 'swps_faq_schema', $schema, $title, $faq_items );
-    }
+	/**
+	 * Apply the FAQ schema filter.
+	 *
+	 * @param array  $schema    The FAQ schema array.
+	 * @param string $title     Post title.
+	 * @param array  $faq_items Raw FAQ items from AI.
+	 * @return array Filtered schema.
+	 */
+	public static function filter_faq_schema( array $schema, string $title, array $faq_items ): array {
+		return apply_filters( 'swps_faq_schema', $schema, $title, $faq_items );
+	}
 
-    /**
-     * Apply the takeaways schema filter.
-     *
-     * @param array $schema    The ItemList schema array.
-     * @param array $takeaways The raw takeaways array.
-     * @return array Filtered schema.
-     */
-    public static function filter_takeaways_schema( array $schema, array $takeaways ): array {
-        return apply_filters( 'swps_takeaways_schema', $schema, $takeaways );
-    }
+	/**
+	 * Apply the takeaways schema filter.
+	 *
+	 * @param array $schema    The ItemList schema array.
+	 * @param array $takeaways The raw takeaways array.
+	 * @return array Filtered schema.
+	 */
+	public static function filter_takeaways_schema( array $schema, array $takeaways ): array {
+		return apply_filters( 'swps_takeaways_schema', $schema, $takeaways );
+	}
 
-    /**
-     * Apply the AI response filter.
-     *
-     * @param array  $response The parsed AI JSON response.
-     * @param string $topic    The requested topic.
-     * @return array Filtered response.
-     */
-    public static function filter_ai_response( array $response, string $topic ): array {
-        return apply_filters( 'swps_ai_response', $response, $topic );
-    }
+	/**
+	 * Apply the AI response filter.
+	 *
+	 * @param array  $response The parsed AI JSON response.
+	 * @param string $topic    The requested topic.
+	 * @return array Filtered response.
+	 */
+	public static function filter_ai_response( array $response, string $topic ): array {
+		return apply_filters( 'swps_ai_response', $response, $topic );
+	}
 
-    /**
-     * Fire the before_generate action.
-     *
-     * @param string $topic    The topic being generated.
-     * @param string $template The template being used.
-     */
-    public static function do_before_generate( string $topic, string $template ): void {
-        do_action( 'swps_before_generate', $topic, $template );
-    }
+	/**
+	 * Fire the before_generate action.
+	 *
+	 * @param string $topic    The topic being generated.
+	 * @param string $template The template being used.
+	 */
+	public static function do_before_generate( string $topic, string $template ): void {
+		do_action( 'swps_before_generate', $topic, $template );
+	}
 
-    /**
-     * Fire the after_generate action.
-     *
-     * @param array  $result   The generation result data.
-     * @param string $topic    The topic that was generated.
-     * @param string $template The template that was used.
-     */
-    public static function do_after_generate( array $result, string $topic, string $template ): void {
-        do_action( 'swps_after_generate', $result, $topic, $template );
-    }
+	/**
+	 * Fire the after_generate action.
+	 *
+	 * @param array  $result   The generation result data.
+	 * @param string $topic    The topic that was generated.
+	 * @param string $template The template that was used.
+	 */
+	public static function do_after_generate( array $result, string $topic, string $template ): void {
+		do_action( 'swps_after_generate', $result, $topic, $template );
+	}
 
-    /**
-     * Fire the post_created action.
-     *
-     * @param int   $post_id   The new post ID.
-     * @param array $ai_result The AI response data.
-     * @param array $post_data The post data that was inserted.
-     */
-    public static function do_post_created( int $post_id, array $ai_result, array $post_data ): void {
-        do_action( 'swps_post_created', $post_id, $ai_result, $post_data );
-    }
+	/**
+	 * Fire the post_created action.
+	 *
+	 * @param int   $post_id   The new post ID.
+	 * @param array $ai_result The AI response data.
+	 * @param array $post_data The post data that was inserted.
+	 */
+	public static function do_post_created( int $post_id, array $ai_result, array $post_data ): void {
+		do_action( 'swps_post_created', $post_id, $ai_result, $post_data );
+	}
 
-    /**
-     * Fire the generation_failed action.
-     *
-     * @param WP_Error $error  The error object.
-     * @param string   $topic  The topic that was attempted.
-     * @param string   $template The template that was used.
-     */
-    public static function do_generation_failed( WP_Error $error, string $topic, string $template ): void {
-        do_action( 'swps_generation_failed', $error, $topic, $template );
-    }
+	/**
+	 * Fire the generation_failed action.
+	 *
+	 * @param WP_Error $error  The error object.
+	 * @param string   $topic  The topic that was attempted.
+	 * @param string   $template The template that was used.
+	 */
+	public static function do_generation_failed( WP_Error $error, string $topic, string $template ): void {
+		do_action( 'swps_generation_failed', $error, $topic, $template );
+	}
 
-    /**
-     * Apply the score weights filter.
-     *
-     * @param array  $weights   Analyzer weight map.
-     * @param int    $post_id   The post being scored.
-     * @param string $post_type The post type being scored.
-     * @return array Filtered weights.
-     */
-    public static function filter_score_weights( array $weights, int $post_id, string $post_type ): array {
-        return apply_filters( 'swps_score_weights', $weights, $post_id, $post_type );
-    }
+	/**
+	 * Apply the score weights filter.
+	 *
+	 * @param array  $weights   Analyzer weight map.
+	 * @param int    $post_id   The post being scored.
+	 * @param string $post_type The post type being scored.
+	 * @return array Filtered weights.
+	 */
+	public static function filter_score_weights( array $weights, int $post_id, string $post_type ): array {
+		return apply_filters( 'swps_score_weights', $weights, $post_id, $post_type );
+	}
 
-    /**
-     * Fire the score_complete action.
-     *
-     * @param array $results Score results array.
-     * @param int   $post_id The scored post ID.
-     */
-    public static function do_score_complete( array $results, int $post_id ): void {
-        do_action( 'swps_score_complete', $results, $post_id );
-    }
+	/**
+	 * Fire the score_complete action.
+	 *
+	 * @param array $results Score results array.
+	 * @param int   $post_id The scored post ID.
+	 */
+	public static function do_score_complete( array $results, int $post_id ): void {
+		do_action( 'swps_score_complete', $results, $post_id );
+	}
 
-    /**
-     * Apply the content images queries filter.
-     *
-     * @param array $queries Visual concept queries keyed by section index.
-     * @param int   $post_id Post ID.
-     * @return array Filtered queries.
-     */
-    public static function filter_content_images_queries( array $queries, int $post_id ): array {
-        return apply_filters( 'swps_content_images_queries', $queries, $post_id );
-    }
+	/**
+	 * Apply the content images queries filter.
+	 *
+	 * @param array $queries Visual concept queries keyed by section index.
+	 * @param int   $post_id Post ID.
+	 * @return array Filtered queries.
+	 */
+	public static function filter_content_images_queries( array $queries, int $post_id ): array {
+		return apply_filters( 'swps_content_images_queries', $queries, $post_id );
+	}
 
-    /**
-     * Apply the image selection filter.
-     *
-     * @param array  $image_data     Image data array.
-     * @param int    $post_id        Post ID.
-     * @param string $section_heading Section heading text.
-     * @return array Filtered image data.
-     */
-    public static function filter_image_selection( array $image_data, int $post_id, string $section_heading ): array {
-        return apply_filters( 'swps_image_selection', $image_data, $post_id, $section_heading );
-    }
+	/**
+	 * Apply the image selection filter.
+	 *
+	 * @param array  $image_data     Image data array.
+	 * @param int    $post_id        Post ID.
+	 * @param string $section_heading Section heading text.
+	 * @return array Filtered image data.
+	 */
+	public static function filter_image_selection( array $image_data, int $post_id, string $section_heading ): array {
+		return apply_filters( 'swps_image_selection', $image_data, $post_id, $section_heading );
+	}
 
-    /**
-     * Fire the image_inserted action.
-     *
-     * @param int    $attachment_id Attachment ID.
-     * @param int    $post_id       Post ID.
-     * @param string $alt_text      Image alt text.
-     * @param int    $position      Section index where image was inserted.
-     */
-    public static function do_image_inserted( int $attachment_id, int $post_id, string $alt_text, int $position ): void {
-        do_action( 'swps_image_inserted', $attachment_id, $post_id, $alt_text, $position );
-    }
+	/**
+	 * Fire the image_inserted action.
+	 *
+	 * @param int    $attachment_id Attachment ID.
+	 * @param int    $post_id       Post ID.
+	 * @param string $alt_text      Image alt text.
+	 * @param int    $position      Section index where image was inserted.
+	 */
+	public static function do_image_inserted( int $attachment_id, int $post_id, string $alt_text, int $position ): void {
+		do_action( 'swps_image_inserted', $attachment_id, $post_id, $alt_text, $position );
+	}
 
-    /**
-     * Apply the audit modules filter.
-     *
-     * @param SWPS_Audit_Module[] $modules Registered modules.
-     * @return SWPS_Audit_Module[]
-     */
-    public static function filter_audit_modules( array $modules ): array {
-        return apply_filters( 'swps_audit_modules', $modules );
-    }
+	/**
+	 * Apply the audit modules filter.
+	 *
+	 * @param SWPS_Audit_Module[] $modules Registered modules.
+	 * @return SWPS_Audit_Module[]
+	 */
+	public static function filter_audit_modules( array $modules ): array {
+		return apply_filters( 'swps_audit_modules', $modules );
+	}
 
-    /**
-     * Apply the audit result filter.
-     *
-     * @param array  $result    Module result array.
-     * @param string $module_id Module ID.
-     * @return array
-     */
-    public static function filter_audit_result( array $result, string $module_id ): array {
-        return apply_filters( 'swps_audit_result', $result, $module_id );
-    }
+	/**
+	 * Apply the audit result filter.
+	 *
+	 * @param array  $result    Module result array.
+	 * @param string $module_id Module ID.
+	 * @return array
+	 */
+	public static function filter_audit_result( array $result, string $module_id ): array {
+		return apply_filters( 'swps_audit_result', $result, $module_id );
+	}
 
-    /**
-     * Apply the Article schema filter.
-     *
-     * @param array $schema  Article schema array.
-     * @param int   $post_id Post ID.
-     * @return array Filtered schema.
-     */
-    public static function filter_schema_article( array $schema, int $post_id ): array {
-        return apply_filters( 'swps_schema_article', $schema, $post_id );
-    }
+	/**
+	 * Apply the Article schema filter.
+	 *
+	 * @param array $schema  Article schema array.
+	 * @param int   $post_id Post ID.
+	 * @return array Filtered schema.
+	 */
+	public static function filter_schema_article( array $schema, int $post_id ): array {
+		return apply_filters( 'swps_schema_article', $schema, $post_id );
+	}
 
-    /**
-     * Apply the Breadcrumb schema filter.
-     *
-     * @param array $schema BreadcrumbList schema array.
-     * @return array Filtered schema.
-     */
-    public static function filter_schema_breadcrumb( array $schema ): array {
-        return apply_filters( 'swps_schema_breadcrumb', $schema );
-    }
+	/**
+	 * Apply the Breadcrumb schema filter.
+	 *
+	 * @param array $schema BreadcrumbList schema array.
+	 * @return array Filtered schema.
+	 */
+	public static function filter_schema_breadcrumb( array $schema ): array {
+		return apply_filters( 'swps_schema_breadcrumb', $schema );
+	}
 
-    /**
-     * Apply the Organization/Person schema filter.
-     *
-     * @param array $schema Organization or Person schema array.
-     * @return array Filtered schema.
-     */
-    public static function filter_schema_organization( array $schema ): array {
-        return apply_filters( 'swps_schema_organization', $schema );
-    }
+	/**
+	 * Apply the Organization/Person schema filter.
+	 *
+	 * @param array $schema Organization or Person schema array.
+	 * @return array Filtered schema.
+	 */
+	public static function filter_schema_organization( array $schema ): array {
+		return apply_filters( 'swps_schema_organization', $schema );
+	}
 
-    /**
-     * Fire the audit_complete action.
-     *
-     * @param array $results All module results.
-     * @param int   $overall Overall score.
-     */
-    public static function do_audit_complete( array $results, int $overall ): void {
-        do_action( 'swps_audit_complete', $results, $overall );
-    }
+	/**
+	 * Fire the audit_complete action.
+	 *
+	 * @param array $results All module results.
+	 * @param int   $overall Overall score.
+	 */
+	public static function do_audit_complete( array $results, int $overall ): void {
+		do_action( 'swps_audit_complete', $results, $overall );
+	}
 
-    /**
-     * Apply the analytics tracking data filter.
-     *
-     * @param array $data    Tracking data array.
-     * @param int   $post_id Post ID.
-     * @return array Filtered data. Return empty array to block.
-     */
-    public static function filter_analytics_track( array $data, int $post_id ): array {
-        return apply_filters( 'swps_analytics_track', $data, $post_id );
-    }
+	/**
+	 * Apply the analytics tracking data filter.
+	 *
+	 * @param array $data    Tracking data array.
+	 * @param int   $post_id Post ID.
+	 * @return array Filtered data. Return empty array to block.
+	 */
+	public static function filter_analytics_track( array $data, int $post_id ): array {
+		return apply_filters( 'swps_analytics_track', $data, $post_id );
+	}
 
-    /**
-     * Apply the analytics exclude filter.
-     *
-     * @param bool $exclude Whether to exclude this page.
-     * @param int  $post_id Post ID.
-     * @return bool
-     */
-    public static function filter_analytics_exclude( bool $exclude, int $post_id ): bool {
-        return apply_filters( 'swps_analytics_exclude', $exclude, $post_id );
-    }
+	/**
+	 * Apply the analytics exclude filter.
+	 *
+	 * @param bool $exclude Whether to exclude this page.
+	 * @param int  $post_id Post ID.
+	 * @return bool
+	 */
+	public static function filter_analytics_exclude( bool $exclude, int $post_id ): bool {
+		return apply_filters( 'swps_analytics_exclude', $exclude, $post_id );
+	}
 
-    /**
-     * Apply the GSC data filter.
-     *
-     * @param array  $data     GSC response data.
-     * @param string $property GSC property URL.
-     * @return array Filtered data.
-     */
-    public static function filter_gsc_data( array $data, string $property ): array {
-        return apply_filters( 'swps_gsc_data', $data, $property );
-    }
+	/**
+	 * Apply the GSC data filter.
+	 *
+	 * @param array  $data     GSC response data.
+	 * @param string $property GSC property URL.
+	 * @return array Filtered data.
+	 */
+	public static function filter_gsc_data( array $data, string $property ): array {
+		return apply_filters( 'swps_gsc_data', $data, $property );
+	}
 
-    /**
-     * Apply the meta title filter.
-     */
-    public static function filter_meta_title( string $title, int $post_id ): string {
-        return apply_filters( 'swps_meta_title', $title, $post_id );
-    }
+	/**
+	 * Apply the meta title filter.
+	 */
+	public static function filter_meta_title( string $title, int $post_id ): string {
+		return apply_filters( 'swps_meta_title', $title, $post_id );
+	}
 
-    /**
-     * Apply the meta description filter.
-     */
-    public static function filter_meta_description( string $description, int $post_id ): string {
-        return apply_filters( 'swps_meta_description', $description, $post_id );
-    }
+	/**
+	 * Apply the meta description filter.
+	 */
+	public static function filter_meta_description( string $description, int $post_id ): string {
+		return apply_filters( 'swps_meta_description', $description, $post_id );
+	}
 
-    /**
-     * Apply the meta robots filter.
-     */
-    public static function filter_meta_robots( string $robots, int $post_id ): string {
-        return apply_filters( 'swps_meta_robots', $robots, $post_id );
-    }
+	/**
+	 * Apply the meta robots filter.
+	 */
+	public static function filter_meta_robots( string $robots, int $post_id ): string {
+		return apply_filters( 'swps_meta_robots', $robots, $post_id );
+	}
 
-    /**
-     * Apply the keyword suggestions filter.
-     */
-    public static function filter_keyword_suggestions( array $suggestions, string $seed ): array {
-        return apply_filters( 'swps_keyword_suggestions', $suggestions, $seed );
-    }
+	/**
+	 * Apply the keyword suggestions filter.
+	 */
+	public static function filter_keyword_suggestions( array $suggestions, string $seed ): array {
+		return apply_filters( 'swps_keyword_suggestions', $suggestions, $seed );
+	}
 
-    /**
-     * Apply the SEO checklist filter.
-     */
-    public static function filter_seo_checklist( array $items, int $post_id ): array {
-        return apply_filters( 'swps_seo_checklist', $items, $post_id );
-    }
+	/**
+	 * Apply the SEO checklist filter.
+	 */
+	public static function filter_seo_checklist( array $items, int $post_id ): array {
+		return apply_filters( 'swps_seo_checklist', $items, $post_id );
+	}
 }

--- a/includes/class-image-inserter.php
+++ b/includes/class-image-inserter.php
@@ -9,515 +9,540 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Image_Inserter {
 
-    private SWPS_Image_Provider $image_provider;
-
-    public function __construct( SWPS_Image_Provider $image_provider ) {
-        $this->image_provider = $image_provider;
-    }
-
-    /**
-     * Insert images into a post's content at semantic positions.
-     *
-     * @param int   $post_id   The post ID.
-     * @param array $ai_result The AI response data.
-     */
-    public function insert_images( int $post_id, array $ai_result ): void {
-        if ( ! get_option( 'swps_insert_content_images', 0 ) ) {
-            return;
-        }
-
-        $content       = get_post_field( 'post_content', $post_id );
-        $max_images    = (int) get_option( 'swps_content_images_count', 2 );
-        $max_width     = (int) get_option( 'swps_image_max_width', 1200 );
-        $focus_keyword = get_post_meta( $post_id, '_swps_focus_keyword', true );
-
-        if ( empty( $content ) || $max_images < 1 ) {
-            return;
-        }
-
-        // Split content into sections by H2.
-        $sections = $this->split_by_headings( $content );
-
-        if ( count( $sections ) < 2 ) {
-            return; // Not enough sections for in-content images.
-        }
-
-        // Skip the first section (intro — featured image covers it).
-        $target_sections = array_slice( $sections, 1 );
-
-        // Pick evenly spaced sections for images.
-        $total    = count( $target_sections );
-        $to_fill  = min( $max_images, $total );
-        $interval = max( 1, (int) floor( $total / $to_fill ) );
-        $indices  = [];
-        for ( $i = 0; $i < $to_fill; $i++ ) {
-            $indices[] = $i * $interval;
-        }
-
-        // Extract visual concepts for each target section.
-        $queries = [];
-        foreach ( $indices as $idx ) {
-            $section = $target_sections[ $idx ];
-            $queries[ $idx ] = $this->extract_visual_concept( $section );
-        }
-
-        $queries = apply_filters( 'swps_content_images_queries', $queries, $post_id );
-
-        // Search and insert images.
-        $inserted = 0;
-        foreach ( $queries as $idx => $query ) {
-            if ( empty( $query ) ) {
-                continue;
-            }
-
-            $image_url = $this->search_image( $query );
-            if ( empty( $image_url ) ) {
-                continue;
-            }
-
-            // Apply image selection filter.
-            $section_heading = $this->extract_heading( $target_sections[ $idx ] );
-            $image_data = apply_filters( 'swps_image_selection', [
-                'url'     => $image_url,
-                'query'   => $query,
-                'alt'     => $section_heading ?: $query,
-                'post_id' => $post_id,
-            ], $post_id, $section_heading );
-
-            if ( empty( $image_data ) || empty( $image_data['url'] ) ) {
-                continue;
-            }
-
-            // Download and attach.
-            $attachment_id = $this->download_image( $image_data['url'], $post_id, $query, $max_width );
-            if ( is_wp_error( $attachment_id ) ) {
-                error_log( '[StrataWP SEO] Content images: Download failed for post ' . $post_id . ' — ' . $attachment_id->get_error_message() );
-                continue;
-            }
-
-            // Set alt text — ensure focus keyword is included for SEO.
-            $alt_text = sanitize_text_field( $image_data['alt'] ?? $query );
-            if ( ! empty( $focus_keyword ) && false === mb_stripos( $alt_text, $focus_keyword ) ) {
-                $alt_text = $alt_text . ' - ' . $focus_keyword;
-            }
-            update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
-
-            // Build the figure HTML.
-            $img_src  = wp_get_attachment_url( $attachment_id );
-            $metadata = wp_get_attachment_metadata( $attachment_id );
-            $width    = $metadata['width'] ?? '';
-            $height   = $metadata['height'] ?? '';
-
-            $figure_html = sprintf(
-                '<figure class="swps-content-image"><img src="%s" alt="%s" loading="lazy"%s%s /><figcaption>%s</figcaption></figure>',
-                esc_url( $img_src ),
-                esc_attr( $alt_text ),
-                $width ? ' width="' . esc_attr( $width ) . '"' : '',
-                $height ? ' height="' . esc_attr( $height ) . '"' : '',
-                esc_html( $alt_text )
-            );
-
-            // Inject into the section (after first paragraph).
-            // The actual index in the full content is $idx + 1 (because we skipped section 0).
-            $section_index = $idx + 1;
-            $content = $this->inject_into_section( $content, $section_index, $figure_html );
-
-            $inserted++;
-
-            do_action( 'swps_image_inserted', $attachment_id, $post_id, $alt_text, $section_index );
-
-            if ( $inserted >= $max_images ) {
-                break;
-            }
-        }
-
-        // Update the post content if images were inserted.
-        if ( $inserted > 0 ) {
-            wp_update_post( [
-                'ID'           => $post_id,
-                'post_content' => $content,
-            ] );
-        }
-    }
-
-    /**
-     * Split content into sections by H2 headings.
-     *
-     * Handles both Gutenberg block markup (<!-- wp:heading -->) and raw HTML (<h2>).
-     *
-     * @param string $content HTML content.
-     * @return array Array of section HTML strings.
-     */
-    private function split_by_headings( string $content ): array {
-        $parts = preg_split( '/(?=<h2[\s>])/i', $content );
-        return array_values( array_filter( $parts, fn( $p ) => trim( $p ) !== '' ) );
-    }
-
-    /**
-     * Extract a visual concept from a section.
-     *
-     * For AI image generators (Gemini), returns the full heading + first sentence
-     * for richer context. For stock photo APIs, returns 2-4 keywords.
-     *
-     * @param string $section HTML of a content section.
-     * @return string Search query.
-     */
-    private function extract_visual_concept( string $section ): string {
-        // Get heading text.
-        $heading = $this->extract_heading( $section );
-
-        // Get first paragraph text.
-        $first_para = '';
-        if ( preg_match( '/<p[^>]*>(.*?)<\/p>/is', $section, $match ) ) {
-            $first_para = wp_strip_all_tags( $match[1] );
-        }
-
-        $provider_slug = get_option( 'swps_image_provider', 'unsplash' );
-
-        // AI generators benefit from descriptive context.
-        if ( 'gemini' === $provider_slug ) {
-            $concept = trim( $heading );
-            // Add first sentence of the paragraph for more context.
-            if ( ! empty( $first_para ) ) {
-                $first_sentence = strtok( $first_para, '.' );
-                if ( ! empty( $first_sentence ) ) {
-                    $concept .= '. ' . trim( $first_sentence );
-                }
-            }
-            return $concept;
-        }
-
-        // Stock photo APIs work best with short keyword queries.
-        $text = $heading . ' ' . $first_para;
-        $text = strtolower( wp_strip_all_tags( $text ) );
-
-        // Remove stop words.
-        $stop_words = [ 'how', 'to', 'the', 'a', 'an', 'is', 'are', 'was', 'were', 'what', 'why', 'when', 'where', 'which', 'who', 'your', 'our', 'their', 'this', 'that', 'for', 'and', 'but', 'with', 'from', 'about', 'into', 'best', 'top', 'guide', 'you', 'can', 'will', 'also', 'more', 'most', 'many', 'some', 'than', 'them', 'then', 'these', 'those', 'have', 'has', 'had', 'not', 'been', 'being', 'does', 'did', 'should', 'would', 'could', 'its', 'it', 'of', 'in', 'on', 'at', 'by' ];
-
-        $words = preg_split( '/\W+/', $text );
-        $words = array_filter( $words, function ( $w ) use ( $stop_words ) {
-            return strlen( $w ) > 2 && ! in_array( $w, $stop_words, true ) && ! is_numeric( $w );
-        } );
-
-        return implode( ' ', array_slice( array_values( $words ), 0, 4 ) );
-    }
-
-    /**
-     * Extract heading text from a section.
-     */
-    private function extract_heading( string $section ): string {
-        if ( preg_match( '/<h[2-3][^>]*>(.*?)<\/h[2-3]>/i', $section, $match ) ) {
-            return wp_strip_all_tags( $match[1] );
-        }
-        return '';
-    }
-
-    /**
-     * Search for an image using the configured provider.
-     *
-     * @param string $query Search query.
-     * @return string Image URL or empty string.
-     */
-    private function search_image( string $query ): string {
-        $provider_slug = get_option( 'swps_image_provider', 'unsplash' );
-
-        // Gemini generates images instead of searching stock photos.
-        // Returns a local temp file path (prefixed with /) instead of a URL.
-        if ( 'gemini' === $provider_slug ) {
-            return $this->generate_gemini_image( $query );
-        }
-
-        // Get the API key for the *selected* provider, not the injected one.
-        $api_key = match ( $provider_slug ) {
-            'unsplash' => (string) get_option( 'swps_unsplash_api_key', '' ),
-            'pexels'   => (string) get_option( 'swps_pexels_api_key', '' ),
-            'pixabay'  => (string) get_option( 'swps_pixabay_api_key', '' ),
-            default    => '',
-        };
-
-        if ( empty( $api_key ) ) {
-            error_log( '[StrataWP SEO] Content images: No API key for provider "' . $provider_slug . '".' );
-            return '';
-        }
-
-        $simplified = $this->simplify_query( $query );
-
-        $url = match ( $provider_slug ) {
-            'unsplash' => $this->search_unsplash( $simplified, $api_key ),
-            'pexels'   => $this->search_pexels( $simplified, $api_key ),
-            'pixabay'  => $this->search_pixabay( $simplified, $api_key ),
-            default    => '',
-        };
-
-        if ( empty( $url ) ) {
-            error_log( '[StrataWP SEO] Content images: No results from "' . $provider_slug . '" for query "' . $simplified . '".' );
-        }
-
-        return $url;
-    }
-
-    /**
-     * Generate a Gemini image and return a local temp file path.
-     *
-     * @param string $query Search/concept query.
-     * @return string Temp file path or empty string on failure.
-     */
-    private function generate_gemini_image( string $query ): string {
-        $provider = new SWPS_Gemini_Image_Provider();
-        $api_key  = $provider->get_api_key();
-
-        if ( empty( $api_key ) ) {
-            error_log( '[StrataWP SEO] Content images: No Google API key configured for Gemini.' );
-            return '';
-        }
-
-        $prompt = sprintf(
-            'Generate a photograph that directly depicts: "%s". '
-            . 'Show the actual subject matter — specific, concrete, and visually relevant. '
-            . 'Clean composition, natural lighting, editorial photography style. '
-            . 'No text, words, letters, watermarks, or logos anywhere in the image.',
-            $query
-        );
-
-        $tmp_file = $provider->generate_image( $prompt, $api_key, '16:9' );
-
-        if ( is_wp_error( $tmp_file ) ) {
-            error_log( '[StrataWP SEO] Content images: Gemini image generation failed — ' . $tmp_file->get_error_message() );
-            return '';
-        }
-
-        return $tmp_file;
-    }
-
-    /**
-     * Search Unsplash for a single image URL.
-     */
-    private function search_unsplash( string $query, string $api_key ): string {
-        $response = wp_remote_get( 'https://api.unsplash.com/search/photos?' . http_build_query( [
-            'query'    => $query,
-            'per_page' => 1,
-            'orientation' => 'landscape',
-        ] ), [
-            'headers' => [ 'Authorization' => 'Client-ID ' . $api_key ],
-            'timeout' => 15,
-        ] );
-
-        if ( is_wp_error( $response ) ) {
-            return '';
-        }
-
-        $data = json_decode( wp_remote_retrieve_body( $response ), true );
-        return $data['results'][0]['urls']['regular'] ?? '';
-    }
-
-    /**
-     * Search Pexels for a single image URL.
-     */
-    private function search_pexels( string $query, string $api_key ): string {
-        $response = wp_remote_get( 'https://api.pexels.com/v1/search?' . http_build_query( [
-            'query'    => $query,
-            'per_page' => 1,
-            'orientation' => 'landscape',
-        ] ), [
-            'headers' => [ 'Authorization' => $api_key ],
-            'timeout' => 15,
-        ] );
-
-        if ( is_wp_error( $response ) ) {
-            return '';
-        }
-
-        $data = json_decode( wp_remote_retrieve_body( $response ), true );
-        return $data['photos'][0]['src']['large'] ?? '';
-    }
-
-    /**
-     * Search Pixabay for a single image URL.
-     */
-    private function search_pixabay( string $query, string $api_key ): string {
-        $response = wp_remote_get( 'https://pixabay.com/api/?' . http_build_query( [
-            'key'         => $api_key,
-            'q'           => $query,
-            'per_page'    => 3,
-            'image_type'  => 'photo',
-            'orientation' => 'horizontal',
-        ] ), [
-            'timeout' => 15,
-        ] );
-
-        if ( is_wp_error( $response ) ) {
-            return '';
-        }
-
-        $data = json_decode( wp_remote_retrieve_body( $response ), true );
-        return $data['hits'][0]['largeImageURL'] ?? '';
-    }
-
-    /**
-     * Simplify a query by removing stop words.
-     */
-    private function simplify_query( string $query ): string {
-        $stop = [ 'how', 'to', 'the', 'a', 'an', 'is', 'are', 'for', 'and', 'with', 'from', 'about', 'your' ];
-        $words = explode( ' ', strtolower( $query ) );
-        $words = array_filter( $words, fn( $w ) => ! in_array( $w, $stop, true ) && strlen( $w ) > 2 );
-        return implode( ' ', array_slice( array_values( $words ), 0, 4 ) );
-    }
-
-    /**
-     * Download an image (or use a local temp file), convert to WebP, and attach to the post.
-     *
-     * @param string $url_or_path Image URL or local temp file path.
-     * @param int    $post_id     Post to attach to.
-     * @param string $query       The search query (used for filename).
-     * @param int    $max_width   Max image width.
-     * @return int|WP_Error Attachment ID or error.
-     */
-    private function download_image( string $url_or_path, int $post_id, string $query, int $max_width ): int|WP_Error {
-        require_once ABSPATH . 'wp-admin/includes/media.php';
-        require_once ABSPATH . 'wp-admin/includes/file.php';
-        require_once ABSPATH . 'wp-admin/includes/image.php';
-
-        // Local temp file (from Gemini) or remote URL.
-        if ( file_exists( $url_or_path ) ) {
-            $tmp = $url_or_path;
-        } else {
-            $tmp = download_url( $url_or_path );
-            if ( is_wp_error( $tmp ) ) {
-                return $tmp;
-            }
-        }
-
-        // Resize if needed.
-        $this->resize_image( $tmp, $max_width );
-
-        // Convert to WebP.
-        $webp = $this->convert_to_webp( $tmp );
-        if ( $webp !== $tmp ) {
-            @unlink( $tmp );
-            $tmp = $webp;
-            $ext = '.webp';
-        } else {
-            $ext = '.jpg';
-        }
-
-        $file_array = [
-            'name'     => sanitize_title( $query ) . '-content' . $ext,
-            'tmp_name' => $tmp,
-        ];
-
-        $attachment_id = media_handle_sideload( $file_array, $post_id );
-
-        if ( is_wp_error( $attachment_id ) ) {
-            @unlink( $tmp );
-        }
-
-        return $attachment_id;
-    }
-
-    /**
-     * Resize an image file to max width.
-     */
-    private function resize_image( string $file_path, int $max_width ): void {
-        if ( ! function_exists( 'imagecreatefromstring' ) ) {
-            return;
-        }
-
-        $data = file_get_contents( $file_path );
-        if ( false === $data ) {
-            return;
-        }
-
-        $image = @imagecreatefromstring( $data );
-        if ( false === $image ) {
-            return;
-        }
-
-        $orig_width  = imagesx( $image );
-        $orig_height = imagesy( $image );
-
-        if ( $orig_width <= $max_width ) {
-            imagedestroy( $image );
-            return;
-        }
-
-        $ratio     = $max_width / $orig_width;
-        $new_height = (int) ( $orig_height * $ratio );
-
-        $resized = imagecreatetruecolor( $max_width, $new_height );
-        imagealphablending( $resized, false );
-        imagesavealpha( $resized, true );
-        imagecopyresampled( $resized, $image, 0, 0, 0, 0, $max_width, $new_height, $orig_width, $orig_height );
-
-        imagejpeg( $resized, $file_path, 85 );
-        imagedestroy( $image );
-        imagedestroy( $resized );
-    }
-
-    /**
-     * Convert an image to WebP.
-     */
-    private function convert_to_webp( string $file_path ): string {
-        if ( ! function_exists( 'imagewebp' ) ) {
-            return $file_path;
-        }
-
-        $data = file_get_contents( $file_path );
-        if ( false === $data ) {
-            return $file_path;
-        }
-
-        $image = @imagecreatefromstring( $data );
-        if ( false === $image ) {
-            return $file_path;
-        }
-
-        imagepalettetotruecolor( $image );
-        imagealphablending( $image, true );
-        imagesavealpha( $image, true );
-
-        $webp_path = $file_path . '.webp';
-
-        if ( ! imagewebp( $image, $webp_path, 85 ) ) {
-            imagedestroy( $image );
-            return $file_path;
-        }
-
-        imagedestroy( $image );
-        return $webp_path;
-    }
-
-    /**
-     * Inject an HTML block after the first paragraph of a specific section.
-     *
-     * @param string $content       Full post content.
-     * @param int    $section_index 0-based section index (split by H2).
-     * @param string $html          HTML to inject.
-     * @return string Modified content.
-     */
-    private function inject_into_section( string $content, int $section_index, string $html ): string {
-        $sections = $this->split_by_headings( $content );
-
-        if ( ! isset( $sections[ $section_index ] ) ) {
-            return $content;
-        }
-
-        $section = $sections[ $section_index ];
-
-        // Find first closing </p> in this section and insert after it.
-        $p_end = strpos( $section, '</p>' );
-        if ( $p_end === false ) {
-            // No paragraph — append to end of section.
-            $sections[ $section_index ] = $section . "\n" . $html . "\n";
-        } else {
-            $insert_pos = $p_end + 4; // after </p>
-            $sections[ $section_index ] = substr( $section, 0, $insert_pos ) . "\n" . $html . "\n" . substr( $section, $insert_pos );
-        }
-
-        return implode( '', $sections );
-    }
+	private SWPS_Image_Provider $image_provider;
+
+	public function __construct( SWPS_Image_Provider $image_provider ) {
+		$this->image_provider = $image_provider;
+	}
+
+	/**
+	 * Insert images into a post's content at semantic positions.
+	 *
+	 * @param int   $post_id   The post ID.
+	 * @param array $ai_result The AI response data.
+	 */
+	public function insert_images( int $post_id, array $ai_result ): void {
+		if ( ! get_option( 'swps_insert_content_images', 0 ) ) {
+			return;
+		}
+
+		$content       = get_post_field( 'post_content', $post_id );
+		$max_images    = (int) get_option( 'swps_content_images_count', 2 );
+		$max_width     = (int) get_option( 'swps_image_max_width', 1200 );
+		$focus_keyword = get_post_meta( $post_id, '_swps_focus_keyword', true );
+
+		if ( empty( $content ) || $max_images < 1 ) {
+			return;
+		}
+
+		// Split content into sections by H2.
+		$sections = $this->split_by_headings( $content );
+
+		if ( count( $sections ) < 2 ) {
+			return; // Not enough sections for in-content images.
+		}
+
+		// Skip the first section (intro — featured image covers it).
+		$target_sections = array_slice( $sections, 1 );
+
+		// Pick evenly spaced sections for images.
+		$total    = count( $target_sections );
+		$to_fill  = min( $max_images, $total );
+		$interval = max( 1, (int) floor( $total / $to_fill ) );
+		$indices  = array();
+		for ( $i = 0; $i < $to_fill; $i++ ) {
+			$indices[] = $i * $interval;
+		}
+
+		// Extract visual concepts for each target section.
+		$queries = array();
+		foreach ( $indices as $idx ) {
+			$section         = $target_sections[ $idx ];
+			$queries[ $idx ] = $this->extract_visual_concept( $section );
+		}
+
+		$queries = apply_filters( 'swps_content_images_queries', $queries, $post_id );
+
+		// Search and insert images.
+		$inserted = 0;
+		foreach ( $queries as $idx => $query ) {
+			if ( empty( $query ) ) {
+				continue;
+			}
+
+			$image_url = $this->search_image( $query );
+			if ( empty( $image_url ) ) {
+				continue;
+			}
+
+			// Apply image selection filter.
+			$section_heading = $this->extract_heading( $target_sections[ $idx ] );
+			$image_data      = apply_filters(
+				'swps_image_selection',
+				array(
+					'url'     => $image_url,
+					'query'   => $query,
+					'alt'     => $section_heading ?: $query,
+					'post_id' => $post_id,
+				),
+				$post_id,
+				$section_heading
+			);
+
+			if ( empty( $image_data ) || empty( $image_data['url'] ) ) {
+				continue;
+			}
+
+			// Download and attach.
+			$attachment_id = $this->download_image( $image_data['url'], $post_id, $query, $max_width );
+			if ( is_wp_error( $attachment_id ) ) {
+				error_log( '[StrataWP SEO] Content images: Download failed for post ' . $post_id . ' — ' . $attachment_id->get_error_message() );
+				continue;
+			}
+
+			// Set alt text — ensure focus keyword is included for SEO.
+			$alt_text = sanitize_text_field( $image_data['alt'] ?? $query );
+			if ( ! empty( $focus_keyword ) && false === mb_stripos( $alt_text, $focus_keyword ) ) {
+				$alt_text = $alt_text . ' - ' . $focus_keyword;
+			}
+			update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
+
+			// Build the figure HTML.
+			$img_src  = wp_get_attachment_url( $attachment_id );
+			$metadata = wp_get_attachment_metadata( $attachment_id );
+			$width    = $metadata['width'] ?? '';
+			$height   = $metadata['height'] ?? '';
+
+			$figure_html = sprintf(
+				'<figure class="swps-content-image"><img src="%s" alt="%s" loading="lazy"%s%s /><figcaption>%s</figcaption></figure>',
+				esc_url( $img_src ),
+				esc_attr( $alt_text ),
+				$width ? ' width="' . esc_attr( $width ) . '"' : '',
+				$height ? ' height="' . esc_attr( $height ) . '"' : '',
+				esc_html( $alt_text )
+			);
+
+			// Inject into the section (after first paragraph).
+			// The actual index in the full content is $idx + 1 (because we skipped section 0).
+			$section_index = $idx + 1;
+			$content       = $this->inject_into_section( $content, $section_index, $figure_html );
+
+			++$inserted;
+
+			do_action( 'swps_image_inserted', $attachment_id, $post_id, $alt_text, $section_index );
+
+			if ( $inserted >= $max_images ) {
+				break;
+			}
+		}
+
+		// Update the post content if images were inserted.
+		if ( $inserted > 0 ) {
+			wp_update_post(
+				array(
+					'ID'           => $post_id,
+					'post_content' => $content,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Split content into sections by H2 headings.
+	 *
+	 * Handles both Gutenberg block markup (<!-- wp:heading -->) and raw HTML (<h2>).
+	 *
+	 * @param string $content HTML content.
+	 * @return array Array of section HTML strings.
+	 */
+	private function split_by_headings( string $content ): array {
+		$parts = preg_split( '/(?=<h2[\s>])/i', $content );
+		return array_values( array_filter( $parts, fn( $p ) => trim( $p ) !== '' ) );
+	}
+
+	/**
+	 * Extract a visual concept from a section.
+	 *
+	 * For AI image generators (Gemini), returns the full heading + first sentence
+	 * for richer context. For stock photo APIs, returns 2-4 keywords.
+	 *
+	 * @param string $section HTML of a content section.
+	 * @return string Search query.
+	 */
+	private function extract_visual_concept( string $section ): string {
+		// Get heading text.
+		$heading = $this->extract_heading( $section );
+
+		// Get first paragraph text.
+		$first_para = '';
+		if ( preg_match( '/<p[^>]*>(.*?)<\/p>/is', $section, $match ) ) {
+			$first_para = wp_strip_all_tags( $match[1] );
+		}
+
+		$provider_slug = get_option( 'swps_image_provider', 'unsplash' );
+
+		// AI generators benefit from descriptive context.
+		if ( 'gemini' === $provider_slug ) {
+			$concept = trim( $heading );
+			// Add first sentence of the paragraph for more context.
+			if ( ! empty( $first_para ) ) {
+				$first_sentence = strtok( $first_para, '.' );
+				if ( ! empty( $first_sentence ) ) {
+					$concept .= '. ' . trim( $first_sentence );
+				}
+			}
+			return $concept;
+		}
+
+		// Stock photo APIs work best with short keyword queries.
+		$text = $heading . ' ' . $first_para;
+		$text = strtolower( wp_strip_all_tags( $text ) );
+
+		// Remove stop words.
+		$stop_words = array( 'how', 'to', 'the', 'a', 'an', 'is', 'are', 'was', 'were', 'what', 'why', 'when', 'where', 'which', 'who', 'your', 'our', 'their', 'this', 'that', 'for', 'and', 'but', 'with', 'from', 'about', 'into', 'best', 'top', 'guide', 'you', 'can', 'will', 'also', 'more', 'most', 'many', 'some', 'than', 'them', 'then', 'these', 'those', 'have', 'has', 'had', 'not', 'been', 'being', 'does', 'did', 'should', 'would', 'could', 'its', 'it', 'of', 'in', 'on', 'at', 'by' );
+
+		$words = preg_split( '/\W+/', $text );
+		$words = array_filter(
+			$words,
+			function ( $w ) use ( $stop_words ) {
+				return strlen( $w ) > 2 && ! in_array( $w, $stop_words, true ) && ! is_numeric( $w );
+			}
+		);
+
+		return implode( ' ', array_slice( array_values( $words ), 0, 4 ) );
+	}
+
+	/**
+	 * Extract heading text from a section.
+	 */
+	private function extract_heading( string $section ): string {
+		if ( preg_match( '/<h[2-3][^>]*>(.*?)<\/h[2-3]>/i', $section, $match ) ) {
+			return wp_strip_all_tags( $match[1] );
+		}
+		return '';
+	}
+
+	/**
+	 * Search for an image using the configured provider.
+	 *
+	 * @param string $query Search query.
+	 * @return string Image URL or empty string.
+	 */
+	private function search_image( string $query ): string {
+		$provider_slug = get_option( 'swps_image_provider', 'unsplash' );
+
+		// Gemini generates images instead of searching stock photos.
+		// Returns a local temp file path (prefixed with /) instead of a URL.
+		if ( 'gemini' === $provider_slug ) {
+			return $this->generate_gemini_image( $query );
+		}
+
+		// Get the API key for the *selected* provider, not the injected one.
+		$api_key = match ( $provider_slug ) {
+			'unsplash' => (string) get_option( 'swps_unsplash_api_key', '' ),
+			'pexels'   => (string) get_option( 'swps_pexels_api_key', '' ),
+			'pixabay'  => (string) get_option( 'swps_pixabay_api_key', '' ),
+			default    => '',
+		};
+
+		if ( empty( $api_key ) ) {
+			error_log( '[StrataWP SEO] Content images: No API key for provider "' . $provider_slug . '".' );
+			return '';
+		}
+
+		$simplified = $this->simplify_query( $query );
+
+		$url = match ( $provider_slug ) {
+			'unsplash' => $this->search_unsplash( $simplified, $api_key ),
+			'pexels'   => $this->search_pexels( $simplified, $api_key ),
+			'pixabay'  => $this->search_pixabay( $simplified, $api_key ),
+			default    => '',
+		};
+
+		if ( empty( $url ) ) {
+			error_log( '[StrataWP SEO] Content images: No results from "' . $provider_slug . '" for query "' . $simplified . '".' );
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Generate a Gemini image and return a local temp file path.
+	 *
+	 * @param string $query Search/concept query.
+	 * @return string Temp file path or empty string on failure.
+	 */
+	private function generate_gemini_image( string $query ): string {
+		$provider = new SWPS_Gemini_Image_Provider();
+		$api_key  = $provider->get_api_key();
+
+		if ( empty( $api_key ) ) {
+			error_log( '[StrataWP SEO] Content images: No Google API key configured for Gemini.' );
+			return '';
+		}
+
+		$prompt = sprintf(
+			'Generate a photograph that directly depicts: "%s". '
+			. 'Show the actual subject matter — specific, concrete, and visually relevant. '
+			. 'Clean composition, natural lighting, editorial photography style. '
+			. 'No text, words, letters, watermarks, or logos anywhere in the image.',
+			$query
+		);
+
+		$tmp_file = $provider->generate_image( $prompt, $api_key, '16:9' );
+
+		if ( is_wp_error( $tmp_file ) ) {
+			error_log( '[StrataWP SEO] Content images: Gemini image generation failed — ' . $tmp_file->get_error_message() );
+			return '';
+		}
+
+		return $tmp_file;
+	}
+
+	/**
+	 * Search Unsplash for a single image URL.
+	 */
+	private function search_unsplash( string $query, string $api_key ): string {
+		$response = wp_remote_get(
+			'https://api.unsplash.com/search/photos?' . http_build_query(
+				array(
+					'query'       => $query,
+					'per_page'    => 1,
+					'orientation' => 'landscape',
+				)
+			),
+			array(
+				'headers' => array( 'Authorization' => 'Client-ID ' . $api_key ),
+				'timeout' => 15,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return '';
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+		return $data['results'][0]['urls']['regular'] ?? '';
+	}
+
+	/**
+	 * Search Pexels for a single image URL.
+	 */
+	private function search_pexels( string $query, string $api_key ): string {
+		$response = wp_remote_get(
+			'https://api.pexels.com/v1/search?' . http_build_query(
+				array(
+					'query'       => $query,
+					'per_page'    => 1,
+					'orientation' => 'landscape',
+				)
+			),
+			array(
+				'headers' => array( 'Authorization' => $api_key ),
+				'timeout' => 15,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return '';
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+		return $data['photos'][0]['src']['large'] ?? '';
+	}
+
+	/**
+	 * Search Pixabay for a single image URL.
+	 */
+	private function search_pixabay( string $query, string $api_key ): string {
+		$response = wp_remote_get(
+			'https://pixabay.com/api/?' . http_build_query(
+				array(
+					'key'         => $api_key,
+					'q'           => $query,
+					'per_page'    => 3,
+					'image_type'  => 'photo',
+					'orientation' => 'horizontal',
+				)
+			),
+			array(
+				'timeout' => 15,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return '';
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+		return $data['hits'][0]['largeImageURL'] ?? '';
+	}
+
+	/**
+	 * Simplify a query by removing stop words.
+	 */
+	private function simplify_query( string $query ): string {
+		$stop  = array( 'how', 'to', 'the', 'a', 'an', 'is', 'are', 'for', 'and', 'with', 'from', 'about', 'your' );
+		$words = explode( ' ', strtolower( $query ) );
+		$words = array_filter( $words, fn( $w ) => ! in_array( $w, $stop, true ) && strlen( $w ) > 2 );
+		return implode( ' ', array_slice( array_values( $words ), 0, 4 ) );
+	}
+
+	/**
+	 * Download an image (or use a local temp file), convert to WebP, and attach to the post.
+	 *
+	 * @param string $url_or_path Image URL or local temp file path.
+	 * @param int    $post_id     Post to attach to.
+	 * @param string $query       The search query (used for filename).
+	 * @param int    $max_width   Max image width.
+	 * @return int|WP_Error Attachment ID or error.
+	 */
+	private function download_image( string $url_or_path, int $post_id, string $query, int $max_width ): int|WP_Error {
+		require_once ABSPATH . 'wp-admin/includes/media.php';
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+
+		// Local temp file (from Gemini) or remote URL.
+		if ( file_exists( $url_or_path ) ) {
+			$tmp = $url_or_path;
+		} else {
+			$tmp = download_url( $url_or_path );
+			if ( is_wp_error( $tmp ) ) {
+				return $tmp;
+			}
+		}
+
+		// Resize if needed.
+		$this->resize_image( $tmp, $max_width );
+
+		// Convert to WebP.
+		$webp = $this->convert_to_webp( $tmp );
+		if ( $webp !== $tmp ) {
+			@unlink( $tmp );
+			$tmp = $webp;
+			$ext = '.webp';
+		} else {
+			$ext = '.jpg';
+		}
+
+		$file_array = array(
+			'name'     => sanitize_title( $query ) . '-content' . $ext,
+			'tmp_name' => $tmp,
+		);
+
+		$attachment_id = media_handle_sideload( $file_array, $post_id );
+
+		if ( is_wp_error( $attachment_id ) ) {
+			@unlink( $tmp );
+		}
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Resize an image file to max width.
+	 */
+	private function resize_image( string $file_path, int $max_width ): void {
+		if ( ! function_exists( 'imagecreatefromstring' ) ) {
+			return;
+		}
+
+		$data = file_get_contents( $file_path );
+		if ( false === $data ) {
+			return;
+		}
+
+		$image = @imagecreatefromstring( $data );
+		if ( false === $image ) {
+			return;
+		}
+
+		$orig_width  = imagesx( $image );
+		$orig_height = imagesy( $image );
+
+		if ( $orig_width <= $max_width ) {
+			imagedestroy( $image );
+			return;
+		}
+
+		$ratio      = $max_width / $orig_width;
+		$new_height = (int) ( $orig_height * $ratio );
+
+		$resized = imagecreatetruecolor( $max_width, $new_height );
+		imagealphablending( $resized, false );
+		imagesavealpha( $resized, true );
+		imagecopyresampled( $resized, $image, 0, 0, 0, 0, $max_width, $new_height, $orig_width, $orig_height );
+
+		imagejpeg( $resized, $file_path, 85 );
+		imagedestroy( $image );
+		imagedestroy( $resized );
+	}
+
+	/**
+	 * Convert an image to WebP.
+	 */
+	private function convert_to_webp( string $file_path ): string {
+		if ( ! function_exists( 'imagewebp' ) ) {
+			return $file_path;
+		}
+
+		$data = file_get_contents( $file_path );
+		if ( false === $data ) {
+			return $file_path;
+		}
+
+		$image = @imagecreatefromstring( $data );
+		if ( false === $image ) {
+			return $file_path;
+		}
+
+		imagepalettetotruecolor( $image );
+		imagealphablending( $image, true );
+		imagesavealpha( $image, true );
+
+		$webp_path = $file_path . '.webp';
+
+		if ( ! imagewebp( $image, $webp_path, 85 ) ) {
+			imagedestroy( $image );
+			return $file_path;
+		}
+
+		imagedestroy( $image );
+		return $webp_path;
+	}
+
+	/**
+	 * Inject an HTML block after the first paragraph of a specific section.
+	 *
+	 * @param string $content       Full post content.
+	 * @param int    $section_index 0-based section index (split by H2).
+	 * @param string $html          HTML to inject.
+	 * @return string Modified content.
+	 */
+	private function inject_into_section( string $content, int $section_index, string $html ): string {
+		$sections = $this->split_by_headings( $content );
+
+		if ( ! isset( $sections[ $section_index ] ) ) {
+			return $content;
+		}
+
+		$section = $sections[ $section_index ];
+
+		// Find first closing </p> in this section and insert after it.
+		$p_end = strpos( $section, '</p>' );
+		if ( $p_end === false ) {
+			// No paragraph — append to end of section.
+			$sections[ $section_index ] = $section . "\n" . $html . "\n";
+		} else {
+			$insert_pos                 = $p_end + 4; // after </p>
+			$sections[ $section_index ] = substr( $section, 0, $insert_pos ) . "\n" . $html . "\n" . substr( $section, $insert_pos );
+		}
+
+		return implode( '', $sections );
+	}
 }

--- a/includes/class-image-provider.php
+++ b/includes/class-image-provider.php
@@ -6,170 +6,175 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 abstract class SWPS_Image_Provider {
 
-    /**
-     * Search for and attach a featured image to a post.
-     *
-     * @param int    $post_id The WordPress post ID.
-     * @param string $query   Search query (usually the post title or focus keyword).
-     * @return int|WP_Error Attachment ID on success, WP_Error on failure.
-     */
-    abstract public function set_featured_image( int $post_id, string $query ): int|WP_Error;
+	/**
+	 * Search for and attach a featured image to a post.
+	 *
+	 * @param int    $post_id The WordPress post ID.
+	 * @param string $query   Search query (usually the post title or focus keyword).
+	 * @return int|WP_Error Attachment ID on success, WP_Error on failure.
+	 */
+	abstract public function set_featured_image( int $post_id, string $query ): int|WP_Error;
 
-    /**
-     * Get the provider slug (e.g., 'unsplash', 'pexels').
-     */
-    abstract public function get_slug(): string;
+	/**
+	 * Get the provider slug (e.g., 'unsplash', 'pexels').
+	 */
+	abstract public function get_slug(): string;
 
-    /**
-     * Get the provider display name (e.g., 'Unsplash').
-     */
-    abstract public function get_name(): string;
+	/**
+	 * Get the provider display name (e.g., 'Unsplash').
+	 */
+	abstract public function get_name(): string;
 
-    /**
-     * Get the URL where users can obtain an API key.
-     */
-    abstract public function get_api_key_url(): string;
+	/**
+	 * Get the URL where users can obtain an API key.
+	 */
+	abstract public function get_api_key_url(): string;
 
-    /**
-     * Whether this provider requires an API key.
-     */
-    abstract public function requires_api_key(): bool;
+	/**
+	 * Whether this provider requires an API key.
+	 */
+	abstract public function requires_api_key(): bool;
 
-    /**
-     * Get the stored API key for this provider.
-     */
-    public function get_api_key(): string {
-        return (string) get_option( $this->get_api_key_option(), '' );
-    }
+	/**
+	 * Get the stored API key for this provider.
+	 */
+	public function get_api_key(): string {
+		return (string) get_option( $this->get_api_key_option(), '' );
+	}
 
-    /**
-     * Get the option name for this provider's API key.
-     */
-    public function get_api_key_option(): string {
-        return 'swps_' . $this->get_slug() . '_api_key';
-    }
+	/**
+	 * Get the option name for this provider's API key.
+	 */
+	public function get_api_key_option(): string {
+		return 'swps_' . $this->get_slug() . '_api_key';
+	}
 
-    /**
-     * Simplify a post title into a better image search query.
-     *
-     * @param string $query The original query (usually post title).
-     * @return string Simplified search query.
-     */
-    protected function simplify_query( string $query ): string {
-        $stop_words = [ 'how', 'to', 'the', 'a', 'an', 'is', 'are', 'was', 'were', 'what', 'why', 'when', 'where', 'which', 'who', 'your', 'our', 'their', 'this', 'that', 'for', 'and', 'but', 'with', 'from', 'about', 'into', 'best', 'top', 'guide', 'ultimate', 'complete', 'tips', 'tricks' ];
+	/**
+	 * Simplify a post title into a better image search query.
+	 *
+	 * @param string $query The original query (usually post title).
+	 * @return string Simplified search query.
+	 */
+	protected function simplify_query( string $query ): string {
+		$stop_words = array( 'how', 'to', 'the', 'a', 'an', 'is', 'are', 'was', 'were', 'what', 'why', 'when', 'where', 'which', 'who', 'your', 'our', 'their', 'this', 'that', 'for', 'and', 'but', 'with', 'from', 'about', 'into', 'best', 'top', 'guide', 'ultimate', 'complete', 'tips', 'tricks' );
 
-        $words = explode( ' ', strtolower( $query ) );
-        $words = array_filter( $words, function ( $word ) use ( $stop_words ) {
-            return ! in_array( $word, $stop_words, true ) && strlen( $word ) > 2;
-        } );
+		$words = explode( ' ', strtolower( $query ) );
+		$words = array_filter(
+			$words,
+			function ( $word ) use ( $stop_words ) {
+				return ! in_array( $word, $stop_words, true ) && strlen( $word ) > 2;
+			}
+		);
 
-        return implode( ' ', array_slice( array_values( $words ), 0, 4 ) );
-    }
+		return implode( ' ', array_slice( array_values( $words ), 0, 4 ) );
+	}
 
-    /**
-     * Download an image URL and attach it to a post as featured image.
-     *
-     * @param string $image_url  The URL to download.
-     * @param int    $post_id    Post to attach to.
-     * @param string $filename   Desired filename (without extension).
-     * @param string $alt_text   Alt text for the image.
-     * @param string $caption    Caption/excerpt for the attachment.
-     * @return int|WP_Error Attachment ID or error.
-     */
-    protected function download_and_attach_image( string $image_url, int $post_id, string $filename, string $alt_text = '', string $caption = '' ): int|WP_Error {
-        if ( empty( $image_url ) ) {
-            return new WP_Error( 'swps_no_image_url', __( 'No image URL found.', 'stratawp-seo' ) );
-        }
+	/**
+	 * Download an image URL and attach it to a post as featured image.
+	 *
+	 * @param string $image_url  The URL to download.
+	 * @param int    $post_id    Post to attach to.
+	 * @param string $filename   Desired filename (without extension).
+	 * @param string $alt_text   Alt text for the image.
+	 * @param string $caption    Caption/excerpt for the attachment.
+	 * @return int|WP_Error Attachment ID or error.
+	 */
+	protected function download_and_attach_image( string $image_url, int $post_id, string $filename, string $alt_text = '', string $caption = '' ): int|WP_Error {
+		if ( empty( $image_url ) ) {
+			return new WP_Error( 'swps_no_image_url', __( 'No image URL found.', 'stratawp-seo' ) );
+		}
 
-        require_once ABSPATH . 'wp-admin/includes/media.php';
-        require_once ABSPATH . 'wp-admin/includes/file.php';
-        require_once ABSPATH . 'wp-admin/includes/image.php';
+		require_once ABSPATH . 'wp-admin/includes/media.php';
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/image.php';
 
-        $tmp = download_url( $image_url );
+		$tmp = download_url( $image_url );
 
-        if ( is_wp_error( $tmp ) ) {
-            return $tmp;
-        }
+		if ( is_wp_error( $tmp ) ) {
+			return $tmp;
+		}
 
-        // Convert to WebP for optimized file size.
-        $webp_tmp = $this->convert_to_webp( $tmp );
+		// Convert to WebP for optimized file size.
+		$webp_tmp = $this->convert_to_webp( $tmp );
 
-        if ( $webp_tmp !== $tmp ) {
-            @unlink( $tmp );
-            $tmp = $webp_tmp;
-            $ext = '.webp';
-        } else {
-            $ext = '.jpg';
-        }
+		if ( $webp_tmp !== $tmp ) {
+			@unlink( $tmp );
+			$tmp = $webp_tmp;
+			$ext = '.webp';
+		} else {
+			$ext = '.jpg';
+		}
 
-        $file_array = [
-            'name'     => sanitize_title( $filename ) . $ext,
-            'tmp_name' => $tmp,
-        ];
+		$file_array = array(
+			'name'     => sanitize_title( $filename ) . $ext,
+			'tmp_name' => $tmp,
+		);
 
-        $attachment_id = media_handle_sideload( $file_array, $post_id );
+		$attachment_id = media_handle_sideload( $file_array, $post_id );
 
-        if ( is_wp_error( $attachment_id ) ) {
-            @unlink( $tmp );
-            return $attachment_id;
-        }
+		if ( is_wp_error( $attachment_id ) ) {
+			@unlink( $tmp );
+			return $attachment_id;
+		}
 
-        if ( ! empty( $alt_text ) ) {
-            update_post_meta( $attachment_id, '_wp_attachment_image_alt', sanitize_text_field( $alt_text ) );
-        }
+		if ( ! empty( $alt_text ) ) {
+			update_post_meta( $attachment_id, '_wp_attachment_image_alt', sanitize_text_field( $alt_text ) );
+		}
 
-        if ( ! empty( $caption ) ) {
-            wp_update_post( [
-                'ID'           => $attachment_id,
-                'post_excerpt' => $caption,
-            ] );
-        }
+		if ( ! empty( $caption ) ) {
+			wp_update_post(
+				array(
+					'ID'           => $attachment_id,
+					'post_excerpt' => $caption,
+				)
+			);
+		}
 
-        set_post_thumbnail( $post_id, $attachment_id );
+		set_post_thumbnail( $post_id, $attachment_id );
 
-        return $attachment_id;
-    }
+		return $attachment_id;
+	}
 
-    /**
-     * Convert an image file to WebP format.
-     *
-     * @param string $file_path Path to the source image file.
-     * @return string Path to the WebP file on success, or the original path on failure.
-     */
-    protected function convert_to_webp( string $file_path ): string {
-        if ( ! function_exists( 'imagewebp' ) ) {
-            return $file_path;
-        }
+	/**
+	 * Convert an image file to WebP format.
+	 *
+	 * @param string $file_path Path to the source image file.
+	 * @return string Path to the WebP file on success, or the original path on failure.
+	 */
+	protected function convert_to_webp( string $file_path ): string {
+		if ( ! function_exists( 'imagewebp' ) ) {
+			return $file_path;
+		}
 
-        $image_data = file_get_contents( $file_path );
-        if ( false === $image_data ) {
-            return $file_path;
-        }
+		$image_data = file_get_contents( $file_path );
+		if ( false === $image_data ) {
+			return $file_path;
+		}
 
-        $image = @imagecreatefromstring( $image_data );
-        if ( false === $image ) {
-            return $file_path;
-        }
+		$image = @imagecreatefromstring( $image_data );
+		if ( false === $image ) {
+			return $file_path;
+		}
 
-        // Preserve transparency (for PNG sources).
-        imagepalettetotruecolor( $image );
-        imagealphablending( $image, true );
-        imagesavealpha( $image, true );
+		// Preserve transparency (for PNG sources).
+		imagepalettetotruecolor( $image );
+		imagealphablending( $image, true );
+		imagesavealpha( $image, true );
 
-        $webp_path = $file_path . '.webp';
+		$webp_path = $file_path . '.webp';
 
-        if ( ! imagewebp( $image, $webp_path, 85 ) ) {
-            imagedestroy( $image );
-            return $file_path;
-        }
+		if ( ! imagewebp( $image, $webp_path, 85 ) ) {
+			imagedestroy( $image );
+			return $file_path;
+		}
 
-        imagedestroy( $image );
+		imagedestroy( $image );
 
-        return $webp_path;
-    }
+		return $webp_path;
+	}
 }

--- a/includes/class-image-seo.php
+++ b/includes/class-image-seo.php
@@ -17,320 +17,324 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Image_SEO {
 
-    public const OPTION_KEY = 'swps_image_seo';
+	public const OPTION_KEY = 'swps_image_seo';
 
-    public function __construct() {
-        add_action( 'admin_menu',            [ $this, 'register_menu' ], 20 );
-        add_action( 'admin_init',            [ $this, 'register_settings' ] );
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'register_menu' ), 20 );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
-        $opts = $this->get();
+		$opts = $this->get();
 
-        if ( ! empty( $opts['filename_sanitize'] ) ) {
-            add_filter( 'sanitize_file_name', [ $this, 'filter_filename' ], 20, 2 );
-        }
+		if ( ! empty( $opts['filename_sanitize'] ) ) {
+			add_filter( 'sanitize_file_name', array( $this, 'filter_filename' ), 20, 2 );
+		}
 
-        if ( ! empty( $opts['auto_alt'] ) ) {
-            add_action( 'add_attachment',          [ $this, 'auto_alt_on_upload' ] );
-            add_filter( 'wp_generate_attachment_metadata', [ $this, 'auto_alt_on_metadata' ], 10, 2 );
-        }
+		if ( ! empty( $opts['auto_alt'] ) ) {
+			add_action( 'add_attachment', array( $this, 'auto_alt_on_upload' ) );
+			add_filter( 'wp_generate_attachment_metadata', array( $this, 'auto_alt_on_metadata' ), 10, 2 );
+		}
 
-        if ( ! empty( $opts['lazy_load'] ) ) {
-            add_filter( 'the_content', [ $this, 'enforce_lazy_loading' ], 99 );
-        }
+		if ( ! empty( $opts['lazy_load'] ) ) {
+			add_filter( 'the_content', array( $this, 'enforce_lazy_loading' ), 99 );
+		}
 
-        // Bulk fix AJAX.
-        add_action( 'wp_ajax_swps_image_seo_scan',  [ $this, 'ajax_scan' ] );
-        add_action( 'wp_ajax_swps_image_seo_fix',   [ $this, 'ajax_fix' ] );
-    }
+		// Bulk fix AJAX.
+		add_action( 'wp_ajax_swps_image_seo_scan', array( $this, 'ajax_scan' ) );
+		add_action( 'wp_ajax_swps_image_seo_fix', array( $this, 'ajax_fix' ) );
+	}
 
-    public function register_menu(): void {
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Image SEO', 'stratawp-seo' ),
-            __( 'Image SEO', 'stratawp-seo' ),
-            'manage_options',
-            'swps-image-seo',
-            [ $this, 'render_page' ]
-        );
-    }
+	public function register_menu(): void {
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Image SEO', 'stratawp-seo' ),
+			__( 'Image SEO', 'stratawp-seo' ),
+			'manage_options',
+			'swps-image-seo',
+			array( $this, 'render_page' )
+		);
+	}
 
-    public function render_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
-        }
-        require SWPS_PLUGIN_DIR . 'templates/image-seo-page.php';
-    }
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
+		}
+		require SWPS_PLUGIN_DIR . 'templates/image-seo-page.php';
+	}
 
-    public function enqueue_assets( string $hook ): void {
-        if ( 'stratawp-seo_page_swps-image-seo' !== $hook ) {
-            return;
-        }
-        wp_enqueue_style(
-            'swps-page-image-seo',
-            SWPS_PLUGIN_URL . 'admin/css/pages/image-seo.css',
-            [ 'swps-tokens', 'swps-components', 'swps-templates' ],
-            SWPS_VERSION
-        );
-        wp_enqueue_script(
-            'swps-image-seo',
-            SWPS_PLUGIN_URL . 'admin/js/image-seo.js',
-            [ 'jquery' ],
-            SWPS_VERSION,
-            true
-        );
-        wp_localize_script( 'swps-image-seo', 'swpsImageSeo', [
-            'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-            'nonce'   => wp_create_nonce( 'swps_nonce' ),
-            'i18n'    => [
-                'scanning'  => __( 'Scanning library...', 'stratawp-seo' ),
-                'fixing'    => __( 'Generating alt text...', 'stratawp-seo' ),
-                'done'      => __( 'Done.', 'stratawp-seo' ),
-                'failed'    => __( 'Request failed.', 'stratawp-seo' ),
-                'fixedOne'  => __( 'Fixed %d image.', 'stratawp-seo' ),
-                'fixedMany' => __( 'Fixed %d images.', 'stratawp-seo' ),
-            ],
-        ] );
-    }
+	public function enqueue_assets( string $hook ): void {
+		if ( 'stratawp-seo_page_swps-image-seo' !== $hook ) {
+			return;
+		}
+		wp_enqueue_style(
+			'swps-page-image-seo',
+			SWPS_PLUGIN_URL . 'admin/css/pages/image-seo.css',
+			array( 'swps-tokens', 'swps-components', 'swps-templates' ),
+			SWPS_VERSION
+		);
+		wp_enqueue_script(
+			'swps-image-seo',
+			SWPS_PLUGIN_URL . 'admin/js/image-seo.js',
+			array( 'jquery' ),
+			SWPS_VERSION,
+			true
+		);
+		wp_localize_script(
+			'swps-image-seo',
+			'swpsImageSeo',
+			array(
+				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'nonce'   => wp_create_nonce( 'swps_nonce' ),
+				'i18n'    => array(
+					'scanning'  => __( 'Scanning library...', 'stratawp-seo' ),
+					'fixing'    => __( 'Generating alt text...', 'stratawp-seo' ),
+					'done'      => __( 'Done.', 'stratawp-seo' ),
+					'failed'    => __( 'Request failed.', 'stratawp-seo' ),
+					'fixedOne'  => __( 'Fixed %d image.', 'stratawp-seo' ),
+					'fixedMany' => __( 'Fixed %d images.', 'stratawp-seo' ),
+				),
+			)
+		);
+	}
 
-    // ---------- Settings ----------
+	// ---------- Settings ----------
 
-    public function register_settings(): void {
-        register_setting(
-            'swps_image_seo_group',
-            self::OPTION_KEY,
-            [
-                'type'              => 'array',
-                'sanitize_callback' => [ $this, 'sanitize' ],
-                'default'           => $this->defaults(),
-            ]
-        );
-    }
+	public function register_settings(): void {
+		register_setting(
+			'swps_image_seo_group',
+			self::OPTION_KEY,
+			array(
+				'type'              => 'array',
+				'sanitize_callback' => array( $this, 'sanitize' ),
+				'default'           => $this->defaults(),
+			)
+		);
+	}
 
-    public function defaults(): array {
-        return [
-            'auto_alt'          => 1,
-            'alt_mode'          => 'heuristic', // heuristic | ai
-            'filename_sanitize' => 1,
-            'lazy_load'         => 1,
-        ];
-    }
+	public function defaults(): array {
+		return array(
+			'auto_alt'          => 1,
+			'alt_mode'          => 'heuristic', // heuristic | ai
+			'filename_sanitize' => 1,
+			'lazy_load'         => 1,
+		);
+	}
 
-    public function get(): array {
-        $stored = get_option( self::OPTION_KEY, [] );
-        return wp_parse_args( is_array( $stored ) ? $stored : [], $this->defaults() );
-    }
+	public function get(): array {
+		$stored = get_option( self::OPTION_KEY, array() );
+		return wp_parse_args( is_array( $stored ) ? $stored : array(), $this->defaults() );
+	}
 
-    public function sanitize( $input ): array {
-        $clean = $this->defaults();
-        if ( ! is_array( $input ) ) {
-            return $clean;
-        }
-        $clean['auto_alt']          = empty( $input['auto_alt'] )          ? 0 : 1;
-        $clean['filename_sanitize'] = empty( $input['filename_sanitize'] ) ? 0 : 1;
-        $clean['lazy_load']         = empty( $input['lazy_load'] )         ? 0 : 1;
-        $clean['alt_mode']          = ( isset( $input['alt_mode'] ) && 'ai' === $input['alt_mode'] ) ? 'ai' : 'heuristic';
-        return $clean;
-    }
+	public function sanitize( $input ): array {
+		$clean = $this->defaults();
+		if ( ! is_array( $input ) ) {
+			return $clean;
+		}
+		$clean['auto_alt']          = empty( $input['auto_alt'] ) ? 0 : 1;
+		$clean['filename_sanitize'] = empty( $input['filename_sanitize'] ) ? 0 : 1;
+		$clean['lazy_load']         = empty( $input['lazy_load'] ) ? 0 : 1;
+		$clean['alt_mode']          = ( isset( $input['alt_mode'] ) && 'ai' === $input['alt_mode'] ) ? 'ai' : 'heuristic';
+		return $clean;
+	}
 
-    // ---------- Filename sanitization ----------
+	// ---------- Filename sanitization ----------
 
-    /**
-     * Lowercase, dash-separated, strip device-camera prefixes (IMG_, DSC_, etc.).
-     * Keeps the existing WP-sanitized name as a base so we don't fight WP.
-     */
-    public function filter_filename( string $filename, string $original = '' ): string {
-        $info = pathinfo( $filename );
-        $name = $info['filename'] ?? $filename;
-        $ext  = isset( $info['extension'] ) ? '.' . strtolower( $info['extension'] ) : '';
+	/**
+	 * Lowercase, dash-separated, strip device-camera prefixes (IMG_, DSC_, etc.).
+	 * Keeps the existing WP-sanitized name as a base so we don't fight WP.
+	 */
+	public function filter_filename( string $filename, string $original = '' ): string {
+		$info = pathinfo( $filename );
+		$name = $info['filename'] ?? $filename;
+		$ext  = isset( $info['extension'] ) ? '.' . strtolower( $info['extension'] ) : '';
 
-        // Strip common camera-roll prefixes.
-        $name = preg_replace( '/^(img|dsc|dscf|dscn|p\d{0,3}|photo|image|screenshot)[-_ ]+/i', '', (string) $name ) ?: $name;
-        // Lowercase + dash-separate.
-        $name = strtolower( $name );
-        $name = preg_replace( '/[^a-z0-9]+/', '-', $name );
-        $name = trim( (string) $name, '-' );
-        if ( '' === $name ) {
-            $name = 'image';
-        }
-        return $name . $ext;
-    }
+		// Strip common camera-roll prefixes.
+		$name = preg_replace( '/^(img|dsc|dscf|dscn|p\d{0,3}|photo|image|screenshot)[-_ ]+/i', '', (string) $name ) ?: $name;
+		// Lowercase + dash-separate.
+		$name = strtolower( $name );
+		$name = preg_replace( '/[^a-z0-9]+/', '-', $name );
+		$name = trim( (string) $name, '-' );
+		if ( '' === $name ) {
+			$name = 'image';
+		}
+		return $name . $ext;
+	}
 
-    // ---------- Auto-alt ----------
+	// ---------- Auto-alt ----------
 
-    /**
-     * Hooked on `add_attachment`. Runs only for images. Skips when alt is
-     * already set (e.g., user pasted alt during upload).
-     */
-    public function auto_alt_on_upload( int $attachment_id ): void {
-        if ( ! wp_attachment_is_image( $attachment_id ) ) {
-            return;
-        }
-        $existing = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
-        if ( ! empty( $existing ) ) {
-            return;
-        }
-        $alt = $this->generate_alt_for( $attachment_id );
-        if ( '' !== $alt ) {
-            update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt );
-        }
-    }
+	/**
+	 * Hooked on `add_attachment`. Runs only for images. Skips when alt is
+	 * already set (e.g., user pasted alt during upload).
+	 */
+	public function auto_alt_on_upload( int $attachment_id ): void {
+		if ( ! wp_attachment_is_image( $attachment_id ) ) {
+			return;
+		}
+		$existing = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+		if ( ! empty( $existing ) ) {
+			return;
+		}
+		$alt = $this->generate_alt_for( $attachment_id );
+		if ( '' !== $alt ) {
+			update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt );
+		}
+	}
 
-    /**
-     * Hooked on `wp_generate_attachment_metadata` — covers cases where
-     * `add_attachment` fired before metadata existed (some upload flows).
-     */
-    public function auto_alt_on_metadata( $metadata, int $attachment_id ) {
-        $this->auto_alt_on_upload( $attachment_id );
-        return $metadata;
-    }
+	/**
+	 * Hooked on `wp_generate_attachment_metadata` — covers cases where
+	 * `add_attachment` fired before metadata existed (some upload flows).
+	 */
+	public function auto_alt_on_metadata( $metadata, int $attachment_id ) {
+		$this->auto_alt_on_upload( $attachment_id );
+		return $metadata;
+	}
 
-    /**
-     * Build an alt string for a single attachment. Public so the bulk tool
-     * and CLI can reuse it.
-     */
-    public function generate_alt_for( int $attachment_id ): string {
-        $opts = $this->get();
-        $mode = $opts['alt_mode'] ?? 'heuristic';
+	/**
+	 * Build an alt string for a single attachment. Public so the bulk tool
+	 * and CLI can reuse it.
+	 */
+	public function generate_alt_for( int $attachment_id ): string {
+		$opts = $this->get();
+		$mode = $opts['alt_mode'] ?? 'heuristic';
 
-        $context = $this->context_for_attachment( $attachment_id );
+		$context = $this->context_for_attachment( $attachment_id );
 
-        if ( 'ai' === $mode ) {
-            $ai = $this->generate_alt_via_ai( $context );
-            if ( '' !== $ai ) {
-                return $ai;
-            }
-        }
+		if ( 'ai' === $mode ) {
+			$ai = $this->generate_alt_via_ai( $context );
+			if ( '' !== $ai ) {
+				return $ai;
+			}
+		}
 
-        return $this->generate_alt_heuristic( $context );
-    }
+		return $this->generate_alt_heuristic( $context );
+	}
 
-    /**
-     * Filename + parent-post context used by both alt strategies.
-     *
-     * @return array{filename:string, slug_words:string, parent_title:string, post_title:string}
-     */
-    private function context_for_attachment( int $attachment_id ): array {
-        $file = get_attached_file( $attachment_id );
-        $base = $file ? basename( $file ) : '';
-        $slug = $base ? pathinfo( $base, PATHINFO_FILENAME ) : '';
+	/**
+	 * Filename + parent-post context used by both alt strategies.
+	 *
+	 * @return array{filename:string, slug_words:string, parent_title:string, post_title:string}
+	 */
+	private function context_for_attachment( int $attachment_id ): array {
+		$file = get_attached_file( $attachment_id );
+		$base = $file ? basename( $file ) : '';
+		$slug = $base ? pathinfo( $base, PATHINFO_FILENAME ) : '';
 
-        $post = get_post( $attachment_id );
+		$post = get_post( $attachment_id );
 
-        $parent_id    = $post && $post->post_parent ? (int) $post->post_parent : 0;
-        $parent_title = $parent_id ? get_the_title( $parent_id ) : '';
+		$parent_id    = $post && $post->post_parent ? (int) $post->post_parent : 0;
+		$parent_title = $parent_id ? get_the_title( $parent_id ) : '';
 
-        $slug_words = trim( preg_replace( '/[^a-z0-9]+/i', ' ', $slug ) ?: '' );
+		$slug_words = trim( preg_replace( '/[^a-z0-9]+/i', ' ', $slug ) ?: '' );
 
-        return [
-            'filename'     => $base,
-            'slug_words'   => $slug_words,
-            'parent_title' => (string) $parent_title,
-            'post_title'   => (string) ( $post->post_title ?? '' ),
-        ];
-    }
+		return array(
+			'filename'     => $base,
+			'slug_words'   => $slug_words,
+			'parent_title' => (string) $parent_title,
+			'post_title'   => (string) ( $post->post_title ?? '' ),
+		);
+	}
 
-    private function generate_alt_heuristic( array $ctx ): string {
-        $words  = $ctx['slug_words'];
-        $title  = $ctx['post_title'];
-        $parent = $ctx['parent_title'];
+	private function generate_alt_heuristic( array $ctx ): string {
+		$words  = $ctx['slug_words'];
+		$title  = $ctx['post_title'];
+		$parent = $ctx['parent_title'];
 
-        // Prefer the cleanest source: parent title > post title > slug words.
-        $base = '';
-        if ( '' !== $parent ) {
-            $base = $parent;
-        } elseif ( '' !== $title && ! preg_match( '/^image[-_ ]?\d*$/i', $title ) ) {
-            $base = $title;
-        } elseif ( '' !== $words ) {
-            $base = ucfirst( $words );
-        }
+		// Prefer the cleanest source: parent title > post title > slug words.
+		$base = '';
+		if ( '' !== $parent ) {
+			$base = $parent;
+		} elseif ( '' !== $title && ! preg_match( '/^image[-_ ]?\d*$/i', $title ) ) {
+			$base = $title;
+		} elseif ( '' !== $words ) {
+			$base = ucfirst( $words );
+		}
 
-        $base = trim( $base );
-        if ( '' === $base ) {
-            return '';
-        }
+		$base = trim( $base );
+		if ( '' === $base ) {
+			return '';
+		}
 
-        // Truncate at word boundary to ~120 chars (Google guidance: keep alts short + descriptive).
-        if ( mb_strlen( $base ) > 120 ) {
-            $base = mb_substr( $base, 0, 120 );
-            $base = preg_replace( '/\s+\S*$/', '', $base ) ?: $base;
-        }
-        return $base;
-    }
+		// Truncate at word boundary to ~120 chars (Google guidance: keep alts short + descriptive).
+		if ( mb_strlen( $base ) > 120 ) {
+			$base = mb_substr( $base, 0, 120 );
+			$base = preg_replace( '/\s+\S*$/', '', $base ) ?: $base;
+		}
+		return $base;
+	}
 
-    private function generate_alt_via_ai( array $ctx ): string {
-        if ( ! function_exists( 'stratawp_seo' ) ) {
-            return '';
-        }
-        $plugin = stratawp_seo();
-        if ( ! isset( $plugin->api ) || ! ( $plugin->api instanceof SWPS_AI_Provider ) ) {
-            return '';
-        }
+	private function generate_alt_via_ai( array $ctx ): string {
+		if ( ! function_exists( 'stratawp_seo' ) ) {
+			return '';
+		}
+		$plugin = stratawp_seo();
+		if ( ! isset( $plugin->api ) || ! ( $plugin->api instanceof SWPS_AI_Provider ) ) {
+			return '';
+		}
 
-        $system = 'You write short, descriptive alt text for images on a WordPress site. '
-                . 'Return ONE concise sentence (10-15 words max), no quotes, no trailing period if it is a noun phrase, '
-                . 'no "image of", no "photo of", and no marketing fluff. Use only what the context gives you.';
+		$system = 'You write short, descriptive alt text for images on a WordPress site. '
+				. 'Return ONE concise sentence (10-15 words max), no quotes, no trailing period if it is a noun phrase, '
+				. 'no "image of", no "photo of", and no marketing fluff. Use only what the context gives you.';
 
-        $user = sprintf(
-            "Filename: %s\nFilename words: %s\nParent post title: %s\n\nWrite the alt text:",
-            $ctx['filename'],
-            $ctx['slug_words'],
-            $ctx['parent_title'] ?: '(none)'
-        );
+		$user = sprintf(
+			"Filename: %s\nFilename words: %s\nParent post title: %s\n\nWrite the alt text:",
+			$ctx['filename'],
+			$ctx['slug_words'],
+			$ctx['parent_title'] ?: '(none)'
+		);
 
-        $resp = $plugin->api->chat( $system, $user, 80 );
-        if ( is_wp_error( $resp ) || ! is_string( $resp ) ) {
-            return '';
-        }
-        $resp = trim( $resp );
-        $resp = trim( $resp, "\"' \t\n\r" );
-        // First line only.
-        if ( false !== ( $nl = strpos( $resp, "\n" ) ) ) {
-            $resp = substr( $resp, 0, $nl );
-        }
-        return $resp;
-    }
+		$resp = $plugin->api->chat( $system, $user, 80 );
+		if ( is_wp_error( $resp ) || ! is_string( $resp ) ) {
+			return '';
+		}
+		$resp = trim( $resp );
+		$resp = trim( $resp, "\"' \t\n\r" );
+		// First line only.
+		if ( false !== ( $nl = strpos( $resp, "\n" ) ) ) {
+			$resp = substr( $resp, 0, $nl );
+		}
+		return $resp;
+	}
 
-    // ---------- Lazy loading ----------
+	// ---------- Lazy loading ----------
 
-    /**
-     * Belt-and-braces lazy-loading on rendered post content. WP core adds
-     * loading="lazy" automatically since 5.5 for content images, but only
-     * when `width`/`height` are present. This pass adds it to anything
-     * that's still missing.
-     */
-    public function enforce_lazy_loading( string $html ): string {
-        if ( '' === trim( $html ) || false === stripos( $html, '<img' ) ) {
-            return $html;
-        }
+	/**
+	 * Belt-and-braces lazy-loading on rendered post content. WP core adds
+	 * loading="lazy" automatically since 5.5 for content images, but only
+	 * when `width`/`height` are present. This pass adds it to anything
+	 * that's still missing.
+	 */
+	public function enforce_lazy_loading( string $html ): string {
+		if ( '' === trim( $html ) || false === stripos( $html, '<img' ) ) {
+			return $html;
+		}
 
-        return preg_replace_callback(
-            '/<img\b([^>]*)>/i',
-            static function ( $m ) {
-                $attrs = $m[1];
-                if ( preg_match( '/\bloading\s*=/i', $attrs ) ) {
-                    return $m[0];
-                }
-                return '<img' . $attrs . ' loading="lazy" decoding="async">';
-            },
-            $html
-        ) ?: $html;
-    }
+		return preg_replace_callback(
+			'/<img\b([^>]*)>/i',
+			static function ( $m ) {
+				$attrs = $m[1];
+				if ( preg_match( '/\bloading\s*=/i', $attrs ) ) {
+					return $m[0];
+				}
+				return '<img' . $attrs . ' loading="lazy" decoding="async">';
+			},
+			$html
+		) ?: $html;
+	}
 
-    // ---------- Bulk fix ----------
+	// ---------- Bulk fix ----------
 
-    /**
-     * Count attachments with missing alt text.
-     */
-    public function get_missing_alt_count(): int {
-        global $wpdb;
+	/**
+	 * Count attachments with missing alt text.
+	 */
+	public function get_missing_alt_count(): int {
+		global $wpdb;
         // phpcs:disable WordPress.DB.DirectDatabaseQuery
-        $sql = "
+		$sql = "
             SELECT COUNT(p.ID)
             FROM {$wpdb->posts} p
             LEFT JOIN {$wpdb->postmeta} m
@@ -339,21 +343,21 @@ class SWPS_Image_SEO {
               AND p.post_mime_type LIKE 'image/%'
               AND ( m.meta_value IS NULL OR m.meta_value = '' )
         ";
-        return (int) $wpdb->get_var( $sql );
+		return (int) $wpdb->get_var( $sql );
         // phpcs:enable
-    }
+	}
 
-    /**
-     * Get up to $limit attachment IDs missing alt text.
-     *
-     * @return int[]
-     */
-    public function get_missing_alt_ids( int $limit = 25 ): array {
-        global $wpdb;
-        $limit = max( 1, min( 100, $limit ) );
+	/**
+	 * Get up to $limit attachment IDs missing alt text.
+	 *
+	 * @return int[]
+	 */
+	public function get_missing_alt_ids( int $limit = 25 ): array {
+		global $wpdb;
+		$limit = max( 1, min( 100, $limit ) );
         // phpcs:disable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
-        $sql = $wpdb->prepare(
-            "
+		$sql = $wpdb->prepare(
+			"
             SELECT p.ID
             FROM {$wpdb->posts} p
             LEFT JOIN {$wpdb->postmeta} m
@@ -364,50 +368,56 @@ class SWPS_Image_SEO {
             ORDER BY p.ID DESC
             LIMIT %d
             ",
-            $limit
-        );
-        return array_map( 'intval', (array) $wpdb->get_col( $sql ) );
+			$limit
+		);
+		return array_map( 'intval', (array) $wpdb->get_col( $sql ) );
         // phpcs:enable
-    }
+	}
 
-    public function ajax_scan(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-        global $wpdb;
+	public function ajax_scan(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		global $wpdb;
         // phpcs:disable WordPress.DB.DirectDatabaseQuery
-        $total = (int) $wpdb->get_var( "
+		$total = (int) $wpdb->get_var(
+			"
             SELECT COUNT(*) FROM {$wpdb->posts}
             WHERE post_type = 'attachment' AND post_mime_type LIKE 'image/%'
-        " );
+        "
+		);
         // phpcs:enable
-        wp_send_json_success( [
-            'total'   => $total,
-            'missing' => $this->get_missing_alt_count(),
-        ] );
-    }
+		wp_send_json_success(
+			array(
+				'total'   => $total,
+				'missing' => $this->get_missing_alt_count(),
+			)
+		);
+	}
 
-    public function ajax_fix(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ] );
-        }
-        $batch = isset( $_POST['batch'] ) ? max( 1, min( 50, (int) $_POST['batch'] ) ) : 20;
+	public function ajax_fix(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		$batch = isset( $_POST['batch'] ) ? max( 1, min( 50, (int) $_POST['batch'] ) ) : 20;
 
-        $ids   = $this->get_missing_alt_ids( $batch );
-        $fixed = 0;
-        foreach ( $ids as $id ) {
-            $alt = $this->generate_alt_for( $id );
-            if ( '' !== $alt ) {
-                update_post_meta( $id, '_wp_attachment_image_alt', $alt );
-                $fixed++;
-            }
-        }
-        wp_send_json_success( [
-            'fixed'     => $fixed,
-            'attempted' => count( $ids ),
-            'remaining' => $this->get_missing_alt_count(),
-        ] );
-    }
+		$ids   = $this->get_missing_alt_ids( $batch );
+		$fixed = 0;
+		foreach ( $ids as $id ) {
+			$alt = $this->generate_alt_for( $id );
+			if ( '' !== $alt ) {
+				update_post_meta( $id, '_wp_attachment_image_alt', $alt );
+				++$fixed;
+			}
+		}
+		wp_send_json_success(
+			array(
+				'fixed'     => $fixed,
+				'attempted' => count( $ids ),
+				'remaining' => $this->get_missing_alt_count(),
+			)
+		);
+	}
 }

--- a/includes/class-images.php
+++ b/includes/class-images.php
@@ -6,7 +6,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Images extends SWPS_Unsplash_Provider {}

--- a/includes/class-internal-links-admin.php
+++ b/includes/class-internal-links-admin.php
@@ -9,125 +9,126 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Internal_Links_Admin {
 
-    private SWPS_Internal_Links $engine;
+	private SWPS_Internal_Links $engine;
 
-    public function __construct( SWPS_Internal_Links $engine ) {
-        $this->engine = $engine;
+	public function __construct( SWPS_Internal_Links $engine ) {
+		$this->engine = $engine;
 
-        if ( ! get_option( 'swps_internal_links_enabled', 1 ) ) {
-            return;
-        }
+		if ( ! get_option( 'swps_internal_links_enabled', 1 ) ) {
+			return;
+		}
 
-        add_action( 'admin_menu', [ $this, 'register_menu' ], 20 );
-        add_action( 'wp_ajax_swps_link_rebuild', [ $this, 'ajax_rebuild' ] );
-        add_action( 'wp_ajax_swps_link_bulk_dismiss', [ $this, 'ajax_bulk_dismiss' ] );
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
-    }
+		add_action( 'admin_menu', array( $this, 'register_menu' ), 20 );
+		add_action( 'wp_ajax_swps_link_rebuild', array( $this, 'ajax_rebuild' ) );
+		add_action( 'wp_ajax_swps_link_bulk_dismiss', array( $this, 'ajax_bulk_dismiss' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+	}
 
-    /**
-     * Register the Internal Links submenu page.
-     */
-    public function register_menu(): void {
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Internal Links', 'stratawp-seo' ),
-            __( 'Internal Links', 'stratawp-seo' ),
-            'manage_options',
-            'swps-internal-links',
-            [ $this, 'render_page' ]
-        );
-    }
+	/**
+	 * Register the Internal Links submenu page.
+	 */
+	public function register_menu(): void {
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Internal Links', 'stratawp-seo' ),
+			__( 'Internal Links', 'stratawp-seo' ),
+			'manage_options',
+			'swps-internal-links',
+			array( $this, 'render_page' )
+		);
+	}
 
-    /**
-     * Render the admin page.
-     */
-    public function render_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
-        }
+	/**
+	 * Render the admin page.
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
+		}
 
-        $stats = $this->get_stats();
-        include SWPS_PLUGIN_DIR . 'templates/internal-links-page.php';
-    }
+		$stats = $this->get_stats();
+		include SWPS_PLUGIN_DIR . 'templates/internal-links-page.php';
+	}
 
-    /**
-     * Get link health statistics.
-     *
-     * @return array Stats array with counts.
-     */
-    public function get_stats(): array {
-        global $wpdb;
-        $table = $wpdb->prefix . 'swps_link_graph';
+	/**
+	 * Get link health statistics.
+	 *
+	 * @return array Stats array with counts.
+	 */
+	public function get_stats(): array {
+		global $wpdb;
+		$table = $wpdb->prefix . 'swps_link_graph';
 
-        $total_links = (int) $wpdb->get_var(
-            "SELECT COUNT(*) FROM {$table} WHERE status IN ('existing', 'inserted')"
-        );
+		$total_links = (int) $wpdb->get_var(
+			"SELECT COUNT(*) FROM {$table} WHERE status IN ('existing', 'inserted')"
+		);
 
-        $pending_suggestions = (int) $wpdb->get_var(
-            "SELECT COUNT(*) FROM {$table} WHERE status = 'suggested'"
-        );
+		$pending_suggestions = (int) $wpdb->get_var(
+			"SELECT COUNT(*) FROM {$table} WHERE status = 'suggested'"
+		);
 
-        $post_types = (array) get_option( 'swps_internal_links_post_types', [ 'post', 'page' ] );
-        $total_posts = 0;
-        foreach ( $post_types as $pt ) {
-            $counts = wp_count_posts( $pt );
-            $total_posts += (int) ( $counts->publish ?? 0 );
-        }
+		$post_types  = (array) get_option( 'swps_internal_links_post_types', array( 'post', 'page' ) );
+		$total_posts = 0;
+		foreach ( $post_types as $pt ) {
+			$counts       = wp_count_posts( $pt );
+			$total_posts += (int) ( $counts->publish ?? 0 );
+		}
 
-        $avg_links = $total_posts > 0 ? round( $total_links / $total_posts, 1 ) : 0;
+		$avg_links = $total_posts > 0 ? round( $total_links / $total_posts, 1 ) : 0;
 
-        // Orphan pages: published posts with zero inbound links.
-        $type_placeholders = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
+		// Orphan pages: published posts with zero inbound links.
+		$type_placeholders = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $orphan_count = (int) $wpdb->get_var(
-            $wpdb->prepare(
-                "SELECT COUNT(*) FROM {$wpdb->posts} p
+		$orphan_count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->posts} p
                  WHERE p.post_type IN ({$type_placeholders})
                  AND p.post_status = 'publish'
                  AND p.ID NOT IN (
                      SELECT DISTINCT target_post_id FROM {$table}
                      WHERE status IN ('existing', 'inserted')
                  )",
-                $post_types
-            )
-        );
+				$post_types
+			)
+		);
 
-        // Most linked posts (top 5 by inbound).
-        $most_linked = $wpdb->get_results(
-            "SELECT target_post_id, COUNT(*) as link_count
+		// Most linked posts (top 5 by inbound).
+		$most_linked = $wpdb->get_results(
+			"SELECT target_post_id, COUNT(*) as link_count
              FROM {$table}
              WHERE status IN ('existing', 'inserted')
              GROUP BY target_post_id
              ORDER BY link_count DESC
              LIMIT 5",
-            ARRAY_A
-        ) ?: [];
+			ARRAY_A
+		) ?: array();
 
-        // Opportunities (paginated).
-        $page  = max( 1, absint( $_GET['link_page'] ?? 1 ) );
-        $per   = 20;
-        $offset = ( $page - 1 ) * $per;
+		// Opportunities (paginated).
+		$page   = max( 1, absint( $_GET['link_page'] ?? 1 ) );
+		$per    = 20;
+		$offset = ( $page - 1 ) * $per;
 
-        $opportunities = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT * FROM {$table} WHERE status = 'suggested' ORDER BY relevance_score DESC LIMIT %d OFFSET %d",
-                $per, $offset
-            ),
-            ARRAY_A
-        ) ?: [];
+		$opportunities = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$table} WHERE status = 'suggested' ORDER BY relevance_score DESC LIMIT %d OFFSET %d",
+				$per,
+				$offset
+			),
+			ARRAY_A
+		) ?: array();
 
-        $total_pages = (int) ceil( $pending_suggestions / $per );
+		$total_pages = (int) ceil( $pending_suggestions / $per );
 
-        // Orphan pages list.
+		// Orphan pages list.
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $orphan_posts = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT p.ID, p.post_title, p.post_date FROM {$wpdb->posts} p
+		$orphan_posts = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT p.ID, p.post_title, p.post_date FROM {$wpdb->posts} p
                  WHERE p.post_type IN ({$type_placeholders})
                  AND p.post_status = 'publish'
                  AND p.ID NOT IN (
@@ -136,95 +137,99 @@ class SWPS_Internal_Links_Admin {
                  )
                  ORDER BY p.post_date DESC
                  LIMIT 50",
-                $post_types
-            ),
-            ARRAY_A
-        ) ?: [];
+				$post_types
+			),
+			ARRAY_A
+		) ?: array();
 
-        return [
-            'total_links'         => $total_links,
-            'avg_links'           => $avg_links,
-            'orphan_count'        => $orphan_count,
-            'pending_suggestions' => $pending_suggestions,
-            'most_linked'         => $most_linked,
-            'opportunities'       => $opportunities,
-            'orphan_posts'        => $orphan_posts,
-            'current_page'        => $page,
-            'total_pages'         => $total_pages,
-        ];
-    }
+		return array(
+			'total_links'         => $total_links,
+			'avg_links'           => $avg_links,
+			'orphan_count'        => $orphan_count,
+			'pending_suggestions' => $pending_suggestions,
+			'most_linked'         => $most_linked,
+			'opportunities'       => $opportunities,
+			'orphan_posts'        => $orphan_posts,
+			'current_page'        => $page,
+			'total_pages'         => $total_pages,
+		);
+	}
 
-    /**
-     * AJAX: Rebuild link index in batches.
-     */
-    public function ajax_rebuild(): void {
-        check_ajax_referer( 'swps_internal_links', 'nonce' );
+	/**
+	 * AJAX: Rebuild link index in batches.
+	 */
+	public function ajax_rebuild(): void {
+		check_ajax_referer( 'swps_internal_links', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $offset = absint( $_POST['offset'] ?? 0 );
-        $result = $this->engine->rebuild_batch( $offset );
+		$offset = absint( $_POST['offset'] ?? 0 );
+		$result = $this->engine->rebuild_batch( $offset );
 
-        wp_send_json_success( $result );
-    }
+		wp_send_json_success( $result );
+	}
 
-    /**
-     * AJAX: Bulk dismiss suggestions.
-     */
-    public function ajax_bulk_dismiss(): void {
-        check_ajax_referer( 'swps_internal_links', 'nonce' );
+	/**
+	 * AJAX: Bulk dismiss suggestions.
+	 */
+	public function ajax_bulk_dismiss(): void {
+		check_ajax_referer( 'swps_internal_links', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $ids = array_map( 'absint', $_POST['ids'] ?? [] );
-        if ( empty( $ids ) ) {
-            wp_send_json_error( [ 'message' => 'No IDs provided.' ] );
-        }
+		$ids = array_map( 'absint', $_POST['ids'] ?? array() );
+		if ( empty( $ids ) ) {
+			wp_send_json_error( array( 'message' => 'No IDs provided.' ) );
+		}
 
-        global $wpdb;
-        $table        = $wpdb->prefix . 'swps_link_graph';
-        $placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+		global $wpdb;
+		$table        = $wpdb->prefix . 'swps_link_graph';
+		$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
 
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $wpdb->query(
-            $wpdb->prepare(
-                "UPDATE {$table} SET status = 'dismissed', updated_at = %s WHERE id IN ({$placeholders})",
-                array_merge( [ current_time( 'mysql' ) ], $ids )
-            )
-        );
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table} SET status = 'dismissed', updated_at = %s WHERE id IN ({$placeholders})",
+				array_merge( array( current_time( 'mysql' ) ), $ids )
+			)
+		);
 
-        wp_send_json_success();
-    }
+		wp_send_json_success();
+	}
 
-    /**
-     * Enqueue admin page JS.
-     */
-    public function enqueue_assets( string $hook ): void {
-        if ( 'stratawp-seo_page_swps-internal-links' !== $hook ) {
-            return;
-        }
+	/**
+	 * Enqueue admin page JS.
+	 */
+	public function enqueue_assets( string $hook ): void {
+		if ( 'stratawp-seo_page_swps-internal-links' !== $hook ) {
+			return;
+		}
 
-        wp_enqueue_script(
-            'swps-internal-links-admin',
-            SWPS_PLUGIN_URL . 'admin/js/internal-links-admin.js',
-            [ 'jquery' ],
-            SWPS_VERSION,
-            true
-        );
+		wp_enqueue_script(
+			'swps-internal-links-admin',
+			SWPS_PLUGIN_URL . 'admin/js/internal-links-admin.js',
+			array( 'jquery' ),
+			SWPS_VERSION,
+			true
+		);
 
-        wp_localize_script( 'swps-internal-links-admin', 'swpsLinksAdmin', [
-            'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-            'nonce'   => wp_create_nonce( 'swps_internal_links' ),
-            'i18n'    => [
-                'rebuilding' => __( 'Rebuilding index...', 'stratawp-seo' ),
-                'progress'   => __( 'Processed %1$d of %2$d posts...', 'stratawp-seo' ),
-                'complete'   => __( 'Rebuild complete!', 'stratawp-seo' ),
-                'error'      => __( 'Error during rebuild.', 'stratawp-seo' ),
-            ],
-        ] );
-    }
+		wp_localize_script(
+			'swps-internal-links-admin',
+			'swpsLinksAdmin',
+			array(
+				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'nonce'   => wp_create_nonce( 'swps_internal_links' ),
+				'i18n'    => array(
+					'rebuilding' => __( 'Rebuilding index...', 'stratawp-seo' ),
+					'progress'   => __( 'Processed %1$d of %2$d posts...', 'stratawp-seo' ),
+					'complete'   => __( 'Rebuild complete!', 'stratawp-seo' ),
+					'error'      => __( 'Error during rebuild.', 'stratawp-seo' ),
+				),
+			)
+		);
+	}
 }

--- a/includes/class-internal-links.php
+++ b/includes/class-internal-links.php
@@ -10,60 +10,60 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Internal_Links {
 
-    private const GRAPH_TABLE = 'swps_link_graph';
-    private const CRON_HOOK   = 'swps_link_maintenance';
+	private const GRAPH_TABLE = 'swps_link_graph';
+	private const CRON_HOOK   = 'swps_link_maintenance';
 
-    private SWPS_Link_Keyword_Engine $keyword_engine;
-    private SWPS_Link_AI_Engine $ai_engine;
+	private SWPS_Link_Keyword_Engine $keyword_engine;
+	private SWPS_Link_AI_Engine $ai_engine;
 
-    public function __construct( SWPS_Link_Keyword_Engine $keyword_engine, SWPS_Link_AI_Engine $ai_engine ) {
-        $this->keyword_engine = $keyword_engine;
-        $this->ai_engine      = $ai_engine;
+	public function __construct( SWPS_Link_Keyword_Engine $keyword_engine, SWPS_Link_AI_Engine $ai_engine ) {
+		$this->keyword_engine = $keyword_engine;
+		$this->ai_engine      = $ai_engine;
 
-        if ( ! get_option( 'swps_internal_links_enabled', 1 ) ) {
-            return;
-        }
+		if ( ! get_option( 'swps_internal_links_enabled', 1 ) ) {
+			return;
+		}
 
-        // Incremental updates on post save.
-        add_action( 'save_post', [ $this, 'on_save_post' ], 20 );
-        add_action( 'trashed_post', [ $this, 'on_trash_post' ] );
-        add_action( 'deleted_post', [ $this, 'on_trash_post' ] );
+		// Incremental updates on post save.
+		add_action( 'save_post', array( $this, 'on_save_post' ), 20 );
+		add_action( 'trashed_post', array( $this, 'on_trash_post' ) );
+		add_action( 'deleted_post', array( $this, 'on_trash_post' ) );
 
-        // Editor metabox.
-        add_action( 'add_meta_boxes', [ $this, 'register_metabox' ] );
+		// Editor metabox.
+		add_action( 'add_meta_boxes', array( $this, 'register_metabox' ) );
 
-        // AJAX endpoints.
-        add_action( 'wp_ajax_swps_link_suggestions', [ $this, 'ajax_get_suggestions' ] );
-        add_action( 'wp_ajax_swps_link_dismiss', [ $this, 'ajax_dismiss' ] );
-        add_action( 'wp_ajax_swps_link_insert', [ $this, 'ajax_insert' ] );
-        add_action( 'wp_ajax_swps_link_deep_analysis', [ $this, 'ajax_deep_analysis' ] );
+		// AJAX endpoints.
+		add_action( 'wp_ajax_swps_link_suggestions', array( $this, 'ajax_get_suggestions' ) );
+		add_action( 'wp_ajax_swps_link_dismiss', array( $this, 'ajax_dismiss' ) );
+		add_action( 'wp_ajax_swps_link_insert', array( $this, 'ajax_insert' ) );
+		add_action( 'wp_ajax_swps_link_deep_analysis', array( $this, 'ajax_deep_analysis' ) );
 
-        // Admin assets.
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+		// Admin assets.
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
-        // Weekly maintenance cron.
-        add_action( self::CRON_HOOK, [ $this, 'run_maintenance' ] );
+		// Weekly maintenance cron.
+		add_action( self::CRON_HOOK, array( $this, 'run_maintenance' ) );
 
-        // Generator integration.
-        add_filter( 'swps_user_prompt', [ $this, 'enrich_generation_prompt' ], 10, 3 );
-        add_action( 'swps_post_created', [ $this, 'on_post_generated' ], 10, 3 );
-    }
+		// Generator integration.
+		add_filter( 'swps_user_prompt', array( $this, 'enrich_generation_prompt' ), 10, 3 );
+		add_action( 'swps_post_created', array( $this, 'on_post_generated' ), 10, 3 );
+	}
 
-    /**
-     * Create the link graph table.
-     */
-    public static function create_tables(): void {
-        global $wpdb;
+	/**
+	 * Create the link graph table.
+	 */
+	public static function create_tables(): void {
+		global $wpdb;
 
-        $charset = $wpdb->get_charset_collate();
-        $table   = $wpdb->prefix . self::GRAPH_TABLE;
+		$charset = $wpdb->get_charset_collate();
+		$table   = $wpdb->prefix . self::GRAPH_TABLE;
 
-        $sql = "CREATE TABLE {$table} (
+		$sql = "CREATE TABLE {$table} (
             id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
             source_post_id BIGINT UNSIGNED NOT NULL,
             target_post_id BIGINT UNSIGNED NOT NULL,
@@ -81,633 +81,667 @@ class SWPS_Internal_Links {
             KEY idx_target (target_post_id)
         ) {$charset};";
 
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        dbDelta( $sql );
-    }
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
 
-    /**
-     * Schedule the maintenance cron.
-     */
-    public static function schedule_cron(): void {
-        if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-            wp_schedule_event( time(), 'weekly', self::CRON_HOOK );
-        }
-    }
+	/**
+	 * Schedule the maintenance cron.
+	 */
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'weekly', self::CRON_HOOK );
+		}
+	}
 
-    // -------------------------------------------------------------------------
-    // Link Graph CRUD
-    // -------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
+	// Link Graph CRUD
+	// -------------------------------------------------------------------------
 
-    /**
-     * Get all link graph entries for a source post.
-     *
-     * @param int    $post_id Source post ID.
-     * @param string $status  Filter by status ('all' for everything).
-     * @return array Array of graph row arrays.
-     */
-    public function get_links( int $post_id, string $status = 'all' ): array {
-        global $wpdb;
-        $table = $wpdb->prefix . self::GRAPH_TABLE;
+	/**
+	 * Get all link graph entries for a source post.
+	 *
+	 * @param int    $post_id Source post ID.
+	 * @param string $status  Filter by status ('all' for everything).
+	 * @return array Array of graph row arrays.
+	 */
+	public function get_links( int $post_id, string $status = 'all' ): array {
+		global $wpdb;
+		$table = $wpdb->prefix . self::GRAPH_TABLE;
 
-        if ( 'all' === $status ) {
-            return $wpdb->get_results(
-                $wpdb->prepare( "SELECT * FROM {$table} WHERE source_post_id = %d ORDER BY relevance_score DESC", $post_id ),
-                ARRAY_A
-            ) ?: [];
-        }
+		if ( 'all' === $status ) {
+			return $wpdb->get_results(
+				$wpdb->prepare( "SELECT * FROM {$table} WHERE source_post_id = %d ORDER BY relevance_score DESC", $post_id ),
+				ARRAY_A
+			) ?: array();
+		}
 
-        return $wpdb->get_results(
-            $wpdb->prepare( "SELECT * FROM {$table} WHERE source_post_id = %d AND status = %s ORDER BY relevance_score DESC", $post_id, $status ),
-            ARRAY_A
-        ) ?: [];
-    }
+		return $wpdb->get_results(
+			$wpdb->prepare( "SELECT * FROM {$table} WHERE source_post_id = %d AND status = %s ORDER BY relevance_score DESC", $post_id, $status ),
+			ARRAY_A
+		) ?: array();
+	}
 
-    /**
-     * Upsert a link graph entry.
-     *
-     * @param array $data Graph entry data.
-     */
-    public function upsert_link( array $data ): void {
-        global $wpdb;
-        $table = $wpdb->prefix . self::GRAPH_TABLE;
-        $now   = current_time( 'mysql' );
+	/**
+	 * Upsert a link graph entry.
+	 *
+	 * @param array $data Graph entry data.
+	 */
+	public function upsert_link( array $data ): void {
+		global $wpdb;
+		$table = $wpdb->prefix . self::GRAPH_TABLE;
+		$now   = current_time( 'mysql' );
 
-        $existing = $wpdb->get_row(
-            $wpdb->prepare(
-                "SELECT id, status FROM {$table} WHERE source_post_id = %d AND target_post_id = %d",
-                $data['source_post_id'],
-                $data['target_post_id']
-            ),
-            ARRAY_A
-        );
+		$existing = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT id, status FROM {$table} WHERE source_post_id = %d AND target_post_id = %d",
+				$data['source_post_id'],
+				$data['target_post_id']
+			),
+			ARRAY_A
+		);
 
-        if ( $existing ) {
-            // Don't overwrite dismissed entries with new suggestions.
-            if ( 'dismissed' === $existing['status'] && 'suggested' === ( $data['status'] ?? 'suggested' ) ) {
-                return;
-            }
+		if ( $existing ) {
+			// Don't overwrite dismissed entries with new suggestions.
+			if ( 'dismissed' === $existing['status'] && 'suggested' === ( $data['status'] ?? 'suggested' ) ) {
+				return;
+			}
 
-            $wpdb->update(
-                $table,
-                array_merge( $data, [ 'updated_at' => $now ] ),
-                [ 'id' => $existing['id'] ],
-            );
-        } else {
-            $wpdb->insert(
-                $table,
-                array_merge( $data, [
-                    'created_at' => $now,
-                    'updated_at' => $now,
-                ] ),
-            );
-        }
-    }
+			$wpdb->update(
+				$table,
+				array_merge( $data, array( 'updated_at' => $now ) ),
+				array( 'id' => $existing['id'] ),
+			);
+		} else {
+			$wpdb->insert(
+				$table,
+				array_merge(
+					$data,
+					array(
+						'created_at' => $now,
+						'updated_at' => $now,
+					)
+				),
+			);
+		}
+	}
 
-    /**
-     * Update the status of a link graph entry.
-     *
-     * @param int    $source_post_id Source post ID.
-     * @param int    $target_post_id Target post ID.
-     * @param string $status         New status.
-     */
-    public function update_status( int $source_post_id, int $target_post_id, string $status ): void {
-        global $wpdb;
-        $table = $wpdb->prefix . self::GRAPH_TABLE;
+	/**
+	 * Update the status of a link graph entry.
+	 *
+	 * @param int    $source_post_id Source post ID.
+	 * @param int    $target_post_id Target post ID.
+	 * @param string $status         New status.
+	 */
+	public function update_status( int $source_post_id, int $target_post_id, string $status ): void {
+		global $wpdb;
+		$table = $wpdb->prefix . self::GRAPH_TABLE;
 
-        $wpdb->update(
-            $table,
-            [ 'status' => $status, 'updated_at' => current_time( 'mysql' ) ],
-            [ 'source_post_id' => $source_post_id, 'target_post_id' => $target_post_id ],
-        );
-    }
+		$wpdb->update(
+			$table,
+			array(
+				'status'     => $status,
+				'updated_at' => current_time( 'mysql' ),
+			),
+			array(
+				'source_post_id' => $source_post_id,
+				'target_post_id' => $target_post_id,
+			),
+		);
+	}
 
-    // -------------------------------------------------------------------------
-    // Post Analysis
-    // -------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
+	// Post Analysis
+	// -------------------------------------------------------------------------
 
-    /**
-     * Fully analyze a post: detect existing links, run keyword matching, update graph.
-     *
-     * @param int $post_id Post to analyze.
-     */
-    public function analyze_post( int $post_id ): void {
-        $post = get_post( $post_id );
-        if ( ! $post || 'publish' !== $post->post_status ) {
-            return;
-        }
+	/**
+	 * Fully analyze a post: detect existing links, run keyword matching, update graph.
+	 *
+	 * @param int $post_id Post to analyze.
+	 */
+	public function analyze_post( int $post_id ): void {
+		$post = get_post( $post_id );
+		if ( ! $post || 'publish' !== $post->post_status ) {
+			return;
+		}
 
-        // Index terms.
-        $this->keyword_engine->index_post( $post_id );
+		// Index terms.
+		$this->keyword_engine->index_post( $post_id );
 
-        // Detect existing internal links in content.
-        $this->detect_existing_links( $post_id, $post->post_content );
+		// Detect existing internal links in content.
+		$this->detect_existing_links( $post_id, $post->post_content );
 
-        // Find keyword-matched candidates.
-        $threshold = (float) get_option( 'swps_link_relevance_threshold', 0.3 );
-        $max       = (int) get_option( 'swps_link_max_suggestions', 10 );
-        $related   = $this->keyword_engine->find_related( $post_id, $threshold, $max );
+		// Find keyword-matched candidates.
+		$threshold = (float) get_option( 'swps_link_relevance_threshold', 0.3 );
+		$max       = (int) get_option( 'swps_link_max_suggestions', 10 );
+		$related   = $this->keyword_engine->find_related( $post_id, $threshold, $max );
 
-        foreach ( $related as $candidate ) {
-            $this->upsert_link( [
-                'source_post_id' => $post_id,
-                'target_post_id' => $candidate['post_id'],
-                'status'         => 'suggested',
-                'match_type'     => 'keyword',
-                'relevance_score' => $candidate['score'],
-            ] );
-        }
-    }
+		foreach ( $related as $candidate ) {
+			$this->upsert_link(
+				array(
+					'source_post_id'  => $post_id,
+					'target_post_id'  => $candidate['post_id'],
+					'status'          => 'suggested',
+					'match_type'      => 'keyword',
+					'relevance_score' => $candidate['score'],
+				)
+			);
+		}
+	}
 
-    /**
-     * Detect existing internal links in post content and record them.
-     *
-     * @param int    $post_id Post ID.
-     * @param string $content Post HTML content.
-     */
-    public function detect_existing_links( int $post_id, string $content ): void {
-        $home_url = home_url();
+	/**
+	 * Detect existing internal links in post content and record them.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $content Post HTML content.
+	 */
+	public function detect_existing_links( int $post_id, string $content ): void {
+		$home_url = home_url();
 
-        if ( ! preg_match_all( '/<a\s[^>]*href=["\']([^"\']+)["\'][^>]*>(.*?)<\/a>/is', $content, $matches, PREG_SET_ORDER ) ) {
-            return;
-        }
+		if ( ! preg_match_all( '/<a\s[^>]*href=["\']([^"\']+)["\'][^>]*>(.*?)<\/a>/is', $content, $matches, PREG_SET_ORDER ) ) {
+			return;
+		}
 
-        foreach ( $matches as $match ) {
-            $href        = $match[1];
-            $anchor_text = wp_strip_all_tags( $match[2] );
+		foreach ( $matches as $match ) {
+			$href        = $match[1];
+			$anchor_text = wp_strip_all_tags( $match[2] );
 
-            // Only internal links.
-            if ( strpos( $href, $home_url ) !== 0 && strpos( $href, '/' ) !== 0 ) {
-                continue;
-            }
+			// Only internal links.
+			if ( strpos( $href, $home_url ) !== 0 && strpos( $href, '/' ) !== 0 ) {
+				continue;
+			}
 
-            $target_id = url_to_postid( $href );
-            if ( ! $target_id || $target_id === $post_id ) {
-                continue;
-            }
+			$target_id = url_to_postid( $href );
+			if ( ! $target_id || $target_id === $post_id ) {
+				continue;
+			}
 
-            $this->upsert_link( [
-                'source_post_id' => $post_id,
-                'target_post_id' => $target_id,
-                'status'         => 'existing',
-                'match_type'     => 'manual',
-                'relevance_score' => 1.0,
-                'anchor_text'    => sanitize_text_field( mb_substr( $anchor_text, 0, 255 ) ),
-            ] );
-        }
-    }
+			$this->upsert_link(
+				array(
+					'source_post_id'  => $post_id,
+					'target_post_id'  => $target_id,
+					'status'          => 'existing',
+					'match_type'      => 'manual',
+					'relevance_score' => 1.0,
+					'anchor_text'     => sanitize_text_field( mb_substr( $anchor_text, 0, 255 ) ),
+				)
+			);
+		}
+	}
 
-    /**
-     * Rebuild the entire link index and graph for all published posts.
-     *
-     * Processes posts in batches. Call repeatedly with increasing offset
-     * until return value indicates completion.
-     *
-     * @param int $offset Start from this post index.
-     * @param int $batch  Posts per batch.
-     * @return array ['processed' => int, 'total' => int, 'done' => bool]
-     */
-    public function rebuild_batch( int $offset = 0, int $batch = 50 ): array {
-        $post_types = (array) get_option( 'swps_internal_links_post_types', [ 'post', 'page' ] );
+	/**
+	 * Rebuild the entire link index and graph for all published posts.
+	 *
+	 * Processes posts in batches. Call repeatedly with increasing offset
+	 * until return value indicates completion.
+	 *
+	 * @param int $offset Start from this post index.
+	 * @param int $batch  Posts per batch.
+	 * @return array ['processed' => int, 'total' => int, 'done' => bool]
+	 */
+	public function rebuild_batch( int $offset = 0, int $batch = 50 ): array {
+		$post_types = (array) get_option( 'swps_internal_links_post_types', array( 'post', 'page' ) );
 
-        $posts = get_posts( [
-            'post_type'      => $post_types,
-            'post_status'    => 'publish',
-            'posts_per_page' => $batch,
-            'offset'         => $offset,
-            'fields'         => 'ids',
-            'orderby'        => 'ID',
-            'order'          => 'ASC',
-        ] );
+		$posts = get_posts(
+			array(
+				'post_type'      => $post_types,
+				'post_status'    => 'publish',
+				'posts_per_page' => $batch,
+				'offset'         => $offset,
+				'fields'         => 'ids',
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+			)
+		);
 
-        foreach ( $posts as $pid ) {
-            $this->analyze_post( $pid );
-        }
+		foreach ( $posts as $pid ) {
+			$this->analyze_post( $pid );
+		}
 
-        $total = 0;
-        foreach ( $post_types as $pt ) {
-            $counts = wp_count_posts( $pt );
-            $total += (int) ( $counts->publish ?? 0 );
-        }
+		$total = 0;
+		foreach ( $post_types as $pt ) {
+			$counts = wp_count_posts( $pt );
+			$total += (int) ( $counts->publish ?? 0 );
+		}
 
-        return [
-            'processed' => $offset + count( $posts ),
-            'total'     => $total,
-            'done'      => count( $posts ) < $batch,
-        ];
-    }
+		return array(
+			'processed' => $offset + count( $posts ),
+			'total'     => $total,
+			'done'      => count( $posts ) < $batch,
+		);
+	}
 
-    // -------------------------------------------------------------------------
-    // Hooks
-    // -------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
+	// Hooks
+	// -------------------------------------------------------------------------
 
-    /**
-     * Incremental update when a post is saved.
-     */
-    public function on_save_post( int $post_id ): void {
-        if ( wp_is_post_autosave( $post_id ) || wp_is_post_revision( $post_id ) ) {
-            return;
-        }
+	/**
+	 * Incremental update when a post is saved.
+	 */
+	public function on_save_post( int $post_id ): void {
+		if ( wp_is_post_autosave( $post_id ) || wp_is_post_revision( $post_id ) ) {
+			return;
+		}
 
-        // Skip during generation to avoid double-processing.
-        if ( defined( 'SWPS_GENERATING' ) && SWPS_GENERATING ) {
-            return;
-        }
+		// Skip during generation to avoid double-processing.
+		if ( defined( 'SWPS_GENERATING' ) && SWPS_GENERATING ) {
+			return;
+		}
 
-        $post_types = (array) get_option( 'swps_internal_links_post_types', [ 'post', 'page' ] );
-        if ( ! in_array( get_post_type( $post_id ), $post_types, true ) ) {
-            return;
-        }
+		$post_types = (array) get_option( 'swps_internal_links_post_types', array( 'post', 'page' ) );
+		if ( ! in_array( get_post_type( $post_id ), $post_types, true ) ) {
+			return;
+		}
 
-        $this->analyze_post( $post_id );
-    }
+		$this->analyze_post( $post_id );
+	}
 
-    /**
-     * Clean up graph entries when a post is trashed or deleted.
-     */
-    public function on_trash_post( int $post_id ): void {
-        global $wpdb;
-        $table = $wpdb->prefix . self::GRAPH_TABLE;
+	/**
+	 * Clean up graph entries when a post is trashed or deleted.
+	 */
+	public function on_trash_post( int $post_id ): void {
+		global $wpdb;
+		$table = $wpdb->prefix . self::GRAPH_TABLE;
 
-        $wpdb->delete( $table, [ 'source_post_id' => $post_id ], [ '%d' ] );
-        $wpdb->delete( $table, [ 'target_post_id' => $post_id ], [ '%d' ] );
+		$wpdb->delete( $table, array( 'source_post_id' => $post_id ), array( '%d' ) );
+		$wpdb->delete( $table, array( 'target_post_id' => $post_id ), array( '%d' ) );
 
-        $this->keyword_engine->clear_post( $post_id );
-    }
+		$this->keyword_engine->clear_post( $post_id );
+	}
 
-    /**
-     * Weekly maintenance cron: clean stale entries.
-     */
-    public function run_maintenance(): void {
-        global $wpdb;
-        $table = $wpdb->prefix . self::GRAPH_TABLE;
+	/**
+	 * Weekly maintenance cron: clean stale entries.
+	 */
+	public function run_maintenance(): void {
+		global $wpdb;
+		$table = $wpdb->prefix . self::GRAPH_TABLE;
 
-        // Remove entries where source or target post no longer exists or is not published.
-        $wpdb->query(
-            "DELETE g FROM {$table} g
+		// Remove entries where source or target post no longer exists or is not published.
+		$wpdb->query(
+			"DELETE g FROM {$table} g
              LEFT JOIN {$wpdb->posts} p1 ON g.source_post_id = p1.ID AND p1.post_status = 'publish'
              LEFT JOIN {$wpdb->posts} p2 ON g.target_post_id = p2.ID AND p2.post_status = 'publish'
              WHERE p1.ID IS NULL OR p2.ID IS NULL"
-        );
+		);
 
-        // Clean orphaned index entries.
-        $index_table = $wpdb->prefix . 'swps_link_index';
-        $wpdb->query(
-            "DELETE li FROM {$index_table} li
+		// Clean orphaned index entries.
+		$index_table = $wpdb->prefix . 'swps_link_index';
+		$wpdb->query(
+			"DELETE li FROM {$index_table} li
              LEFT JOIN {$wpdb->posts} p ON li.post_id = p.ID AND p.post_status = 'publish'
              WHERE p.ID IS NULL"
-        );
-    }
+		);
+	}
 
-    // -------------------------------------------------------------------------
-    // Generator Integration
-    // -------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
+	// Generator Integration
+	// -------------------------------------------------------------------------
 
-    /**
-     * Enrich the generation prompt with internal link suggestions.
-     *
-     * Hooked to swps_user_prompt filter.
-     */
-    public function enrich_generation_prompt( string $prompt, string $topic, string $site_context ): string {
-        if ( ! get_option( 'swps_internal_links_in_generation', 1 ) ) {
-            return $prompt;
-        }
+	/**
+	 * Enrich the generation prompt with internal link suggestions.
+	 *
+	 * Hooked to swps_user_prompt filter.
+	 */
+	public function enrich_generation_prompt( string $prompt, string $topic, string $site_context ): string {
+		if ( ! get_option( 'swps_internal_links_in_generation', 1 ) ) {
+			return $prompt;
+		}
 
-        if ( empty( $topic ) ) {
-            return $prompt;
-        }
+		if ( empty( $topic ) ) {
+			return $prompt;
+		}
 
-        // Find posts related to the generation topic by indexing a temporary "virtual post".
-        // Instead, we do a simpler approach: search the link index for matching terms.
-        $terms = ( new SWPS_Link_Keyword_Engine() )->tokenize_public( $topic );
-        if ( empty( $terms ) ) {
-            return $prompt;
-        }
+		// Find posts related to the generation topic by indexing a temporary "virtual post".
+		// Instead, we do a simpler approach: search the link index for matching terms.
+		$terms = ( new SWPS_Link_Keyword_Engine() )->tokenize_public( $topic );
+		if ( empty( $terms ) ) {
+			return $prompt;
+		}
 
-        global $wpdb;
-        $index_table = $wpdb->prefix . 'swps_link_index';
+		global $wpdb;
+		$index_table = $wpdb->prefix . 'swps_link_index';
 
-        $placeholders = implode( ',', array_fill( 0, count( $terms ), '%s' ) );
+		$placeholders = implode( ',', array_fill( 0, count( $terms ), '%s' ) );
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-        $matches = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT post_id, SUM(weight) as total_weight
+		$matches = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_id, SUM(weight) as total_weight
                  FROM {$index_table}
                  WHERE term IN ({$placeholders})
                  GROUP BY post_id
                  ORDER BY total_weight DESC
                  LIMIT 5",
-                $terms
-            ),
-            ARRAY_A
-        );
+				$terms
+			),
+			ARRAY_A
+		);
 
-        if ( empty( $matches ) ) {
-            return $prompt;
-        }
+		if ( empty( $matches ) ) {
+			return $prompt;
+		}
 
-        $link_section = "\n=== PRIORITY INTERNAL LINKS ===\n";
-        $link_section .= "In addition to the existing pages above, prioritize linking to these highly relevant posts:\n";
+		$link_section  = "\n=== PRIORITY INTERNAL LINKS ===\n";
+		$link_section .= "In addition to the existing pages above, prioritize linking to these highly relevant posts:\n";
 
-        foreach ( $matches as $match ) {
-            $post = get_post( (int) $match['post_id'] );
-            if ( ! $post ) {
-                continue;
-            }
-            $url   = get_permalink( $post->ID );
-            $title = $post->post_title;
-            $link_section .= "- \"{$title}\" → {$url}\n";
-        }
+		foreach ( $matches as $match ) {
+			$post = get_post( (int) $match['post_id'] );
+			if ( ! $post ) {
+				continue;
+			}
+			$url           = get_permalink( $post->ID );
+			$title         = $post->post_title;
+			$link_section .= "- \"{$title}\" → {$url}\n";
+		}
 
-        return $prompt . $link_section;
-    }
+		return $prompt . $link_section;
+	}
 
-    /**
-     * After a post is generated, record its internal links in the graph.
-     *
-     * Hooked to swps_post_created action.
-     */
-    public function on_post_generated( int $post_id, array $ai_result, array $post_data ): void {
-        $content = $post_data['post_content'] ?? '';
-        if ( empty( $content ) ) {
-            $content = get_post_field( 'post_content', $post_id );
-        }
+	/**
+	 * After a post is generated, record its internal links in the graph.
+	 *
+	 * Hooked to swps_post_created action.
+	 */
+	public function on_post_generated( int $post_id, array $ai_result, array $post_data ): void {
+		$content = $post_data['post_content'] ?? '';
+		if ( empty( $content ) ) {
+			$content = get_post_field( 'post_content', $post_id );
+		}
 
-        // Index the new post and detect its links.
-        $this->keyword_engine->index_post( $post_id );
-        $this->detect_existing_links( $post_id, $content );
-    }
+		// Index the new post and detect its links.
+		$this->keyword_engine->index_post( $post_id );
+		$this->detect_existing_links( $post_id, $content );
+	}
 
-    // -------------------------------------------------------------------------
-    // Editor Metabox
-    // -------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
+	// Editor Metabox
+	// -------------------------------------------------------------------------
 
-    /**
-     * Register the Internal Links metabox.
-     */
-    public function register_metabox(): void {
-        $post_types = (array) get_option( 'swps_internal_links_post_types', [ 'post', 'page' ] );
+	/**
+	 * Register the Internal Links metabox.
+	 */
+	public function register_metabox(): void {
+		$post_types = (array) get_option( 'swps_internal_links_post_types', array( 'post', 'page' ) );
 
-        foreach ( $post_types as $post_type ) {
-            add_meta_box(
-                'swps_internal_links',
-                __( 'Internal Links', 'stratawp-seo' ),
-                [ $this, 'render_metabox' ],
-                $post_type,
-                'normal',
-                'default'
-            );
-        }
-    }
+		foreach ( $post_types as $post_type ) {
+			add_meta_box(
+				'swps_internal_links',
+				__( 'Internal Links', 'stratawp-seo' ),
+				array( $this, 'render_metabox' ),
+				$post_type,
+				'normal',
+				'default'
+			);
+		}
+	}
 
-    /**
-     * Render the Internal Links metabox.
-     */
-    public function render_metabox( WP_Post $post ): void {
-        $existing  = $this->get_links( $post->ID, 'existing' );
-        $inserted  = $this->get_links( $post->ID, 'inserted' );
-        $suggested = $this->get_links( $post->ID, 'suggested' );
+	/**
+	 * Render the Internal Links metabox.
+	 */
+	public function render_metabox( WP_Post $post ): void {
+		$existing  = $this->get_links( $post->ID, 'existing' );
+		$inserted  = $this->get_links( $post->ID, 'inserted' );
+		$suggested = $this->get_links( $post->ID, 'suggested' );
 
-        $all_existing = array_merge( $existing, $inserted );
+		$all_existing = array_merge( $existing, $inserted );
 
-        wp_nonce_field( 'swps_internal_links', 'swps_internal_links_nonce' );
-        ?>
-        <div id="swps-internal-links-metabox">
-            <p class="swps-link-stats">
-                <?php
-                printf(
-                    esc_html__( 'This post has %1$d internal links. %2$d suggestions available.', 'stratawp-seo' ),
-                    count( $all_existing ),
-                    count( $suggested )
-                );
-                ?>
-            </p>
+		wp_nonce_field( 'swps_internal_links', 'swps_internal_links_nonce' );
+		?>
+		<div id="swps-internal-links-metabox">
+			<p class="swps-link-stats">
+				<?php
+				printf(
+					esc_html__( 'This post has %1$d internal links. %2$d suggestions available.', 'stratawp-seo' ),
+					count( $all_existing ),
+					count( $suggested )
+				);
+				?>
+			</p>
 
-            <?php if ( ! empty( $all_existing ) ) : ?>
-                <h4><?php esc_html_e( 'Existing Links', 'stratawp-seo' ); ?></h4>
-                <ul class="swps-existing-links">
-                    <?php foreach ( $all_existing as $link ) :
-                        $target = get_post( (int) $link['target_post_id'] );
-                        if ( ! $target ) continue;
-                    ?>
-                        <li>
-                            <a href="<?php echo esc_url( get_edit_post_link( $target->ID ) ); ?>" target="_blank">
-                                <?php echo esc_html( $target->post_title ); ?>
-                            </a>
-                            <?php if ( ! empty( $link['anchor_text'] ) ) : ?>
-                                <span class="swps-anchor-text">(<?php echo esc_html( $link['anchor_text'] ); ?>)</span>
-                            <?php endif; ?>
-                        </li>
-                    <?php endforeach; ?>
-                </ul>
-            <?php endif; ?>
+			<?php if ( ! empty( $all_existing ) ) : ?>
+				<h4><?php esc_html_e( 'Existing Links', 'stratawp-seo' ); ?></h4>
+				<ul class="swps-existing-links">
+					<?php
+					foreach ( $all_existing as $link ) :
+						$target = get_post( (int) $link['target_post_id'] );
+						if ( ! $target ) {
+							continue;
+						}
+						?>
+						<li>
+							<a href="<?php echo esc_url( get_edit_post_link( $target->ID ) ); ?>" target="_blank">
+								<?php echo esc_html( $target->post_title ); ?>
+							</a>
+							<?php if ( ! empty( $link['anchor_text'] ) ) : ?>
+								<span class="swps-anchor-text">(<?php echo esc_html( $link['anchor_text'] ); ?>)</span>
+							<?php endif; ?>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+			<?php endif; ?>
 
-            <?php if ( ! empty( $suggested ) ) : ?>
-                <h4><?php esc_html_e( 'Suggested Links', 'stratawp-seo' ); ?></h4>
-                <ul class="swps-suggested-links">
-                    <?php foreach ( $suggested as $link ) :
-                        $target = get_post( (int) $link['target_post_id'] );
-                        if ( ! $target ) continue;
-                        $score = (float) $link['relevance_score'];
-                        $color = $score >= 0.7 ? 'green' : ( $score >= 0.4 ? 'orange' : 'red' );
-                        $anchor = ! empty( $link['anchor_text'] ) ? $link['anchor_text'] : $target->post_title;
-                    ?>
-                        <li data-target-id="<?php echo esc_attr( $target->ID ); ?>"
-                            data-target-url="<?php echo esc_url( get_permalink( $target->ID ) ); ?>"
-                            data-anchor="<?php echo esc_attr( $anchor ); ?>">
-                            <span class="swps-score-dot" style="color:<?php echo esc_attr( $color ); ?>;">&#9679;</span>
-                            <a href="<?php echo esc_url( get_edit_post_link( $target->ID ) ); ?>" target="_blank">
-                                <?php echo esc_html( $target->post_title ); ?>
-                            </a>
-                            <span class="swps-suggested-anchor"><?php echo esc_html( $anchor ); ?></span>
-                            <?php if ( ! empty( $link['anchor_context'] ) ) : ?>
-                                <span class="swps-rationale"><?php echo esc_html( $link['anchor_context'] ); ?></span>
-                            <?php endif; ?>
-                            <span class="swps-link-actions">
-                                <button type="button" class="button button-small swps-insert-link"><?php esc_html_e( 'Insert', 'stratawp-seo' ); ?></button>
-                                <button type="button" class="button button-small swps-dismiss-link"><?php esc_html_e( 'Dismiss', 'stratawp-seo' ); ?></button>
-                            </span>
-                        </li>
-                    <?php endforeach; ?>
-                </ul>
-            <?php endif; ?>
+			<?php if ( ! empty( $suggested ) ) : ?>
+				<h4><?php esc_html_e( 'Suggested Links', 'stratawp-seo' ); ?></h4>
+				<ul class="swps-suggested-links">
+					<?php
+					foreach ( $suggested as $link ) :
+						$target = get_post( (int) $link['target_post_id'] );
+						if ( ! $target ) {
+							continue;
+						}
+						$score  = (float) $link['relevance_score'];
+						$color  = $score >= 0.7 ? 'green' : ( $score >= 0.4 ? 'orange' : 'red' );
+						$anchor = ! empty( $link['anchor_text'] ) ? $link['anchor_text'] : $target->post_title;
+						?>
+						<li data-target-id="<?php echo esc_attr( $target->ID ); ?>"
+							data-target-url="<?php echo esc_url( get_permalink( $target->ID ) ); ?>"
+							data-anchor="<?php echo esc_attr( $anchor ); ?>">
+							<span class="swps-score-dot" style="color:<?php echo esc_attr( $color ); ?>;">&#9679;</span>
+							<a href="<?php echo esc_url( get_edit_post_link( $target->ID ) ); ?>" target="_blank">
+								<?php echo esc_html( $target->post_title ); ?>
+							</a>
+							<span class="swps-suggested-anchor"><?php echo esc_html( $anchor ); ?></span>
+							<?php if ( ! empty( $link['anchor_context'] ) ) : ?>
+								<span class="swps-rationale"><?php echo esc_html( $link['anchor_context'] ); ?></span>
+							<?php endif; ?>
+							<span class="swps-link-actions">
+								<button type="button" class="button button-small swps-insert-link"><?php esc_html_e( 'Insert', 'stratawp-seo' ); ?></button>
+								<button type="button" class="button button-small swps-dismiss-link"><?php esc_html_e( 'Dismiss', 'stratawp-seo' ); ?></button>
+							</span>
+						</li>
+					<?php endforeach; ?>
+				</ul>
+			<?php endif; ?>
 
-            <div class="swps-link-metabox-actions">
-                <button type="button" class="button" id="swps-deep-analysis" data-post-id="<?php echo esc_attr( $post->ID ); ?>">
-                    <?php esc_html_e( 'Deep Analysis (AI)', 'stratawp-seo' ); ?>
-                </button>
-                <span id="swps-deep-analysis-status"></span>
-            </div>
-        </div>
-        <?php
-    }
+			<div class="swps-link-metabox-actions">
+				<button type="button" class="button" id="swps-deep-analysis" data-post-id="<?php echo esc_attr( $post->ID ); ?>">
+					<?php esc_html_e( 'Deep Analysis (AI)', 'stratawp-seo' ); ?>
+				</button>
+				<span id="swps-deep-analysis-status"></span>
+			</div>
+		</div>
+		<?php
+	}
 
-    // -------------------------------------------------------------------------
-    // AJAX Handlers
-    // -------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
+	// AJAX Handlers
+	// -------------------------------------------------------------------------
 
-    /**
-     * AJAX: Get link suggestions for a post.
-     */
-    public function ajax_get_suggestions(): void {
-        check_ajax_referer( 'swps_internal_links', 'nonce' );
+	/**
+	 * AJAX: Get link suggestions for a post.
+	 */
+	public function ajax_get_suggestions(): void {
+		check_ajax_referer( 'swps_internal_links', 'nonce' );
 
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $post_id = absint( $_POST['post_id'] ?? 0 );
-        if ( ! $post_id ) {
-            wp_send_json_error( [ 'message' => 'Invalid post ID.' ] );
-        }
+		$post_id = absint( $_POST['post_id'] ?? 0 );
+		if ( ! $post_id ) {
+			wp_send_json_error( array( 'message' => 'Invalid post ID.' ) );
+		}
 
-        $suggested = $this->get_links( $post_id, 'suggested' );
-        $existing  = $this->get_links( $post_id, 'existing' );
+		$suggested = $this->get_links( $post_id, 'suggested' );
+		$existing  = $this->get_links( $post_id, 'existing' );
 
-        wp_send_json_success( [
-            'suggested' => $suggested,
-            'existing'  => $existing,
-        ] );
-    }
+		wp_send_json_success(
+			array(
+				'suggested' => $suggested,
+				'existing'  => $existing,
+			)
+		);
+	}
 
-    /**
-     * AJAX: Dismiss a link suggestion.
-     */
-    public function ajax_dismiss(): void {
-        check_ajax_referer( 'swps_internal_links', 'nonce' );
+	/**
+	 * AJAX: Dismiss a link suggestion.
+	 */
+	public function ajax_dismiss(): void {
+		check_ajax_referer( 'swps_internal_links', 'nonce' );
 
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $post_id   = absint( $_POST['post_id'] ?? 0 );
-        $target_id = absint( $_POST['target_id'] ?? 0 );
+		$post_id   = absint( $_POST['post_id'] ?? 0 );
+		$target_id = absint( $_POST['target_id'] ?? 0 );
 
-        if ( ! $post_id || ! $target_id ) {
-            wp_send_json_error( [ 'message' => 'Invalid IDs.' ] );
-        }
+		if ( ! $post_id || ! $target_id ) {
+			wp_send_json_error( array( 'message' => 'Invalid IDs.' ) );
+		}
 
-        $this->update_status( $post_id, $target_id, 'dismissed' );
-        wp_send_json_success();
-    }
+		$this->update_status( $post_id, $target_id, 'dismissed' );
+		wp_send_json_success();
+	}
 
-    /**
-     * AJAX: Mark a link as inserted.
-     */
-    public function ajax_insert(): void {
-        check_ajax_referer( 'swps_internal_links', 'nonce' );
+	/**
+	 * AJAX: Mark a link as inserted.
+	 */
+	public function ajax_insert(): void {
+		check_ajax_referer( 'swps_internal_links', 'nonce' );
 
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $post_id     = absint( $_POST['post_id'] ?? 0 );
-        $target_id   = absint( $_POST['target_id'] ?? 0 );
-        $anchor_text = sanitize_text_field( $_POST['anchor_text'] ?? '' );
+		$post_id     = absint( $_POST['post_id'] ?? 0 );
+		$target_id   = absint( $_POST['target_id'] ?? 0 );
+		$anchor_text = sanitize_text_field( $_POST['anchor_text'] ?? '' );
 
-        if ( ! $post_id || ! $target_id ) {
-            wp_send_json_error( [ 'message' => 'Invalid IDs.' ] );
-        }
+		if ( ! $post_id || ! $target_id ) {
+			wp_send_json_error( array( 'message' => 'Invalid IDs.' ) );
+		}
 
-        $this->upsert_link( [
-            'source_post_id' => $post_id,
-            'target_post_id' => $target_id,
-            'status'         => 'inserted',
-            'anchor_text'    => $anchor_text,
-        ] );
+		$this->upsert_link(
+			array(
+				'source_post_id' => $post_id,
+				'target_post_id' => $target_id,
+				'status'         => 'inserted',
+				'anchor_text'    => $anchor_text,
+			)
+		);
 
-        wp_send_json_success();
-    }
+		wp_send_json_success();
+	}
 
-    /**
-     * AJAX: Run AI deep analysis for a post's suggestions.
-     */
-    public function ajax_deep_analysis(): void {
-        check_ajax_referer( 'swps_internal_links', 'nonce' );
+	/**
+	 * AJAX: Run AI deep analysis for a post's suggestions.
+	 */
+	public function ajax_deep_analysis(): void {
+		check_ajax_referer( 'swps_internal_links', 'nonce' );
 
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $post_id = absint( $_POST['post_id'] ?? 0 );
-        if ( ! $post_id ) {
-            wp_send_json_error( [ 'message' => 'Invalid post ID.' ] );
-        }
+		$post_id = absint( $_POST['post_id'] ?? 0 );
+		if ( ! $post_id ) {
+			wp_send_json_error( array( 'message' => 'Invalid post ID.' ) );
+		}
 
-        // Get current keyword-matched suggestions.
-        $suggested = $this->get_links( $post_id, 'suggested' );
-        if ( empty( $suggested ) ) {
-            wp_send_json_error( [ 'message' => 'No suggestions to analyze.' ] );
-        }
+		// Get current keyword-matched suggestions.
+		$suggested = $this->get_links( $post_id, 'suggested' );
+		if ( empty( $suggested ) ) {
+			wp_send_json_error( array( 'message' => 'No suggestions to analyze.' ) );
+		}
 
-        $candidates = array_map( fn( $link ) => [
-            'post_id' => (int) $link['target_post_id'],
-            'score'   => (float) $link['relevance_score'],
-        ], $suggested );
+		$candidates = array_map(
+			fn( $link ) => array(
+				'post_id' => (int) $link['target_post_id'],
+				'score'   => (float) $link['relevance_score'],
+			),
+			$suggested
+		);
 
-        $result = $this->ai_engine->analyze( $post_id, $candidates );
+		$result = $this->ai_engine->analyze( $post_id, $candidates );
 
-        if ( is_wp_error( $result ) ) {
-            wp_send_json_error( [ 'message' => $result->get_error_message() ] );
-        }
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+		}
 
-        // Update graph with AI results.
-        foreach ( $result as $enriched ) {
-            $this->upsert_link( [
-                'source_post_id'  => $post_id,
-                'target_post_id'  => $enriched['post_id'],
-                'relevance_score' => $enriched['relevance_score'],
-                'anchor_text'     => $enriched['anchor_text'],
-                'anchor_context'  => $enriched['rationale'],
-                'ai_enriched'     => 1,
-                'match_type'      => 'ai',
-            ] );
-        }
+		// Update graph with AI results.
+		foreach ( $result as $enriched ) {
+			$this->upsert_link(
+				array(
+					'source_post_id'  => $post_id,
+					'target_post_id'  => $enriched['post_id'],
+					'relevance_score' => $enriched['relevance_score'],
+					'anchor_text'     => $enriched['anchor_text'],
+					'anchor_context'  => $enriched['rationale'],
+					'ai_enriched'     => 1,
+					'match_type'      => 'ai',
+				)
+			);
+		}
 
-        // Return updated suggestions.
-        $updated = $this->get_links( $post_id, 'suggested' );
-        wp_send_json_success( [ 'suggestions' => $updated ] );
-    }
+		// Return updated suggestions.
+		$updated = $this->get_links( $post_id, 'suggested' );
+		wp_send_json_success( array( 'suggestions' => $updated ) );
+	}
 
-    // -------------------------------------------------------------------------
-    // Admin Assets
-    // -------------------------------------------------------------------------
+	// -------------------------------------------------------------------------
+	// Admin Assets
+	// -------------------------------------------------------------------------
 
-    /**
-     * Enqueue metabox JS on post edit screens.
-     */
-    public function enqueue_assets( string $hook ): void {
-        if ( ! in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
-            return;
-        }
+	/**
+	 * Enqueue metabox JS on post edit screens.
+	 */
+	public function enqueue_assets( string $hook ): void {
+		if ( ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
+			return;
+		}
 
-        $screen = get_current_screen();
-        if ( ! $screen ) {
-            return;
-        }
+		$screen = get_current_screen();
+		if ( ! $screen ) {
+			return;
+		}
 
-        $post_types = (array) get_option( 'swps_internal_links_post_types', [ 'post', 'page' ] );
-        if ( ! in_array( $screen->post_type, $post_types, true ) ) {
-            return;
-        }
+		$post_types = (array) get_option( 'swps_internal_links_post_types', array( 'post', 'page' ) );
+		if ( ! in_array( $screen->post_type, $post_types, true ) ) {
+			return;
+		}
 
-        wp_enqueue_script(
-            'swps-internal-links',
-            SWPS_PLUGIN_URL . 'admin/js/internal-links.js',
-            [ 'jquery' ],
-            SWPS_VERSION,
-            true
-        );
+		wp_enqueue_script(
+			'swps-internal-links',
+			SWPS_PLUGIN_URL . 'admin/js/internal-links.js',
+			array( 'jquery' ),
+			SWPS_VERSION,
+			true
+		);
 
-        wp_localize_script( 'swps-internal-links', 'swpsInternalLinks', [
-            'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-            'nonce'   => wp_create_nonce( 'swps_internal_links' ),
-            'i18n'    => [
-                'inserting'  => __( 'Inserting...', 'stratawp-seo' ),
-                'analyzing'  => __( 'Running AI analysis...', 'stratawp-seo' ),
-                'done'       => __( 'Done!', 'stratawp-seo' ),
-                'error'      => __( 'Error occurred.', 'stratawp-seo' ),
-                'noProvider' => __( 'Configure an AI provider in Settings to use Deep Analysis.', 'stratawp-seo' ),
-            ],
-        ] );
-    }
+		wp_localize_script(
+			'swps-internal-links',
+			'swpsInternalLinks',
+			array(
+				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'nonce'   => wp_create_nonce( 'swps_internal_links' ),
+				'i18n'    => array(
+					'inserting'  => __( 'Inserting...', 'stratawp-seo' ),
+					'analyzing'  => __( 'Running AI analysis...', 'stratawp-seo' ),
+					'done'       => __( 'Done!', 'stratawp-seo' ),
+					'error'      => __( 'Error occurred.', 'stratawp-seo' ),
+					'noProvider' => __( 'Configure an AI provider in Settings to use Deep Analysis.', 'stratawp-seo' ),
+				),
+			)
+		);
+	}
 }

--- a/includes/class-keyword-tracker.php
+++ b/includes/class-keyword-tracker.php
@@ -18,7 +18,7 @@ class SWPS_Keyword_Tracker {
 
 	public function __construct( SWPS_Search_Console $search_console ) {
 		$this->search_console = $search_console;
-		add_action( self::CRON_HOOK, [ $this, 'sync_from_gsc' ] );
+		add_action( self::CRON_HOOK, array( $this, 'sync_from_gsc' ) );
 	}
 
 	/**
@@ -92,16 +92,18 @@ class SWPS_Keyword_Tracker {
 		}
 
 		// Check if already tracked.
-		$exists = $wpdb->get_var( $wpdb->prepare(
-			"SELECT COUNT(*) FROM {$wpdb->prefix}" . self::TABLE . " WHERE keyword = %s LIMIT 1",
-			$keyword
-		) );
+		$exists = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->prefix}" . self::TABLE . ' WHERE keyword = %s LIMIT 1',
+				$keyword
+			)
+		);
 
 		if ( $exists ) {
 			return true; // Already tracking.
 		}
 
-		$data = [
+		$data    = array(
 			'keyword'     => $keyword,
 			'post_id'     => $post_id ?: null,
 			'position'    => null,
@@ -109,8 +111,8 @@ class SWPS_Keyword_Tracker {
 			'impressions' => 0,
 			'ctr'         => 0,
 			'date'        => gmdate( 'Y-m-d' ),
-		];
-		$formats = [ '%s', '%d', '%f', '%d', '%d', '%f', '%s' ];
+		);
+		$formats = array( '%s', '%d', '%f', '%d', '%d', '%f', '%s' );
 
 		return (bool) $wpdb->insert( $wpdb->prefix . self::TABLE, $data, $formats );
 	}
@@ -125,8 +127,8 @@ class SWPS_Keyword_Tracker {
 		global $wpdb;
 		return (bool) $wpdb->delete(
 			$wpdb->prefix . self::TABLE,
-			[ 'keyword' => sanitize_text_field( strtolower( trim( $keyword ) ) ) ],
-			[ '%s' ]
+			array( 'keyword' => sanitize_text_field( strtolower( trim( $keyword ) ) ) ),
+			array( '%s' )
 		);
 	}
 
@@ -141,10 +143,10 @@ class SWPS_Keyword_Tracker {
 		global $wpdb;
 		return (bool) $wpdb->update(
 			$wpdb->prefix . self::TABLE,
-			[ 'post_id' => $post_id ],
-			[ 'keyword' => sanitize_text_field( strtolower( trim( $keyword ) ) ) ],
-			[ '%d' ],
-			[ '%s' ]
+			array( 'post_id' => $post_id ),
+			array( 'keyword' => sanitize_text_field( strtolower( trim( $keyword ) ) ) ),
+			array( '%d' ),
+			array( '%s' )
 		);
 	}
 
@@ -160,8 +162,9 @@ class SWPS_Keyword_Tracker {
 		$table = $wpdb->prefix . self::TABLE;
 
 		// Get the most recent row per keyword.
-		$results = $wpdb->get_results( $wpdb->prepare(
-			"SELECT t1.*
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT t1.*
 			 FROM {$table} t1
 			 INNER JOIN (
 				 SELECT keyword, MAX(date) as max_date
@@ -170,10 +173,12 @@ class SWPS_Keyword_Tracker {
 			 ) t2 ON t1.keyword = t2.keyword AND t1.date = t2.max_date
 			 ORDER BY t1.impressions DESC
 			 LIMIT %d",
-			$limit
-		), ARRAY_A );
+				$limit
+			),
+			ARRAY_A
+		);
 
-		return $results ?: [];
+		return $results ?: array();
 	}
 
 	/**
@@ -189,16 +194,19 @@ class SWPS_Keyword_Tracker {
 		$table = $wpdb->prefix . self::TABLE;
 		$since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
 
-		$results = $wpdb->get_results( $wpdb->prepare(
-			"SELECT date, position, clicks, impressions, ctr
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT date, position, clicks, impressions, ctr
 			 FROM {$table}
 			 WHERE keyword = %s AND date >= %s
 			 ORDER BY date ASC",
-			sanitize_text_field( strtolower( trim( $keyword ) ) ),
-			$since
-		), ARRAY_A );
+				sanitize_text_field( strtolower( trim( $keyword ) ) ),
+				$since
+			),
+			ARRAY_A
+		);
 
-		return $results ?: [];
+		return $results ?: array();
 	}
 
 	/**
@@ -212,8 +220,9 @@ class SWPS_Keyword_Tracker {
 
 		$table = $wpdb->prefix . self::TABLE;
 
-		$results = $wpdb->get_results( $wpdb->prepare(
-			"SELECT t1.*
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT t1.*
 			 FROM {$table} t1
 			 INNER JOIN (
 				 SELECT keyword, MAX(date) as max_date
@@ -224,10 +233,12 @@ class SWPS_Keyword_Tracker {
 			 AND t1.impressions > 0
 			 ORDER BY t1.impressions DESC
 			 LIMIT %d",
-			$limit
-		), ARRAY_A );
+				$limit
+			),
+			ARRAY_A
+		);
 
-		return $results ?: [];
+		return $results ?: array();
 	}
 
 	/**
@@ -245,10 +256,10 @@ class SWPS_Keyword_Tracker {
 		}
 
 		// Pull GSC query data for the last 7 days.
-		$gsc_data = $this->search_console->get_search_data( 7 );
-		$gsc_queries = [];
+		$gsc_data    = $this->search_console->get_search_data( 7 );
+		$gsc_queries = array();
 
-		foreach ( $gsc_data['queries'] ?? [] as $row ) {
+		foreach ( $gsc_data['queries'] ?? array() as $row ) {
 			$query = strtolower( $row['keys'][0] ?? '' );
 			if ( $query ) {
 				$gsc_queries[ $query ] = $row;
@@ -267,7 +278,7 @@ class SWPS_Keyword_Tracker {
 
 			$wpdb->replace(
 				$table,
-				[
+				array(
 					'keyword'     => $keyword,
 					'post_id'     => $this->find_post_for_keyword( $keyword, $tracked ),
 					'position'    => $gsc_row ? round( $gsc_row['position'] ?? 0, 1 ) : null,
@@ -275,8 +286,8 @@ class SWPS_Keyword_Tracker {
 					'impressions' => $gsc_row['impressions'] ?? 0,
 					'ctr'         => $gsc_row ? round( ( $gsc_row['ctr'] ?? 0 ) * 100, 1 ) : 0,
 					'date'        => $today,
-				],
-				[ '%s', '%d', '%f', '%d', '%d', '%f', '%s' ]
+				),
+				array( '%s', '%d', '%f', '%d', '%d', '%f', '%s' )
 			);
 		}
 	}
@@ -302,7 +313,7 @@ class SWPS_Keyword_Tracker {
 			. "- difficulty: low, medium, or high (estimate)\n"
 			. "- suggested_title: a blog post title targeting this keyword\n\n"
 			. "Return JSON array only. No markdown, no explanation.\n"
-			. "Example: [{\"keyword\":\"best running shoes\",\"intent\":\"transactional\",\"difficulty\":\"high\",\"suggested_title\":\"10 Best Running Shoes for Every Budget in 2026\"}]",
+			. 'Example: [{"keyword":"best running shoes","intent":"transactional","difficulty":"high","suggested_title":"10 Best Running Shoes for Every Budget in 2026"}]',
 			$niche,
 			$desc,
 			$seed_topic
@@ -317,7 +328,7 @@ class SWPS_Keyword_Tracker {
 		$text = $response;
 
 		// Extract JSON from response.
-		$json_match = [];
+		$json_match = array();
 		if ( preg_match( '/\[.*\]/s', $text, $json_match ) ) {
 			$suggestions = json_decode( $json_match[0], true );
 			if ( is_array( $suggestions ) ) {

--- a/includes/class-keywords-page.php
+++ b/includes/class-keywords-page.php
@@ -6,168 +6,168 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Keywords_Page {
 
-    private SWPS_Keyword_Tracker $tracker;
+	private SWPS_Keyword_Tracker $tracker;
 
-    public function __construct( SWPS_Keyword_Tracker $tracker ) {
-        $this->tracker = $tracker;
+	public function __construct( SWPS_Keyword_Tracker $tracker ) {
+		$this->tracker = $tracker;
 
-        // Register after parent menu (priority 20).
-        add_action( 'admin_menu', [ $this, 'register_menu' ], 20 );
+		// Register after parent menu (priority 20).
+		add_action( 'admin_menu', array( $this, 'register_menu' ), 20 );
 
-        // AJAX endpoints.
-        add_action( 'wp_ajax_swps_suggest_keywords', [ $this, 'ajax_suggest' ] );
-        add_action( 'wp_ajax_swps_track_keyword', [ $this, 'ajax_track' ] );
-        add_action( 'wp_ajax_swps_untrack_keyword', [ $this, 'ajax_untrack' ] );
-        add_action( 'wp_ajax_swps_link_keyword', [ $this, 'ajax_link' ] );
-        add_action( 'wp_ajax_swps_keyword_history', [ $this, 'ajax_history' ] );
-        add_action( 'wp_ajax_swps_get_keywords', [ $this, 'ajax_get_keywords' ] );
-        add_action( 'wp_ajax_swps_get_opportunities', [ $this, 'ajax_get_opportunities' ] );
-    }
+		// AJAX endpoints.
+		add_action( 'wp_ajax_swps_suggest_keywords', array( $this, 'ajax_suggest' ) );
+		add_action( 'wp_ajax_swps_track_keyword', array( $this, 'ajax_track' ) );
+		add_action( 'wp_ajax_swps_untrack_keyword', array( $this, 'ajax_untrack' ) );
+		add_action( 'wp_ajax_swps_link_keyword', array( $this, 'ajax_link' ) );
+		add_action( 'wp_ajax_swps_keyword_history', array( $this, 'ajax_history' ) );
+		add_action( 'wp_ajax_swps_get_keywords', array( $this, 'ajax_get_keywords' ) );
+		add_action( 'wp_ajax_swps_get_opportunities', array( $this, 'ajax_get_opportunities' ) );
+	}
 
-    public function register_menu(): void {
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Keywords', 'stratawp-seo' ),
-            __( 'Keywords', 'stratawp-seo' ),
-            'manage_options',
-            'swps-keywords',
-            [ $this, 'render_page' ]
-        );
-    }
+	public function register_menu(): void {
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Keywords', 'stratawp-seo' ),
+			__( 'Keywords', 'stratawp-seo' ),
+			'manage_options',
+			'swps-keywords',
+			array( $this, 'render_page' )
+		);
+	}
 
-    public function render_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            return;
-        }
-        $gsc_connected = stratawp_seo()->search_console->is_connected();
-        include SWPS_PLUGIN_DIR . 'templates/keywords-page.php';
-    }
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		$gsc_connected = stratawp_seo()->search_console->is_connected();
+		include SWPS_PLUGIN_DIR . 'templates/keywords-page.php';
+	}
 
-    public function ajax_suggest(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+	public function ajax_suggest(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $seed = sanitize_text_field( $_POST['seed_topic'] ?? '' );
-        if ( empty( $seed ) ) {
-            wp_send_json_error( [ 'message' => 'Please enter a seed topic.' ] );
-        }
+		$seed = sanitize_text_field( $_POST['seed_topic'] ?? '' );
+		if ( empty( $seed ) ) {
+			wp_send_json_error( array( 'message' => 'Please enter a seed topic.' ) );
+		}
 
-        $suggestions = $this->tracker->suggest_keywords( $seed );
-        if ( is_wp_error( $suggestions ) ) {
-            wp_send_json_error( [ 'message' => $suggestions->get_error_message() ] );
-        }
+		$suggestions = $this->tracker->suggest_keywords( $seed );
+		if ( is_wp_error( $suggestions ) ) {
+			wp_send_json_error( array( 'message' => $suggestions->get_error_message() ) );
+		}
 
-        wp_send_json_success( $suggestions );
-    }
+		wp_send_json_success( $suggestions );
+	}
 
-    public function ajax_track(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+	public function ajax_track(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
-        $post_id = absint( $_POST['post_id'] ?? 0 );
+		$keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
+		$post_id = absint( $_POST['post_id'] ?? 0 );
 
-        if ( empty( $keyword ) ) {
-            wp_send_json_error( [ 'message' => 'Keyword is required.' ] );
-        }
+		if ( empty( $keyword ) ) {
+			wp_send_json_error( array( 'message' => 'Keyword is required.' ) );
+		}
 
-        $this->tracker->track_keyword( $keyword, $post_id );
-        wp_send_json_success();
-    }
+		$this->tracker->track_keyword( $keyword, $post_id );
+		wp_send_json_success();
+	}
 
-    public function ajax_untrack(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+	public function ajax_untrack(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
-        if ( empty( $keyword ) ) {
-            wp_send_json_error( [ 'message' => 'Keyword is required.' ] );
-        }
-        $this->tracker->untrack_keyword( $keyword );
-        wp_send_json_success();
-    }
+		$keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
+		if ( empty( $keyword ) ) {
+			wp_send_json_error( array( 'message' => 'Keyword is required.' ) );
+		}
+		$this->tracker->untrack_keyword( $keyword );
+		wp_send_json_success();
+	}
 
-    public function ajax_link(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+	public function ajax_link(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
-        $post_id = absint( $_POST['post_id'] ?? 0 );
-        if ( empty( $keyword ) || ! $post_id ) {
-            wp_send_json_error( [ 'message' => 'Keyword and post ID are required.' ] );
-        }
-        $this->tracker->link_to_post( $keyword, $post_id );
-        wp_send_json_success();
-    }
+		$keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
+		$post_id = absint( $_POST['post_id'] ?? 0 );
+		if ( empty( $keyword ) || ! $post_id ) {
+			wp_send_json_error( array( 'message' => 'Keyword and post ID are required.' ) );
+		}
+		$this->tracker->link_to_post( $keyword, $post_id );
+		wp_send_json_success();
+	}
 
-    public function ajax_history(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+	public function ajax_history(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
-        if ( empty( $keyword ) ) {
-            wp_send_json_error( [ 'message' => 'Keyword is required.' ] );
-        }
-        $days    = max( 7, absint( $_POST['days'] ?? 90 ) );
-        $history = $this->tracker->get_keyword_history( $keyword, $days );
-        wp_send_json_success( $history );
-    }
+		$keyword = sanitize_text_field( $_POST['keyword'] ?? '' );
+		if ( empty( $keyword ) ) {
+			wp_send_json_error( array( 'message' => 'Keyword is required.' ) );
+		}
+		$days    = max( 7, absint( $_POST['days'] ?? 90 ) );
+		$history = $this->tracker->get_keyword_history( $keyword, $days );
+		wp_send_json_success( $history );
+	}
 
-    public function ajax_get_keywords(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+	public function ajax_get_keywords(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $keywords = $this->tracker->get_tracked_keywords();
+		$keywords = $this->tracker->get_tracked_keywords();
 
-        // Enrich with post titles.
-        foreach ( $keywords as &$kw ) {
-            $kw['post_title'] = '';
-            $kw['post_url']   = '';
-            if ( ! empty( $kw['post_id'] ) ) {
-                $post = get_post( (int) $kw['post_id'] );
-                $kw['post_title'] = $post ? $post->post_title : '';
-                $kw['post_url']   = $post ? get_edit_post_link( $post->ID, 'raw' ) : '';
-            }
-        }
-        unset( $kw );
+		// Enrich with post titles.
+		foreach ( $keywords as &$kw ) {
+			$kw['post_title'] = '';
+			$kw['post_url']   = '';
+			if ( ! empty( $kw['post_id'] ) ) {
+				$post             = get_post( (int) $kw['post_id'] );
+				$kw['post_title'] = $post ? $post->post_title : '';
+				$kw['post_url']   = $post ? get_edit_post_link( $post->ID, 'raw' ) : '';
+			}
+		}
+		unset( $kw );
 
-        wp_send_json_success( $keywords );
-    }
+		wp_send_json_success( $keywords );
+	}
 
-    public function ajax_get_opportunities(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+	public function ajax_get_opportunities(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $opportunities = $this->tracker->get_opportunities();
+		$opportunities = $this->tracker->get_opportunities();
 
-        foreach ( $opportunities as &$opp ) {
-            $opp['post_title'] = '';
-            if ( ! empty( $opp['post_id'] ) ) {
-                $post = get_post( (int) $opp['post_id'] );
-                $opp['post_title'] = $post ? $post->post_title : '';
-            }
-        }
-        unset( $opp );
+		foreach ( $opportunities as &$opp ) {
+			$opp['post_title'] = '';
+			if ( ! empty( $opp['post_id'] ) ) {
+				$post              = get_post( (int) $opp['post_id'] );
+				$opp['post_title'] = $post ? $post->post_title : '';
+			}
+		}
+		unset( $opp );
 
-        wp_send_json_success( $opportunities );
-    }
+		wp_send_json_success( $opportunities );
+	}
 }

--- a/includes/class-link-ai-engine.php
+++ b/includes/class-link-ai-engine.php
@@ -38,24 +38,24 @@ class SWPS_Link_AI_Engine {
 		$batch_size = (int) get_option( 'swps_link_ai_batch_size', 10 );
 		$candidates = array_slice( $candidates, 0, $batch_size );
 
-		$candidate_data = [];
+		$candidate_data = array();
 		foreach ( $candidates as $candidate ) {
 			$post = get_post( $candidate['post_id'] );
 			if ( ! $post ) {
 				continue;
 			}
 			$focus_kw         = get_post_meta( $post->ID, '_swps_focus_keyword', true );
-			$candidate_data[] = [
+			$candidate_data[] = array(
 				'post_id'       => $post->ID,
 				'title'         => $post->post_title,
 				'excerpt'       => wp_trim_words( wp_strip_all_tags( $post->post_content ), 50 ),
 				'url'           => get_permalink( $post->ID ),
 				'focus_keyword' => $focus_kw ?: '',
-			];
+			);
 		}
 
 		if ( empty( $candidate_data ) ) {
-			return [];
+			return array();
 		}
 
 		$source_focus_kw = get_post_meta( $source_post_id, '_swps_focus_keyword', true );
@@ -83,10 +83,10 @@ PROMPT;
 
 		$user_prompt  = "SOURCE POST:\n";
 		$user_prompt .= "Title: {$source_post->post_title}\n";
-		$user_prompt .= "Focus Keyword: " . ( $source_focus_kw ?: 'none' ) . "\n";
-		$user_prompt .= "Excerpt: " . wp_trim_words( wp_strip_all_tags( $source_post->post_content ), 80 ) . "\n\n";
+		$user_prompt .= 'Focus Keyword: ' . ( $source_focus_kw ?: 'none' ) . "\n";
+		$user_prompt .= 'Excerpt: ' . wp_trim_words( wp_strip_all_tags( $source_post->post_content ), 80 ) . "\n\n";
 		$user_prompt .= "CANDIDATE TARGET POSTS:\n{$candidates_json}\n\n";
-		$user_prompt .= "Analyze each candidate and respond with the JSON array.";
+		$user_prompt .= 'Analyze each candidate and respond with the JSON array.';
 
 		$result = $this->api->chat_json( $system_prompt, $user_prompt, 2048 );
 
@@ -114,17 +114,17 @@ PROMPT;
 			$analysis = $result['candidates'];
 		}
 
-		$enriched = [];
+		$enriched = array();
 		foreach ( $analysis as $item ) {
 			if ( ! isset( $item['post_id'], $item['relevance_score'] ) ) {
 				continue;
 			}
-			$enriched[] = [
+			$enriched[] = array(
 				'post_id'         => (int) $item['post_id'],
 				'relevance_score' => max( 0.0, min( 1.0, (float) $item['relevance_score'] ) ),
 				'anchor_text'     => sanitize_text_field( $item['anchor_text'] ?? '' ),
 				'rationale'       => sanitize_text_field( $item['rationale'] ?? '' ),
-			];
+			);
 		}
 
 		return $enriched;

--- a/includes/class-link-keyword-engine.php
+++ b/includes/class-link-keyword-engine.php
@@ -9,42 +9,141 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Link_Keyword_Engine {
 
-    private const TABLE = 'swps_link_index';
+	private const TABLE = 'swps_link_index';
 
-    private const WEIGHTS = [
-        'title'    => 1.0,
-        'focus_kw' => 0.9,
-        'h2'       => 0.8,
-        'h3'       => 0.6,
-        'body'     => 0.3,
-    ];
+	private const WEIGHTS = array(
+		'title'    => 1.0,
+		'focus_kw' => 0.9,
+		'h2'       => 0.8,
+		'h3'       => 0.6,
+		'body'     => 0.3,
+	);
 
-    private const STOP_WORDS = [
-        'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
-        'of', 'with', 'by', 'from', 'is', 'are', 'was', 'were', 'be', 'been',
-        'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would',
-        'could', 'should', 'may', 'might', 'shall', 'can', 'this', 'that',
-        'these', 'those', 'it', 'its', 'not', 'no', 'nor', 'so', 'if', 'then',
-        'than', 'too', 'very', 'just', 'about', 'above', 'after', 'again',
-        'all', 'also', 'am', 'as', 'because', 'before', 'between', 'both',
-        'each', 'few', 'get', 'got', 'he', 'her', 'here', 'him', 'his', 'how',
-        'i', 'into', 'me', 'more', 'most', 'my', 'new', 'now', 'only', 'other',
-        'our', 'out', 'over', 'own', 'same', 'she', 'some', 'such', 'their',
-        'them', 'there', 'they', 'through', 'under', 'up', 'us', 'use', 'what',
-        'when', 'where', 'which', 'while', 'who', 'whom', 'why', 'you', 'your',
-    ];
+	private const STOP_WORDS = array(
+		'the',
+		'a',
+		'an',
+		'and',
+		'or',
+		'but',
+		'in',
+		'on',
+		'at',
+		'to',
+		'for',
+		'of',
+		'with',
+		'by',
+		'from',
+		'is',
+		'are',
+		'was',
+		'were',
+		'be',
+		'been',
+		'being',
+		'have',
+		'has',
+		'had',
+		'do',
+		'does',
+		'did',
+		'will',
+		'would',
+		'could',
+		'should',
+		'may',
+		'might',
+		'shall',
+		'can',
+		'this',
+		'that',
+		'these',
+		'those',
+		'it',
+		'its',
+		'not',
+		'no',
+		'nor',
+		'so',
+		'if',
+		'then',
+		'than',
+		'too',
+		'very',
+		'just',
+		'about',
+		'above',
+		'after',
+		'again',
+		'all',
+		'also',
+		'am',
+		'as',
+		'because',
+		'before',
+		'between',
+		'both',
+		'each',
+		'few',
+		'get',
+		'got',
+		'he',
+		'her',
+		'here',
+		'him',
+		'his',
+		'how',
+		'i',
+		'into',
+		'me',
+		'more',
+		'most',
+		'my',
+		'new',
+		'now',
+		'only',
+		'other',
+		'our',
+		'out',
+		'over',
+		'own',
+		'same',
+		'she',
+		'some',
+		'such',
+		'their',
+		'them',
+		'there',
+		'they',
+		'through',
+		'under',
+		'up',
+		'us',
+		'use',
+		'what',
+		'when',
+		'where',
+		'which',
+		'while',
+		'who',
+		'whom',
+		'why',
+		'you',
+		'your',
+	);
 
-    public static function create_tables(): void {
-        global $wpdb;
-        $charset = $wpdb->get_charset_collate();
-        $table   = $wpdb->prefix . self::TABLE;
+	public static function create_tables(): void {
+		global $wpdb;
+		$charset = $wpdb->get_charset_collate();
+		$table   = $wpdb->prefix . self::TABLE;
 
-        $sql = "CREATE TABLE {$table} (
+		$sql = "CREATE TABLE {$table} (
             id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
             post_id BIGINT UNSIGNED NOT NULL,
             term VARCHAR(100) NOT NULL,
@@ -57,190 +156,218 @@ class SWPS_Link_Keyword_Engine {
             KEY idx_term_weight (term, weight)
         ) {$charset};";
 
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        dbDelta( $sql );
-    }
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
 
-    public function index_post( int $post_id ): void {
-        $post = get_post( $post_id );
-        if ( ! $post || 'publish' !== $post->post_status ) {
-            $this->clear_post( $post_id );
-            return;
-        }
-        $terms = $this->extract_terms( $post );
-        $this->clear_post( $post_id );
-        $this->store_terms( $post_id, $terms );
-    }
+	public function index_post( int $post_id ): void {
+		$post = get_post( $post_id );
+		if ( ! $post || 'publish' !== $post->post_status ) {
+			$this->clear_post( $post_id );
+			return;
+		}
+		$terms = $this->extract_terms( $post );
+		$this->clear_post( $post_id );
+		$this->store_terms( $post_id, $terms );
+	}
 
-    public function clear_post( int $post_id ): void {
-        global $wpdb;
-        $table = $wpdb->prefix . self::TABLE;
-        $wpdb->delete( $table, [ 'post_id' => $post_id ], [ '%d' ] );
-    }
+	public function clear_post( int $post_id ): void {
+		global $wpdb;
+		$table = $wpdb->prefix . self::TABLE;
+		$wpdb->delete( $table, array( 'post_id' => $post_id ), array( '%d' ) );
+	}
 
-    public function extract_terms( WP_Post $post ): array {
-        $terms = [];
+	public function extract_terms( WP_Post $post ): array {
+		$terms = array();
 
-        $title_terms = $this->tokenize( $post->post_title );
-        foreach ( $title_terms as $term ) {
-            $terms[] = [ 'term' => $term, 'source' => 'title', 'weight' => self::WEIGHTS['title'] ];
-        }
+		$title_terms = $this->tokenize( $post->post_title );
+		foreach ( $title_terms as $term ) {
+			$terms[] = array(
+				'term'   => $term,
+				'source' => 'title',
+				'weight' => self::WEIGHTS['title'],
+			);
+		}
 
-        $focus_kw = get_post_meta( $post->ID, '_swps_focus_keyword', true );
-        if ( ! empty( $focus_kw ) ) {
-            $normalized = $this->normalize( $focus_kw );
-            if ( strlen( $normalized ) >= 3 ) {
-                $terms[] = [ 'term' => $normalized, 'source' => 'focus_kw', 'weight' => self::WEIGHTS['focus_kw'] ];
-            }
-        }
+		$focus_kw = get_post_meta( $post->ID, '_swps_focus_keyword', true );
+		if ( ! empty( $focus_kw ) ) {
+			$normalized = $this->normalize( $focus_kw );
+			if ( strlen( $normalized ) >= 3 ) {
+				$terms[] = array(
+					'term'   => $normalized,
+					'source' => 'focus_kw',
+					'weight' => self::WEIGHTS['focus_kw'],
+				);
+			}
+		}
 
-        $h2s = $this->extract_headings( $post->post_content, 'h2' );
-        foreach ( $h2s as $heading ) {
-            foreach ( $this->tokenize( $heading ) as $term ) {
-                $terms[] = [ 'term' => $term, 'source' => 'h2', 'weight' => self::WEIGHTS['h2'] ];
-            }
-        }
+		$h2s = $this->extract_headings( $post->post_content, 'h2' );
+		foreach ( $h2s as $heading ) {
+			foreach ( $this->tokenize( $heading ) as $term ) {
+				$terms[] = array(
+					'term'   => $term,
+					'source' => 'h2',
+					'weight' => self::WEIGHTS['h2'],
+				);
+			}
+		}
 
-        $h3s = $this->extract_headings( $post->post_content, 'h3' );
-        foreach ( $h3s as $heading ) {
-            foreach ( $this->tokenize( $heading ) as $term ) {
-                $terms[] = [ 'term' => $term, 'source' => 'h3', 'weight' => self::WEIGHTS['h3'] ];
-            }
-        }
+		$h3s = $this->extract_headings( $post->post_content, 'h3' );
+		foreach ( $h3s as $heading ) {
+			foreach ( $this->tokenize( $heading ) as $term ) {
+				$terms[] = array(
+					'term'   => $term,
+					'source' => 'h3',
+					'weight' => self::WEIGHTS['h3'],
+				);
+			}
+		}
 
-        $plain = wp_strip_all_tags( $post->post_content );
-        $body_terms = $this->extract_top_body_terms( $plain, 10 );
-        foreach ( $body_terms as $term ) {
-            $terms[] = [ 'term' => $term, 'source' => 'body', 'weight' => self::WEIGHTS['body'] ];
-        }
+		$plain      = wp_strip_all_tags( $post->post_content );
+		$body_terms = $this->extract_top_body_terms( $plain, 10 );
+		foreach ( $body_terms as $term ) {
+			$terms[] = array(
+				'term'   => $term,
+				'source' => 'body',
+				'weight' => self::WEIGHTS['body'],
+			);
+		}
 
-        $unique = [];
-        foreach ( $terms as $entry ) {
-            $key = $entry['term'];
-            if ( ! isset( $unique[ $key ] ) || $entry['weight'] > $unique[ $key ]['weight'] ) {
-                $unique[ $key ] = $entry;
-            }
-        }
+		$unique = array();
+		foreach ( $terms as $entry ) {
+			$key = $entry['term'];
+			if ( ! isset( $unique[ $key ] ) || $entry['weight'] > $unique[ $key ]['weight'] ) {
+				$unique[ $key ] = $entry;
+			}
+		}
 
-        return array_values( $unique );
-    }
+		return array_values( $unique );
+	}
 
-    public function find_related( int $post_id, float $threshold = 0.3, int $limit = 20 ): array {
-        global $wpdb;
-        $table = $wpdb->prefix . self::TABLE;
+	public function find_related( int $post_id, float $threshold = 0.3, int $limit = 20 ): array {
+		global $wpdb;
+		$table = $wpdb->prefix . self::TABLE;
 
-        $source_terms = $wpdb->get_results(
-            $wpdb->prepare( "SELECT term, weight FROM {$table} WHERE post_id = %d", $post_id ),
-            ARRAY_A
-        );
+		$source_terms = $wpdb->get_results(
+			$wpdb->prepare( "SELECT term, weight FROM {$table} WHERE post_id = %d", $post_id ),
+			ARRAY_A
+		);
 
-        if ( empty( $source_terms ) ) {
-            return [];
-        }
+		if ( empty( $source_terms ) ) {
+			return array();
+		}
 
-        $term_weights = [];
-        foreach ( $source_terms as $row ) {
-            $term_weights[ $row['term'] ] = (float) $row['weight'];
-        }
+		$term_weights = array();
+		foreach ( $source_terms as $row ) {
+			$term_weights[ $row['term'] ] = (float) $row['weight'];
+		}
 
-        $placeholders = implode( ',', array_fill( 0, count( $term_weights ), '%s' ) );
-        $term_values  = array_keys( $term_weights );
+		$placeholders = implode( ',', array_fill( 0, count( $term_weights ), '%s' ) );
+		$term_values  = array_keys( $term_weights );
 
-        $matches = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT post_id, term, weight FROM {$table} WHERE term IN ({$placeholders}) AND post_id != %d",
-                array_merge( $term_values, [ $post_id ] )
-            ),
-            ARRAY_A
-        );
+		$matches = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_id, term, weight FROM {$table} WHERE term IN ({$placeholders}) AND post_id != %d",
+				array_merge( $term_values, array( $post_id ) )
+			),
+			ARRAY_A
+		);
 
-        if ( empty( $matches ) ) {
-            return [];
-        }
+		if ( empty( $matches ) ) {
+			return array();
+		}
 
-        $scores = [];
-        foreach ( $matches as $row ) {
-            $pid = (int) $row['post_id'];
-            if ( ! isset( $scores[ $pid ] ) ) {
-                $scores[ $pid ] = 0.0;
-            }
-            $scores[ $pid ] += $term_weights[ $row['term'] ] * (float) $row['weight'];
-        }
+		$scores = array();
+		foreach ( $matches as $row ) {
+			$pid = (int) $row['post_id'];
+			if ( ! isset( $scores[ $pid ] ) ) {
+				$scores[ $pid ] = 0.0;
+			}
+			$scores[ $pid ] += $term_weights[ $row['term'] ] * (float) $row['weight'];
+		}
 
-        $max_score = max( $scores );
-        if ( $max_score > 0 ) {
-            foreach ( $scores as &$score ) {
-                $score = round( $score / $max_score, 3 );
-            }
-            unset( $score );
-        }
+		$max_score = max( $scores );
+		if ( $max_score > 0 ) {
+			foreach ( $scores as &$score ) {
+				$score = round( $score / $max_score, 3 );
+			}
+			unset( $score );
+		}
 
-        $results = [];
-        foreach ( $scores as $pid => $score ) {
-            if ( $score >= $threshold ) {
-                $results[] = [ 'post_id' => $pid, 'score' => $score ];
-            }
-        }
+		$results = array();
+		foreach ( $scores as $pid => $score ) {
+			if ( $score >= $threshold ) {
+				$results[] = array(
+					'post_id' => $pid,
+					'score'   => $score,
+				);
+			}
+		}
 
-        usort( $results, fn( $a, $b ) => $b['score'] <=> $a['score'] );
-        return array_slice( $results, 0, $limit );
-    }
+		usort( $results, fn( $a, $b ) => $b['score'] <=> $a['score'] );
+		return array_slice( $results, 0, $limit );
+	}
 
-    public function tokenize_public( string $text ): array {
-        return $this->tokenize( $text );
-    }
+	public function tokenize_public( string $text ): array {
+		return $this->tokenize( $text );
+	}
 
-    private function store_terms( int $post_id, array $terms ): void {
-        global $wpdb;
-        $table = $wpdb->prefix . self::TABLE;
-        $now   = current_time( 'mysql' );
+	private function store_terms( int $post_id, array $terms ): void {
+		global $wpdb;
+		$table = $wpdb->prefix . self::TABLE;
+		$now   = current_time( 'mysql' );
 
-        foreach ( $terms as $entry ) {
-            $wpdb->insert(
-                $table,
-                [
-                    'post_id'    => $post_id,
-                    'term'       => mb_substr( $entry['term'], 0, 100 ),
-                    'source'     => $entry['source'],
-                    'weight'     => $entry['weight'],
-                    'updated_at' => $now,
-                ],
-                [ '%d', '%s', '%s', '%f', '%s' ]
-            );
-        }
-    }
+		foreach ( $terms as $entry ) {
+			$wpdb->insert(
+				$table,
+				array(
+					'post_id'    => $post_id,
+					'term'       => mb_substr( $entry['term'], 0, 100 ),
+					'source'     => $entry['source'],
+					'weight'     => $entry['weight'],
+					'updated_at' => $now,
+				),
+				array( '%d', '%s', '%s', '%f', '%s' )
+			);
+		}
+	}
 
-    private function extract_headings( string $html, string $tag ): array {
-        $headings = [];
-        if ( preg_match_all( "/<{$tag}[^>]*>(.*?)<\/{$tag}>/is", $html, $matches ) ) {
-            foreach ( $matches[1] as $heading ) {
-                $headings[] = wp_strip_all_tags( $heading );
-            }
-        }
-        return $headings;
-    }
+	private function extract_headings( string $html, string $tag ): array {
+		$headings = array();
+		if ( preg_match_all( "/<{$tag}[^>]*>(.*?)<\/{$tag}>/is", $html, $matches ) ) {
+			foreach ( $matches[1] as $heading ) {
+				$headings[] = wp_strip_all_tags( $heading );
+			}
+		}
+		return $headings;
+	}
 
-    private function extract_top_body_terms( string $plain_text, int $count = 10 ): array {
-        $words = $this->tokenize( $plain_text );
-        if ( empty( $words ) ) {
-            return [];
-        }
-        $freq = array_count_values( $words );
-        arsort( $freq );
-        return array_slice( array_keys( $freq ), 0, $count );
-    }
+	private function extract_top_body_terms( string $plain_text, int $count = 10 ): array {
+		$words = $this->tokenize( $plain_text );
+		if ( empty( $words ) ) {
+			return array();
+		}
+		$freq = array_count_values( $words );
+		arsort( $freq );
+		return array_slice( array_keys( $freq ), 0, $count );
+	}
 
-    private function tokenize( string $text ): array {
-        $normalized = $this->normalize( $text );
-        $words      = preg_split( '/\s+/', $normalized, -1, PREG_SPLIT_NO_EMPTY );
-        return array_values( array_filter( $words, function ( string $word ): bool {
-            return strlen( $word ) >= 3 && ! in_array( $word, self::STOP_WORDS, true );
-        } ) );
-    }
+	private function tokenize( string $text ): array {
+		$normalized = $this->normalize( $text );
+		$words      = preg_split( '/\s+/', $normalized, -1, PREG_SPLIT_NO_EMPTY );
+		return array_values(
+			array_filter(
+				$words,
+				function ( string $word ): bool {
+					return strlen( $word ) >= 3 && ! in_array( $word, self::STOP_WORDS, true );
+				}
+			)
+		);
+	}
 
-    private function normalize( string $text ): string {
-        $text = mb_strtolower( wp_strip_all_tags( $text ) );
-        $text = preg_replace( '/[^\p{L}\p{N}\s]/u', '', $text );
-        return trim( $text );
-    }
+	private function normalize( string $text ): string {
+		$text = mb_strtolower( wp_strip_all_tags( $text ) );
+		$text = preg_replace( '/[^\p{L}\p{N}\s]/u', '', $text );
+		return trim( $text );
+	}
 }

--- a/includes/class-local-seo.php
+++ b/includes/class-local-seo.php
@@ -12,354 +12,359 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Local_SEO {
 
-    public const OPTION_KEY = 'swps_local_seo';
+	public const OPTION_KEY = 'swps_local_seo';
 
-    /**
-     * Schema.org LocalBusiness sub-types we surface in the picker.
-     * Not exhaustive — covers the most common small-business cases.
-     */
-    public const BUSINESS_TYPES = [
-        'LocalBusiness'        => 'Local business (generic)',
-        'Restaurant'           => 'Restaurant',
-        'CafeOrCoffeeShop'     => 'Cafe / coffee shop',
-        'Bakery'               => 'Bakery',
-        'Store'                => 'Store / retail',
-        'ClothingStore'        => 'Clothing store',
-        'GroceryStore'         => 'Grocery store',
-        'Dentist'              => 'Dentist',
-        'MedicalClinic'        => 'Medical clinic',
-        'Physician'            => 'Physician',
-        'HealthAndBeautyBusiness' => 'Health & beauty',
-        'BeautySalon'          => 'Beauty salon',
-        'HairSalon'            => 'Hair salon',
-        'DaySpa'               => 'Day spa',
-        'AutoRepair'           => 'Auto repair',
-        'Plumber'              => 'Plumber',
-        'Electrician'          => 'Electrician',
-        'HVACBusiness'         => 'HVAC',
-        'RoofingContractor'    => 'Roofing contractor',
-        'GeneralContractor'    => 'General contractor',
-        'HomeAndConstructionBusiness' => 'Home & construction',
-        'RealEstateAgent'      => 'Real estate agent',
-        'LegalService'         => 'Legal services',
-        'Attorney'             => 'Attorney',
-        'AccountingService'    => 'Accounting',
-        'FinancialService'     => 'Financial services',
-        'InsuranceAgency'      => 'Insurance',
-        'TravelAgency'         => 'Travel agency',
-        'Hotel'                => 'Hotel',
-        'LodgingBusiness'      => 'Lodging',
-        'GymLocation'          => 'Gym',
-        'SportsActivityLocation' => 'Sports / fitness',
-        'ChildCare'            => 'Childcare',
-        'EducationOrganization' => 'Education',
-        'ProfessionalService'  => 'Professional services',
-    ];
+	/**
+	 * Schema.org LocalBusiness sub-types we surface in the picker.
+	 * Not exhaustive — covers the most common small-business cases.
+	 */
+	public const BUSINESS_TYPES = array(
+		'LocalBusiness'               => 'Local business (generic)',
+		'Restaurant'                  => 'Restaurant',
+		'CafeOrCoffeeShop'            => 'Cafe / coffee shop',
+		'Bakery'                      => 'Bakery',
+		'Store'                       => 'Store / retail',
+		'ClothingStore'               => 'Clothing store',
+		'GroceryStore'                => 'Grocery store',
+		'Dentist'                     => 'Dentist',
+		'MedicalClinic'               => 'Medical clinic',
+		'Physician'                   => 'Physician',
+		'HealthAndBeautyBusiness'     => 'Health & beauty',
+		'BeautySalon'                 => 'Beauty salon',
+		'HairSalon'                   => 'Hair salon',
+		'DaySpa'                      => 'Day spa',
+		'AutoRepair'                  => 'Auto repair',
+		'Plumber'                     => 'Plumber',
+		'Electrician'                 => 'Electrician',
+		'HVACBusiness'                => 'HVAC',
+		'RoofingContractor'           => 'Roofing contractor',
+		'GeneralContractor'           => 'General contractor',
+		'HomeAndConstructionBusiness' => 'Home & construction',
+		'RealEstateAgent'             => 'Real estate agent',
+		'LegalService'                => 'Legal services',
+		'Attorney'                    => 'Attorney',
+		'AccountingService'           => 'Accounting',
+		'FinancialService'            => 'Financial services',
+		'InsuranceAgency'             => 'Insurance',
+		'TravelAgency'                => 'Travel agency',
+		'Hotel'                       => 'Hotel',
+		'LodgingBusiness'             => 'Lodging',
+		'GymLocation'                 => 'Gym',
+		'SportsActivityLocation'      => 'Sports / fitness',
+		'ChildCare'                   => 'Childcare',
+		'EducationOrganization'       => 'Education',
+		'ProfessionalService'         => 'Professional services',
+	);
 
-    public const DAYS = [
-        'Monday'    => 'Mon',
-        'Tuesday'   => 'Tue',
-        'Wednesday' => 'Wed',
-        'Thursday'  => 'Thu',
-        'Friday'    => 'Fri',
-        'Saturday'  => 'Sat',
-        'Sunday'    => 'Sun',
-    ];
+	public const DAYS = array(
+		'Monday'    => 'Mon',
+		'Tuesday'   => 'Tue',
+		'Wednesday' => 'Wed',
+		'Thursday'  => 'Thu',
+		'Friday'    => 'Fri',
+		'Saturday'  => 'Sat',
+		'Sunday'    => 'Sun',
+	);
 
-    public function __construct() {
-        add_action( 'admin_menu',            [ $this, 'register_menu' ], 20 );
-        add_action( 'admin_init',            [ $this, 'register_settings' ] );
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'register_menu' ), 20 );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
-        if ( ! is_admin() && $this->is_enabled() && ! $this->other_seo_plugin_active() ) {
-            add_action( 'wp_head', [ $this, 'output_schema' ], 2 );
-        }
-    }
+		if ( ! is_admin() && $this->is_enabled() && ! $this->other_seo_plugin_active() ) {
+			add_action( 'wp_head', array( $this, 'output_schema' ), 2 );
+		}
+	}
 
-    public function register_menu(): void {
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Local SEO', 'stratawp-seo' ),
-            __( 'Local SEO', 'stratawp-seo' ),
-            'manage_options',
-            'swps-local-seo',
-            [ $this, 'render_page' ]
-        );
-    }
+	public function register_menu(): void {
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Local SEO', 'stratawp-seo' ),
+			__( 'Local SEO', 'stratawp-seo' ),
+			'manage_options',
+			'swps-local-seo',
+			array( $this, 'render_page' )
+		);
+	}
 
-    public function render_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
-        }
-        require SWPS_PLUGIN_DIR . 'templates/local-seo-page.php';
-    }
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
+		}
+		require SWPS_PLUGIN_DIR . 'templates/local-seo-page.php';
+	}
 
-    public function enqueue_assets( string $hook ): void {
-        if ( 'stratawp-seo_page_swps-local-seo' !== $hook ) {
-            return;
-        }
-        wp_enqueue_style(
-            'swps-page-local-seo',
-            SWPS_PLUGIN_URL . 'admin/css/pages/local-seo.css',
-            [ 'swps-tokens', 'swps-components', 'swps-templates' ],
-            SWPS_VERSION
-        );
-    }
+	public function enqueue_assets( string $hook ): void {
+		if ( 'stratawp-seo_page_swps-local-seo' !== $hook ) {
+			return;
+		}
+		wp_enqueue_style(
+			'swps-page-local-seo',
+			SWPS_PLUGIN_URL . 'admin/css/pages/local-seo.css',
+			array( 'swps-tokens', 'swps-components', 'swps-templates' ),
+			SWPS_VERSION
+		);
+	}
 
-    // ---------- Settings ----------
+	// ---------- Settings ----------
 
-    public function register_settings(): void {
-        register_setting(
-            'swps_local_seo_group',
-            self::OPTION_KEY,
-            [
-                'type'              => 'array',
-                'sanitize_callback' => [ $this, 'sanitize' ],
-                'default'           => $this->defaults(),
-            ]
-        );
-    }
+	public function register_settings(): void {
+		register_setting(
+			'swps_local_seo_group',
+			self::OPTION_KEY,
+			array(
+				'type'              => 'array',
+				'sanitize_callback' => array( $this, 'sanitize' ),
+				'default'           => $this->defaults(),
+			)
+		);
+	}
 
-    public function defaults(): array {
-        return [
-            'enabled'        => 0,
-            'business_type'  => 'LocalBusiness',
-            'name'           => '',
-            'phone'          => '',
-            'email'          => '',
-            'price_range'    => '',
-            'street'         => '',
-            'locality'       => '',
-            'region'         => '',
-            'postal_code'    => '',
-            'country'        => '',
-            'latitude'       => '',
-            'longitude'      => '',
-            'area_served'    => '', // newline-separated list
-            'hours'          => [], // day => [ 'open' => 'HH:MM', 'close' => 'HH:MM', 'closed' => 0 ]
-            'place_id'       => '', // Google Business Profile place ID (optional)
-        ];
-    }
+	public function defaults(): array {
+		return array(
+			'enabled'       => 0,
+			'business_type' => 'LocalBusiness',
+			'name'          => '',
+			'phone'         => '',
+			'email'         => '',
+			'price_range'   => '',
+			'street'        => '',
+			'locality'      => '',
+			'region'        => '',
+			'postal_code'   => '',
+			'country'       => '',
+			'latitude'      => '',
+			'longitude'     => '',
+			'area_served'   => '', // newline-separated list
+			'hours'         => array(), // day => [ 'open' => 'HH:MM', 'close' => 'HH:MM', 'closed' => 0 ]
+			'place_id'      => '', // Google Business Profile place ID (optional)
+		);
+	}
 
-    public function get(): array {
-        $stored = get_option( self::OPTION_KEY, [] );
-        return wp_parse_args( is_array( $stored ) ? $stored : [], $this->defaults() );
-    }
+	public function get(): array {
+		$stored = get_option( self::OPTION_KEY, array() );
+		return wp_parse_args( is_array( $stored ) ? $stored : array(), $this->defaults() );
+	}
 
-    public function is_enabled(): bool {
-        $data = $this->get();
-        if ( empty( $data['enabled'] ) ) {
-            return false;
-        }
-        // Need at least a name + locality to publish anything meaningful.
-        return '' !== trim( (string) $data['name'] ) && '' !== trim( (string) $data['locality'] );
-    }
+	public function is_enabled(): bool {
+		$data = $this->get();
+		if ( empty( $data['enabled'] ) ) {
+			return false;
+		}
+		// Need at least a name + locality to publish anything meaningful.
+		return '' !== trim( (string) $data['name'] ) && '' !== trim( (string) $data['locality'] );
+	}
 
-    public function sanitize( $input ): array {
-        $defaults = $this->defaults();
-        $clean    = $defaults;
+	public function sanitize( $input ): array {
+		$defaults = $this->defaults();
+		$clean    = $defaults;
 
-        if ( ! is_array( $input ) ) {
-            return $clean;
-        }
+		if ( ! is_array( $input ) ) {
+			return $clean;
+		}
 
-        $clean['enabled']       = empty( $input['enabled'] ) ? 0 : 1;
-        $clean['business_type'] = isset( $input['business_type'], self::BUSINESS_TYPES[ $input['business_type'] ] )
-            ? sanitize_text_field( $input['business_type'] )
-            : 'LocalBusiness';
+		$clean['enabled']       = empty( $input['enabled'] ) ? 0 : 1;
+		$clean['business_type'] = isset( $input['business_type'], self::BUSINESS_TYPES[ $input['business_type'] ] )
+			? sanitize_text_field( $input['business_type'] )
+			: 'LocalBusiness';
 
-        foreach ( [ 'name', 'phone', 'price_range', 'street', 'locality', 'region', 'postal_code', 'country', 'place_id' ] as $key ) {
-            $clean[ $key ] = isset( $input[ $key ] ) ? sanitize_text_field( $input[ $key ] ) : '';
-        }
+		foreach ( array( 'name', 'phone', 'price_range', 'street', 'locality', 'region', 'postal_code', 'country', 'place_id' ) as $key ) {
+			$clean[ $key ] = isset( $input[ $key ] ) ? sanitize_text_field( $input[ $key ] ) : '';
+		}
 
-        $clean['email'] = isset( $input['email'] ) ? sanitize_email( $input['email'] ) : '';
+		$clean['email'] = isset( $input['email'] ) ? sanitize_email( $input['email'] ) : '';
 
-        // Geo — must be valid float-ish (or empty). Stored as string to preserve formatting.
-        foreach ( [ 'latitude', 'longitude' ] as $geo ) {
-            $val = isset( $input[ $geo ] ) ? trim( (string) $input[ $geo ] ) : '';
-            if ( '' === $val ) {
-                $clean[ $geo ] = '';
-            } elseif ( is_numeric( $val ) ) {
-                $clean[ $geo ] = (string) (float) $val;
-            } else {
-                $clean[ $geo ] = '';
-            }
-        }
+		// Geo — must be valid float-ish (or empty). Stored as string to preserve formatting.
+		foreach ( array( 'latitude', 'longitude' ) as $geo ) {
+			$val = isset( $input[ $geo ] ) ? trim( (string) $input[ $geo ] ) : '';
+			if ( '' === $val ) {
+				$clean[ $geo ] = '';
+			} elseif ( is_numeric( $val ) ) {
+				$clean[ $geo ] = (string) (float) $val;
+			} else {
+				$clean[ $geo ] = '';
+			}
+		}
 
-        // Area served — newline-separated list, one location per line.
-        $area_raw = isset( $input['area_served'] ) ? (string) $input['area_served'] : '';
-        $lines    = array_filter( array_map( 'trim', preg_split( '/\r\n|\r|\n/', $area_raw ) ?: [] ) );
-        $lines    = array_map( 'sanitize_text_field', $lines );
-        $clean['area_served'] = implode( "\n", array_slice( $lines, 0, 25 ) );
+		// Area served — newline-separated list, one location per line.
+		$area_raw             = isset( $input['area_served'] ) ? (string) $input['area_served'] : '';
+		$lines                = array_filter( array_map( 'trim', preg_split( '/\r\n|\r|\n/', $area_raw ) ?: array() ) );
+		$lines                = array_map( 'sanitize_text_field', $lines );
+		$clean['area_served'] = implode( "\n", array_slice( $lines, 0, 25 ) );
 
-        // Hours — keyed by canonical day name.
-        $clean['hours'] = [];
-        $hours_in       = isset( $input['hours'] ) && is_array( $input['hours'] ) ? $input['hours'] : [];
-        foreach ( array_keys( self::DAYS ) as $day ) {
-            $row    = isset( $hours_in[ $day ] ) && is_array( $hours_in[ $day ] ) ? $hours_in[ $day ] : [];
-            $closed = ! empty( $row['closed'] ) ? 1 : 0;
-            $open   = isset( $row['open'] )  ? $this->normalize_time( $row['open'] )  : '';
-            $close  = isset( $row['close'] ) ? $this->normalize_time( $row['close'] ) : '';
-            $clean['hours'][ $day ] = [
-                'closed' => $closed,
-                'open'   => $closed ? '' : $open,
-                'close'  => $closed ? '' : $close,
-            ];
-        }
+		// Hours — keyed by canonical day name.
+		$clean['hours'] = array();
+		$hours_in       = isset( $input['hours'] ) && is_array( $input['hours'] ) ? $input['hours'] : array();
+		foreach ( array_keys( self::DAYS ) as $day ) {
+			$row                    = isset( $hours_in[ $day ] ) && is_array( $hours_in[ $day ] ) ? $hours_in[ $day ] : array();
+			$closed                 = ! empty( $row['closed'] ) ? 1 : 0;
+			$open                   = isset( $row['open'] ) ? $this->normalize_time( $row['open'] ) : '';
+			$close                  = isset( $row['close'] ) ? $this->normalize_time( $row['close'] ) : '';
+			$clean['hours'][ $day ] = array(
+				'closed' => $closed,
+				'open'   => $closed ? '' : $open,
+				'close'  => $closed ? '' : $close,
+			);
+		}
 
-        return $clean;
-    }
+		return $clean;
+	}
 
-    private function normalize_time( string $val ): string {
-        $val = trim( $val );
-        if ( '' === $val ) {
-            return '';
-        }
-        if ( preg_match( '/^([01]?\d|2[0-3]):([0-5]\d)$/', $val, $m ) ) {
-            return sprintf( '%02d:%02d', (int) $m[1], (int) $m[2] );
-        }
-        return '';
-    }
+	private function normalize_time( string $val ): string {
+		$val = trim( $val );
+		if ( '' === $val ) {
+			return '';
+		}
+		if ( preg_match( '/^([01]?\d|2[0-3]):([0-5]\d)$/', $val, $m ) ) {
+			return sprintf( '%02d:%02d', (int) $m[1], (int) $m[2] );
+		}
+		return '';
+	}
 
-    // ---------- Schema ----------
+	// ---------- Schema ----------
 
-    private function other_seo_plugin_active(): bool {
-        return defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' );
-    }
+	private function other_seo_plugin_active(): bool {
+		return defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' );
+	}
 
-    /**
-     * Output LocalBusiness JSON-LD on the homepage (and any page slug listed
-     * via the `swps_local_seo_schema_pages` filter — defaults to homepage only).
-     */
-    public function output_schema(): void {
-        $show_on_home = is_front_page() || is_home();
+	/**
+	 * Output LocalBusiness JSON-LD on the homepage (and any page slug listed
+	 * via the `swps_local_seo_schema_pages` filter — defaults to homepage only).
+	 */
+	public function output_schema(): void {
+		$show_on_home = is_front_page() || is_home();
 
-        /**
-         * Filter which contexts get the LocalBusiness schema.
-         *
-         * @param bool $show True to emit on this request.
-         */
-        $show = (bool) apply_filters( 'swps_local_seo_emit', $show_on_home );
+		/**
+		 * Filter which contexts get the LocalBusiness schema.
+		 *
+		 * @param bool $show True to emit on this request.
+		 */
+		$show = (bool) apply_filters( 'swps_local_seo_emit', $show_on_home );
 
-        if ( ! $show ) {
-            return;
-        }
+		if ( ! $show ) {
+			return;
+		}
 
-        $schema = $this->build_schema();
-        if ( empty( $schema ) ) {
-            return;
-        }
+		$schema = $this->build_schema();
+		if ( empty( $schema ) ) {
+			return;
+		}
 
         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON-LD.
-        echo '<script type="application/ld+json">'
-            . wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT )
-            . '</script>' . "\n";
-    }
+		echo '<script type="application/ld+json">'
+			. wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT )
+			. '</script>' . "\n";
+	}
 
-    public function build_schema(): array {
-        $d = $this->get();
+	public function build_schema(): array {
+		$d = $this->get();
 
-        if ( '' === trim( (string) $d['name'] ) ) {
-            return [];
-        }
+		if ( '' === trim( (string) $d['name'] ) ) {
+			return array();
+		}
 
-        $schema = [
-            '@context' => 'https://schema.org',
-            '@type'    => $d['business_type'] ?: 'LocalBusiness',
-            'name'     => $d['name'],
-            'url'      => home_url( '/' ),
-        ];
+		$schema = array(
+			'@context' => 'https://schema.org',
+			'@type'    => $d['business_type'] ?: 'LocalBusiness',
+			'name'     => $d['name'],
+			'url'      => home_url( '/' ),
+		);
 
-        if ( '' !== trim( $d['phone'] ) ) {
-            $schema['telephone'] = $d['phone'];
-        }
-        if ( '' !== trim( $d['email'] ) ) {
-            $schema['email'] = $d['email'];
-        }
-        if ( '' !== trim( $d['price_range'] ) ) {
-            $schema['priceRange'] = $d['price_range'];
-        }
+		if ( '' !== trim( $d['phone'] ) ) {
+			$schema['telephone'] = $d['phone'];
+		}
+		if ( '' !== trim( $d['email'] ) ) {
+			$schema['email'] = $d['email'];
+		}
+		if ( '' !== trim( $d['price_range'] ) ) {
+			$schema['priceRange'] = $d['price_range'];
+		}
 
-        $address = [];
-        if ( '' !== trim( $d['street'] ) )      { $address['streetAddress']    = $d['street']; }
-        if ( '' !== trim( $d['locality'] ) )    { $address['addressLocality']  = $d['locality']; }
-        if ( '' !== trim( $d['region'] ) )      { $address['addressRegion']    = $d['region']; }
-        if ( '' !== trim( $d['postal_code'] ) ) { $address['postalCode']       = $d['postal_code']; }
-        if ( '' !== trim( $d['country'] ) )     { $address['addressCountry']   = $d['country']; }
-        if ( ! empty( $address ) ) {
-            $address['@type']   = 'PostalAddress';
-            $schema['address']  = $address;
-        }
+		$address = array();
+		if ( '' !== trim( $d['street'] ) ) {
+			$address['streetAddress'] = $d['street']; }
+		if ( '' !== trim( $d['locality'] ) ) {
+			$address['addressLocality'] = $d['locality']; }
+		if ( '' !== trim( $d['region'] ) ) {
+			$address['addressRegion'] = $d['region']; }
+		if ( '' !== trim( $d['postal_code'] ) ) {
+			$address['postalCode'] = $d['postal_code']; }
+		if ( '' !== trim( $d['country'] ) ) {
+			$address['addressCountry'] = $d['country']; }
+		if ( ! empty( $address ) ) {
+			$address['@type']  = 'PostalAddress';
+			$schema['address'] = $address;
+		}
 
-        if ( '' !== $d['latitude'] && '' !== $d['longitude'] ) {
-            $schema['geo'] = [
-                '@type'     => 'GeoCoordinates',
-                'latitude'  => (float) $d['latitude'],
-                'longitude' => (float) $d['longitude'],
-            ];
-        }
+		if ( '' !== $d['latitude'] && '' !== $d['longitude'] ) {
+			$schema['geo'] = array(
+				'@type'     => 'GeoCoordinates',
+				'latitude'  => (float) $d['latitude'],
+				'longitude' => (float) $d['longitude'],
+			);
+		}
 
-        // Logo / image: reuse the existing organization logo setting if present.
-        $logo = get_option( 'swps_schema_logo', '' );
-        if ( ! empty( $logo ) ) {
-            $schema['image'] = $logo;
-            $schema['logo']  = $logo;
-        }
+		// Logo / image: reuse the existing organization logo setting if present.
+		$logo = get_option( 'swps_schema_logo', '' );
+		if ( ! empty( $logo ) ) {
+			$schema['image'] = $logo;
+			$schema['logo']  = $logo;
+		}
 
-        // Hours.
-        $opening = [];
-        foreach ( array_keys( self::DAYS ) as $day ) {
-            $row = $d['hours'][ $day ] ?? [];
-            if ( empty( $row ) || ! empty( $row['closed'] ) ) {
-                continue;
-            }
-            $open  = (string) ( $row['open']  ?? '' );
-            $close = (string) ( $row['close'] ?? '' );
-            if ( '' === $open || '' === $close ) {
-                continue;
-            }
-            $opening[] = [
-                '@type'     => 'OpeningHoursSpecification',
-                'dayOfWeek' => 'https://schema.org/' . $day,
-                'opens'     => $open,
-                'closes'    => $close,
-            ];
-        }
-        if ( ! empty( $opening ) ) {
-            $schema['openingHoursSpecification'] = $opening;
-        }
+		// Hours.
+		$opening = array();
+		foreach ( array_keys( self::DAYS ) as $day ) {
+			$row = $d['hours'][ $day ] ?? array();
+			if ( empty( $row ) || ! empty( $row['closed'] ) ) {
+				continue;
+			}
+			$open  = (string) ( $row['open'] ?? '' );
+			$close = (string) ( $row['close'] ?? '' );
+			if ( '' === $open || '' === $close ) {
+				continue;
+			}
+			$opening[] = array(
+				'@type'     => 'OpeningHoursSpecification',
+				'dayOfWeek' => 'https://schema.org/' . $day,
+				'opens'     => $open,
+				'closes'    => $close,
+			);
+		}
+		if ( ! empty( $opening ) ) {
+			$schema['openingHoursSpecification'] = $opening;
+		}
 
-        // Area served.
-        $area_lines = array_filter( array_map( 'trim', explode( "\n", (string) $d['area_served'] ) ) );
-        if ( ! empty( $area_lines ) ) {
-            $schema['areaServed'] = array_values( $area_lines );
-        }
+		// Area served.
+		$area_lines = array_filter( array_map( 'trim', explode( "\n", (string) $d['area_served'] ) ) );
+		if ( ! empty( $area_lines ) ) {
+			$schema['areaServed'] = array_values( $area_lines );
+		}
 
-        // Same-as: reuse existing social profiles.
-        $social_raw = (string) get_option( 'swps_schema_social_profiles', '' );
-        if ( '' !== trim( $social_raw ) ) {
-            $urls = array_filter( array_map( 'trim', explode( "\n", $social_raw ) ) );
-            if ( ! empty( $urls ) ) {
-                $schema['sameAs'] = array_values( $urls );
-            }
-        }
+		// Same-as: reuse existing social profiles.
+		$social_raw = (string) get_option( 'swps_schema_social_profiles', '' );
+		if ( '' !== trim( $social_raw ) ) {
+			$urls = array_filter( array_map( 'trim', explode( "\n", $social_raw ) ) );
+			if ( ! empty( $urls ) ) {
+				$schema['sameAs'] = array_values( $urls );
+			}
+		}
 
-        // Google Place ID — optional hasMap.
-        if ( '' !== trim( (string) $d['place_id'] ) ) {
-            $schema['hasMap'] = 'https://www.google.com/maps/place/?q=place_id:' . rawurlencode( $d['place_id'] );
-        }
+		// Google Place ID — optional hasMap.
+		if ( '' !== trim( (string) $d['place_id'] ) ) {
+			$schema['hasMap'] = 'https://www.google.com/maps/place/?q=place_id:' . rawurlencode( $d['place_id'] );
+		}
 
-        /**
-         * Filter the LocalBusiness schema before output.
-         *
-         * @param array $schema  The assembled schema array.
-         * @param array $data    Raw settings.
-         */
-        return (array) apply_filters( 'swps_local_seo_schema', $schema, $d );
-    }
+		/**
+		 * Filter the LocalBusiness schema before output.
+		 *
+		 * @param array $schema  The assembled schema array.
+		 * @param array $data    Raw settings.
+		 */
+		return (array) apply_filters( 'swps_local_seo_schema', $schema, $d );
+	}
 }

--- a/includes/class-meta-editor.php
+++ b/includes/class-meta-editor.php
@@ -6,595 +6,607 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Meta_Editor {
 
-    private bool $conflict = false;
-
-    public function __construct() {
-        // Detect conflicting SEO plugins.
-        if ( defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' ) ) {
-            $this->conflict = true;
-        }
-
-        if ( ! get_option( 'swps_meta_editor_enabled', 1 ) ) {
-            return;
-        }
-
-        // Admin: register metabox and save hook.
-        add_action( 'add_meta_boxes', [ $this, 'register_metabox' ] );
-        add_action( 'save_post', [ $this, 'save_meta' ], 10, 2 );
-
-        // AJAX: AI-generate meta.
-        add_action( 'wp_ajax_swps_generate_meta', [ $this, 'ajax_generate_meta' ] );
-        add_action( 'wp_ajax_swps_bulk_generate_meta', [ $this, 'ajax_bulk_generate_meta' ] );
-
-        // Frontend output — only when no conflict.
-        if ( ! $this->conflict && ! is_admin() ) {
-            add_action( 'wp_head', [ $this, 'output_meta_tags' ], 2 );
-            add_filter( 'pre_get_document_title', [ $this, 'filter_document_title' ], 20 );
-            add_filter( 'document_title_parts', [ $this, 'filter_title_parts' ], 20 );
-        }
-
-        // Auto-generate meta on publish if setting is enabled.
-        if ( get_option( 'swps_meta_auto_generate', 0 ) ) {
-            add_action( 'transition_post_status', [ $this, 'maybe_auto_generate' ], 10, 3 );
-        }
-
-        // Admin notice if conflict detected.
-        if ( $this->conflict ) {
-            add_action( 'admin_notices', [ $this, 'conflict_notice' ] );
-        }
-    }
-
-    /**
-     * Check if there's an SEO plugin conflict.
-     */
-    public function has_conflict(): bool {
-        return $this->conflict;
-    }
-
-    /**
-     * Register the SEO metabox on configured post types.
-     */
-    public function register_metabox(): void {
-        $post_types = $this->get_enabled_post_types();
-
-        foreach ( $post_types as $post_type ) {
-            add_meta_box(
-                'swps_meta_editor',
-                __( 'StrataWP SEO', 'stratawp-seo' ),
-                [ $this, 'render_metabox' ],
-                $post_type,
-                'normal',
-                'high'
-            );
-        }
-    }
-
-    /**
-     * Render the SEO metabox.
-     */
-    public function render_metabox( WP_Post $post ): void {
-        wp_nonce_field( 'swps_meta_editor', 'swps_meta_editor_nonce' );
-
-        $meta_title        = get_post_meta( $post->ID, '_swps_meta_title', true );
-        $meta_description  = get_post_meta( $post->ID, '_swps_meta_description', true );
-        $focus_keyword     = get_post_meta( $post->ID, '_swps_focus_keyword', true );
-        $secondary_kws     = get_post_meta( $post->ID, '_swps_secondary_keywords', true );
-        $canonical_url     = get_post_meta( $post->ID, '_swps_canonical_url', true );
-        $robots            = get_post_meta( $post->ID, '_swps_robots', true );
-        $breadcrumb_title  = get_post_meta( $post->ID, '_swps_breadcrumb_title', true );
-        $social_title      = get_post_meta( $post->ID, '_swps_social_title', true );
-        $social_desc       = get_post_meta( $post->ID, '_swps_social_description', true );
-        $social_image      = get_post_meta( $post->ID, '_swps_social_image', true );
-
-        // Sitemap controls.
-        $sitemap_exclude    = get_post_meta( $post->ID, '_swps_sitemap_exclude', true );
-        $sitemap_priority   = get_post_meta( $post->ID, '_swps_sitemap_priority', true );
-        $sitemap_changefreq = get_post_meta( $post->ID, '_swps_sitemap_changefreq', true );
-
-        if ( $this->conflict ) {
-            echo '<div class="notice notice-warning inline"><p>';
-            esc_html_e( 'Meta output is disabled because another SEO plugin is active. Fields are saved but not output on the frontend.', 'stratawp-seo' );
-            echo '</p></div>';
-        }
-
-        include SWPS_PLUGIN_DIR . 'templates/meta-editor-metabox.php';
-    }
-
-    /**
-     * Save meta fields on post save.
-     */
-    public function save_meta( int $post_id, WP_Post $post ): void {
-        if ( ! isset( $_POST['swps_meta_editor_nonce'] ) ) {
-            return;
-        }
-        if ( ! wp_verify_nonce( $_POST['swps_meta_editor_nonce'], 'swps_meta_editor' ) ) {
-            return;
-        }
-        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-            return;
-        }
-        if ( ! current_user_can( 'edit_post', $post_id ) ) {
-            return;
-        }
-
-        $fields = [
-            '_swps_meta_title'          => 'sanitize_text_field',
-            '_swps_meta_description'    => 'sanitize_textarea_field',
-            '_swps_focus_keyword'       => 'sanitize_text_field',
-            '_swps_secondary_keywords'  => 'sanitize_text_field',
-            '_swps_canonical_url'       => 'esc_url_raw',
-            '_swps_robots'              => [ $this, 'sanitize_robots' ],
-            '_swps_breadcrumb_title'    => 'sanitize_text_field',
-            '_swps_social_title'        => 'sanitize_text_field',
-            '_swps_social_description'  => 'sanitize_textarea_field',
-            '_swps_social_image'        => 'esc_url_raw',
-        ];
-
-        foreach ( $fields as $key => $sanitizer ) {
-            if ( isset( $_POST[ $key ] ) ) {
-                $value = call_user_func( $sanitizer, $_POST[ $key ] );
-                if ( ! empty( $value ) ) {
-                    update_post_meta( $post_id, $key, $value );
-                } else {
-                    delete_post_meta( $post_id, $key );
-                }
-            }
-        }
-
-        // Sitemap meta.
-        update_post_meta( $post_id, '_swps_sitemap_exclude', ! empty( $_POST['swps_sitemap_exclude'] ) ? 1 : 0 );
-
-        $priority = isset( $_POST['swps_sitemap_priority'] ) ? sanitize_text_field( $_POST['swps_sitemap_priority'] ) : '';
-        update_post_meta( $post_id, '_swps_sitemap_priority', $priority );
-
-        $changefreq = isset( $_POST['swps_sitemap_changefreq'] ) ? sanitize_text_field( $_POST['swps_sitemap_changefreq'] ) : '';
-        update_post_meta( $post_id, '_swps_sitemap_changefreq', $changefreq );
-    }
-
-    /**
-     * Output meta tags in wp_head.
-     */
-    public function output_meta_tags(): void {
-        if ( ! is_singular() ) {
-            return;
-        }
-
-        $post_id = get_the_ID();
-        if ( ! $post_id ) {
-            return;
-        }
-
-        $meta_desc  = get_post_meta( $post_id, '_swps_meta_description', true );
-        $canonical  = get_post_meta( $post_id, '_swps_canonical_url', true );
-        $robots     = get_post_meta( $post_id, '_swps_robots', true );
-
-        // Meta description.
-        $meta_desc = SWPS_Hooks::filter_meta_description( $meta_desc, $post_id );
-        if ( ! empty( $meta_desc ) ) {
-            printf( '<meta name="description" content="%s" />' . "\n", esc_attr( $meta_desc ) );
-        }
-
-        // Canonical.
-        if ( ! empty( $canonical ) ) {
-            printf( '<link rel="canonical" href="%s" />' . "\n", esc_url( $canonical ) );
-            // Remove WP default canonical.
-            remove_action( 'wp_head', 'rel_canonical' );
-        }
-
-        // Robots.
-        $robots = SWPS_Hooks::filter_meta_robots( $robots, $post_id );
-        if ( ! empty( $robots ) && 'index, follow' !== $robots ) {
-            printf( '<meta name="robots" content="%s" />' . "\n", esc_attr( $robots ) );
-        }
-
-        // Open Graph.
-        $this->output_og_tags( $post_id );
-
-        // Twitter Card.
-        $this->output_twitter_tags( $post_id );
-    }
-
-    /**
-     * Filter the document title for our custom meta title.
-     */
-    public function filter_document_title( string $title ): string {
-        if ( ! is_singular() ) {
-            return $title;
-        }
-
-        $custom = get_post_meta( get_the_ID(), '_swps_meta_title', true );
-        $custom = SWPS_Hooks::filter_meta_title( $custom, get_the_ID() );
-
-        return ! empty( $custom ) ? $custom : $title;
-    }
-
-    /**
-     * Filter document title parts.
-     */
-    public function filter_title_parts( array $parts ): array {
-        if ( ! is_singular() ) {
-            return $parts;
-        }
-
-        $custom = get_post_meta( get_the_ID(), '_swps_meta_title', true );
-        $custom = SWPS_Hooks::filter_meta_title( $custom, get_the_ID() );
-
-        if ( ! empty( $custom ) ) {
-            $parts['title'] = $custom;
-            // Remove site name suffix if custom title is set.
-            unset( $parts['site'] );
-        }
-
-        return $parts;
-    }
-
-    /**
-     * AJAX: Generate meta title and description using AI.
-     */
-    public function ajax_generate_meta(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $post_id       = absint( $_POST['post_id'] ?? 0 );
-        $focus_keyword = sanitize_text_field( $_POST['focus_keyword'] ?? '' );
-
-        if ( ! $post_id ) {
-            wp_send_json_error( [ 'message' => 'Invalid post ID.' ] );
-        }
-
-        $post = get_post( $post_id );
-        if ( ! $post ) {
-            wp_send_json_error( [ 'message' => 'Post not found.' ] );
-        }
-
-        $content = wp_strip_all_tags( $post->post_content );
-        $content = mb_substr( $content, 0, 2000 ); // Limit to keep prompt short.
-
-        $kw_instruction = ! empty( $focus_keyword )
-            ? "Focus keyword (provided by user): {$focus_keyword}"
-            : 'Focus keyword: (none specified — you MUST suggest one based on the content)';
-
-        $prompt = sprintf(
-            "Generate an SEO-optimized meta title (50-60 chars), meta description (140-160 chars), and focus keyword for this blog post.\n\n"
-            . "Post title: %s\n"
-            . "%s\n"
-            . "Content excerpt: %s\n\n"
-            . "Requirements:\n"
-            . "- If no focus keyword was provided, analyze the content and suggest the single best 2-4 word keyword phrase (e.g. 'WordPress SEO', 'Claude Skills' — NEVER a long sentence)\n"
-            . "- If a focus keyword was provided, use it as-is\n"
-            . "- Include the focus keyword naturally in both the meta title and meta description\n"
-            . "- Meta title: compelling, 50-60 characters, includes the focus keyword\n"
-            . "- Meta description: actionable, includes a call to read, 147-160 characters, includes the focus keyword\n\n"
-            . "Return JSON only: {\"meta_title\":\"...\",\"meta_description\":\"...\",\"focus_keyword\":\"...\"}",
-            $post->post_title,
-            $kw_instruction,
-            $content
-        );
-
-        $api      = SWPS_Provider_Factory::create_ai_provider();
-        $response = $api->chat( 'You are an SEO copywriting expert. Return only valid JSON.', $prompt, 1024 );
-
-        if ( is_wp_error( $response ) ) {
-            wp_send_json_error( [ 'message' => $response->get_error_message() ] );
-        }
-
-        $json_match = [];
-        if ( preg_match( '/\{.*\}/s', $response, $json_match ) ) {
-            $result = json_decode( $json_match[0], true );
-            if ( is_array( $result ) ) {
-                // Save focus keyword to post meta immediately.
-                if ( ! empty( $result['focus_keyword'] ) ) {
-                    $kw = sanitize_text_field( $result['focus_keyword'] );
-                    update_post_meta( $post_id, '_swps_focus_keyword', $kw );
-                    update_post_meta( $post_id, '_yoast_wpseo_focuskw', $kw );
-                    update_post_meta( $post_id, 'rank_math_focus_keyword', $kw );
-                }
-                wp_send_json_success( $result );
-            }
-        }
-
-        wp_send_json_error( [ 'message' => 'Failed to parse AI response.' ] );
-    }
-
-    /**
-     * AJAX: Bulk generate meta for all posts missing SEO meta.
-     *
-     * Processes one post per request to avoid AI timeout. JS loops until done.
-     */
-    public function ajax_bulk_generate_meta(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $offset = absint( $_POST['offset'] ?? 0 );
-
-        $enabled_types = (array) get_option( 'swps_seo_column_post_types', [ 'post', 'page' ] );
-
-        // Count total posts.
-        $total = 0;
-        foreach ( $enabled_types as $pt ) {
-            $counts = wp_count_posts( $pt );
-            $total += ( $counts->publish ?? 0 ) + ( $counts->draft ?? 0 );
-        }
-
-        // Get one post at the current offset (AI calls are slow, so one at a time).
-        $posts = get_posts( [
-            'post_type'      => $enabled_types,
-            'post_status'    => [ 'publish', 'draft' ],
-            'posts_per_page' => 1,
-            'offset'         => $offset,
-            'orderby'        => 'ID',
-            'order'          => 'ASC',
-        ] );
-
-        if ( empty( $posts ) ) {
-            wp_send_json_success( [
-                'processed' => $offset,
-                'total'     => $total,
-                'done'      => true,
-                'post_title' => '',
-            ] );
-        }
-
-        $post = $posts[0];
-
-        // Skip posts that already have meta title AND focus keyword.
-        $existing_title = get_post_meta( $post->ID, '_swps_meta_title', true );
-        $existing_kw    = get_post_meta( $post->ID, '_swps_focus_keyword', true );
-
-        if ( ! empty( $existing_title ) && ! empty( $existing_kw ) ) {
-            wp_send_json_success( [
-                'processed'  => $offset + 1,
-                'total'      => $total,
-                'done'       => ( $offset + 1 ) >= $total,
-                'post_title' => $post->post_title,
-                'skipped'    => true,
-            ] );
-        }
-
-        // Build the AI prompt (same logic as ajax_generate_meta).
-        $content = wp_strip_all_tags( $post->post_content );
-        $content = mb_substr( $content, 0, 2000 );
-
-        $prompt = sprintf(
-            "Generate an SEO-optimized meta title (50-60 chars), meta description (140-160 chars), and focus keyword for this blog post.\n\n"
-            . "Post title: %s\n"
-            . "Focus keyword: (none specified — you MUST suggest one based on the content)\n"
-            . "Content excerpt: %s\n\n"
-            . "Requirements:\n"
-            . "- Analyze the content and suggest the single best 2-4 word keyword phrase (e.g. 'WordPress SEO', 'Claude Skills' — NEVER a long sentence)\n"
-            . "- Include the focus keyword naturally in both the meta title and meta description\n"
-            . "- Meta title: compelling, 50-60 characters, includes the focus keyword\n"
-            . "- Meta description: actionable, includes a call to read, 147-160 characters, includes the focus keyword\n\n"
-            . "Return JSON only: {\"meta_title\":\"...\",\"meta_description\":\"...\",\"focus_keyword\":\"...\"}",
-            $post->post_title,
-            $content
-        );
-
-        $api      = SWPS_Provider_Factory::create_ai_provider();
-        $response = $api->chat( 'You are an SEO copywriting expert. Return only valid JSON.', $prompt, 1024 );
-
-        if ( is_wp_error( $response ) ) {
-            wp_send_json_success( [
-                'processed'  => $offset + 1,
-                'total'      => $total,
-                'done'       => ( $offset + 1 ) >= $total,
-                'post_title' => $post->post_title,
-                'error'      => $response->get_error_message(),
-            ] );
-        }
-
-        $json_match = [];
-        if ( preg_match( '/\{.*\}/s', $response, $json_match ) ) {
-            $result = json_decode( $json_match[0], true );
-            if ( is_array( $result ) ) {
-                // Save meta title.
-                if ( ! empty( $result['meta_title'] ) ) {
-                    $title = sanitize_text_field( $result['meta_title'] );
-                    update_post_meta( $post->ID, '_swps_meta_title', $title );
-                }
-
-                // Save meta description.
-                if ( ! empty( $result['meta_description'] ) ) {
-                    $desc = sanitize_text_field( $result['meta_description'] );
-                    update_post_meta( $post->ID, '_swps_meta_description', $desc );
-                    update_post_meta( $post->ID, '_yoast_wpseo_metadesc', $desc );
-                    update_post_meta( $post->ID, 'rank_math_description', $desc );
-                }
-
-                // Save focus keyword.
-                if ( ! empty( $result['focus_keyword'] ) ) {
-                    $kw = sanitize_text_field( $result['focus_keyword'] );
-                    update_post_meta( $post->ID, '_swps_focus_keyword', $kw );
-                    update_post_meta( $post->ID, '_yoast_wpseo_focuskw', $kw );
-                    update_post_meta( $post->ID, 'rank_math_focus_keyword', $kw );
-                }
-
-                // Invalidate cached SEO score so it recalculates.
-                delete_post_meta( $post->ID, '_swps_seo_score' );
-                delete_post_meta( $post->ID, '_swps_seo_score_value' );
-
-                wp_send_json_success( [
-                    'processed'  => $offset + 1,
-                    'total'      => $total,
-                    'done'       => ( $offset + 1 ) >= $total,
-                    'post_title' => $post->post_title,
-                    'generated'  => $result,
-                ] );
-            }
-        }
-
-        wp_send_json_success( [
-            'processed'  => $offset + 1,
-            'total'      => $total,
-            'done'       => ( $offset + 1 ) >= $total,
-            'post_title' => $post->post_title,
-            'error'      => 'Failed to parse AI response.',
-        ] );
-    }
-
-    /**
-     * Show admin notice when SEO plugin conflict detected.
-     */
-    public function conflict_notice(): void {
-        $screen = get_current_screen();
-        if ( ! $screen || strpos( $screen->id, 'stratawp-seo' ) === false ) {
-            return;
-        }
-
-        echo '<div class="notice notice-info"><p>';
-        esc_html_e( 'StrataWP SEO: Meta tag output is disabled because another SEO plugin (Yoast, RankMath, or AIOSEO) is active. The meta editor fields are still saved for reference.', 'stratawp-seo' );
-        echo '</p></div>';
-    }
-
-    /**
-     * Sanitize robots meta value against allowed options.
-     */
-    public function sanitize_robots( string $value ): string {
-        $allowed = [ '', 'noindex, follow', 'index, nofollow', 'noindex, nofollow' ];
-        return in_array( $value, $allowed, true ) ? $value : '';
-    }
-
-    /**
-     * Auto-generate meta title/description when a post transitions to publish.
-     */
-    public function maybe_auto_generate( string $new_status, string $old_status, WP_Post $post ): void {
-        if ( 'publish' !== $new_status || 'publish' === $old_status ) {
-            return;
-        }
-
-        // Skip posts created by the StrataWP generator — it handles meta itself.
-        if ( defined( 'SWPS_GENERATING' ) && SWPS_GENERATING ) {
-            return;
-        }
-
-        if ( ! in_array( $post->post_type, $this->get_enabled_post_types(), true ) ) {
-            return;
-        }
-
-        // Only generate if both fields are empty.
-        $existing_title = get_post_meta( $post->ID, '_swps_meta_title', true );
-        $existing_desc  = get_post_meta( $post->ID, '_swps_meta_description', true );
-        if ( ! empty( $existing_title ) || ! empty( $existing_desc ) ) {
-            return;
-        }
-
-        $content = wp_strip_all_tags( $post->post_content );
-        $content = mb_substr( $content, 0, 2000 );
-
-        $focus_keyword = get_post_meta( $post->ID, '_swps_focus_keyword', true );
-
-        $kw_instruction = ! empty( $focus_keyword )
-            ? "Focus keyword (provided by user): {$focus_keyword}"
-            : 'Focus keyword: (none specified — you MUST suggest one based on the content)';
-
-        $prompt = sprintf(
-            "Generate an SEO-optimized meta title (50-60 chars), meta description (140-160 chars), and focus keyword for this blog post.\n\n"
-            . "Post title: %s\n"
-            . "%s\n"
-            . "Content excerpt: %s\n\n"
-            . "Requirements:\n"
-            . "- If no focus keyword was provided, analyze the content and suggest the single best 2-4 word keyword phrase (e.g. 'WordPress SEO', 'Claude Skills' — NEVER a long sentence)\n"
-            . "- If a focus keyword was provided, use it as-is\n"
-            . "- Include the focus keyword naturally in both the meta title and meta description\n"
-            . "- Meta title: compelling, 50-60 characters, includes the focus keyword\n"
-            . "- Meta description: actionable, includes a call to read, 147-160 characters, includes the focus keyword\n\n"
-            . "Return JSON only: {\"meta_title\":\"...\",\"meta_description\":\"...\",\"focus_keyword\":\"...\"}",
-            $post->post_title,
-            $kw_instruction,
-            $content
-        );
-
-        $api      = SWPS_Provider_Factory::create_ai_provider();
-        $response = $api->chat( 'You are an SEO copywriting expert. Return only valid JSON.', $prompt, 1024 );
-
-        if ( is_wp_error( $response ) ) {
-            return;
-        }
-
-        $json_match = [];
-        if ( preg_match( '/\{.*\}/s', $response, $json_match ) ) {
-            $result = json_decode( $json_match[0], true );
-            if ( is_array( $result ) ) {
-                if ( ! empty( $result['meta_title'] ) ) {
-                    update_post_meta( $post->ID, '_swps_meta_title', sanitize_text_field( $result['meta_title'] ) );
-                }
-                if ( ! empty( $result['meta_description'] ) ) {
-                    update_post_meta( $post->ID, '_swps_meta_description', sanitize_textarea_field( $result['meta_description'] ) );
-                }
-                if ( ! empty( $result['focus_keyword'] ) ) {
-                    update_post_meta( $post->ID, '_swps_focus_keyword', sanitize_text_field( $result['focus_keyword'] ) );
-                }
-            }
-        }
-    }
-
-    /**
-     * Get post types where the meta editor is enabled.
-     */
-    private function get_enabled_post_types(): array {
-        $saved = get_option( 'swps_meta_editor_post_types', '' );
-        if ( ! empty( $saved ) ) {
-            return array_map( 'sanitize_text_field', explode( ',', $saved ) );
-        }
-        return [ 'post', 'page' ];
-    }
-
-    /**
-     * Output Open Graph tags.
-     */
-    private function output_og_tags( int $post_id ): void {
-        $title = get_post_meta( $post_id, '_swps_social_title', true )
-              ?: get_post_meta( $post_id, '_swps_meta_title', true )
-              ?: get_the_title( $post_id );
-
-        $desc = get_post_meta( $post_id, '_swps_social_description', true )
-             ?: get_post_meta( $post_id, '_swps_meta_description', true )
-             ?: get_the_excerpt( $post_id );
-
-        $image = get_post_meta( $post_id, '_swps_social_image', true )
-              ?: get_the_post_thumbnail_url( $post_id, 'large' );
-
-        printf( '<meta property="og:type" content="article" />' . "\n" );
-        printf( '<meta property="og:title" content="%s" />' . "\n", esc_attr( $title ) );
-        printf( '<meta property="og:description" content="%s" />' . "\n", esc_attr( $desc ) );
-        printf( '<meta property="og:url" content="%s" />' . "\n", esc_url( get_permalink( $post_id ) ) );
-        if ( $image ) {
-            printf( '<meta property="og:image" content="%s" />' . "\n", esc_url( $image ) );
-        }
-        printf( '<meta property="og:site_name" content="%s" />' . "\n", esc_attr( get_bloginfo( 'name' ) ) );
-    }
-
-    /**
-     * Output Twitter Card tags.
-     */
-    private function output_twitter_tags( int $post_id ): void {
-        $title = get_post_meta( $post_id, '_swps_social_title', true )
-              ?: get_post_meta( $post_id, '_swps_meta_title', true )
-              ?: get_the_title( $post_id );
-
-        $desc = get_post_meta( $post_id, '_swps_social_description', true )
-             ?: get_post_meta( $post_id, '_swps_meta_description', true )
-             ?: get_the_excerpt( $post_id );
-
-        $image = get_post_meta( $post_id, '_swps_social_image', true )
-              ?: get_the_post_thumbnail_url( $post_id, 'large' );
-
-        printf( '<meta name="twitter:card" content="%s" />' . "\n", $image ? 'summary_large_image' : 'summary' );
-        printf( '<meta name="twitter:title" content="%s" />' . "\n", esc_attr( $title ) );
-        printf( '<meta name="twitter:description" content="%s" />' . "\n", esc_attr( $desc ) );
-        if ( $image ) {
-            printf( '<meta name="twitter:image" content="%s" />' . "\n", esc_url( $image ) );
-        }
-    }
+	private bool $conflict = false;
+
+	public function __construct() {
+		// Detect conflicting SEO plugins.
+		if ( defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' ) ) {
+			$this->conflict = true;
+		}
+
+		if ( ! get_option( 'swps_meta_editor_enabled', 1 ) ) {
+			return;
+		}
+
+		// Admin: register metabox and save hook.
+		add_action( 'add_meta_boxes', array( $this, 'register_metabox' ) );
+		add_action( 'save_post', array( $this, 'save_meta' ), 10, 2 );
+
+		// AJAX: AI-generate meta.
+		add_action( 'wp_ajax_swps_generate_meta', array( $this, 'ajax_generate_meta' ) );
+		add_action( 'wp_ajax_swps_bulk_generate_meta', array( $this, 'ajax_bulk_generate_meta' ) );
+
+		// Frontend output — only when no conflict.
+		if ( ! $this->conflict && ! is_admin() ) {
+			add_action( 'wp_head', array( $this, 'output_meta_tags' ), 2 );
+			add_filter( 'pre_get_document_title', array( $this, 'filter_document_title' ), 20 );
+			add_filter( 'document_title_parts', array( $this, 'filter_title_parts' ), 20 );
+		}
+
+		// Auto-generate meta on publish if setting is enabled.
+		if ( get_option( 'swps_meta_auto_generate', 0 ) ) {
+			add_action( 'transition_post_status', array( $this, 'maybe_auto_generate' ), 10, 3 );
+		}
+
+		// Admin notice if conflict detected.
+		if ( $this->conflict ) {
+			add_action( 'admin_notices', array( $this, 'conflict_notice' ) );
+		}
+	}
+
+	/**
+	 * Check if there's an SEO plugin conflict.
+	 */
+	public function has_conflict(): bool {
+		return $this->conflict;
+	}
+
+	/**
+	 * Register the SEO metabox on configured post types.
+	 */
+	public function register_metabox(): void {
+		$post_types = $this->get_enabled_post_types();
+
+		foreach ( $post_types as $post_type ) {
+			add_meta_box(
+				'swps_meta_editor',
+				__( 'StrataWP SEO', 'stratawp-seo' ),
+				array( $this, 'render_metabox' ),
+				$post_type,
+				'normal',
+				'high'
+			);
+		}
+	}
+
+	/**
+	 * Render the SEO metabox.
+	 */
+	public function render_metabox( WP_Post $post ): void {
+		wp_nonce_field( 'swps_meta_editor', 'swps_meta_editor_nonce' );
+
+		$meta_title       = get_post_meta( $post->ID, '_swps_meta_title', true );
+		$meta_description = get_post_meta( $post->ID, '_swps_meta_description', true );
+		$focus_keyword    = get_post_meta( $post->ID, '_swps_focus_keyword', true );
+		$secondary_kws    = get_post_meta( $post->ID, '_swps_secondary_keywords', true );
+		$canonical_url    = get_post_meta( $post->ID, '_swps_canonical_url', true );
+		$robots           = get_post_meta( $post->ID, '_swps_robots', true );
+		$breadcrumb_title = get_post_meta( $post->ID, '_swps_breadcrumb_title', true );
+		$social_title     = get_post_meta( $post->ID, '_swps_social_title', true );
+		$social_desc      = get_post_meta( $post->ID, '_swps_social_description', true );
+		$social_image     = get_post_meta( $post->ID, '_swps_social_image', true );
+
+		// Sitemap controls.
+		$sitemap_exclude    = get_post_meta( $post->ID, '_swps_sitemap_exclude', true );
+		$sitemap_priority   = get_post_meta( $post->ID, '_swps_sitemap_priority', true );
+		$sitemap_changefreq = get_post_meta( $post->ID, '_swps_sitemap_changefreq', true );
+
+		if ( $this->conflict ) {
+			echo '<div class="notice notice-warning inline"><p>';
+			esc_html_e( 'Meta output is disabled because another SEO plugin is active. Fields are saved but not output on the frontend.', 'stratawp-seo' );
+			echo '</p></div>';
+		}
+
+		include SWPS_PLUGIN_DIR . 'templates/meta-editor-metabox.php';
+	}
+
+	/**
+	 * Save meta fields on post save.
+	 */
+	public function save_meta( int $post_id, WP_Post $post ): void {
+		if ( ! isset( $_POST['swps_meta_editor_nonce'] ) ) {
+			return;
+		}
+		if ( ! wp_verify_nonce( $_POST['swps_meta_editor_nonce'], 'swps_meta_editor' ) ) {
+			return;
+		}
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		$fields = array(
+			'_swps_meta_title'         => 'sanitize_text_field',
+			'_swps_meta_description'   => 'sanitize_textarea_field',
+			'_swps_focus_keyword'      => 'sanitize_text_field',
+			'_swps_secondary_keywords' => 'sanitize_text_field',
+			'_swps_canonical_url'      => 'esc_url_raw',
+			'_swps_robots'             => array( $this, 'sanitize_robots' ),
+			'_swps_breadcrumb_title'   => 'sanitize_text_field',
+			'_swps_social_title'       => 'sanitize_text_field',
+			'_swps_social_description' => 'sanitize_textarea_field',
+			'_swps_social_image'       => 'esc_url_raw',
+		);
+
+		foreach ( $fields as $key => $sanitizer ) {
+			if ( isset( $_POST[ $key ] ) ) {
+				$value = call_user_func( $sanitizer, $_POST[ $key ] );
+				if ( ! empty( $value ) ) {
+					update_post_meta( $post_id, $key, $value );
+				} else {
+					delete_post_meta( $post_id, $key );
+				}
+			}
+		}
+
+		// Sitemap meta.
+		update_post_meta( $post_id, '_swps_sitemap_exclude', ! empty( $_POST['swps_sitemap_exclude'] ) ? 1 : 0 );
+
+		$priority = isset( $_POST['swps_sitemap_priority'] ) ? sanitize_text_field( $_POST['swps_sitemap_priority'] ) : '';
+		update_post_meta( $post_id, '_swps_sitemap_priority', $priority );
+
+		$changefreq = isset( $_POST['swps_sitemap_changefreq'] ) ? sanitize_text_field( $_POST['swps_sitemap_changefreq'] ) : '';
+		update_post_meta( $post_id, '_swps_sitemap_changefreq', $changefreq );
+	}
+
+	/**
+	 * Output meta tags in wp_head.
+	 */
+	public function output_meta_tags(): void {
+		if ( ! is_singular() ) {
+			return;
+		}
+
+		$post_id = get_the_ID();
+		if ( ! $post_id ) {
+			return;
+		}
+
+		$meta_desc = get_post_meta( $post_id, '_swps_meta_description', true );
+		$canonical = get_post_meta( $post_id, '_swps_canonical_url', true );
+		$robots    = get_post_meta( $post_id, '_swps_robots', true );
+
+		// Meta description.
+		$meta_desc = SWPS_Hooks::filter_meta_description( $meta_desc, $post_id );
+		if ( ! empty( $meta_desc ) ) {
+			printf( '<meta name="description" content="%s" />' . "\n", esc_attr( $meta_desc ) );
+		}
+
+		// Canonical.
+		if ( ! empty( $canonical ) ) {
+			printf( '<link rel="canonical" href="%s" />' . "\n", esc_url( $canonical ) );
+			// Remove WP default canonical.
+			remove_action( 'wp_head', 'rel_canonical' );
+		}
+
+		// Robots.
+		$robots = SWPS_Hooks::filter_meta_robots( $robots, $post_id );
+		if ( ! empty( $robots ) && 'index, follow' !== $robots ) {
+			printf( '<meta name="robots" content="%s" />' . "\n", esc_attr( $robots ) );
+		}
+
+		// Open Graph.
+		$this->output_og_tags( $post_id );
+
+		// Twitter Card.
+		$this->output_twitter_tags( $post_id );
+	}
+
+	/**
+	 * Filter the document title for our custom meta title.
+	 */
+	public function filter_document_title( string $title ): string {
+		if ( ! is_singular() ) {
+			return $title;
+		}
+
+		$custom = get_post_meta( get_the_ID(), '_swps_meta_title', true );
+		$custom = SWPS_Hooks::filter_meta_title( $custom, get_the_ID() );
+
+		return ! empty( $custom ) ? $custom : $title;
+	}
+
+	/**
+	 * Filter document title parts.
+	 */
+	public function filter_title_parts( array $parts ): array {
+		if ( ! is_singular() ) {
+			return $parts;
+		}
+
+		$custom = get_post_meta( get_the_ID(), '_swps_meta_title', true );
+		$custom = SWPS_Hooks::filter_meta_title( $custom, get_the_ID() );
+
+		if ( ! empty( $custom ) ) {
+			$parts['title'] = $custom;
+			// Remove site name suffix if custom title is set.
+			unset( $parts['site'] );
+		}
+
+		return $parts;
+	}
+
+	/**
+	 * AJAX: Generate meta title and description using AI.
+	 */
+	public function ajax_generate_meta(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$post_id       = absint( $_POST['post_id'] ?? 0 );
+		$focus_keyword = sanitize_text_field( $_POST['focus_keyword'] ?? '' );
+
+		if ( ! $post_id ) {
+			wp_send_json_error( array( 'message' => 'Invalid post ID.' ) );
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			wp_send_json_error( array( 'message' => 'Post not found.' ) );
+		}
+
+		$content = wp_strip_all_tags( $post->post_content );
+		$content = mb_substr( $content, 0, 2000 ); // Limit to keep prompt short.
+
+		$kw_instruction = ! empty( $focus_keyword )
+			? "Focus keyword (provided by user): {$focus_keyword}"
+			: 'Focus keyword: (none specified — you MUST suggest one based on the content)';
+
+		$prompt = sprintf(
+			"Generate an SEO-optimized meta title (50-60 chars), meta description (140-160 chars), and focus keyword for this blog post.\n\n"
+			. "Post title: %s\n"
+			. "%s\n"
+			. "Content excerpt: %s\n\n"
+			. "Requirements:\n"
+			. "- If no focus keyword was provided, analyze the content and suggest the single best 2-4 word keyword phrase (e.g. 'WordPress SEO', 'Claude Skills' — NEVER a long sentence)\n"
+			. "- If a focus keyword was provided, use it as-is\n"
+			. "- Include the focus keyword naturally in both the meta title and meta description\n"
+			. "- Meta title: compelling, 50-60 characters, includes the focus keyword\n"
+			. "- Meta description: actionable, includes a call to read, 147-160 characters, includes the focus keyword\n\n"
+			. 'Return JSON only: {"meta_title":"...","meta_description":"...","focus_keyword":"..."}',
+			$post->post_title,
+			$kw_instruction,
+			$content
+		);
+
+		$api      = SWPS_Provider_Factory::create_ai_provider();
+		$response = $api->chat( 'You are an SEO copywriting expert. Return only valid JSON.', $prompt, 1024 );
+
+		if ( is_wp_error( $response ) ) {
+			wp_send_json_error( array( 'message' => $response->get_error_message() ) );
+		}
+
+		$json_match = array();
+		if ( preg_match( '/\{.*\}/s', $response, $json_match ) ) {
+			$result = json_decode( $json_match[0], true );
+			if ( is_array( $result ) ) {
+				// Save focus keyword to post meta immediately.
+				if ( ! empty( $result['focus_keyword'] ) ) {
+					$kw = sanitize_text_field( $result['focus_keyword'] );
+					update_post_meta( $post_id, '_swps_focus_keyword', $kw );
+					update_post_meta( $post_id, '_yoast_wpseo_focuskw', $kw );
+					update_post_meta( $post_id, 'rank_math_focus_keyword', $kw );
+				}
+				wp_send_json_success( $result );
+			}
+		}
+
+		wp_send_json_error( array( 'message' => 'Failed to parse AI response.' ) );
+	}
+
+	/**
+	 * AJAX: Bulk generate meta for all posts missing SEO meta.
+	 *
+	 * Processes one post per request to avoid AI timeout. JS loops until done.
+	 */
+	public function ajax_bulk_generate_meta(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$offset = absint( $_POST['offset'] ?? 0 );
+
+		$enabled_types = (array) get_option( 'swps_seo_column_post_types', array( 'post', 'page' ) );
+
+		// Count total posts.
+		$total = 0;
+		foreach ( $enabled_types as $pt ) {
+			$counts = wp_count_posts( $pt );
+			$total += ( $counts->publish ?? 0 ) + ( $counts->draft ?? 0 );
+		}
+
+		// Get one post at the current offset (AI calls are slow, so one at a time).
+		$posts = get_posts(
+			array(
+				'post_type'      => $enabled_types,
+				'post_status'    => array( 'publish', 'draft' ),
+				'posts_per_page' => 1,
+				'offset'         => $offset,
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+			)
+		);
+
+		if ( empty( $posts ) ) {
+			wp_send_json_success(
+				array(
+					'processed'  => $offset,
+					'total'      => $total,
+					'done'       => true,
+					'post_title' => '',
+				)
+			);
+		}
+
+		$post = $posts[0];
+
+		// Skip posts that already have meta title AND focus keyword.
+		$existing_title = get_post_meta( $post->ID, '_swps_meta_title', true );
+		$existing_kw    = get_post_meta( $post->ID, '_swps_focus_keyword', true );
+
+		if ( ! empty( $existing_title ) && ! empty( $existing_kw ) ) {
+			wp_send_json_success(
+				array(
+					'processed'  => $offset + 1,
+					'total'      => $total,
+					'done'       => ( $offset + 1 ) >= $total,
+					'post_title' => $post->post_title,
+					'skipped'    => true,
+				)
+			);
+		}
+
+		// Build the AI prompt (same logic as ajax_generate_meta).
+		$content = wp_strip_all_tags( $post->post_content );
+		$content = mb_substr( $content, 0, 2000 );
+
+		$prompt = sprintf(
+			"Generate an SEO-optimized meta title (50-60 chars), meta description (140-160 chars), and focus keyword for this blog post.\n\n"
+			. "Post title: %s\n"
+			. "Focus keyword: (none specified — you MUST suggest one based on the content)\n"
+			. "Content excerpt: %s\n\n"
+			. "Requirements:\n"
+			. "- Analyze the content and suggest the single best 2-4 word keyword phrase (e.g. 'WordPress SEO', 'Claude Skills' — NEVER a long sentence)\n"
+			. "- Include the focus keyword naturally in both the meta title and meta description\n"
+			. "- Meta title: compelling, 50-60 characters, includes the focus keyword\n"
+			. "- Meta description: actionable, includes a call to read, 147-160 characters, includes the focus keyword\n\n"
+			. 'Return JSON only: {"meta_title":"...","meta_description":"...","focus_keyword":"..."}',
+			$post->post_title,
+			$content
+		);
+
+		$api      = SWPS_Provider_Factory::create_ai_provider();
+		$response = $api->chat( 'You are an SEO copywriting expert. Return only valid JSON.', $prompt, 1024 );
+
+		if ( is_wp_error( $response ) ) {
+			wp_send_json_success(
+				array(
+					'processed'  => $offset + 1,
+					'total'      => $total,
+					'done'       => ( $offset + 1 ) >= $total,
+					'post_title' => $post->post_title,
+					'error'      => $response->get_error_message(),
+				)
+			);
+		}
+
+		$json_match = array();
+		if ( preg_match( '/\{.*\}/s', $response, $json_match ) ) {
+			$result = json_decode( $json_match[0], true );
+			if ( is_array( $result ) ) {
+				// Save meta title.
+				if ( ! empty( $result['meta_title'] ) ) {
+					$title = sanitize_text_field( $result['meta_title'] );
+					update_post_meta( $post->ID, '_swps_meta_title', $title );
+				}
+
+				// Save meta description.
+				if ( ! empty( $result['meta_description'] ) ) {
+					$desc = sanitize_text_field( $result['meta_description'] );
+					update_post_meta( $post->ID, '_swps_meta_description', $desc );
+					update_post_meta( $post->ID, '_yoast_wpseo_metadesc', $desc );
+					update_post_meta( $post->ID, 'rank_math_description', $desc );
+				}
+
+				// Save focus keyword.
+				if ( ! empty( $result['focus_keyword'] ) ) {
+					$kw = sanitize_text_field( $result['focus_keyword'] );
+					update_post_meta( $post->ID, '_swps_focus_keyword', $kw );
+					update_post_meta( $post->ID, '_yoast_wpseo_focuskw', $kw );
+					update_post_meta( $post->ID, 'rank_math_focus_keyword', $kw );
+				}
+
+				// Invalidate cached SEO score so it recalculates.
+				delete_post_meta( $post->ID, '_swps_seo_score' );
+				delete_post_meta( $post->ID, '_swps_seo_score_value' );
+
+				wp_send_json_success(
+					array(
+						'processed'  => $offset + 1,
+						'total'      => $total,
+						'done'       => ( $offset + 1 ) >= $total,
+						'post_title' => $post->post_title,
+						'generated'  => $result,
+					)
+				);
+			}
+		}
+
+		wp_send_json_success(
+			array(
+				'processed'  => $offset + 1,
+				'total'      => $total,
+				'done'       => ( $offset + 1 ) >= $total,
+				'post_title' => $post->post_title,
+				'error'      => 'Failed to parse AI response.',
+			)
+		);
+	}
+
+	/**
+	 * Show admin notice when SEO plugin conflict detected.
+	 */
+	public function conflict_notice(): void {
+		$screen = get_current_screen();
+		if ( ! $screen || strpos( $screen->id, 'stratawp-seo' ) === false ) {
+			return;
+		}
+
+		echo '<div class="notice notice-info"><p>';
+		esc_html_e( 'StrataWP SEO: Meta tag output is disabled because another SEO plugin (Yoast, RankMath, or AIOSEO) is active. The meta editor fields are still saved for reference.', 'stratawp-seo' );
+		echo '</p></div>';
+	}
+
+	/**
+	 * Sanitize robots meta value against allowed options.
+	 */
+	public function sanitize_robots( string $value ): string {
+		$allowed = array( '', 'noindex, follow', 'index, nofollow', 'noindex, nofollow' );
+		return in_array( $value, $allowed, true ) ? $value : '';
+	}
+
+	/**
+	 * Auto-generate meta title/description when a post transitions to publish.
+	 */
+	public function maybe_auto_generate( string $new_status, string $old_status, WP_Post $post ): void {
+		if ( 'publish' !== $new_status || 'publish' === $old_status ) {
+			return;
+		}
+
+		// Skip posts created by the StrataWP generator — it handles meta itself.
+		if ( defined( 'SWPS_GENERATING' ) && SWPS_GENERATING ) {
+			return;
+		}
+
+		if ( ! in_array( $post->post_type, $this->get_enabled_post_types(), true ) ) {
+			return;
+		}
+
+		// Only generate if both fields are empty.
+		$existing_title = get_post_meta( $post->ID, '_swps_meta_title', true );
+		$existing_desc  = get_post_meta( $post->ID, '_swps_meta_description', true );
+		if ( ! empty( $existing_title ) || ! empty( $existing_desc ) ) {
+			return;
+		}
+
+		$content = wp_strip_all_tags( $post->post_content );
+		$content = mb_substr( $content, 0, 2000 );
+
+		$focus_keyword = get_post_meta( $post->ID, '_swps_focus_keyword', true );
+
+		$kw_instruction = ! empty( $focus_keyword )
+			? "Focus keyword (provided by user): {$focus_keyword}"
+			: 'Focus keyword: (none specified — you MUST suggest one based on the content)';
+
+		$prompt = sprintf(
+			"Generate an SEO-optimized meta title (50-60 chars), meta description (140-160 chars), and focus keyword for this blog post.\n\n"
+			. "Post title: %s\n"
+			. "%s\n"
+			. "Content excerpt: %s\n\n"
+			. "Requirements:\n"
+			. "- If no focus keyword was provided, analyze the content and suggest the single best 2-4 word keyword phrase (e.g. 'WordPress SEO', 'Claude Skills' — NEVER a long sentence)\n"
+			. "- If a focus keyword was provided, use it as-is\n"
+			. "- Include the focus keyword naturally in both the meta title and meta description\n"
+			. "- Meta title: compelling, 50-60 characters, includes the focus keyword\n"
+			. "- Meta description: actionable, includes a call to read, 147-160 characters, includes the focus keyword\n\n"
+			. 'Return JSON only: {"meta_title":"...","meta_description":"...","focus_keyword":"..."}',
+			$post->post_title,
+			$kw_instruction,
+			$content
+		);
+
+		$api      = SWPS_Provider_Factory::create_ai_provider();
+		$response = $api->chat( 'You are an SEO copywriting expert. Return only valid JSON.', $prompt, 1024 );
+
+		if ( is_wp_error( $response ) ) {
+			return;
+		}
+
+		$json_match = array();
+		if ( preg_match( '/\{.*\}/s', $response, $json_match ) ) {
+			$result = json_decode( $json_match[0], true );
+			if ( is_array( $result ) ) {
+				if ( ! empty( $result['meta_title'] ) ) {
+					update_post_meta( $post->ID, '_swps_meta_title', sanitize_text_field( $result['meta_title'] ) );
+				}
+				if ( ! empty( $result['meta_description'] ) ) {
+					update_post_meta( $post->ID, '_swps_meta_description', sanitize_textarea_field( $result['meta_description'] ) );
+				}
+				if ( ! empty( $result['focus_keyword'] ) ) {
+					update_post_meta( $post->ID, '_swps_focus_keyword', sanitize_text_field( $result['focus_keyword'] ) );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get post types where the meta editor is enabled.
+	 */
+	private function get_enabled_post_types(): array {
+		$saved = get_option( 'swps_meta_editor_post_types', '' );
+		if ( ! empty( $saved ) ) {
+			return array_map( 'sanitize_text_field', explode( ',', $saved ) );
+		}
+		return array( 'post', 'page' );
+	}
+
+	/**
+	 * Output Open Graph tags.
+	 */
+	private function output_og_tags( int $post_id ): void {
+		$title = get_post_meta( $post_id, '_swps_social_title', true )
+				?: get_post_meta( $post_id, '_swps_meta_title', true )
+				?: get_the_title( $post_id );
+
+		$desc = get_post_meta( $post_id, '_swps_social_description', true )
+			?: get_post_meta( $post_id, '_swps_meta_description', true )
+			?: get_the_excerpt( $post_id );
+
+		$image = get_post_meta( $post_id, '_swps_social_image', true )
+				?: get_the_post_thumbnail_url( $post_id, 'large' );
+
+		printf( '<meta property="og:type" content="article" />' . "\n" );
+		printf( '<meta property="og:title" content="%s" />' . "\n", esc_attr( $title ) );
+		printf( '<meta property="og:description" content="%s" />' . "\n", esc_attr( $desc ) );
+		printf( '<meta property="og:url" content="%s" />' . "\n", esc_url( get_permalink( $post_id ) ) );
+		if ( $image ) {
+			printf( '<meta property="og:image" content="%s" />' . "\n", esc_url( $image ) );
+		}
+		printf( '<meta property="og:site_name" content="%s" />' . "\n", esc_attr( get_bloginfo( 'name' ) ) );
+	}
+
+	/**
+	 * Output Twitter Card tags.
+	 */
+	private function output_twitter_tags( int $post_id ): void {
+		$title = get_post_meta( $post_id, '_swps_social_title', true )
+				?: get_post_meta( $post_id, '_swps_meta_title', true )
+				?: get_the_title( $post_id );
+
+		$desc = get_post_meta( $post_id, '_swps_social_description', true )
+			?: get_post_meta( $post_id, '_swps_meta_description', true )
+			?: get_the_excerpt( $post_id );
+
+		$image = get_post_meta( $post_id, '_swps_social_image', true )
+				?: get_the_post_thumbnail_url( $post_id, 'large' );
+
+		printf( '<meta name="twitter:card" content="%s" />' . "\n", $image ? 'summary_large_image' : 'summary' );
+		printf( '<meta name="twitter:title" content="%s" />' . "\n", esc_attr( $title ) );
+		printf( '<meta name="twitter:description" content="%s" />' . "\n", esc_attr( $desc ) );
+		if ( $image ) {
+			printf( '<meta name="twitter:image" content="%s" />' . "\n", esc_url( $image ) );
+		}
+	}
 }

--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -8,745 +8,762 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Migration {
 
-    /** Backup option key (stores overwritten StrataWP values for undo). */
-    private const BACKUP_OPTION = 'swps_migration_backup';
+	/** Backup option key (stores overwritten StrataWP values for undo). */
+	private const BACKUP_OPTION = 'swps_migration_backup';
 
-    /** Report option key (last migration summary). */
-    private const REPORT_OPTION = 'swps_migration_last_report';
+	/** Report option key (last migration summary). */
+	private const REPORT_OPTION = 'swps_migration_last_report';
 
-    /** Batch size for post meta migration. */
-    private const BATCH_SIZE = 100;
+	/** Batch size for post meta migration. */
+	private const BATCH_SIZE = 100;
 
-    /**
-     * Per-post meta key map.
-     *
-     * StrataWP key => [ yoast_keys[], rank_math_keys[] ]
-     * The first non-empty source wins.
-     */
-    private const META_MAP = [
-        '_swps_meta_title'        => [ [ '_yoast_wpseo_title' ],            [ 'rank_math_title' ] ],
-        '_swps_meta_description'  => [ [ '_yoast_wpseo_metadesc' ],         [ 'rank_math_description' ] ],
-        '_swps_focus_keyword'     => [ [ '_yoast_wpseo_focuskw' ],          [ 'rank_math_focus_keyword' ] ],
-        '_swps_canonical_url'     => [ [ '_yoast_wpseo_canonical' ],        [ 'rank_math_canonical_url' ] ],
-        '_swps_breadcrumb_title'  => [ [ '_yoast_wpseo_bctitle' ],          [ 'rank_math_breadcrumb_title' ] ],
-        '_swps_social_title'      => [ [ '_yoast_wpseo_opengraph-title' ],  [ 'rank_math_facebook_title' ] ],
-        '_swps_social_description'=> [ [ '_yoast_wpseo_opengraph-description' ], [ 'rank_math_facebook_description' ] ],
-        '_swps_social_image'      => [ [ '_yoast_wpseo_opengraph-image' ],  [ 'rank_math_facebook_image' ] ],
-    ];
+	/**
+	 * Per-post meta key map.
+	 *
+	 * StrataWP key => [ yoast_keys[], rank_math_keys[] ]
+	 * The first non-empty source wins.
+	 */
+	private const META_MAP = array(
+		'_swps_meta_title'         => array( array( '_yoast_wpseo_title' ), array( 'rank_math_title' ) ),
+		'_swps_meta_description'   => array( array( '_yoast_wpseo_metadesc' ), array( 'rank_math_description' ) ),
+		'_swps_focus_keyword'      => array( array( '_yoast_wpseo_focuskw' ), array( 'rank_math_focus_keyword' ) ),
+		'_swps_canonical_url'      => array( array( '_yoast_wpseo_canonical' ), array( 'rank_math_canonical_url' ) ),
+		'_swps_breadcrumb_title'   => array( array( '_yoast_wpseo_bctitle' ), array( 'rank_math_breadcrumb_title' ) ),
+		'_swps_social_title'       => array( array( '_yoast_wpseo_opengraph-title' ), array( 'rank_math_facebook_title' ) ),
+		'_swps_social_description' => array( array( '_yoast_wpseo_opengraph-description' ), array( 'rank_math_facebook_description' ) ),
+		'_swps_social_image'       => array( array( '_yoast_wpseo_opengraph-image' ), array( 'rank_math_facebook_image' ) ),
+	);
 
-    /**
-     * Yoast separator codes → literal characters.
-     */
-    private const YOAST_SEPARATOR_MAP = [
-        'sc-dash'    => '-',
-        'sc-ndash'   => '–',
-        'sc-mdash'   => '—',
-        'sc-middot'  => '·',
-        'sc-bull'    => '•',
-        'sc-star'    => '*',
-        'sc-smstar'  => '⋆',
-        'sc-pipe'    => '|',
-        'sc-tilde'   => '~',
-        'sc-laquo'   => '«',
-        'sc-raquo'   => '»',
-        'sc-lt'      => '<',
-        'sc-gt'      => '>',
-    ];
+	/**
+	 * Yoast separator codes → literal characters.
+	 */
+	private const YOAST_SEPARATOR_MAP = array(
+		'sc-dash'   => '-',
+		'sc-ndash'  => '–',
+		'sc-mdash'  => '—',
+		'sc-middot' => '·',
+		'sc-bull'   => '•',
+		'sc-star'   => '*',
+		'sc-smstar' => '⋆',
+		'sc-pipe'   => '|',
+		'sc-tilde'  => '~',
+		'sc-laquo'  => '«',
+		'sc-raquo'  => '»',
+		'sc-lt'     => '<',
+		'sc-gt'     => '>',
+	);
 
-    /**
-     * Rank Math single-percent variable → StrataWP double-percent variable.
-     */
-    private const RM_VAR_MAP = [
-        '%title%'        => '%%title%%',
-        '%sitename%'     => '%%sitename%%',
-        '%sitedesc%'     => '%%sitedesc%%',
-        '%sep%'          => '%%sep%%',
-        '%excerpt%'      => '%%excerpt%%',
-        '%excerpt_only%' => '%%excerpt%%',
-        '%page%'         => '%%page%%',
-        '%pagenumber%'   => '%%pagenumber%%',
-        '%pagetotal%'    => '%%pagetotal%%',
-        '%category%'     => '%%category%%',
-        '%tag%'          => '%%tag%%',
-        '%term%'         => '%%term_title%%',
-        '%term_title%'   => '%%term_title%%',
-        '%date%'         => '%%date%%',
-        '%modified%'     => '%%modified%%',
-        '%search_query%' => '%%searchphrase%%',
-        '%name%'         => '%%name%%',
-        '%user_description%' => '%%user_description%%',
-        '%pt_plural%'    => '%%pt_plural%%',
-        '%pt_single%'    => '%%pt_single%%',
-        '%currenttime%'  => '%%currenttime%%',
-        '%currentdate%'  => '%%currentdate%%',
-        '%currentyear%'  => '%%currentyear%%',
-        '%currentmonth%' => '%%currentmonth%%',
-        '%currentday%'   => '%%currentday%%',
-    ];
+	/**
+	 * Rank Math single-percent variable → StrataWP double-percent variable.
+	 */
+	private const RM_VAR_MAP = array(
+		'%title%'            => '%%title%%',
+		'%sitename%'         => '%%sitename%%',
+		'%sitedesc%'         => '%%sitedesc%%',
+		'%sep%'              => '%%sep%%',
+		'%excerpt%'          => '%%excerpt%%',
+		'%excerpt_only%'     => '%%excerpt%%',
+		'%page%'             => '%%page%%',
+		'%pagenumber%'       => '%%pagenumber%%',
+		'%pagetotal%'        => '%%pagetotal%%',
+		'%category%'         => '%%category%%',
+		'%tag%'              => '%%tag%%',
+		'%term%'             => '%%term_title%%',
+		'%term_title%'       => '%%term_title%%',
+		'%date%'             => '%%date%%',
+		'%modified%'         => '%%modified%%',
+		'%search_query%'     => '%%searchphrase%%',
+		'%name%'             => '%%name%%',
+		'%user_description%' => '%%user_description%%',
+		'%pt_plural%'        => '%%pt_plural%%',
+		'%pt_single%'        => '%%pt_single%%',
+		'%currenttime%'      => '%%currenttime%%',
+		'%currentdate%'      => '%%currentdate%%',
+		'%currentyear%'      => '%%currentyear%%',
+		'%currentmonth%'     => '%%currentmonth%%',
+		'%currentday%'       => '%%currentday%%',
+	);
 
-    public function __construct() {
-        add_action( 'admin_post_swps_run_migration', [ $this, 'handle_run' ] );
-        add_action( 'admin_post_swps_undo_migration', [ $this, 'handle_undo' ] );
-    }
+	public function __construct() {
+		add_action( 'admin_post_swps_run_migration', array( $this, 'handle_run' ) );
+		add_action( 'admin_post_swps_undo_migration', array( $this, 'handle_undo' ) );
+	}
 
-    /**
-     * Detect installed source plugins.
-     *
-     * Returns array keyed by source slug => [ 'label' => string, 'post_count' => int ].
-     */
-    public function detect_sources(): array {
-        global $wpdb;
-        $sources = [];
+	/**
+	 * Detect installed source plugins.
+	 *
+	 * Returns array keyed by source slug => [ 'label' => string, 'post_count' => int ].
+	 */
+	public function detect_sources(): array {
+		global $wpdb;
+		$sources = array();
 
-        $yoast_count = (int) $wpdb->get_var(
-            "SELECT COUNT(DISTINCT post_id) FROM {$wpdb->postmeta}
+		$yoast_count = (int) $wpdb->get_var(
+			"SELECT COUNT(DISTINCT post_id) FROM {$wpdb->postmeta}
              WHERE meta_key IN ('_yoast_wpseo_title','_yoast_wpseo_metadesc','_yoast_wpseo_focuskw','_yoast_wpseo_canonical')
              AND meta_value <> ''"
-        );
-        if ( $yoast_count > 0 || get_option( 'wpseo' ) || get_option( 'wpseo_titles' ) ) {
-            $sources['yoast'] = [
-                'label'      => __( 'Yoast SEO / Yoast SEO Premium', 'stratawp-seo' ),
-                'post_count' => $yoast_count,
-            ];
-        }
+		);
+		if ( $yoast_count > 0 || get_option( 'wpseo' ) || get_option( 'wpseo_titles' ) ) {
+			$sources['yoast'] = array(
+				'label'      => __( 'Yoast SEO / Yoast SEO Premium', 'stratawp-seo' ),
+				'post_count' => $yoast_count,
+			);
+		}
 
-        $rm_count = (int) $wpdb->get_var(
-            "SELECT COUNT(DISTINCT post_id) FROM {$wpdb->postmeta}
+		$rm_count = (int) $wpdb->get_var(
+			"SELECT COUNT(DISTINCT post_id) FROM {$wpdb->postmeta}
              WHERE meta_key IN ('rank_math_title','rank_math_description','rank_math_focus_keyword','rank_math_canonical_url')
              AND meta_value <> ''"
-        );
-        if ( $rm_count > 0 || get_option( 'rank-math-options-titles' ) || get_option( 'rank-math-options-general' ) ) {
-            $sources['rank_math'] = [
-                'label'      => __( 'Rank Math SEO / Rank Math Pro', 'stratawp-seo' ),
-                'post_count' => $rm_count,
-            ];
-        }
-
-        return $sources;
-    }
-
-    /**
-     * Preview without writing — counts what would change.
-     *
-     * @param string[] $phases subset of ['post_meta','settings','redirects'].
-     */
-    public function preview( string $source, string $conflict_policy, array $phases ): array {
-        $stats = [
-            'posts_scanned'           => 0,
-            'fields_to_write'         => 0,
-            'fields_skipped_existing' => 0,
-            'fields_overwritten'      => 0,
-            'options_to_write'        => 0,
-            'options_skipped'         => 0,
-            'redirects_to_write'      => 0,
-        ];
-        $valid_phases = array_intersect( $phases, [ 'post_meta', 'settings', 'redirects' ] );
-
-        if ( in_array( 'post_meta', $valid_phases, true ) ) {
-            foreach ( $this->iterate_source_posts( $source ) as $post_id => $source_meta ) {
-                $stats['posts_scanned']++;
-                foreach ( self::META_MAP as $swps_key => $sources ) {
-                    $value = $this->pick_value( $source_meta, $sources, $source );
-                    if ( '' === $value ) {
-                        continue;
-                    }
-                    $existing = get_post_meta( $post_id, $swps_key, true );
-                    if ( '' !== (string) $existing && (string) $existing !== $value ) {
-                        if ( 'skip' === $conflict_policy ) {
-                            $stats['fields_skipped_existing']++;
-                            continue;
-                        }
-                        $stats['fields_overwritten']++;
-                    }
-                    $stats['fields_to_write']++;
-                }
-            }
-        }
-
-        if ( in_array( 'settings', $valid_phases, true ) ) {
-            $mappings = $this->build_settings_mappings( $source );
-            foreach ( $mappings as $opt => $val ) {
-                if ( null === $val || '' === $val ) {
-                    continue;
-                }
-                $existing = get_option( $opt, '' );
-                $existing_str = is_scalar( $existing ) ? (string) $existing : '';
-                if ( '' !== $existing_str && $existing_str !== (string) $val && 'skip' === $conflict_policy ) {
-                    $stats['options_skipped']++;
-                    continue;
-                }
-                $stats['options_to_write']++;
-            }
-        }
-
-        if ( in_array( 'redirects', $valid_phases, true ) ) {
-            $stats['redirects_to_write'] = $this->count_source_redirects( $source );
-        }
-
-        return $stats;
-    }
-
-    /**
-     * Count redirects available in the source plugin (no insert).
-     */
-    private function count_source_redirects( string $source ): int {
-        if ( 'yoast' === $source ) {
-            $plain = get_option( 'wpseo-premium-redirects-base', [] );
-            $regex = get_option( 'wpseo-premium-redirects-base-regex', [] );
-            return ( is_array( $plain ) ? count( $plain ) : 0 ) + ( is_array( $regex ) ? count( $regex ) : 0 );
-        }
-        global $wpdb;
-        $rm_table = $wpdb->prefix . 'rank_math_redirections';
-        $exists   = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $rm_table ) );
-        if ( ! $exists ) {
-            return 0;
-        }
-        return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$rm_table} WHERE status = 'active'" );
-    }
-
-    /**
-     * Run the migration. Returns a report array.
-     *
-     * @param string   $source          'yoast' or 'rank_math'.
-     * @param string   $conflict_policy 'skip' or 'overwrite'.
-     * @param string[] $phases          subset of ['post_meta','settings','redirects'].
-     */
-    public function run( string $source, string $conflict_policy, array $phases ): array {
-        if ( ! in_array( $source, [ 'yoast', 'rank_math' ], true ) ) {
-            return [ 'error' => __( 'Unknown source.', 'stratawp-seo' ) ];
-        }
-        if ( ! in_array( $conflict_policy, [ 'skip', 'overwrite' ], true ) ) {
-            $conflict_policy = 'skip';
-        }
-        $valid_phases = array_intersect( $phases, [ 'post_meta', 'settings', 'redirects' ] );
-
-        $report = [
-            'source'           => $source,
-            'conflict_policy'  => $conflict_policy,
-            'phases'           => array_values( $valid_phases ),
-            'started_at'       => current_time( 'mysql' ),
-            'posts_processed'  => 0,
-            'fields_written'   => 0,
-            'fields_skipped'   => 0,
-            'fields_overwritten' => 0,
-            'options_written'  => 0,
-            'options_skipped'  => 0,
-            'redirects_written' => 0,
-            'redirects_skipped' => 0,
-            'redirects_errors'  => [],
-            'notes'            => [],
-        ];
-
-        $backup = $this->fresh_backup();
-
-        if ( in_array( 'post_meta', $valid_phases, true ) ) {
-            $this->run_post_meta( $source, $conflict_policy, $report, $backup );
-        }
-        if ( in_array( 'settings', $valid_phases, true ) ) {
-            $this->run_settings( $source, $conflict_policy, $report, $backup );
-        }
-        if ( in_array( 'redirects', $valid_phases, true ) ) {
-            $this->run_redirects( $source, $report, $backup );
-        }
-
-        $report['finished_at'] = current_time( 'mysql' );
-
-        update_option( self::BACKUP_OPTION, $backup, false );
-        update_option( self::REPORT_OPTION, $report, false );
-
-        return $report;
-    }
-
-    /**
-     * Undo last migration using the backup snapshot.
-     */
-    public function undo(): array {
-        $backup = get_option( self::BACKUP_OPTION, [] );
-        if ( ! is_array( $backup ) || empty( $backup ) ) {
-            return [ 'error' => __( 'Nothing to undo.', 'stratawp-seo' ) ];
-        }
-
-        $reverted = 0;
-
-        // New typed format.
-        $post_meta = $backup['post_meta'] ?? null;
-        $options   = $backup['options']   ?? null;
-        $redirects = $backup['redirects'] ?? null;
-
-        // Backwards-compat with v4.3.0 flat format ( post_id => [ key => prev ] ).
-        if ( null === $post_meta && null === $options && null === $redirects ) {
-            $post_meta = $backup;
-        }
-
-        if ( is_array( $post_meta ) ) {
-            foreach ( $post_meta as $post_id => $keys ) {
-                if ( ! is_array( $keys ) ) {
-                    continue;
-                }
-                foreach ( $keys as $swps_key => $previous ) {
-                    if ( null === $previous ) {
-                        delete_post_meta( (int) $post_id, $swps_key );
-                    } else {
-                        update_post_meta( (int) $post_id, $swps_key, $previous );
-                    }
-                    $reverted++;
-                }
-            }
-        }
-
-        if ( is_array( $options ) ) {
-            foreach ( $options as $name => $previous ) {
-                if ( null === $previous ) {
-                    delete_option( $name );
-                } else {
-                    update_option( $name, $previous, false );
-                }
-                $reverted++;
-            }
-        }
-
-        if ( is_array( $redirects ) && ! empty( $redirects ) ) {
-            global $wpdb;
-            $table = $wpdb->prefix . 'swps_redirects';
-            $ids   = array_map( 'intval', $redirects );
-            $placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
-            $wpdb->query( $wpdb->prepare( "DELETE FROM {$table} WHERE id IN ($placeholders)", $ids ) );
-            $reverted += count( $ids );
-            delete_transient( 'swps_redirects_cache' );
-        }
-
-        delete_option( self::BACKUP_OPTION );
-
-        return [
-            'reverted' => $reverted,
-        ];
-    }
-
-    /**
-     * Build a fresh, typed backup container.
-     */
-    private function fresh_backup(): array {
-        return [
-            'post_meta' => [],
-            'options'   => [],
-            'redirects' => [],
-        ];
-    }
-
-    /**
-     * Phase 1: per-post meta.
-     */
-    private function run_post_meta( string $source, string $conflict_policy, array &$report, array &$backup ): void {
-        foreach ( $this->iterate_source_posts( $source ) as $post_id => $source_meta ) {
-            $report['posts_processed']++;
-
-            foreach ( self::META_MAP as $swps_key => $sources ) {
-                $value = $this->pick_value( $source_meta, $sources, $source );
-                if ( '' === $value ) {
-                    continue;
-                }
-
-                $existing     = get_post_meta( $post_id, $swps_key, true );
-                $existing_str = (string) $existing;
-
-                if ( '' !== $existing_str && $existing_str !== $value ) {
-                    if ( 'skip' === $conflict_policy ) {
-                        $report['fields_skipped']++;
-                        continue;
-                    }
-                    $report['fields_overwritten']++;
-                }
-
-                if ( ! isset( $backup['post_meta'][ $post_id ][ $swps_key ] ) ) {
-                    $backup['post_meta'][ $post_id ][ $swps_key ] = '' === $existing_str ? null : $existing_str;
-                }
-
-                update_post_meta( $post_id, $swps_key, $value );
-                $report['fields_written']++;
-            }
-        }
-    }
-
-    /**
-     * Phase 2: global settings (separator, title templates, noindex flags).
-     */
-    private function run_settings( string $source, string $conflict_policy, array &$report, array &$backup ): void {
-        $mappings = $this->build_settings_mappings( $source );
-
-        foreach ( $mappings as $swps_option => $value ) {
-            if ( null === $value || '' === $value ) {
-                continue;
-            }
-
-            $existing     = get_option( $swps_option, '' );
-            $existing_str = is_scalar( $existing ) ? (string) $existing : '';
-
-            if ( '' !== $existing_str && $existing_str !== (string) $value && 'skip' === $conflict_policy ) {
-                $report['options_skipped']++;
-                continue;
-            }
-
-            if ( ! array_key_exists( $swps_option, $backup['options'] ) ) {
-                $backup['options'][ $swps_option ] = ( false === get_option( $swps_option, false ) ) ? null : $existing;
-            }
-
-            update_option( $swps_option, $value, false );
-            $report['options_written']++;
-        }
-    }
-
-    /**
-     * Build StrataWP option => value map from source plugin options.
-     */
-    private function build_settings_mappings( string $source ): array {
-        $out = [];
-
-        if ( 'yoast' === $source ) {
-            $titles = get_option( 'wpseo_titles', [] );
-            if ( ! is_array( $titles ) ) {
-                $titles = [];
-            }
-
-            // Separator.
-            if ( ! empty( $titles['separator'] ) ) {
-                $code = (string) $titles['separator'];
-                $out['swps_title_separator'] = self::YOAST_SEPARATOR_MAP[ $code ] ?? $code;
-            }
-
-            // Title templates: title-{post_type}, title-tax-{taxonomy}, title-author-wpseo, etc.
-            foreach ( $titles as $key => $val ) {
-                if ( ! is_string( $val ) || '' === $val ) {
-                    continue;
-                }
-                $rewritten = $this->rewrite_template_vars( $val, 'yoast' );
-
-                if ( 'title-author-wpseo' === $key ) {
-                    $out['swps_title_template_author'] = $rewritten;
-                } elseif ( 'title-archive-wpseo' === $key ) {
-                    $out['swps_title_template_date'] = $rewritten;
-                } elseif ( 'title-search-wpseo' === $key ) {
-                    $out['swps_title_template_search'] = $rewritten;
-                } elseif ( 'title-404-wpseo' === $key ) {
-                    $out['swps_title_template_404'] = $rewritten;
-                } elseif ( 0 === strpos( $key, 'title-tax-' ) ) {
-                    $tax = substr( $key, strlen( 'title-tax-' ) );
-                    if ( $tax ) {
-                        $out[ "swps_title_template_{$tax}" ] = $rewritten;
-                    }
-                } elseif ( 0 === strpos( $key, 'title-ptarchive-' ) ) {
-                    $pt = substr( $key, strlen( 'title-ptarchive-' ) );
-                    if ( $pt ) {
-                        $out[ "swps_title_template_{$pt}_archive" ] = $rewritten;
-                    }
-                } elseif ( 0 === strpos( $key, 'title-' ) ) {
-                    $pt = substr( $key, strlen( 'title-' ) );
-                    if ( $pt && false === strpos( $pt, '-wpseo' ) && false === strpos( $pt, 'tax-' ) && false === strpos( $pt, 'ptarchive-' ) ) {
-                        $out[ "swps_title_template_{$pt}" ] = $rewritten;
-                    }
-                }
-            }
-
-            // noindex flags: noindex-{post_type} → swps_noindex_{post_type}.
-            foreach ( $titles as $key => $val ) {
-                if ( 0 === strpos( $key, 'noindex-' ) ) {
-                    $rest = substr( $key, strlen( 'noindex-' ) );
-                    if ( 'author-wpseo' === $rest || 'archive-wpseo' === $rest ) {
-                        continue;
-                    }
-                    if ( 0 === strpos( $rest, 'tax-' ) ) {
-                        $rest = substr( $rest, strlen( 'tax-' ) );
-                    }
-                    if ( $rest ) {
-                        $out[ "swps_noindex_{$rest}" ] = ! empty( $val ) ? 1 : 0;
-                    }
-                }
-            }
-        } else {
-            $titles = get_option( 'rank-math-options-titles', [] );
-            if ( ! is_array( $titles ) ) {
-                $titles = [];
-            }
-
-            if ( ! empty( $titles['title_separator'] ) ) {
-                $out['swps_title_separator'] = (string) $titles['title_separator'];
-            }
-
-            foreach ( $titles as $key => $val ) {
-                if ( ! is_string( $val ) || '' === $val ) {
-                    continue;
-                }
-                $rewritten = $this->rewrite_template_vars( $val, 'rank_math' );
-
-                if ( preg_match( '/^pt_(.+)_title$/', $key, $m ) ) {
-                    $out[ "swps_title_template_{$m[1]}" ] = $rewritten;
-                } elseif ( preg_match( '/^tax_(.+)_title$/', $key, $m ) ) {
-                    $out[ "swps_title_template_{$m[1]}" ] = $rewritten;
-                } elseif ( 'author_archive_title' === $key ) {
-                    $out['swps_title_template_author'] = $rewritten;
-                } elseif ( 'date_archive_title' === $key ) {
-                    $out['swps_title_template_date'] = $rewritten;
-                } elseif ( 'search_title' === $key ) {
-                    $out['swps_title_template_search'] = $rewritten;
-                } elseif ( '404_title' === $key ) {
-                    $out['swps_title_template_404'] = $rewritten;
-                }
-            }
-
-            // noindex flags.
-            foreach ( $titles as $key => $val ) {
-                if ( preg_match( '/^pt_(.+)_robots$/', $key, $m ) && is_array( $val ) && in_array( 'noindex', $val, true ) ) {
-                    $out[ "swps_noindex_{$m[1]}" ] = 1;
-                } elseif ( preg_match( '/^tax_(.+)_robots$/', $key, $m ) && is_array( $val ) && in_array( 'noindex', $val, true ) ) {
-                    $out[ "swps_noindex_{$m[1]}" ] = 1;
-                }
-            }
-        }
-
-        return $out;
-    }
-
-    /**
-     * Rewrite source-plugin template variables to StrataWP %%var%% syntax.
-     */
-    private function rewrite_template_vars( string $template, string $source ): string {
-        if ( 'rank_math' === $source ) {
-            // Sort keys by length descending so longer matches replace first.
-            $keys = array_keys( self::RM_VAR_MAP );
-            usort( $keys, static fn( $a, $b ) => strlen( $b ) - strlen( $a ) );
-            foreach ( $keys as $k ) {
-                $template = str_replace( $k, self::RM_VAR_MAP[ $k ], $template );
-            }
-        }
-        // Yoast already uses %%var%% so no rewriting needed.
-        return $template;
-    }
-
-    /**
-     * Phase 3: redirects (Yoast Premium + Rank Math Pro).
-     */
-    private function run_redirects( string $source, array &$report, array &$backup ): void {
-        if ( ! isset( stratawp_seo()->redirect_manager ) ) {
-            $report['notes'][] = __( 'Redirect manager unavailable; skipping redirects.', 'stratawp-seo' );
-            return;
-        }
-        $manager = stratawp_seo()->redirect_manager;
-
-        if ( 'yoast' === $source ) {
-            $plain = get_option( 'wpseo-premium-redirects-base', [] );
-            $regex = get_option( 'wpseo-premium-redirects-base-regex', [] );
-
-            foreach ( (array) $plain as $src => $row ) {
-                $this->insert_redirect_safe( $manager, (string) $src, (string) ( $row['url'] ?? '' ), (int) ( $row['type'] ?? 301 ), false, $report, $backup );
-            }
-            foreach ( (array) $regex as $src => $row ) {
-                $this->insert_redirect_safe( $manager, (string) $src, (string) ( $row['url'] ?? '' ), (int) ( $row['type'] ?? 301 ), true, $report, $backup );
-            }
-        } else {
-            global $wpdb;
-            $rm_table = $wpdb->prefix . 'rank_math_redirections';
-            $exists   = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $rm_table ) );
-            if ( ! $exists ) {
-                $report['notes'][] = __( 'Rank Math redirections table not found.', 'stratawp-seo' );
-                return;
-            }
-
-            $rows = $wpdb->get_results( "SELECT sources, url_to, header_code FROM {$rm_table} WHERE status = 'active'" );
-            foreach ( (array) $rows as $row ) {
-                $sources = maybe_unserialize( $row->sources );
-                if ( ! is_array( $sources ) ) {
-                    continue;
-                }
-                $type = (int) ( $row->header_code ?: 301 );
-                $tgt  = (string) ( $row->url_to ?? '' );
-
-                foreach ( $sources as $entry ) {
-                    if ( ! is_array( $entry ) || empty( $entry['pattern'] ) ) {
-                        continue;
-                    }
-                    $is_regex = isset( $entry['comparison'] ) && 'regex' === $entry['comparison'];
-                    $this->insert_redirect_safe( $manager, (string) $entry['pattern'], $tgt, $type, $is_regex, $report, $backup );
-                }
-            }
-        }
-    }
-
-    /**
-     * Insert one redirect, recording the new ID in backup for undo.
-     */
-    private function insert_redirect_safe( $manager, string $source, string $target, int $type, bool $is_regex, array &$report, array &$backup ): void {
-        if ( '' === $source ) {
-            $report['redirects_skipped']++;
-            return;
-        }
-        if ( ! in_array( $type, [ 301, 302, 307, 410 ], true ) ) {
-            $type = 301;
-        }
-
-        $result = $manager->add_redirect( $source, $target, $type, $is_regex );
-
-        if ( is_wp_error( $result ) ) {
-            $report['redirects_errors'][] = sprintf( '%s: %s', $source, $result->get_error_message() );
-            $report['redirects_skipped']++;
-            return;
-        }
-        if ( false === $result ) {
-            $report['redirects_skipped']++;
-            return;
-        }
-
-        $backup['redirects'][] = (int) $result;
-        $report['redirects_written']++;
-    }
-
-    /**
-     * Form handler: run migration.
-     */
-    public function handle_run(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have permission to do this.', 'stratawp-seo' ) );
-        }
-        check_admin_referer( 'swps_run_migration' );
-
-        $source          = isset( $_POST['source'] ) ? sanitize_key( wp_unslash( $_POST['source'] ) ) : '';
-        $conflict_policy = isset( $_POST['conflict_policy'] ) ? sanitize_key( wp_unslash( $_POST['conflict_policy'] ) ) : 'skip';
-        $mode            = isset( $_POST['mode'] ) ? sanitize_key( wp_unslash( $_POST['mode'] ) ) : 'preview';
-        $phases_raw      = isset( $_POST['phases'] ) && is_array( $_POST['phases'] ) ? array_map( 'sanitize_key', wp_unslash( $_POST['phases'] ) ) : [];
-        if ( empty( $phases_raw ) ) {
-            $phases_raw = [ 'post_meta' ];
-        }
-
-        if ( 'run' === $mode ) {
-            $this->run( $source, $conflict_policy, $phases_raw );
-            $redirect = add_query_arg(
-                [ 'page' => 'swps-migration', 'migration' => 'done' ],
-                admin_url( 'admin.php' )
-            );
-        } else {
-            $preview = $this->preview( $source, $conflict_policy, $phases_raw );
-            set_transient( 'swps_migration_preview_' . get_current_user_id(), [
-                'source' => $source,
-                'conflict_policy' => $conflict_policy,
-                'phases' => $phases_raw,
-                'stats' => $preview,
-            ], 10 * MINUTE_IN_SECONDS );
-            $redirect = add_query_arg(
-                [ 'page' => 'swps-migration', 'migration' => 'preview' ],
-                admin_url( 'admin.php' )
-            );
-        }
-
-        wp_safe_redirect( $redirect );
-        exit;
-    }
-
-    /**
-     * Form handler: undo last migration.
-     */
-    public function handle_undo(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have permission to do this.', 'stratawp-seo' ) );
-        }
-        check_admin_referer( 'swps_undo_migration' );
-
-        $this->undo();
-
-        wp_safe_redirect( add_query_arg(
-            [ 'page' => 'swps-migration', 'migration' => 'undone' ],
-            admin_url( 'admin.php' )
-        ) );
-        exit;
-    }
-
-    /**
-     * Pick the source value for a StrataWP key from a row of source meta.
-     *
-     * @param array  $row        post_id meta as key=>value (string).
-     * @param array  $source_def [ yoast_keys[], rm_keys[] ]
-     * @param string $source     'yoast' or 'rank_math'.
-     */
-    private function pick_value( array $row, array $source_def, string $source ): string {
-        $keys = 'yoast' === $source ? $source_def[0] : $source_def[1];
-        foreach ( $keys as $k ) {
-            if ( isset( $row[ $k ] ) && '' !== (string) $row[ $k ] ) {
-                return (string) $row[ $k ];
-            }
-        }
-        return '';
-    }
-
-    /**
-     * Generator: yields post_id => [ meta_key => meta_value ] for posts with source meta.
-     *
-     * Streams in batches of self::BATCH_SIZE to avoid loading the whole site into memory.
-     */
-    private function iterate_source_posts( string $source ): Generator {
-        global $wpdb;
-
-        $keys = 'yoast' === $source
-            ? array_merge( ...array_column( self::META_MAP, 0 ) )
-            : array_merge( ...array_column( self::META_MAP, 1 ) );
-
-        if ( empty( $keys ) ) {
-            return;
-        }
-
-        $placeholders = implode( ',', array_fill( 0, count( $keys ), '%s' ) );
-
-        $offset = 0;
-        while ( true ) {
-            $sql = $wpdb->prepare(
-                "SELECT DISTINCT post_id FROM {$wpdb->postmeta}
+		);
+		if ( $rm_count > 0 || get_option( 'rank-math-options-titles' ) || get_option( 'rank-math-options-general' ) ) {
+			$sources['rank_math'] = array(
+				'label'      => __( 'Rank Math SEO / Rank Math Pro', 'stratawp-seo' ),
+				'post_count' => $rm_count,
+			);
+		}
+
+		return $sources;
+	}
+
+	/**
+	 * Preview without writing — counts what would change.
+	 *
+	 * @param string[] $phases subset of ['post_meta','settings','redirects'].
+	 */
+	public function preview( string $source, string $conflict_policy, array $phases ): array {
+		$stats        = array(
+			'posts_scanned'           => 0,
+			'fields_to_write'         => 0,
+			'fields_skipped_existing' => 0,
+			'fields_overwritten'      => 0,
+			'options_to_write'        => 0,
+			'options_skipped'         => 0,
+			'redirects_to_write'      => 0,
+		);
+		$valid_phases = array_intersect( $phases, array( 'post_meta', 'settings', 'redirects' ) );
+
+		if ( in_array( 'post_meta', $valid_phases, true ) ) {
+			foreach ( $this->iterate_source_posts( $source ) as $post_id => $source_meta ) {
+				++$stats['posts_scanned'];
+				foreach ( self::META_MAP as $swps_key => $sources ) {
+					$value = $this->pick_value( $source_meta, $sources, $source );
+					if ( '' === $value ) {
+						continue;
+					}
+					$existing = get_post_meta( $post_id, $swps_key, true );
+					if ( '' !== (string) $existing && (string) $existing !== $value ) {
+						if ( 'skip' === $conflict_policy ) {
+							++$stats['fields_skipped_existing'];
+							continue;
+						}
+						++$stats['fields_overwritten'];
+					}
+					++$stats['fields_to_write'];
+				}
+			}
+		}
+
+		if ( in_array( 'settings', $valid_phases, true ) ) {
+			$mappings = $this->build_settings_mappings( $source );
+			foreach ( $mappings as $opt => $val ) {
+				if ( null === $val || '' === $val ) {
+					continue;
+				}
+				$existing     = get_option( $opt, '' );
+				$existing_str = is_scalar( $existing ) ? (string) $existing : '';
+				if ( '' !== $existing_str && $existing_str !== (string) $val && 'skip' === $conflict_policy ) {
+					++$stats['options_skipped'];
+					continue;
+				}
+				++$stats['options_to_write'];
+			}
+		}
+
+		if ( in_array( 'redirects', $valid_phases, true ) ) {
+			$stats['redirects_to_write'] = $this->count_source_redirects( $source );
+		}
+
+		return $stats;
+	}
+
+	/**
+	 * Count redirects available in the source plugin (no insert).
+	 */
+	private function count_source_redirects( string $source ): int {
+		if ( 'yoast' === $source ) {
+			$plain = get_option( 'wpseo-premium-redirects-base', array() );
+			$regex = get_option( 'wpseo-premium-redirects-base-regex', array() );
+			return ( is_array( $plain ) ? count( $plain ) : 0 ) + ( is_array( $regex ) ? count( $regex ) : 0 );
+		}
+		global $wpdb;
+		$rm_table = $wpdb->prefix . 'rank_math_redirections';
+		$exists   = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $rm_table ) );
+		if ( ! $exists ) {
+			return 0;
+		}
+		return (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$rm_table} WHERE status = 'active'" );
+	}
+
+	/**
+	 * Run the migration. Returns a report array.
+	 *
+	 * @param string   $source          'yoast' or 'rank_math'.
+	 * @param string   $conflict_policy 'skip' or 'overwrite'.
+	 * @param string[] $phases          subset of ['post_meta','settings','redirects'].
+	 */
+	public function run( string $source, string $conflict_policy, array $phases ): array {
+		if ( ! in_array( $source, array( 'yoast', 'rank_math' ), true ) ) {
+			return array( 'error' => __( 'Unknown source.', 'stratawp-seo' ) );
+		}
+		if ( ! in_array( $conflict_policy, array( 'skip', 'overwrite' ), true ) ) {
+			$conflict_policy = 'skip';
+		}
+		$valid_phases = array_intersect( $phases, array( 'post_meta', 'settings', 'redirects' ) );
+
+		$report = array(
+			'source'             => $source,
+			'conflict_policy'    => $conflict_policy,
+			'phases'             => array_values( $valid_phases ),
+			'started_at'         => current_time( 'mysql' ),
+			'posts_processed'    => 0,
+			'fields_written'     => 0,
+			'fields_skipped'     => 0,
+			'fields_overwritten' => 0,
+			'options_written'    => 0,
+			'options_skipped'    => 0,
+			'redirects_written'  => 0,
+			'redirects_skipped'  => 0,
+			'redirects_errors'   => array(),
+			'notes'              => array(),
+		);
+
+		$backup = $this->fresh_backup();
+
+		if ( in_array( 'post_meta', $valid_phases, true ) ) {
+			$this->run_post_meta( $source, $conflict_policy, $report, $backup );
+		}
+		if ( in_array( 'settings', $valid_phases, true ) ) {
+			$this->run_settings( $source, $conflict_policy, $report, $backup );
+		}
+		if ( in_array( 'redirects', $valid_phases, true ) ) {
+			$this->run_redirects( $source, $report, $backup );
+		}
+
+		$report['finished_at'] = current_time( 'mysql' );
+
+		update_option( self::BACKUP_OPTION, $backup, false );
+		update_option( self::REPORT_OPTION, $report, false );
+
+		return $report;
+	}
+
+	/**
+	 * Undo last migration using the backup snapshot.
+	 */
+	public function undo(): array {
+		$backup = get_option( self::BACKUP_OPTION, array() );
+		if ( ! is_array( $backup ) || empty( $backup ) ) {
+			return array( 'error' => __( 'Nothing to undo.', 'stratawp-seo' ) );
+		}
+
+		$reverted = 0;
+
+		// New typed format.
+		$post_meta = $backup['post_meta'] ?? null;
+		$options   = $backup['options'] ?? null;
+		$redirects = $backup['redirects'] ?? null;
+
+		// Backwards-compat with v4.3.0 flat format ( post_id => [ key => prev ] ).
+		if ( null === $post_meta && null === $options && null === $redirects ) {
+			$post_meta = $backup;
+		}
+
+		if ( is_array( $post_meta ) ) {
+			foreach ( $post_meta as $post_id => $keys ) {
+				if ( ! is_array( $keys ) ) {
+					continue;
+				}
+				foreach ( $keys as $swps_key => $previous ) {
+					if ( null === $previous ) {
+						delete_post_meta( (int) $post_id, $swps_key );
+					} else {
+						update_post_meta( (int) $post_id, $swps_key, $previous );
+					}
+					++$reverted;
+				}
+			}
+		}
+
+		if ( is_array( $options ) ) {
+			foreach ( $options as $name => $previous ) {
+				if ( null === $previous ) {
+					delete_option( $name );
+				} else {
+					update_option( $name, $previous, false );
+				}
+				++$reverted;
+			}
+		}
+
+		if ( is_array( $redirects ) && ! empty( $redirects ) ) {
+			global $wpdb;
+			$table        = $wpdb->prefix . 'swps_redirects';
+			$ids          = array_map( 'intval', $redirects );
+			$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+			$wpdb->query( $wpdb->prepare( "DELETE FROM {$table} WHERE id IN ($placeholders)", $ids ) );
+			$reverted += count( $ids );
+			delete_transient( 'swps_redirects_cache' );
+		}
+
+		delete_option( self::BACKUP_OPTION );
+
+		return array(
+			'reverted' => $reverted,
+		);
+	}
+
+	/**
+	 * Build a fresh, typed backup container.
+	 */
+	private function fresh_backup(): array {
+		return array(
+			'post_meta' => array(),
+			'options'   => array(),
+			'redirects' => array(),
+		);
+	}
+
+	/**
+	 * Phase 1: per-post meta.
+	 */
+	private function run_post_meta( string $source, string $conflict_policy, array &$report, array &$backup ): void {
+		foreach ( $this->iterate_source_posts( $source ) as $post_id => $source_meta ) {
+			++$report['posts_processed'];
+
+			foreach ( self::META_MAP as $swps_key => $sources ) {
+				$value = $this->pick_value( $source_meta, $sources, $source );
+				if ( '' === $value ) {
+					continue;
+				}
+
+				$existing     = get_post_meta( $post_id, $swps_key, true );
+				$existing_str = (string) $existing;
+
+				if ( '' !== $existing_str && $existing_str !== $value ) {
+					if ( 'skip' === $conflict_policy ) {
+						++$report['fields_skipped'];
+						continue;
+					}
+					++$report['fields_overwritten'];
+				}
+
+				if ( ! isset( $backup['post_meta'][ $post_id ][ $swps_key ] ) ) {
+					$backup['post_meta'][ $post_id ][ $swps_key ] = '' === $existing_str ? null : $existing_str;
+				}
+
+				update_post_meta( $post_id, $swps_key, $value );
+				++$report['fields_written'];
+			}
+		}
+	}
+
+	/**
+	 * Phase 2: global settings (separator, title templates, noindex flags).
+	 */
+	private function run_settings( string $source, string $conflict_policy, array &$report, array &$backup ): void {
+		$mappings = $this->build_settings_mappings( $source );
+
+		foreach ( $mappings as $swps_option => $value ) {
+			if ( null === $value || '' === $value ) {
+				continue;
+			}
+
+			$existing     = get_option( $swps_option, '' );
+			$existing_str = is_scalar( $existing ) ? (string) $existing : '';
+
+			if ( '' !== $existing_str && $existing_str !== (string) $value && 'skip' === $conflict_policy ) {
+				++$report['options_skipped'];
+				continue;
+			}
+
+			if ( ! array_key_exists( $swps_option, $backup['options'] ) ) {
+				$backup['options'][ $swps_option ] = ( false === get_option( $swps_option, false ) ) ? null : $existing;
+			}
+
+			update_option( $swps_option, $value, false );
+			++$report['options_written'];
+		}
+	}
+
+	/**
+	 * Build StrataWP option => value map from source plugin options.
+	 */
+	private function build_settings_mappings( string $source ): array {
+		$out = array();
+
+		if ( 'yoast' === $source ) {
+			$titles = get_option( 'wpseo_titles', array() );
+			if ( ! is_array( $titles ) ) {
+				$titles = array();
+			}
+
+			// Separator.
+			if ( ! empty( $titles['separator'] ) ) {
+				$code                        = (string) $titles['separator'];
+				$out['swps_title_separator'] = self::YOAST_SEPARATOR_MAP[ $code ] ?? $code;
+			}
+
+			// Title templates: title-{post_type}, title-tax-{taxonomy}, title-author-wpseo, etc.
+			foreach ( $titles as $key => $val ) {
+				if ( ! is_string( $val ) || '' === $val ) {
+					continue;
+				}
+				$rewritten = $this->rewrite_template_vars( $val, 'yoast' );
+
+				if ( 'title-author-wpseo' === $key ) {
+					$out['swps_title_template_author'] = $rewritten;
+				} elseif ( 'title-archive-wpseo' === $key ) {
+					$out['swps_title_template_date'] = $rewritten;
+				} elseif ( 'title-search-wpseo' === $key ) {
+					$out['swps_title_template_search'] = $rewritten;
+				} elseif ( 'title-404-wpseo' === $key ) {
+					$out['swps_title_template_404'] = $rewritten;
+				} elseif ( 0 === strpos( $key, 'title-tax-' ) ) {
+					$tax = substr( $key, strlen( 'title-tax-' ) );
+					if ( $tax ) {
+						$out[ "swps_title_template_{$tax}" ] = $rewritten;
+					}
+				} elseif ( 0 === strpos( $key, 'title-ptarchive-' ) ) {
+					$pt = substr( $key, strlen( 'title-ptarchive-' ) );
+					if ( $pt ) {
+						$out[ "swps_title_template_{$pt}_archive" ] = $rewritten;
+					}
+				} elseif ( 0 === strpos( $key, 'title-' ) ) {
+					$pt = substr( $key, strlen( 'title-' ) );
+					if ( $pt && false === strpos( $pt, '-wpseo' ) && false === strpos( $pt, 'tax-' ) && false === strpos( $pt, 'ptarchive-' ) ) {
+						$out[ "swps_title_template_{$pt}" ] = $rewritten;
+					}
+				}
+			}
+
+			// noindex flags: noindex-{post_type} → swps_noindex_{post_type}.
+			foreach ( $titles as $key => $val ) {
+				if ( 0 === strpos( $key, 'noindex-' ) ) {
+					$rest = substr( $key, strlen( 'noindex-' ) );
+					if ( 'author-wpseo' === $rest || 'archive-wpseo' === $rest ) {
+						continue;
+					}
+					if ( 0 === strpos( $rest, 'tax-' ) ) {
+						$rest = substr( $rest, strlen( 'tax-' ) );
+					}
+					if ( $rest ) {
+						$out[ "swps_noindex_{$rest}" ] = ! empty( $val ) ? 1 : 0;
+					}
+				}
+			}
+		} else {
+			$titles = get_option( 'rank-math-options-titles', array() );
+			if ( ! is_array( $titles ) ) {
+				$titles = array();
+			}
+
+			if ( ! empty( $titles['title_separator'] ) ) {
+				$out['swps_title_separator'] = (string) $titles['title_separator'];
+			}
+
+			foreach ( $titles as $key => $val ) {
+				if ( ! is_string( $val ) || '' === $val ) {
+					continue;
+				}
+				$rewritten = $this->rewrite_template_vars( $val, 'rank_math' );
+
+				if ( preg_match( '/^pt_(.+)_title$/', $key, $m ) ) {
+					$out[ "swps_title_template_{$m[1]}" ] = $rewritten;
+				} elseif ( preg_match( '/^tax_(.+)_title$/', $key, $m ) ) {
+					$out[ "swps_title_template_{$m[1]}" ] = $rewritten;
+				} elseif ( 'author_archive_title' === $key ) {
+					$out['swps_title_template_author'] = $rewritten;
+				} elseif ( 'date_archive_title' === $key ) {
+					$out['swps_title_template_date'] = $rewritten;
+				} elseif ( 'search_title' === $key ) {
+					$out['swps_title_template_search'] = $rewritten;
+				} elseif ( '404_title' === $key ) {
+					$out['swps_title_template_404'] = $rewritten;
+				}
+			}
+
+			// noindex flags.
+			foreach ( $titles as $key => $val ) {
+				if ( preg_match( '/^pt_(.+)_robots$/', $key, $m ) && is_array( $val ) && in_array( 'noindex', $val, true ) ) {
+					$out[ "swps_noindex_{$m[1]}" ] = 1;
+				} elseif ( preg_match( '/^tax_(.+)_robots$/', $key, $m ) && is_array( $val ) && in_array( 'noindex', $val, true ) ) {
+					$out[ "swps_noindex_{$m[1]}" ] = 1;
+				}
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Rewrite source-plugin template variables to StrataWP %%var%% syntax.
+	 */
+	private function rewrite_template_vars( string $template, string $source ): string {
+		if ( 'rank_math' === $source ) {
+			// Sort keys by length descending so longer matches replace first.
+			$keys = array_keys( self::RM_VAR_MAP );
+			usort( $keys, static fn( $a, $b ) => strlen( $b ) - strlen( $a ) );
+			foreach ( $keys as $k ) {
+				$template = str_replace( $k, self::RM_VAR_MAP[ $k ], $template );
+			}
+		}
+		// Yoast already uses %%var%% so no rewriting needed.
+		return $template;
+	}
+
+	/**
+	 * Phase 3: redirects (Yoast Premium + Rank Math Pro).
+	 */
+	private function run_redirects( string $source, array &$report, array &$backup ): void {
+		if ( ! isset( stratawp_seo()->redirect_manager ) ) {
+			$report['notes'][] = __( 'Redirect manager unavailable; skipping redirects.', 'stratawp-seo' );
+			return;
+		}
+		$manager = stratawp_seo()->redirect_manager;
+
+		if ( 'yoast' === $source ) {
+			$plain = get_option( 'wpseo-premium-redirects-base', array() );
+			$regex = get_option( 'wpseo-premium-redirects-base-regex', array() );
+
+			foreach ( (array) $plain as $src => $row ) {
+				$this->insert_redirect_safe( $manager, (string) $src, (string) ( $row['url'] ?? '' ), (int) ( $row['type'] ?? 301 ), false, $report, $backup );
+			}
+			foreach ( (array) $regex as $src => $row ) {
+				$this->insert_redirect_safe( $manager, (string) $src, (string) ( $row['url'] ?? '' ), (int) ( $row['type'] ?? 301 ), true, $report, $backup );
+			}
+		} else {
+			global $wpdb;
+			$rm_table = $wpdb->prefix . 'rank_math_redirections';
+			$exists   = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $rm_table ) );
+			if ( ! $exists ) {
+				$report['notes'][] = __( 'Rank Math redirections table not found.', 'stratawp-seo' );
+				return;
+			}
+
+			$rows = $wpdb->get_results( "SELECT sources, url_to, header_code FROM {$rm_table} WHERE status = 'active'" );
+			foreach ( (array) $rows as $row ) {
+				$sources = maybe_unserialize( $row->sources );
+				if ( ! is_array( $sources ) ) {
+					continue;
+				}
+				$type = (int) ( $row->header_code ?: 301 );
+				$tgt  = (string) ( $row->url_to ?? '' );
+
+				foreach ( $sources as $entry ) {
+					if ( ! is_array( $entry ) || empty( $entry['pattern'] ) ) {
+						continue;
+					}
+					$is_regex = isset( $entry['comparison'] ) && 'regex' === $entry['comparison'];
+					$this->insert_redirect_safe( $manager, (string) $entry['pattern'], $tgt, $type, $is_regex, $report, $backup );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Insert one redirect, recording the new ID in backup for undo.
+	 */
+	private function insert_redirect_safe( $manager, string $source, string $target, int $type, bool $is_regex, array &$report, array &$backup ): void {
+		if ( '' === $source ) {
+			++$report['redirects_skipped'];
+			return;
+		}
+		if ( ! in_array( $type, array( 301, 302, 307, 410 ), true ) ) {
+			$type = 301;
+		}
+
+		$result = $manager->add_redirect( $source, $target, $type, $is_regex );
+
+		if ( is_wp_error( $result ) ) {
+			$report['redirects_errors'][] = sprintf( '%s: %s', $source, $result->get_error_message() );
+			++$report['redirects_skipped'];
+			return;
+		}
+		if ( false === $result ) {
+			++$report['redirects_skipped'];
+			return;
+		}
+
+		$backup['redirects'][] = (int) $result;
+		++$report['redirects_written'];
+	}
+
+	/**
+	 * Form handler: run migration.
+	 */
+	public function handle_run(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to do this.', 'stratawp-seo' ) );
+		}
+		check_admin_referer( 'swps_run_migration' );
+
+		$source          = isset( $_POST['source'] ) ? sanitize_key( wp_unslash( $_POST['source'] ) ) : '';
+		$conflict_policy = isset( $_POST['conflict_policy'] ) ? sanitize_key( wp_unslash( $_POST['conflict_policy'] ) ) : 'skip';
+		$mode            = isset( $_POST['mode'] ) ? sanitize_key( wp_unslash( $_POST['mode'] ) ) : 'preview';
+		$phases_raw      = isset( $_POST['phases'] ) && is_array( $_POST['phases'] ) ? array_map( 'sanitize_key', wp_unslash( $_POST['phases'] ) ) : array();
+		if ( empty( $phases_raw ) ) {
+			$phases_raw = array( 'post_meta' );
+		}
+
+		if ( 'run' === $mode ) {
+			$this->run( $source, $conflict_policy, $phases_raw );
+			$redirect = add_query_arg(
+				array(
+					'page'      => 'swps-migration',
+					'migration' => 'done',
+				),
+				admin_url( 'admin.php' )
+			);
+		} else {
+			$preview = $this->preview( $source, $conflict_policy, $phases_raw );
+			set_transient(
+				'swps_migration_preview_' . get_current_user_id(),
+				array(
+					'source'          => $source,
+					'conflict_policy' => $conflict_policy,
+					'phases'          => $phases_raw,
+					'stats'           => $preview,
+				),
+				10 * MINUTE_IN_SECONDS
+			);
+			$redirect = add_query_arg(
+				array(
+					'page'      => 'swps-migration',
+					'migration' => 'preview',
+				),
+				admin_url( 'admin.php' )
+			);
+		}
+
+		wp_safe_redirect( $redirect );
+		exit;
+	}
+
+	/**
+	 * Form handler: undo last migration.
+	 */
+	public function handle_undo(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to do this.', 'stratawp-seo' ) );
+		}
+		check_admin_referer( 'swps_undo_migration' );
+
+		$this->undo();
+
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'      => 'swps-migration',
+					'migration' => 'undone',
+				),
+				admin_url( 'admin.php' )
+			)
+		);
+		exit;
+	}
+
+	/**
+	 * Pick the source value for a StrataWP key from a row of source meta.
+	 *
+	 * @param array  $row        post_id meta as key=>value (string).
+	 * @param array  $source_def [ yoast_keys[], rm_keys[] ]
+	 * @param string $source     'yoast' or 'rank_math'.
+	 */
+	private function pick_value( array $row, array $source_def, string $source ): string {
+		$keys = 'yoast' === $source ? $source_def[0] : $source_def[1];
+		foreach ( $keys as $k ) {
+			if ( isset( $row[ $k ] ) && '' !== (string) $row[ $k ] ) {
+				return (string) $row[ $k ];
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Generator: yields post_id => [ meta_key => meta_value ] for posts with source meta.
+	 *
+	 * Streams in batches of self::BATCH_SIZE to avoid loading the whole site into memory.
+	 */
+	private function iterate_source_posts( string $source ): Generator {
+		global $wpdb;
+
+		$keys = 'yoast' === $source
+			? array_merge( ...array_column( self::META_MAP, 0 ) )
+			: array_merge( ...array_column( self::META_MAP, 1 ) );
+
+		if ( empty( $keys ) ) {
+			return;
+		}
+
+		$placeholders = implode( ',', array_fill( 0, count( $keys ), '%s' ) );
+
+		$offset = 0;
+		while ( true ) {
+			$sql      = $wpdb->prepare(
+				"SELECT DISTINCT post_id FROM {$wpdb->postmeta}
                  WHERE meta_key IN ($placeholders) AND meta_value <> ''
                  ORDER BY post_id ASC
                  LIMIT %d OFFSET %d",
-                array_merge( $keys, [ self::BATCH_SIZE, $offset ] )
-            );
-            $post_ids = $wpdb->get_col( $sql );
+				array_merge( $keys, array( self::BATCH_SIZE, $offset ) )
+			);
+			$post_ids = $wpdb->get_col( $sql );
 
-            if ( empty( $post_ids ) ) {
-                break;
-            }
+			if ( empty( $post_ids ) ) {
+				break;
+			}
 
-            // Fetch all relevant meta for this batch in one query.
-            $id_placeholders = implode( ',', array_fill( 0, count( $post_ids ), '%d' ) );
-            $rows = $wpdb->get_results( $wpdb->prepare(
-                "SELECT post_id, meta_key, meta_value FROM {$wpdb->postmeta}
+			// Fetch all relevant meta for this batch in one query.
+			$id_placeholders = implode( ',', array_fill( 0, count( $post_ids ), '%d' ) );
+			$rows            = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT post_id, meta_key, meta_value FROM {$wpdb->postmeta}
                  WHERE post_id IN ($id_placeholders) AND meta_key IN ($placeholders)",
-                array_merge( array_map( 'intval', $post_ids ), $keys )
-            ) );
+					array_merge( array_map( 'intval', $post_ids ), $keys )
+				)
+			);
 
-            $grouped = [];
-            foreach ( $rows as $row ) {
-                $grouped[ (int) $row->post_id ][ $row->meta_key ] = $row->meta_value;
-            }
+			$grouped = array();
+			foreach ( $rows as $row ) {
+				$grouped[ (int) $row->post_id ][ $row->meta_key ] = $row->meta_value;
+			}
 
-            foreach ( $post_ids as $pid ) {
-                $pid = (int) $pid;
-                yield $pid => $grouped[ $pid ] ?? [];
-            }
+			foreach ( $post_ids as $pid ) {
+				$pid = (int) $pid;
+				yield $pid => $grouped[ $pid ] ?? array();
+			}
 
-            $offset += self::BATCH_SIZE;
-        }
-    }
+			$offset += self::BATCH_SIZE;
+		}
+	}
 
-    /**
-     * Public accessor for last report (for the template).
-     */
-    public function get_last_report(): array {
-        $r = get_option( self::REPORT_OPTION, [] );
-        return is_array( $r ) ? $r : [];
-    }
+	/**
+	 * Public accessor for last report (for the template).
+	 */
+	public function get_last_report(): array {
+		$r = get_option( self::REPORT_OPTION, array() );
+		return is_array( $r ) ? $r : array();
+	}
 
-    /**
-     * Public accessor for whether undo is available.
-     */
-    public function has_backup(): bool {
-        $b = get_option( self::BACKUP_OPTION, [] );
-        return is_array( $b ) && ! empty( $b );
-    }
+	/**
+	 * Public accessor for whether undo is available.
+	 */
+	public function has_backup(): bool {
+		$b = get_option( self::BACKUP_OPTION, array() );
+		return is_array( $b ) && ! empty( $b );
+	}
 }

--- a/includes/class-modules.php
+++ b/includes/class-modules.php
@@ -15,134 +15,303 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Modules {
 
-    public const OPTION_KEY = 'swps_modules_enabled';
+	public const OPTION_KEY = 'swps_modules_enabled';
 
-    /** @var array<string, array> */
-    private array $registry = [];
+	/** @var array<string, array> */
+	private array $registry = array();
 
-    public function __construct() {
-        add_action( 'init', [ $this, 'register_defaults' ], 1 );
-    }
+	public function __construct() {
+		add_action( 'init', array( $this, 'register_defaults' ), 1 );
+	}
 
-    /**
-     * Register the default v4.0 module set.
-     *
-     * Called on `init` priority 1 so other plugins can hook
-     * `swps_modules_register` to add their own.
-     */
-    public function register_defaults(): void {
-        // Existing always-on features (toggle visual only in v4.0).
-        $this->register( 'ai-generation',  [ 'name' => __( 'AI Content Generation', 'stratawp-seo' ),  'desc' => __( 'Site-aware AI posts with internal links, FAQs, schema.', 'stratawp-seo' ),     'icon' => '✦', 'group' => 'content',  'default_on' => true,  'badge' => '',    'settings_url' => admin_url( 'admin.php?page=swps-settings#ai-content' ) ] );
-        $this->register( 'seo-audit',      [ 'name' => __( 'SEO Audit', 'stratawp-seo' ),              'desc' => __( '8-module health check with one-click auto-fix.', 'stratawp-seo' ),              'icon' => '⚡', 'group' => 'seo',      'default_on' => true,  'badge' => '',    'settings_url' => admin_url( 'admin.php?page=swps-seo-audit' ) ] );
-        $this->register( 'schema',         [ 'name' => __( 'Schema', 'stratawp-seo' ),                 'desc' => __( 'Article, FAQ, BreadcrumbList, Organization JSON-LD.', 'stratawp-seo' ),         'icon' => '{}', 'group' => 'seo',      'default_on' => true,  'badge' => '',    'settings_url' => admin_url( 'admin.php?page=swps-settings#seo' ) ] );
-        $this->register( 'redirects',      [ 'name' => __( 'Redirects', 'stratawp-seo' ),              'desc' => __( '301/302/307/410, regex, 404 monitor with one-click fix.', 'stratawp-seo' ),     'icon' => '⤳', 'group' => 'seo',      'default_on' => true,  'badge' => '',    'settings_url' => admin_url( 'admin.php?page=swps-redirects' ) ] );
-        $this->register( 'sitemaps',       [ 'name' => __( 'Sitemaps', 'stratawp-seo' ),               'desc' => __( 'XML index, image sitemap, IndexNow batch submit.', 'stratawp-seo' ),            'icon' => '⌘', 'group' => 'seo',      'default_on' => true,  'badge' => '',    'settings_url' => admin_url( 'admin.php?page=swps-sitemaps' ) ] );
-        $this->register( 'internal-links', [ 'name' => __( 'Internal Links', 'stratawp-seo' ),         'desc' => __( 'Keyword + AI-suggested internal linking.', 'stratawp-seo' ),                   'icon' => '⟿', 'group' => 'seo',      'default_on' => true,  'badge' => '',    'settings_url' => admin_url( 'admin.php?page=swps-internal-links' ) ] );
-        $this->register( 'meta-editor',    [ 'name' => __( 'Meta Editor', 'stratawp-seo' ),            'desc' => __( 'Per-post title, description, OG, Twitter, robots, canonical.', 'stratawp-seo' ), 'icon' => '◆', 'group' => 'seo',      'default_on' => true,  'badge' => '',    'settings_url' => admin_url( 'admin.php?page=swps-settings#seo' ) ] );
-        $this->register( 'analytics',      [ 'name' => __( 'Analytics', 'stratawp-seo' ),              'desc' => __( 'Cookie-free pageviews, time on page, scroll depth.', 'stratawp-seo' ),          'icon' => '◔', 'group' => 'insights', 'default_on' => true,  'badge' => '',    'settings_url' => admin_url( 'admin.php?page=swps-analytics' ) ] );
-        $this->register( 'ai-bots',        [ 'name' => __( 'AI Crawlers + llms.txt', 'stratawp-seo' ), 'desc' => __( 'GPTBot, ClaudeBot, PerplexityBot allowlist + dynamic /llms.txt.', 'stratawp-seo' ), 'icon' => '⌨', 'group' => 'seo',      'default_on' => true,  'badge' => '',    'settings_url' => admin_url( 'admin.php?page=swps-settings#discoverability' ) ] );
+	/**
+	 * Register the default v4.0 module set.
+	 *
+	 * Called on `init` priority 1 so other plugins can hook
+	 * `swps_modules_register` to add their own.
+	 */
+	public function register_defaults(): void {
+		// Existing always-on features (toggle visual only in v4.0).
+		$this->register(
+			'ai-generation',
+			array(
+				'name'         => __( 'AI Content Generation', 'stratawp-seo' ),
+				'desc'         => __( 'Site-aware AI posts with internal links, FAQs, schema.', 'stratawp-seo' ),
+				'icon'         => '✦',
+				'group'        => 'content',
+				'default_on'   => true,
+				'badge'        => '',
+				'settings_url' => admin_url( 'admin.php?page=swps-settings#ai-content' ),
+			)
+		);
+		$this->register(
+			'seo-audit',
+			array(
+				'name'         => __( 'SEO Audit', 'stratawp-seo' ),
+				'desc'         => __( '8-module health check with one-click auto-fix.', 'stratawp-seo' ),
+				'icon'         => '⚡',
+				'group'        => 'seo',
+				'default_on'   => true,
+				'badge'        => '',
+				'settings_url' => admin_url( 'admin.php?page=swps-seo-audit' ),
+			)
+		);
+		$this->register(
+			'schema',
+			array(
+				'name'         => __( 'Schema', 'stratawp-seo' ),
+				'desc'         => __( 'Article, FAQ, BreadcrumbList, Organization JSON-LD.', 'stratawp-seo' ),
+				'icon'         => '{}',
+				'group'        => 'seo',
+				'default_on'   => true,
+				'badge'        => '',
+				'settings_url' => admin_url( 'admin.php?page=swps-settings#seo' ),
+			)
+		);
+		$this->register(
+			'redirects',
+			array(
+				'name'         => __( 'Redirects', 'stratawp-seo' ),
+				'desc'         => __( '301/302/307/410, regex, 404 monitor with one-click fix.', 'stratawp-seo' ),
+				'icon'         => '⤳',
+				'group'        => 'seo',
+				'default_on'   => true,
+				'badge'        => '',
+				'settings_url' => admin_url( 'admin.php?page=swps-redirects' ),
+			)
+		);
+		$this->register(
+			'sitemaps',
+			array(
+				'name'         => __( 'Sitemaps', 'stratawp-seo' ),
+				'desc'         => __( 'XML index, image sitemap, IndexNow batch submit.', 'stratawp-seo' ),
+				'icon'         => '⌘',
+				'group'        => 'seo',
+				'default_on'   => true,
+				'badge'        => '',
+				'settings_url' => admin_url( 'admin.php?page=swps-sitemaps' ),
+			)
+		);
+		$this->register(
+			'internal-links',
+			array(
+				'name'         => __( 'Internal Links', 'stratawp-seo' ),
+				'desc'         => __( 'Keyword + AI-suggested internal linking.', 'stratawp-seo' ),
+				'icon'         => '⟿',
+				'group'        => 'seo',
+				'default_on'   => true,
+				'badge'        => '',
+				'settings_url' => admin_url( 'admin.php?page=swps-internal-links' ),
+			)
+		);
+		$this->register(
+			'meta-editor',
+			array(
+				'name'         => __( 'Meta Editor', 'stratawp-seo' ),
+				'desc'         => __( 'Per-post title, description, OG, Twitter, robots, canonical.', 'stratawp-seo' ),
+				'icon'         => '◆',
+				'group'        => 'seo',
+				'default_on'   => true,
+				'badge'        => '',
+				'settings_url' => admin_url( 'admin.php?page=swps-settings#seo' ),
+			)
+		);
+		$this->register(
+			'analytics',
+			array(
+				'name'         => __( 'Analytics', 'stratawp-seo' ),
+				'desc'         => __( 'Cookie-free pageviews, time on page, scroll depth.', 'stratawp-seo' ),
+				'icon'         => '◔',
+				'group'        => 'insights',
+				'default_on'   => true,
+				'badge'        => '',
+				'settings_url' => admin_url( 'admin.php?page=swps-analytics' ),
+			)
+		);
+		$this->register(
+			'ai-bots',
+			array(
+				'name'         => __( 'AI Crawlers + llms.txt', 'stratawp-seo' ),
+				'desc'         => __( 'GPTBot, ClaudeBot, PerplexityBot allowlist + dynamic /llms.txt.', 'stratawp-seo' ),
+				'icon'         => '⌨',
+				'group'        => 'seo',
+				'default_on'   => true,
+				'badge'        => '',
+				'settings_url' => admin_url( 'admin.php?page=swps-settings#discoverability' ),
+			)
+		);
 
-        // New modules (v4.0 scaffold pages, full features in v4.1).
-        $this->register( 'auto-optimize',  [ 'name' => __( 'AI Auto-Optimize', 'stratawp-seo' ),       'desc' => __( 'Auto-refresh old posts: kw in H2, first paragraph, schema, alt text.', 'stratawp-seo' ), 'icon' => '↻', 'group' => 'content',  'default_on' => false, 'badge' => 'ai',  'settings_url' => admin_url( 'admin.php?page=swps-auto-optimize' ) ] );
-        $this->register( 'competitors',    [ 'name' => __( 'Competitors', 'stratawp-seo' ),            'desc' => __( 'Track sites, schema, keyword gaps, content velocity.', 'stratawp-seo' ),         'icon' => '◎', 'group' => 'insights', 'default_on' => false, 'badge' => 'new', 'settings_url' => admin_url( 'admin.php?page=swps-competitors' ) ] );
+		// New modules (v4.0 scaffold pages, full features in v4.1).
+		$this->register(
+			'auto-optimize',
+			array(
+				'name'         => __( 'AI Auto-Optimize', 'stratawp-seo' ),
+				'desc'         => __( 'Auto-refresh old posts: kw in H2, first paragraph, schema, alt text.', 'stratawp-seo' ),
+				'icon'         => '↻',
+				'group'        => 'content',
+				'default_on'   => false,
+				'badge'        => 'ai',
+				'settings_url' => admin_url( 'admin.php?page=swps-auto-optimize' ),
+			)
+		);
+		$this->register(
+			'competitors',
+			array(
+				'name'         => __( 'Competitors', 'stratawp-seo' ),
+				'desc'         => __( 'Track sites, schema, keyword gaps, content velocity.', 'stratawp-seo' ),
+				'icon'         => '◎',
+				'group'        => 'insights',
+				'default_on'   => false,
+				'badge'        => 'new',
+				'settings_url' => admin_url( 'admin.php?page=swps-competitors' ),
+			)
+		);
 
-        // v4.2 — newly shipped modules.
-        $this->register( 'local-seo',      [ 'name' => __( 'Local SEO', 'stratawp-seo' ),              'desc' => __( 'NAP, opening hours, LocalBusiness JSON-LD for local + service-area sites.', 'stratawp-seo' ), 'icon' => '◉', 'group' => 'seo', 'default_on' => false, 'badge' => 'new', 'settings_url' => admin_url( 'admin.php?page=swps-local-seo' ) ] );
-        $this->register( 'image-seo',      [ 'name' => __( 'Image SEO', 'stratawp-seo' ),              'desc' => __( 'AI auto-alt, filename sanitization, lazy-loading, image sitemap.', 'stratawp-seo' ),     'icon' => '◈', 'group' => 'seo', 'default_on' => false, 'badge' => 'new', 'settings_url' => admin_url( 'admin.php?page=swps-image-seo' ) ] );
+		// v4.2 — newly shipped modules.
+		$this->register(
+			'local-seo',
+			array(
+				'name'         => __( 'Local SEO', 'stratawp-seo' ),
+				'desc'         => __( 'NAP, opening hours, LocalBusiness JSON-LD for local + service-area sites.', 'stratawp-seo' ),
+				'icon'         => '◉',
+				'group'        => 'seo',
+				'default_on'   => false,
+				'badge'        => 'new',
+				'settings_url' => admin_url( 'admin.php?page=swps-local-seo' ),
+			)
+		);
+		$this->register(
+			'image-seo',
+			array(
+				'name'         => __( 'Image SEO', 'stratawp-seo' ),
+				'desc'         => __( 'AI auto-alt, filename sanitization, lazy-loading, image sitemap.', 'stratawp-seo' ),
+				'icon'         => '◈',
+				'group'        => 'seo',
+				'default_on'   => false,
+				'badge'        => 'new',
+				'settings_url' => admin_url( 'admin.php?page=swps-image-seo' ),
+			)
+		);
 
-        $this->register( 'backlinks',      [ 'name' => __( 'Backlinks', 'stratawp-seo' ),              'desc' => __( 'Manual + CSV-import backlink tracker with daily health monitoring.', 'stratawp-seo' ), 'icon' => '⇄', 'group' => 'insights', 'default_on' => false, 'badge' => 'new', 'settings_url' => admin_url( 'admin.php?page=swps-backlinks' ) ] );
+		$this->register(
+			'backlinks',
+			array(
+				'name'         => __( 'Backlinks', 'stratawp-seo' ),
+				'desc'         => __( 'Manual + CSV-import backlink tracker with daily health monitoring.', 'stratawp-seo' ),
+				'icon'         => '⇄',
+				'group'        => 'insights',
+				'default_on'   => false,
+				'badge'        => 'new',
+				'settings_url' => admin_url( 'admin.php?page=swps-backlinks' ),
+			)
+		);
 
-        // Coming soon — disabled, not user-toggleable.
-        $this->register( 'woocommerce',    [ 'name' => __( 'WooCommerce SEO', 'stratawp-seo' ),        'desc' => __( 'Product schema, category SEO, OG for variations.', 'stratawp-seo' ),            'icon' => '⌥', 'group' => 'seo',      'default_on' => false, 'badge' => 'soon', 'settings_url' => '', 'locked' => true ] );
+		// Coming soon — disabled, not user-toggleable.
+		$this->register(
+			'woocommerce',
+			array(
+				'name'         => __( 'WooCommerce SEO', 'stratawp-seo' ),
+				'desc'         => __( 'Product schema, category SEO, OG for variations.', 'stratawp-seo' ),
+				'icon'         => '⌥',
+				'group'        => 'seo',
+				'default_on'   => false,
+				'badge'        => 'soon',
+				'settings_url' => '',
+				'locked'       => true,
+			)
+		);
 
-        /**
-         * Fires after default modules are registered. Use this to add custom modules.
-         *
-         * @param SWPS_Modules $modules This registry instance.
-         */
-        do_action( 'swps_modules_register', $this );
-    }
+		/**
+		 * Fires after default modules are registered. Use this to add custom modules.
+		 *
+		 * @param SWPS_Modules $modules This registry instance.
+		 */
+		do_action( 'swps_modules_register', $this );
+	}
 
-    /**
-     * Register a module.
-     *
-     * @param string $slug Unique slug (kebab-case).
-     * @param array  $args  Module metadata.
-     */
-    public function register( string $slug, array $args ): void {
-        $this->registry[ $slug ] = wp_parse_args( $args, [
-            'name'         => '',
-            'desc'         => '',
-            'icon'         => '•',
-            'group'        => 'system',
-            'default_on'   => true,
-            'badge'        => '',
-            'settings_url' => '',
-            'locked'       => false,
-        ] );
-    }
+	/**
+	 * Register a module.
+	 *
+	 * @param string $slug Unique slug (kebab-case).
+	 * @param array  $args  Module metadata.
+	 */
+	public function register( string $slug, array $args ): void {
+		$this->registry[ $slug ] = wp_parse_args(
+			$args,
+			array(
+				'name'         => '',
+				'desc'         => '',
+				'icon'         => '•',
+				'group'        => 'system',
+				'default_on'   => true,
+				'badge'        => '',
+				'settings_url' => '',
+				'locked'       => false,
+			)
+		);
+	}
 
-    /**
-     * Is this module enabled?
-     */
-    public function is_enabled( string $slug ): bool {
-        if ( ! isset( $this->registry[ $slug ] ) ) {
-            return false;
-        }
-        $stored = get_option( self::OPTION_KEY, [] );
-        if ( isset( $stored[ $slug ] ) ) {
-            return (bool) $stored[ $slug ];
-        }
-        return (bool) $this->registry[ $slug ]['default_on'];
-    }
+	/**
+	 * Is this module enabled?
+	 */
+	public function is_enabled( string $slug ): bool {
+		if ( ! isset( $this->registry[ $slug ] ) ) {
+			return false;
+		}
+		$stored = get_option( self::OPTION_KEY, array() );
+		if ( isset( $stored[ $slug ] ) ) {
+			return (bool) $stored[ $slug ];
+		}
+		return (bool) $this->registry[ $slug ]['default_on'];
+	}
 
-    /**
-     * Toggle a module's enabled state.
-     */
-    public function set_enabled( string $slug, bool $enabled ): bool {
-        if ( ! isset( $this->registry[ $slug ] ) ) {
-            return false;
-        }
-        if ( ! empty( $this->registry[ $slug ]['locked'] ) ) {
-            return false;
-        }
-        $stored          = get_option( self::OPTION_KEY, [] );
-        $stored[ $slug ] = (bool) $enabled;
-        update_option( self::OPTION_KEY, $stored );
-        return true;
-    }
+	/**
+	 * Toggle a module's enabled state.
+	 */
+	public function set_enabled( string $slug, bool $enabled ): bool {
+		if ( ! isset( $this->registry[ $slug ] ) ) {
+			return false;
+		}
+		if ( ! empty( $this->registry[ $slug ]['locked'] ) ) {
+			return false;
+		}
+		$stored          = get_option( self::OPTION_KEY, array() );
+		$stored[ $slug ] = (bool) $enabled;
+		update_option( self::OPTION_KEY, $stored );
+		return true;
+	}
 
-    /**
-     * Get every registered module with its current state.
-     *
-     * @return array<string, array>
-     */
-    public function get_all(): array {
-        $out = [];
-        foreach ( $this->registry as $slug => $meta ) {
-            $out[ $slug ] = $meta + [
-                'slug'    => $slug,
-                'enabled' => $this->is_enabled( $slug ),
-            ];
-        }
-        return $out;
-    }
+	/**
+	 * Get every registered module with its current state.
+	 *
+	 * @return array<string, array>
+	 */
+	public function get_all(): array {
+		$out = array();
+		foreach ( $this->registry as $slug => $meta ) {
+			$out[ $slug ] = $meta + array(
+				'slug'    => $slug,
+				'enabled' => $this->is_enabled( $slug ),
+			);
+		}
+		return $out;
+	}
 
-    /**
-     * Get one module's metadata + state, or null if unknown.
-     */
-    public function get( string $slug ): ?array {
-        if ( ! isset( $this->registry[ $slug ] ) ) {
-            return null;
-        }
-        return $this->registry[ $slug ] + [
-            'slug'    => $slug,
-            'enabled' => $this->is_enabled( $slug ),
-        ];
-    }
+	/**
+	 * Get one module's metadata + state, or null if unknown.
+	 */
+	public function get( string $slug ): ?array {
+		if ( ! isset( $this->registry[ $slug ] ) ) {
+			return null;
+		}
+		return $this->registry[ $slug ] + array(
+			'slug'    => $slug,
+			'enabled' => $this->is_enabled( $slug ),
+		);
+	}
 }

--- a/includes/class-post-list-seo.php
+++ b/includes/class-post-list-seo.php
@@ -19,28 +19,28 @@ class SWPS_Post_List_SEO {
 	public function __construct( SWPS_Content_Scorer $scorer ) {
 		$this->scorer = $scorer;
 
-		$enabled_types = (array) get_option( 'swps_seo_column_post_types', [ 'post', 'page' ] );
+		$enabled_types = (array) get_option( 'swps_seo_column_post_types', array( 'post', 'page' ) );
 
 		foreach ( $enabled_types as $post_type ) {
 			if ( 'post' === $post_type ) {
-				add_filter( 'manage_posts_columns', [ $this, 'add_column' ] );
-				add_action( 'manage_posts_custom_column', [ $this, 'render_column' ], 10, 2 );
+				add_filter( 'manage_posts_columns', array( $this, 'add_column' ) );
+				add_action( 'manage_posts_custom_column', array( $this, 'render_column' ), 10, 2 );
 			} elseif ( 'page' === $post_type ) {
-				add_filter( 'manage_pages_columns', [ $this, 'add_column' ] );
-				add_action( 'manage_pages_custom_column', [ $this, 'render_column' ], 10, 2 );
+				add_filter( 'manage_pages_columns', array( $this, 'add_column' ) );
+				add_action( 'manage_pages_custom_column', array( $this, 'render_column' ), 10, 2 );
 			} else {
-				add_filter( "manage_{$post_type}_posts_columns", [ $this, 'add_column' ] );
-				add_action( "manage_{$post_type}_posts_custom_column", [ $this, 'render_column' ], 10, 2 );
+				add_filter( "manage_{$post_type}_posts_columns", array( $this, 'add_column' ) );
+				add_action( "manage_{$post_type}_posts_custom_column", array( $this, 'render_column' ), 10, 2 );
 			}
 
-			add_filter( "manage_edit-{$post_type}_sortable_columns", [ $this, 'sortable_column' ] );
+			add_filter( "manage_edit-{$post_type}_sortable_columns", array( $this, 'sortable_column' ) );
 		}
 
-		add_action( 'pre_get_posts', [ $this, 'handle_orderby' ] );
-		add_action( 'save_post', [ $this, 'invalidate_score' ] );
-		add_action( 'wp_ajax_swps_refresh_seo_score', [ $this, 'ajax_refresh' ] );
-		add_action( 'wp_ajax_swps_bulk_refresh_seo_scores', [ $this, 'ajax_bulk_refresh' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+		add_action( 'pre_get_posts', array( $this, 'handle_orderby' ) );
+		add_action( 'save_post', array( $this, 'invalidate_score' ) );
+		add_action( 'wp_ajax_swps_refresh_seo_score', array( $this, 'ajax_refresh' ) );
+		add_action( 'wp_ajax_swps_bulk_refresh_seo_scores', array( $this, 'ajax_bulk_refresh' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 	}
 
 	/**
@@ -76,7 +76,7 @@ class SWPS_Post_List_SEO {
 
 		$score  = (int) ( $cached['score'] ?? 0 );
 		$status = $cached['status'] ?? 'poor';
-		$checks = $cached['checks'] ?? [];
+		$checks = $cached['checks'] ?? array();
 
 		if ( 'no_keyword' === $status ) {
 			echo '<div class="swps-seo-indicator" data-post-id="' . esc_attr( $post_id ) . '">';
@@ -164,12 +164,12 @@ class SWPS_Post_List_SEO {
 		check_ajax_referer( 'swps_nonce', 'nonce' );
 
 		if ( ! current_user_can( 'edit_posts' ) ) {
-			wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
 		}
 
 		$post_id = absint( $_POST['post_id'] ?? 0 );
 		if ( ! $post_id ) {
-			wp_send_json_error( [ 'message' => 'Invalid post ID.' ] );
+			wp_send_json_error( array( 'message' => 'Invalid post ID.' ) );
 		}
 
 		$result = $this->scorer->score_post( $post_id );
@@ -178,10 +178,12 @@ class SWPS_Post_List_SEO {
 		$this->render_column( 'swps_seo', $post_id );
 		$html = ob_get_clean();
 
-		wp_send_json_success( [
-			'html'  => $html,
-			'score' => $result['score'],
-		] );
+		wp_send_json_success(
+			array(
+				'html'  => $html,
+				'score' => $result['score'],
+			)
+		);
 	}
 
 	/**
@@ -191,23 +193,25 @@ class SWPS_Post_List_SEO {
 		check_ajax_referer( 'swps_nonce', 'nonce' );
 
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
 		}
 
 		$offset = absint( $_POST['offset'] ?? 0 );
 		$batch  = 20;
 
-		$enabled_types = (array) get_option( 'swps_seo_column_post_types', [ 'post', 'page' ] );
+		$enabled_types = (array) get_option( 'swps_seo_column_post_types', array( 'post', 'page' ) );
 
-		$posts = get_posts( [
-			'post_type'      => $enabled_types,
-			'post_status'    => [ 'publish', 'draft' ],
-			'posts_per_page' => $batch,
-			'offset'         => $offset,
-			'fields'         => 'ids',
-			'orderby'        => 'ID',
-			'order'          => 'ASC',
-		] );
+		$posts = get_posts(
+			array(
+				'post_type'      => $enabled_types,
+				'post_status'    => array( 'publish', 'draft' ),
+				'posts_per_page' => $batch,
+				'offset'         => $offset,
+				'fields'         => 'ids',
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+			)
+		);
 
 		foreach ( $posts as $pid ) {
 			$this->scorer->score_post( $pid );
@@ -219,11 +223,13 @@ class SWPS_Post_List_SEO {
 			$total += ( $counts->publish ?? 0 ) + ( $counts->draft ?? 0 );
 		}
 
-		wp_send_json_success( [
-			'processed' => $offset + count( $posts ),
-			'total'     => $total,
-			'done'      => count( $posts ) < $batch,
-		] );
+		wp_send_json_success(
+			array(
+				'processed' => $offset + count( $posts ),
+				'total'     => $total,
+				'done'      => count( $posts ) < $batch,
+			)
+		);
 	}
 
 	/**
@@ -239,7 +245,7 @@ class SWPS_Post_List_SEO {
 			return;
 		}
 
-		$enabled_types = (array) get_option( 'swps_seo_column_post_types', [ 'post', 'page' ] );
+		$enabled_types = (array) get_option( 'swps_seo_column_post_types', array( 'post', 'page' ) );
 		if ( ! in_array( $screen->post_type, $enabled_types, true ) ) {
 			return;
 		}
@@ -247,21 +253,25 @@ class SWPS_Post_List_SEO {
 		wp_enqueue_style(
 			'swps-admin',
 			SWPS_PLUGIN_URL . 'admin/css/admin.css',
-			[],
+			array(),
 			SWPS_VERSION
 		);
 
 		wp_enqueue_script(
 			'swps-post-list-seo',
 			SWPS_PLUGIN_URL . 'admin/js/post-list-seo.js',
-			[ 'jquery' ],
+			array( 'jquery' ),
 			SWPS_VERSION,
 			true
 		);
 
-		wp_localize_script( 'swps-post-list-seo', 'swpsPostListSeo', [
-			'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-			'nonce'   => wp_create_nonce( 'swps_nonce' ),
-		] );
+		wp_localize_script(
+			'swps-post-list-seo',
+			'swpsPostListSeo',
+			array(
+				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'nonce'   => wp_create_nonce( 'swps_nonce' ),
+			)
+		);
 	}
 }

--- a/includes/class-provider-factory.php
+++ b/includes/class-provider-factory.php
@@ -6,92 +6,92 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Provider_Factory {
 
-    /**
-     * AI provider slug => class name.
-     */
-    private const AI_PROVIDERS = [
-        'anthropic' => 'SWPS_Anthropic_Provider',
-        'openai'    => 'SWPS_OpenAI_Provider',
-        'google'    => 'SWPS_Google_Provider',
-        'xai'       => 'SWPS_XAI_Provider',
-    ];
+	/**
+	 * AI provider slug => class name.
+	 */
+	private const AI_PROVIDERS = array(
+		'anthropic' => 'SWPS_Anthropic_Provider',
+		'openai'    => 'SWPS_OpenAI_Provider',
+		'google'    => 'SWPS_Google_Provider',
+		'xai'       => 'SWPS_XAI_Provider',
+	);
 
-    /**
-     * Image provider slug => class name.
-     */
-    private const IMAGE_PROVIDERS = [
-        'unsplash' => 'SWPS_Unsplash_Provider',
-        'pexels'   => 'SWPS_Pexels_Provider',
-        'pixabay'  => 'SWPS_Pixabay_Provider',
-        'gemini'   => 'SWPS_Gemini_Image_Provider',
-    ];
+	/**
+	 * Image provider slug => class name.
+	 */
+	private const IMAGE_PROVIDERS = array(
+		'unsplash' => 'SWPS_Unsplash_Provider',
+		'pexels'   => 'SWPS_Pexels_Provider',
+		'pixabay'  => 'SWPS_Pixabay_Provider',
+		'gemini'   => 'SWPS_Gemini_Image_Provider',
+	);
 
-    /**
-     * Create the active AI provider based on the stored option.
-     */
-    public static function create_ai_provider(): SWPS_AI_Provider {
-        $slug  = get_option( 'swps_ai_provider', 'anthropic' );
-        $class = self::AI_PROVIDERS[ $slug ] ?? self::AI_PROVIDERS['anthropic'];
+	/**
+	 * Create the active AI provider based on the stored option.
+	 */
+	public static function create_ai_provider(): SWPS_AI_Provider {
+		$slug  = get_option( 'swps_ai_provider', 'anthropic' );
+		$class = self::AI_PROVIDERS[ $slug ] ?? self::AI_PROVIDERS['anthropic'];
 
-        return new $class();
-    }
+		return new $class();
+	}
 
-    /**
-     * Create the active image provider based on the stored option.
-     */
-    public static function create_image_provider(): SWPS_Image_Provider {
-        $slug  = get_option( 'swps_image_provider', 'unsplash' );
-        $class = self::IMAGE_PROVIDERS[ $slug ] ?? self::IMAGE_PROVIDERS['unsplash'];
+	/**
+	 * Create the active image provider based on the stored option.
+	 */
+	public static function create_image_provider(): SWPS_Image_Provider {
+		$slug  = get_option( 'swps_image_provider', 'unsplash' );
+		$class = self::IMAGE_PROVIDERS[ $slug ] ?? self::IMAGE_PROVIDERS['unsplash'];
 
-        return new $class();
-    }
+		return new $class();
+	}
 
-    /**
-     * Get AI provider options for a settings dropdown.
-     *
-     * @return array<string, string> slug => display name.
-     */
-    public static function get_ai_provider_options(): array {
-        $options = [];
-        foreach ( self::AI_PROVIDERS as $slug => $class ) {
-            $instance = new $class();
-            $options[ $slug ] = $instance->get_name();
-        }
-        return $options;
-    }
+	/**
+	 * Get AI provider options for a settings dropdown.
+	 *
+	 * @return array<string, string> slug => display name.
+	 */
+	public static function get_ai_provider_options(): array {
+		$options = array();
+		foreach ( self::AI_PROVIDERS as $slug => $class ) {
+			$instance         = new $class();
+			$options[ $slug ] = $instance->get_name();
+		}
+		return $options;
+	}
 
-    /**
-     * Get image provider options for a settings dropdown.
-     *
-     * @return array<string, string> slug => display name.
-     */
-    public static function get_image_provider_options(): array {
-        $options = [];
-        foreach ( self::IMAGE_PROVIDERS as $slug => $class ) {
-            $instance = new $class();
-            $options[ $slug ] = $instance->get_name();
-        }
-        return $options;
-    }
+	/**
+	 * Get image provider options for a settings dropdown.
+	 *
+	 * @return array<string, string> slug => display name.
+	 */
+	public static function get_image_provider_options(): array {
+		$options = array();
+		foreach ( self::IMAGE_PROVIDERS as $slug => $class ) {
+			$instance         = new $class();
+			$options[ $slug ] = $instance->get_name();
+		}
+		return $options;
+	}
 
-    /**
-     * Get available models for a specific AI provider slug.
-     *
-     * @return array<string, string> model ID => display name.
-     */
-    public static function get_models_for_provider( string $slug ): array {
-        $class = self::AI_PROVIDERS[ $slug ] ?? null;
+	/**
+	 * Get available models for a specific AI provider slug.
+	 *
+	 * @return array<string, string> model ID => display name.
+	 */
+	public static function get_models_for_provider( string $slug ): array {
+		$class = self::AI_PROVIDERS[ $slug ] ?? null;
 
-        if ( ! $class ) {
-            return [];
-        }
+		if ( ! $class ) {
+			return array();
+		}
 
-        $instance = new $class();
-        return $instance->get_available_models();
-    }
+		$instance = new $class();
+		return $instance->get_available_models();
+	}
 }

--- a/includes/class-rate-limiter.php
+++ b/includes/class-rate-limiter.php
@@ -6,53 +6,53 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Rate_Limiter {
 
-    private const TRANSIENT_KEY = 'swps_rate_limit_lock';
+	private const TRANSIENT_KEY = 'swps_rate_limit_lock';
 
-    /**
-     * Check if generation is currently allowed.
-     *
-     * @return bool True if generation can proceed.
-     */
-    public function can_generate(): bool {
-        return false === get_transient( self::TRANSIENT_KEY );
-    }
+	/**
+	 * Check if generation is currently allowed.
+	 *
+	 * @return bool True if generation can proceed.
+	 */
+	public function can_generate(): bool {
+		return false === get_transient( self::TRANSIENT_KEY );
+	}
 
-    /**
-     * Lock generation for the configured cooldown period.
-     */
-    public function lock(): void {
-        $cooldown = (int) get_option( 'swps_rate_limit', 60 );
-        set_transient( self::TRANSIENT_KEY, time(), $cooldown );
-    }
+	/**
+	 * Lock generation for the configured cooldown period.
+	 */
+	public function lock(): void {
+		$cooldown = (int) get_option( 'swps_rate_limit', 60 );
+		set_transient( self::TRANSIENT_KEY, time(), $cooldown );
+	}
 
-    /**
-     * Get remaining seconds until generation is allowed.
-     *
-     * @return int Seconds remaining, 0 if ready.
-     */
-    public function get_remaining_seconds(): int {
-        $lock_time = get_transient( self::TRANSIENT_KEY );
+	/**
+	 * Get remaining seconds until generation is allowed.
+	 *
+	 * @return int Seconds remaining, 0 if ready.
+	 */
+	public function get_remaining_seconds(): int {
+		$lock_time = get_transient( self::TRANSIENT_KEY );
 
-        if ( false === $lock_time ) {
-            return 0;
-        }
+		if ( false === $lock_time ) {
+			return 0;
+		}
 
-        $cooldown  = (int) get_option( 'swps_rate_limit', 60 );
-        $elapsed   = time() - (int) $lock_time;
-        $remaining = $cooldown - $elapsed;
+		$cooldown  = (int) get_option( 'swps_rate_limit', 60 );
+		$elapsed   = time() - (int) $lock_time;
+		$remaining = $cooldown - $elapsed;
 
-        return max( 0, $remaining );
-    }
+		return max( 0, $remaining );
+	}
 
-    /**
-     * Clear the rate limit lock.
-     */
-    public function clear(): void {
-        delete_transient( self::TRANSIENT_KEY );
-    }
+	/**
+	 * Clear the rate limit lock.
+	 */
+	public function clear(): void {
+		delete_transient( self::TRANSIENT_KEY );
+	}
 }

--- a/includes/class-redirect-admin.php
+++ b/includes/class-redirect-admin.php
@@ -6,19 +6,19 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Redirect_Admin {
 
-    public function __construct() {
-        // Admin page rendering is handled by SWPS_Settings menu registration.
-    }
+	public function __construct() {
+		// Admin page rendering is handled by SWPS_Settings menu registration.
+	}
 
-    /**
-     * Render the redirects admin page.
-     */
-    public static function render(): void {
-        include SWPS_PLUGIN_DIR . 'templates/redirects-page.php';
-    }
+	/**
+	 * Render the redirects admin page.
+	 */
+	public static function render(): void {
+		include SWPS_PLUGIN_DIR . 'templates/redirects-page.php';
+	}
 }

--- a/includes/class-redirect-manager.php
+++ b/includes/class-redirect-manager.php
@@ -10,588 +10,612 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Redirect_Manager {
 
-    private const REDIRECTS_TABLE = 'swps_redirects';
-    private const LOG_TABLE       = 'swps_404_log';
-    private const CACHE_KEY       = 'swps_redirects_cache';
-
-    public function __construct() {
-        // Execute redirects — must be very early.
-        add_action( 'template_redirect', [ $this, 'maybe_redirect' ], 1 );
-
-        // Log 404s.
-        add_action( 'template_redirect', [ $this, 'maybe_log_404' ], 99 );
-
-        // Auto-redirect on slug change.
-        if ( get_option( 'swps_auto_redirect_slug_change', 1 ) ) {
-            add_action( 'post_updated', [ $this, 'detect_slug_change' ], 10, 3 );
-        }
-
-        // AJAX handlers.
-        add_action( 'wp_ajax_swps_add_redirect', [ $this, 'ajax_add_redirect' ] );
-        add_action( 'wp_ajax_swps_delete_redirect', [ $this, 'ajax_delete_redirect' ] );
-        add_action( 'wp_ajax_swps_get_redirects', [ $this, 'ajax_get_redirects' ] );
-        add_action( 'wp_ajax_swps_get_404s', [ $this, 'ajax_get_404s' ] );
-        add_action( 'wp_ajax_swps_delete_404', [ $this, 'ajax_delete_404' ] );
-        add_action( 'wp_ajax_swps_suggest_redirect_target', [ $this, 'ajax_suggest_redirect_target' ] );
-        add_action( 'wp_ajax_swps_bulk_delete_404s', [ $this, 'ajax_bulk_delete_404s' ] );
-        add_action( 'wp_ajax_swps_bulk_redirect_404s', [ $this, 'ajax_bulk_redirect_404s' ] );
-    }
-
-    /**
-     * Check if current request matches a redirect and execute it.
-     */
-    public function maybe_redirect(): void {
-        if ( is_admin() ) {
-            return;
-        }
-
-        $request_path = wp_parse_url( $_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH );
-        $request_path = rtrim( $request_path, '/' );
-
-        if ( empty( $request_path ) || '/' === $request_path ) {
-            return;
-        }
-
-        $redirects = $this->get_cached_redirects();
-
-        // Exact match first.
-        foreach ( $redirects as $redirect ) {
-            if ( ! $redirect->is_regex && rtrim( $redirect->source_url, '/' ) === $request_path ) {
-                $this->execute_redirect( $redirect );
-                return;
-            }
-        }
-
-        // Regex match.
-        foreach ( $redirects as $redirect ) {
-            if ( $redirect->is_regex ) {
-                $pattern = '#' . str_replace( '#', '\#', $redirect->source_url ) . '#';
-                if ( preg_match( $pattern, $request_path, $matches ) ) {
-                    $target = $redirect->target_url;
-                    // Replace capture groups.
-                    for ( $i = 1; $i < count( $matches ); $i++ ) {
-                        $target = str_replace( '$' . $i, $matches[ $i ], $target );
-                    }
-                    $redirect->target_url = $target;
-                    $this->execute_redirect( $redirect );
-                    return;
-                }
-            }
-        }
-    }
-
-    /**
-     * Execute a redirect.
-     */
-    private function execute_redirect( object $redirect ): void {
-        global $wpdb;
-        $table = $wpdb->prefix . self::REDIRECTS_TABLE;
-
-        // Update hit counter.
-        $wpdb->query( $wpdb->prepare(
-            "UPDATE {$table} SET hits = hits + 1, last_hit = NOW() WHERE id = %d",
-            $redirect->id
-        ) );
-
-        if ( 410 === (int) $redirect->type ) {
-            status_header( 410 );
-            nocache_headers();
-            echo '<h1>410 Gone</h1><p>This page has been permanently removed.</p>';
-            exit;
-        }
-
-        $request_path = wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ), PHP_URL_PATH );
-        if ( is_string( $request_path ) && $this->paths_match( $request_path, $redirect->target_url ) ) {
-            return;
-        }
-
-        wp_redirect( $redirect->target_url, (int) $redirect->type );
-        exit;
-    }
-
-    /**
-     * Log 404 errors.
-     */
-    public function maybe_log_404(): void {
-        if ( ! is_404() ) {
-            return;
-        }
-
-        global $wpdb;
-        $table = $wpdb->prefix . self::LOG_TABLE;
-        $url   = sanitize_text_field( $_SERVER['REQUEST_URI'] ?? '' );
-
-        if ( empty( $url ) ) {
-            return;
-        }
-
-        // Upsert: increment count if exists, insert if not.
-        $existing = $wpdb->get_var( $wpdb->prepare(
-            "SELECT id FROM {$table} WHERE url = %s",
-            $url
-        ) );
-
-        if ( $existing ) {
-            $wpdb->query( $wpdb->prepare(
-                "UPDATE {$table} SET count = count + 1, last_seen = NOW() WHERE id = %d",
-                $existing
-            ) );
-        } else {
-            $wpdb->insert( $table, [
-                'url'       => $url,
-                'referrer'  => sanitize_text_field( $_SERVER['HTTP_REFERER'] ?? '' ),
-                'count'     => 1,
-                'last_seen' => current_time( 'mysql' ),
-            ], [ '%s', '%s', '%d', '%s' ] );
-        }
-    }
-
-    /**
-     * Detect slug changes and auto-create 301 redirects.
-     */
-    public function detect_slug_change( int $post_id, \WP_Post $post_after, \WP_Post $post_before ): void {
-        if ( 'publish' !== $post_before->post_status || 'publish' !== $post_after->post_status ) {
-            return;
-        }
-
-        if ( $post_before->post_name === $post_after->post_name ) {
-            return;
-        }
-
-        // Build old URL path.
-        $old_url = str_replace( home_url(), '', get_permalink( $post_before ) );
-
-        // We need the actual old permalink — reconstruct it.
-        $old_link = get_permalink( $post_id );
-        $old_link = str_replace( $post_after->post_name, $post_before->post_name, $old_link );
-        $old_path = wp_parse_url( $old_link, PHP_URL_PATH );
-        $new_path = wp_parse_url( get_permalink( $post_id ), PHP_URL_PATH );
-
-        if ( $old_path && $new_path && $old_path !== $new_path ) {
-            $this->add_redirect( $old_path, $new_path, 301 );
-        }
-    }
-
-    /**
-     * Add a redirect.
-     */
-    public function add_redirect( string $source, string $target, int $type = 301, bool $is_regex = false ): int|false|WP_Error {
-        global $wpdb;
-        $table = $wpdb->prefix . self::REDIRECTS_TABLE;
-
-        $validation = $this->validate_redirect( $source, $target, $type, $is_regex );
-        if ( is_wp_error( $validation ) ) {
-            return $validation;
-        }
-
-        $source = $validation['source'];
-        $target = $validation['target'];
-        $type   = $validation['type'];
-
-        $result = $wpdb->insert( $table, [
-            'source_url' => $source,
-            'target_url' => $target,
-            'type'       => $type,
-            'is_regex'   => $is_regex ? 1 : 0,
-            'hits'       => 0,
-            'created_at' => current_time( 'mysql' ),
-            'updated_at' => current_time( 'mysql' ),
-        ], [ '%s', '%s', '%d', '%d', '%d', '%s', '%s' ] );
-
-        delete_transient( self::CACHE_KEY );
-
-        return $result ? $wpdb->insert_id : false;
-    }
-
-    /**
-     * Validate and normalize redirect data before storage.
-     */
-    private function validate_redirect( string $source, string $target, int $type, bool $is_regex ): array|WP_Error {
-        $allowed_types = [ 301, 302, 307, 410 ];
-        if ( ! in_array( $type, $allowed_types, true ) ) {
-            return new WP_Error( 'swps_invalid_redirect_type', __( 'Invalid redirect type.', 'stratawp-seo' ) );
-        }
-
-        $source = $this->normalize_source_url( $source, $is_regex );
-        $target = $this->normalize_target_url( $target, $type );
-
-        if ( '' === $source || '/' === $source ) {
-            return new WP_Error( 'swps_invalid_redirect_source', __( 'Source URL must be a non-root path.', 'stratawp-seo' ) );
-        }
-
-        if ( $is_regex ) {
-            $pattern = '#' . str_replace( '#', '\#', $source ) . '#';
-            if ( false === @preg_match( $pattern, '' ) ) {
-                return new WP_Error( 'swps_invalid_redirect_regex', __( 'Source regex is not valid.', 'stratawp-seo' ) );
-            }
-        }
-
-        if ( 410 !== $type && '' === $target ) {
-            return new WP_Error( 'swps_invalid_redirect_target', __( 'Target URL is required unless the redirect type is 410 Gone.', 'stratawp-seo' ) );
-        }
-
-        if ( 410 !== $type && ! $is_regex && $this->paths_match( $source, $target ) ) {
-            return new WP_Error( 'swps_redirect_loop', __( 'Source and target cannot resolve to the same path.', 'stratawp-seo' ) );
-        }
-
-        return [
-            'source' => $source,
-            'target' => $target,
-            'type'   => $type,
-        ];
-    }
-
-    /**
-     * Normalize a source URL to the path format used during request matching.
-     */
-    private function normalize_source_url( string $source, bool $is_regex ): string {
-        $source = trim( wp_unslash( $source ) );
-
-        if ( $is_regex ) {
-            return $source;
-        }
-
-        $path = wp_parse_url( $source, PHP_URL_PATH );
-        if ( ! is_string( $path ) || '' === $path ) {
-            $path = $source;
-        }
-
-        $path = '/' . ltrim( $path, '/' );
-        $path = rtrim( $path, '/' );
-
-        return '' === $path ? '/' : sanitize_text_field( $path );
-    }
-
-    /**
-     * Normalize a target URL while preserving intentional external redirects.
-     */
-    private function normalize_target_url( string $target, int $type ): string {
-        if ( 410 === $type ) {
-            return '';
-        }
-
-        $target = trim( wp_unslash( $target ) );
-        if ( '' === $target ) {
-            return '';
-        }
-
-        $scheme = wp_parse_url( $target, PHP_URL_SCHEME );
-        if ( $scheme && ! in_array( strtolower( $scheme ), [ 'http', 'https' ], true ) ) {
-            return '';
-        }
-
-        if ( ! $scheme ) {
-            $target = '/' . ltrim( $target, '/' );
-        }
-
-        return esc_url_raw( $target );
-    }
-
-    /**
-     * Compare source and target paths after trimming trailing slashes.
-     */
-    private function paths_match( string $source, string $target ): bool {
-        $target_host = wp_parse_url( $target, PHP_URL_HOST );
-        $home_host   = wp_parse_url( home_url(), PHP_URL_HOST );
-
-        if ( $target_host && $home_host && strtolower( $target_host ) !== strtolower( $home_host ) ) {
-            return false;
-        }
-
-        $target_path = wp_parse_url( $target, PHP_URL_PATH );
-        if ( ! is_string( $target_path ) || '' === $target_path ) {
-            return false;
-        }
-
-        return untrailingslashit( $source ) === untrailingslashit( $target_path );
-    }
-
-    /**
-     * Get cached redirects.
-     */
-    private function get_cached_redirects(): array {
-        $cached = get_transient( self::CACHE_KEY );
-        if ( false !== $cached ) {
-            return $cached;
-        }
-
-        global $wpdb;
-        $table = $wpdb->prefix . self::REDIRECTS_TABLE;
-        $redirects = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY is_regex ASC, id ASC" );
-
-        set_transient( self::CACHE_KEY, $redirects ?: [], HOUR_IN_SECONDS );
-
-        return $redirects ?: [];
-    }
-
-    // --- AJAX Handlers ---
-
-    public function ajax_add_redirect(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( 'Unauthorized' );
-        }
-
-        $source   = sanitize_text_field( wp_unslash( $_POST['source'] ?? '' ) );
-        $target   = sanitize_text_field( wp_unslash( $_POST['target'] ?? '' ) );
-        $type     = (int) ( $_POST['type'] ?? 301 );
-        $is_regex = ! empty( $_POST['is_regex'] );
-
-        if ( empty( $source ) ) {
-            wp_send_json_error( 'Source URL is required.' );
-        }
-
-        $id = $this->add_redirect( $source, $target, $type, $is_regex );
-        if ( is_wp_error( $id ) ) {
-            wp_send_json_error( $id->get_error_message() );
-        }
-
-        if ( false === $id ) {
-            wp_send_json_error( 'Could not save redirect.' );
-        }
-
-        wp_send_json_success( [ 'id' => $id ] );
-    }
-
-    public function ajax_delete_redirect(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( 'Unauthorized' );
-        }
-
-        global $wpdb;
-        $table = $wpdb->prefix . self::REDIRECTS_TABLE;
-        $id    = (int) ( $_POST['id'] ?? 0 );
-
-        $wpdb->delete( $table, [ 'id' => $id ], [ '%d' ] );
-        delete_transient( self::CACHE_KEY );
-
-        wp_send_json_success();
-    }
-
-    public function ajax_get_redirects(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( 'Unauthorized' );
-        }
-
-        global $wpdb;
-        $table = $wpdb->prefix . self::REDIRECTS_TABLE;
-        $redirects = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY created_at DESC LIMIT 100" );
-
-        wp_send_json_success( $redirects );
-    }
-
-    public function ajax_get_404s(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( 'Unauthorized' );
-        }
-
-        global $wpdb;
-        $table = $wpdb->prefix . self::LOG_TABLE;
-        $logs = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY count DESC LIMIT 100" );
-
-        foreach ( $logs as $log ) {
-            $suggestions             = $this->find_similar_posts( $log->url );
-            $log->suggested_target   = ! empty( $suggestions ) ? $suggestions[0]['url'] : '';
-            $log->suggestions        = $suggestions;
-        }
-
-        wp_send_json_success( $logs );
-    }
-
-    public function ajax_delete_404(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( 'Unauthorized' );
-        }
-
-        global $wpdb;
-        $table = $wpdb->prefix . self::LOG_TABLE;
-        $id    = (int) ( $_POST['id'] ?? 0 );
-
-        $wpdb->delete( $table, [ 'id' => $id ], [ '%d' ] );
-        wp_send_json_success();
-    }
-
-    /**
-     * Find existing posts/pages similar to a given 404 URL.
-     *
-     * @param string $url The 404 URL to find matches for.
-     * @return array<int, array{title: string, url: string}>
-     */
-    private function find_similar_posts( string $url ): array {
-        global $wpdb;
-
-        // Extract slug from the last path segment.
-        $path = wp_parse_url( $url, PHP_URL_PATH ) ?? '';
-        $slug = basename( $path );
-
-        // Strip common extensions.
-        $slug = preg_replace( '/\.(html?|php|aspx)$/i', '', $slug );
-        $slug = sanitize_title( $slug );
-
-        if ( empty( $slug ) ) {
-            return [];
-        }
-
-        $results = $this->query_posts_by_slug( $slug );
-
-        // Fallback: split on hyphens and use the longest part (min 3 chars).
-        if ( empty( $results ) && strpos( $slug, '-' ) !== false ) {
-            $parts       = explode( '-', $slug );
-            $longest     = '';
-            foreach ( $parts as $part ) {
-                if ( strlen( $part ) >= 3 && strlen( $part ) > strlen( $longest ) ) {
-                    $longest = $part;
-                }
-            }
-            if ( ! empty( $longest ) ) {
-                $results = $this->query_posts_by_slug( $longest );
-            }
-        }
-
-        $suggestions = [];
-        foreach ( array_slice( $results, 0, 5 ) as $post ) {
-            $suggestions[] = [
-                'title' => $post->post_title,
-                'url'   => get_permalink( $post ),
-            ];
-        }
-
-        return $suggestions;
-    }
-
-    /**
-     * Query published posts/pages whose post_name matches a slug pattern.
-     *
-     * @param string $slug Slug to match against.
-     * @return array<int, \WP_Post>
-     */
-    private function query_posts_by_slug( string $slug ): array {
-        global $wpdb;
-
-        $like = '%' . $wpdb->esc_like( $slug ) . '%';
-
-        return $wpdb->get_results( $wpdb->prepare(
-            "SELECT * FROM {$wpdb->posts}
+	private const REDIRECTS_TABLE = 'swps_redirects';
+	private const LOG_TABLE       = 'swps_404_log';
+	private const CACHE_KEY       = 'swps_redirects_cache';
+
+	public function __construct() {
+		// Execute redirects — must be very early.
+		add_action( 'template_redirect', array( $this, 'maybe_redirect' ), 1 );
+
+		// Log 404s.
+		add_action( 'template_redirect', array( $this, 'maybe_log_404' ), 99 );
+
+		// Auto-redirect on slug change.
+		if ( get_option( 'swps_auto_redirect_slug_change', 1 ) ) {
+			add_action( 'post_updated', array( $this, 'detect_slug_change' ), 10, 3 );
+		}
+
+		// AJAX handlers.
+		add_action( 'wp_ajax_swps_add_redirect', array( $this, 'ajax_add_redirect' ) );
+		add_action( 'wp_ajax_swps_delete_redirect', array( $this, 'ajax_delete_redirect' ) );
+		add_action( 'wp_ajax_swps_get_redirects', array( $this, 'ajax_get_redirects' ) );
+		add_action( 'wp_ajax_swps_get_404s', array( $this, 'ajax_get_404s' ) );
+		add_action( 'wp_ajax_swps_delete_404', array( $this, 'ajax_delete_404' ) );
+		add_action( 'wp_ajax_swps_suggest_redirect_target', array( $this, 'ajax_suggest_redirect_target' ) );
+		add_action( 'wp_ajax_swps_bulk_delete_404s', array( $this, 'ajax_bulk_delete_404s' ) );
+		add_action( 'wp_ajax_swps_bulk_redirect_404s', array( $this, 'ajax_bulk_redirect_404s' ) );
+	}
+
+	/**
+	 * Check if current request matches a redirect and execute it.
+	 */
+	public function maybe_redirect(): void {
+		if ( is_admin() ) {
+			return;
+		}
+
+		$request_path = wp_parse_url( $_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH );
+		$request_path = rtrim( $request_path, '/' );
+
+		if ( empty( $request_path ) || '/' === $request_path ) {
+			return;
+		}
+
+		$redirects = $this->get_cached_redirects();
+
+		// Exact match first.
+		foreach ( $redirects as $redirect ) {
+			if ( ! $redirect->is_regex && rtrim( $redirect->source_url, '/' ) === $request_path ) {
+				$this->execute_redirect( $redirect );
+				return;
+			}
+		}
+
+		// Regex match.
+		foreach ( $redirects as $redirect ) {
+			if ( $redirect->is_regex ) {
+				$pattern = '#' . str_replace( '#', '\#', $redirect->source_url ) . '#';
+				if ( preg_match( $pattern, $request_path, $matches ) ) {
+					$target = $redirect->target_url;
+					// Replace capture groups.
+					for ( $i = 1; $i < count( $matches ); $i++ ) {
+						$target = str_replace( '$' . $i, $matches[ $i ], $target );
+					}
+					$redirect->target_url = $target;
+					$this->execute_redirect( $redirect );
+					return;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Execute a redirect.
+	 */
+	private function execute_redirect( object $redirect ): void {
+		global $wpdb;
+		$table = $wpdb->prefix . self::REDIRECTS_TABLE;
+
+		// Update hit counter.
+		$wpdb->query(
+			$wpdb->prepare(
+				"UPDATE {$table} SET hits = hits + 1, last_hit = NOW() WHERE id = %d",
+				$redirect->id
+			)
+		);
+
+		if ( 410 === (int) $redirect->type ) {
+			status_header( 410 );
+			nocache_headers();
+			echo '<h1>410 Gone</h1><p>This page has been permanently removed.</p>';
+			exit;
+		}
+
+		$request_path = wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ), PHP_URL_PATH );
+		if ( is_string( $request_path ) && $this->paths_match( $request_path, $redirect->target_url ) ) {
+			return;
+		}
+
+		wp_redirect( $redirect->target_url, (int) $redirect->type );
+		exit;
+	}
+
+	/**
+	 * Log 404 errors.
+	 */
+	public function maybe_log_404(): void {
+		if ( ! is_404() ) {
+			return;
+		}
+
+		global $wpdb;
+		$table = $wpdb->prefix . self::LOG_TABLE;
+		$url   = sanitize_text_field( $_SERVER['REQUEST_URI'] ?? '' );
+
+		if ( empty( $url ) ) {
+			return;
+		}
+
+		// Upsert: increment count if exists, insert if not.
+		$existing = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT id FROM {$table} WHERE url = %s",
+				$url
+			)
+		);
+
+		if ( $existing ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					"UPDATE {$table} SET count = count + 1, last_seen = NOW() WHERE id = %d",
+					$existing
+				)
+			);
+		} else {
+			$wpdb->insert(
+				$table,
+				array(
+					'url'       => $url,
+					'referrer'  => sanitize_text_field( $_SERVER['HTTP_REFERER'] ?? '' ),
+					'count'     => 1,
+					'last_seen' => current_time( 'mysql' ),
+				),
+				array( '%s', '%s', '%d', '%s' )
+			);
+		}
+	}
+
+	/**
+	 * Detect slug changes and auto-create 301 redirects.
+	 */
+	public function detect_slug_change( int $post_id, \WP_Post $post_after, \WP_Post $post_before ): void {
+		if ( 'publish' !== $post_before->post_status || 'publish' !== $post_after->post_status ) {
+			return;
+		}
+
+		if ( $post_before->post_name === $post_after->post_name ) {
+			return;
+		}
+
+		// Build old URL path.
+		$old_url = str_replace( home_url(), '', get_permalink( $post_before ) );
+
+		// We need the actual old permalink — reconstruct it.
+		$old_link = get_permalink( $post_id );
+		$old_link = str_replace( $post_after->post_name, $post_before->post_name, $old_link );
+		$old_path = wp_parse_url( $old_link, PHP_URL_PATH );
+		$new_path = wp_parse_url( get_permalink( $post_id ), PHP_URL_PATH );
+
+		if ( $old_path && $new_path && $old_path !== $new_path ) {
+			$this->add_redirect( $old_path, $new_path, 301 );
+		}
+	}
+
+	/**
+	 * Add a redirect.
+	 */
+	public function add_redirect( string $source, string $target, int $type = 301, bool $is_regex = false ): int|false|WP_Error {
+		global $wpdb;
+		$table = $wpdb->prefix . self::REDIRECTS_TABLE;
+
+		$validation = $this->validate_redirect( $source, $target, $type, $is_regex );
+		if ( is_wp_error( $validation ) ) {
+			return $validation;
+		}
+
+		$source = $validation['source'];
+		$target = $validation['target'];
+		$type   = $validation['type'];
+
+		$result = $wpdb->insert(
+			$table,
+			array(
+				'source_url' => $source,
+				'target_url' => $target,
+				'type'       => $type,
+				'is_regex'   => $is_regex ? 1 : 0,
+				'hits'       => 0,
+				'created_at' => current_time( 'mysql' ),
+				'updated_at' => current_time( 'mysql' ),
+			),
+			array( '%s', '%s', '%d', '%d', '%d', '%s', '%s' )
+		);
+
+		delete_transient( self::CACHE_KEY );
+
+		return $result ? $wpdb->insert_id : false;
+	}
+
+	/**
+	 * Validate and normalize redirect data before storage.
+	 */
+	private function validate_redirect( string $source, string $target, int $type, bool $is_regex ): array|WP_Error {
+		$allowed_types = array( 301, 302, 307, 410 );
+		if ( ! in_array( $type, $allowed_types, true ) ) {
+			return new WP_Error( 'swps_invalid_redirect_type', __( 'Invalid redirect type.', 'stratawp-seo' ) );
+		}
+
+		$source = $this->normalize_source_url( $source, $is_regex );
+		$target = $this->normalize_target_url( $target, $type );
+
+		if ( '' === $source || '/' === $source ) {
+			return new WP_Error( 'swps_invalid_redirect_source', __( 'Source URL must be a non-root path.', 'stratawp-seo' ) );
+		}
+
+		if ( $is_regex ) {
+			$pattern = '#' . str_replace( '#', '\#', $source ) . '#';
+			if ( false === @preg_match( $pattern, '' ) ) {
+				return new WP_Error( 'swps_invalid_redirect_regex', __( 'Source regex is not valid.', 'stratawp-seo' ) );
+			}
+		}
+
+		if ( 410 !== $type && '' === $target ) {
+			return new WP_Error( 'swps_invalid_redirect_target', __( 'Target URL is required unless the redirect type is 410 Gone.', 'stratawp-seo' ) );
+		}
+
+		if ( 410 !== $type && ! $is_regex && $this->paths_match( $source, $target ) ) {
+			return new WP_Error( 'swps_redirect_loop', __( 'Source and target cannot resolve to the same path.', 'stratawp-seo' ) );
+		}
+
+		return array(
+			'source' => $source,
+			'target' => $target,
+			'type'   => $type,
+		);
+	}
+
+	/**
+	 * Normalize a source URL to the path format used during request matching.
+	 */
+	private function normalize_source_url( string $source, bool $is_regex ): string {
+		$source = trim( wp_unslash( $source ) );
+
+		if ( $is_regex ) {
+			return $source;
+		}
+
+		$path = wp_parse_url( $source, PHP_URL_PATH );
+		if ( ! is_string( $path ) || '' === $path ) {
+			$path = $source;
+		}
+
+		$path = '/' . ltrim( $path, '/' );
+		$path = rtrim( $path, '/' );
+
+		return '' === $path ? '/' : sanitize_text_field( $path );
+	}
+
+	/**
+	 * Normalize a target URL while preserving intentional external redirects.
+	 */
+	private function normalize_target_url( string $target, int $type ): string {
+		if ( 410 === $type ) {
+			return '';
+		}
+
+		$target = trim( wp_unslash( $target ) );
+		if ( '' === $target ) {
+			return '';
+		}
+
+		$scheme = wp_parse_url( $target, PHP_URL_SCHEME );
+		if ( $scheme && ! in_array( strtolower( $scheme ), array( 'http', 'https' ), true ) ) {
+			return '';
+		}
+
+		if ( ! $scheme ) {
+			$target = '/' . ltrim( $target, '/' );
+		}
+
+		return esc_url_raw( $target );
+	}
+
+	/**
+	 * Compare source and target paths after trimming trailing slashes.
+	 */
+	private function paths_match( string $source, string $target ): bool {
+		$target_host = wp_parse_url( $target, PHP_URL_HOST );
+		$home_host   = wp_parse_url( home_url(), PHP_URL_HOST );
+
+		if ( $target_host && $home_host && strtolower( $target_host ) !== strtolower( $home_host ) ) {
+			return false;
+		}
+
+		$target_path = wp_parse_url( $target, PHP_URL_PATH );
+		if ( ! is_string( $target_path ) || '' === $target_path ) {
+			return false;
+		}
+
+		return untrailingslashit( $source ) === untrailingslashit( $target_path );
+	}
+
+	/**
+	 * Get cached redirects.
+	 */
+	private function get_cached_redirects(): array {
+		$cached = get_transient( self::CACHE_KEY );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		global $wpdb;
+		$table     = $wpdb->prefix . self::REDIRECTS_TABLE;
+		$redirects = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY is_regex ASC, id ASC" );
+
+		set_transient( self::CACHE_KEY, $redirects ?: array(), HOUR_IN_SECONDS );
+
+		return $redirects ?: array();
+	}
+
+	// --- AJAX Handlers ---
+
+	public function ajax_add_redirect(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( 'Unauthorized' );
+		}
+
+		$source   = sanitize_text_field( wp_unslash( $_POST['source'] ?? '' ) );
+		$target   = sanitize_text_field( wp_unslash( $_POST['target'] ?? '' ) );
+		$type     = (int) ( $_POST['type'] ?? 301 );
+		$is_regex = ! empty( $_POST['is_regex'] );
+
+		if ( empty( $source ) ) {
+			wp_send_json_error( 'Source URL is required.' );
+		}
+
+		$id = $this->add_redirect( $source, $target, $type, $is_regex );
+		if ( is_wp_error( $id ) ) {
+			wp_send_json_error( $id->get_error_message() );
+		}
+
+		if ( false === $id ) {
+			wp_send_json_error( 'Could not save redirect.' );
+		}
+
+		wp_send_json_success( array( 'id' => $id ) );
+	}
+
+	public function ajax_delete_redirect(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( 'Unauthorized' );
+		}
+
+		global $wpdb;
+		$table = $wpdb->prefix . self::REDIRECTS_TABLE;
+		$id    = (int) ( $_POST['id'] ?? 0 );
+
+		$wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
+		delete_transient( self::CACHE_KEY );
+
+		wp_send_json_success();
+	}
+
+	public function ajax_get_redirects(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( 'Unauthorized' );
+		}
+
+		global $wpdb;
+		$table     = $wpdb->prefix . self::REDIRECTS_TABLE;
+		$redirects = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY created_at DESC LIMIT 100" );
+
+		wp_send_json_success( $redirects );
+	}
+
+	public function ajax_get_404s(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( 'Unauthorized' );
+		}
+
+		global $wpdb;
+		$table = $wpdb->prefix . self::LOG_TABLE;
+		$logs  = $wpdb->get_results( "SELECT * FROM {$table} ORDER BY count DESC LIMIT 100" );
+
+		foreach ( $logs as $log ) {
+			$suggestions           = $this->find_similar_posts( $log->url );
+			$log->suggested_target = ! empty( $suggestions ) ? $suggestions[0]['url'] : '';
+			$log->suggestions      = $suggestions;
+		}
+
+		wp_send_json_success( $logs );
+	}
+
+	public function ajax_delete_404(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( 'Unauthorized' );
+		}
+
+		global $wpdb;
+		$table = $wpdb->prefix . self::LOG_TABLE;
+		$id    = (int) ( $_POST['id'] ?? 0 );
+
+		$wpdb->delete( $table, array( 'id' => $id ), array( '%d' ) );
+		wp_send_json_success();
+	}
+
+	/**
+	 * Find existing posts/pages similar to a given 404 URL.
+	 *
+	 * @param string $url The 404 URL to find matches for.
+	 * @return array<int, array{title: string, url: string}>
+	 */
+	private function find_similar_posts( string $url ): array {
+		global $wpdb;
+
+		// Extract slug from the last path segment.
+		$path = wp_parse_url( $url, PHP_URL_PATH ) ?? '';
+		$slug = basename( $path );
+
+		// Strip common extensions.
+		$slug = preg_replace( '/\.(html?|php|aspx)$/i', '', $slug );
+		$slug = sanitize_title( $slug );
+
+		if ( empty( $slug ) ) {
+			return array();
+		}
+
+		$results = $this->query_posts_by_slug( $slug );
+
+		// Fallback: split on hyphens and use the longest part (min 3 chars).
+		if ( empty( $results ) && strpos( $slug, '-' ) !== false ) {
+			$parts   = explode( '-', $slug );
+			$longest = '';
+			foreach ( $parts as $part ) {
+				if ( strlen( $part ) >= 3 && strlen( $part ) > strlen( $longest ) ) {
+					$longest = $part;
+				}
+			}
+			if ( ! empty( $longest ) ) {
+				$results = $this->query_posts_by_slug( $longest );
+			}
+		}
+
+		$suggestions = array();
+		foreach ( array_slice( $results, 0, 5 ) as $post ) {
+			$suggestions[] = array(
+				'title' => $post->post_title,
+				'url'   => get_permalink( $post ),
+			);
+		}
+
+		return $suggestions;
+	}
+
+	/**
+	 * Query published posts/pages whose post_name matches a slug pattern.
+	 *
+	 * @param string $slug Slug to match against.
+	 * @return array<int, \WP_Post>
+	 */
+	private function query_posts_by_slug( string $slug ): array {
+		global $wpdb;
+
+		$like = '%' . $wpdb->esc_like( $slug ) . '%';
+
+		return $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$wpdb->posts}
              WHERE post_status = 'publish'
                AND post_type IN ('post', 'page')
                AND post_name LIKE %s
              ORDER BY (post_name = %s) DESC, post_date DESC
              LIMIT 5",
-            $like,
-            $slug
-        ) ) ?? [];
-    }
+				$like,
+				$slug
+			)
+		) ?? array();
+	}
 
-    public function ajax_suggest_redirect_target(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( 'Unauthorized' );
-        }
+	public function ajax_suggest_redirect_target(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( 'Unauthorized' );
+		}
 
-        $url         = sanitize_text_field( wp_unslash( $_POST['url'] ?? '' ) );
-        $suggestions = $this->find_similar_posts( $url );
+		$url         = sanitize_text_field( wp_unslash( $_POST['url'] ?? '' ) );
+		$suggestions = $this->find_similar_posts( $url );
 
-        wp_send_json_success( $suggestions );
-    }
+		wp_send_json_success( $suggestions );
+	}
 
-    public function ajax_bulk_delete_404s(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( 'Unauthorized' );
-        }
+	public function ajax_bulk_delete_404s(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( 'Unauthorized' );
+		}
 
-        $ids = array_map( 'absint', (array) ( $_POST['ids'] ?? [] ) );
-        $ids = array_filter( $ids );
+		$ids = array_map( 'absint', (array) ( $_POST['ids'] ?? array() ) );
+		$ids = array_filter( $ids );
 
-        if ( empty( $ids ) ) {
-            wp_send_json_error( 'No IDs provided.' );
-        }
+		if ( empty( $ids ) ) {
+			wp_send_json_error( 'No IDs provided.' );
+		}
 
-        global $wpdb;
-        $table        = $wpdb->prefix . self::LOG_TABLE;
-        $placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
-
-        // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-        $wpdb->query( $wpdb->prepare(
-            "DELETE FROM {$table} WHERE id IN ({$placeholders})",
-            ...$ids
-        ) );
-
-        wp_send_json_success();
-    }
-
-    public function ajax_bulk_redirect_404s(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( 'Unauthorized' );
-        }
-
-        $ids    = array_map( 'absint', (array) ( $_POST['ids'] ?? [] ) );
-        $ids    = array_filter( $ids );
-        $target = sanitize_text_field( wp_unslash( $_POST['target'] ?? '' ) );
-
-        if ( empty( $ids ) || empty( $target ) ) {
-            wp_send_json_error( 'IDs and target are required.' );
-        }
-
-        global $wpdb;
-        $table        = $wpdb->prefix . self::LOG_TABLE;
-        $placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+		global $wpdb;
+		$table        = $wpdb->prefix . self::LOG_TABLE;
+		$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
 
         // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-        $rows = $wpdb->get_results( $wpdb->prepare(
-            "SELECT id, url FROM {$table} WHERE id IN ({$placeholders})",
-            ...$ids
-        ) );
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$table} WHERE id IN ({$placeholders})",
+				...$ids
+			)
+		);
 
-        $created = 0;
-        $errors  = [];
+		wp_send_json_success();
+	}
 
-        foreach ( $rows as $row ) {
-            $source = wp_parse_url( $row->url, PHP_URL_PATH );
-            if ( $source ) {
-                $result = $this->add_redirect( $source, $target, 301 );
-                if ( is_wp_error( $result ) ) {
-                    $errors[] = $result->get_error_message();
-                } elseif ( $result ) {
-                    $created++;
-                }
-            }
-        }
+	public function ajax_bulk_redirect_404s(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( 'Unauthorized' );
+		}
 
-        // Delete the processed 404 entries.
+		$ids    = array_map( 'absint', (array) ( $_POST['ids'] ?? array() ) );
+		$ids    = array_filter( $ids );
+		$target = sanitize_text_field( wp_unslash( $_POST['target'] ?? '' ) );
+
+		if ( empty( $ids ) || empty( $target ) ) {
+			wp_send_json_error( 'IDs and target are required.' );
+		}
+
+		global $wpdb;
+		$table        = $wpdb->prefix . self::LOG_TABLE;
+		$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+
         // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-        $wpdb->query( $wpdb->prepare(
-            "DELETE FROM {$table} WHERE id IN ({$placeholders})",
-            ...$ids
-        ) );
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT id, url FROM {$table} WHERE id IN ({$placeholders})",
+				...$ids
+			)
+		);
 
-        wp_send_json_success( [
-            'created' => $created,
-            'errors'  => array_values( array_unique( $errors ) ),
-        ] );
-    }
+		$created = 0;
+		$errors  = array();
 
-    /**
-     * Create database tables. Called on activation.
-     */
-    public static function create_tables(): void {
-        global $wpdb;
+		foreach ( $rows as $row ) {
+			$source = wp_parse_url( $row->url, PHP_URL_PATH );
+			if ( $source ) {
+				$result = $this->add_redirect( $source, $target, 301 );
+				if ( is_wp_error( $result ) ) {
+					$errors[] = $result->get_error_message();
+				} elseif ( $result ) {
+					++$created;
+				}
+			}
+		}
 
-        $charset    = $wpdb->get_charset_collate();
-        $redirects  = $wpdb->prefix . self::REDIRECTS_TABLE;
-        $log        = $wpdb->prefix . self::LOG_TABLE;
+		// Delete the processed 404 entries.
+        // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$table} WHERE id IN ({$placeholders})",
+				...$ids
+			)
+		);
 
-        $sql_redirects = "CREATE TABLE {$redirects} (
+		wp_send_json_success(
+			array(
+				'created' => $created,
+				'errors'  => array_values( array_unique( $errors ) ),
+			)
+		);
+	}
+
+	/**
+	 * Create database tables. Called on activation.
+	 */
+	public static function create_tables(): void {
+		global $wpdb;
+
+		$charset   = $wpdb->get_charset_collate();
+		$redirects = $wpdb->prefix . self::REDIRECTS_TABLE;
+		$log       = $wpdb->prefix . self::LOG_TABLE;
+
+		$sql_redirects = "CREATE TABLE {$redirects} (
             id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
             source_url VARCHAR(500) NOT NULL DEFAULT '',
             target_url VARCHAR(500) NOT NULL DEFAULT '',
@@ -605,7 +629,7 @@ class SWPS_Redirect_Manager {
             KEY idx_source_url (source_url(191))
         ) {$charset};";
 
-        $sql_log = "CREATE TABLE {$log} (
+		$sql_log = "CREATE TABLE {$log} (
             id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
             url VARCHAR(500) NOT NULL DEFAULT '',
             referrer VARCHAR(500) NOT NULL DEFAULT '',
@@ -615,17 +639,17 @@ class SWPS_Redirect_Manager {
             UNIQUE KEY idx_url (url(191))
         ) {$charset};";
 
-        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        dbDelta( $sql_redirects );
-        dbDelta( $sql_log );
-    }
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql_redirects );
+		dbDelta( $sql_log );
+	}
 
-    /**
-     * Prune old 404 logs (older than 90 days). Called via cron.
-     */
-    public static function prune_404_logs(): void {
-        global $wpdb;
-        $table = $wpdb->prefix . self::LOG_TABLE;
-        $wpdb->query( "DELETE FROM {$table} WHERE last_seen < DATE_SUB(NOW(), INTERVAL 90 DAY)" );
-    }
+	/**
+	 * Prune old 404 logs (older than 90 days). Called via cron.
+	 */
+	public static function prune_404_logs(): void {
+		global $wpdb;
+		$table = $wpdb->prefix . self::LOG_TABLE;
+		$wpdb->query( "DELETE FROM {$table} WHERE last_seen < DATE_SUB(NOW(), INTERVAL 90 DAY)" );
+	}
 }

--- a/includes/class-rest-api.php
+++ b/includes/class-rest-api.php
@@ -6,658 +6,874 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_REST_API {
 
-    private const NAMESPACE = 'swps/v1';
-
-    public function __construct() {
-        add_action( 'rest_api_init', [ $this, 'register_routes' ] );
-    }
-
-    /**
-     * Register REST API routes.
-     */
-    public function register_routes(): void {
-        register_rest_route( self::NAMESPACE, '/generate', [
-            'methods'             => 'POST',
-            'callback'            => [ $this, 'generate_post' ],
-            'permission_callback' => [ $this, 'check_permissions' ],
-            'args'                => [
-                'topic'    => [
-                    'type'              => 'string',
-                    'sanitize_callback' => 'sanitize_text_field',
-                    'default'           => '',
-                ],
-                'template' => [
-                    'type'              => 'string',
-                    'sanitize_callback' => 'sanitize_text_field',
-                    'default'           => 'auto',
-                ],
-            ],
-        ] );
-
-        register_rest_route( self::NAMESPACE, '/status', [
-            'methods'             => 'GET',
-            'callback'            => [ $this, 'get_status' ],
-            'permission_callback' => [ $this, 'check_permissions' ],
-        ] );
-
-        register_rest_route( self::NAMESPACE, '/queue', [
-            [
-                'methods'             => 'GET',
-                'callback'            => [ $this, 'get_queue' ],
-                'permission_callback' => [ $this, 'check_permissions' ],
-            ],
-            [
-                'methods'             => 'POST',
-                'callback'            => [ $this, 'add_to_queue' ],
-                'permission_callback' => [ $this, 'check_permissions' ],
-                'args'                => [
-                    'title'    => [
-                        'type'              => 'string',
-                        'required'          => true,
-                        'sanitize_callback' => 'sanitize_text_field',
-                    ],
-                    'date'     => [
-                        'type'              => 'string',
-                        'sanitize_callback' => 'sanitize_text_field',
-                        'default'           => '',
-                    ],
-                    'template' => [
-                        'type'              => 'string',
-                        'sanitize_callback' => 'sanitize_text_field',
-                        'default'           => 'auto',
-                    ],
-                    'notes'    => [
-                        'type'              => 'string',
-                        'sanitize_callback' => 'sanitize_textarea_field',
-                        'default'           => '',
-                    ],
-                ],
-            ],
-        ] );
-
-        register_rest_route( self::NAMESPACE, '/queue/(?P<id>\d+)', [
-            'methods'             => 'DELETE',
-            'callback'            => [ $this, 'delete_from_queue' ],
-            'permission_callback' => [ $this, 'check_permissions' ],
-            'args'                => [
-                'id' => [
-                    'type'              => 'integer',
-                    'required'          => true,
-                    'sanitize_callback' => 'absint',
-                ],
-            ],
-        ] );
-
-        // Score endpoints.
-        register_rest_route( self::NAMESPACE, '/score/(?P<id>\d+)', [
-            [
-                'methods'             => 'GET',
-                'callback'            => [ $this, 'get_score' ],
-                'permission_callback' => [ $this, 'check_permissions' ],
-                'args'                => [
-                    'id' => [ 'type' => 'integer', 'required' => true, 'sanitize_callback' => 'absint' ],
-                ],
-            ],
-            [
-                'methods'             => 'POST',
-                'callback'            => [ $this, 'score_post' ],
-                'permission_callback' => [ $this, 'check_permissions' ],
-                'args'                => [
-                    'id' => [ 'type' => 'integer', 'required' => true, 'sanitize_callback' => 'absint' ],
-                ],
-            ],
-        ] );
-
-        // Voice profile endpoints.
-        register_rest_route( self::NAMESPACE, '/voice-profiles', [
-            [
-                'methods'             => 'GET',
-                'callback'            => [ $this, 'get_voice_profiles' ],
-                'permission_callback' => [ $this, 'check_permissions' ],
-            ],
-            [
-                'methods'             => 'POST',
-                'callback'            => [ $this, 'create_voice_profile' ],
-                'permission_callback' => [ $this, 'check_permissions' ],
-                'args'                => [
-                    'name'             => [ 'type' => 'string', 'required' => true, 'sanitize_callback' => 'sanitize_text_field' ],
-                    'tone'             => [ 'type' => 'string', 'default' => 'professional', 'sanitize_callback' => 'sanitize_text_field' ],
-                    'formality'        => [ 'type' => 'integer', 'default' => 5, 'sanitize_callback' => 'absint' ],
-                    'sentence_length'  => [ 'type' => 'string', 'default' => 'varied', 'sanitize_callback' => 'sanitize_text_field' ],
-                    'vocabulary_level' => [ 'type' => 'string', 'default' => 'moderate', 'sanitize_callback' => 'sanitize_text_field' ],
-                    'person'           => [ 'type' => 'string', 'default' => 'second', 'sanitize_callback' => 'sanitize_text_field' ],
-                    'example_content'  => [ 'type' => 'string', 'default' => '', 'sanitize_callback' => 'sanitize_textarea_field' ],
-                    'avoid_phrases'    => [ 'type' => 'string', 'default' => '', 'sanitize_callback' => 'sanitize_textarea_field' ],
-                    'preferred_phrases' => [ 'type' => 'string', 'default' => '', 'sanitize_callback' => 'sanitize_textarea_field' ],
-                ],
-            ],
-        ] );
-
-        register_rest_route( self::NAMESPACE, '/voice-profiles/(?P<id>\d+)', [
-            [
-                'methods'             => 'PUT',
-                'callback'            => [ $this, 'update_voice_profile' ],
-                'permission_callback' => [ $this, 'check_permissions' ],
-                'args'                => [
-                    'id'   => [ 'type' => 'integer', 'required' => true, 'sanitize_callback' => 'absint' ],
-                    'name' => [ 'type' => 'string', 'required' => true, 'sanitize_callback' => 'sanitize_text_field' ],
-                ],
-            ],
-            [
-                'methods'             => 'DELETE',
-                'callback'            => [ $this, 'delete_voice_profile' ],
-                'permission_callback' => [ $this, 'check_permissions' ],
-                'args'                => [
-                    'id' => [ 'type' => 'integer', 'required' => true, 'sanitize_callback' => 'absint' ],
-                ],
-            ],
-        ] );
-
-        // Audit endpoints.
-        register_rest_route( self::NAMESPACE, '/audit', [
-            [
-                'methods'             => 'GET',
-                'callback'            => [ $this, 'get_audit' ],
-                'permission_callback' => [ $this, 'check_permissions' ],
-            ],
-            [
-                'methods'             => 'POST',
-                'callback'            => [ $this, 'run_audit' ],
-                'permission_callback' => [ $this, 'check_permissions' ],
-            ],
-        ] );
-
-        register_rest_route( self::NAMESPACE, '/audit/fix/(?P<module_id>[a-z_]+)', [
-            'methods'             => 'POST',
-            'callback'            => [ $this, 'fix_audit_module' ],
-            'permission_callback' => [ $this, 'check_permissions' ],
-            'args'                => [
-                'module_id' => [ 'type' => 'string', 'required' => true, 'sanitize_callback' => 'sanitize_text_field' ],
-            ],
-        ] );
-
-        // User preferences (v4.0 — theme toggle).
-        register_rest_route( self::NAMESPACE, '/user-prefs/theme', [
-            'methods'             => 'POST',
-            'callback'            => [ $this, 'update_theme' ],
-            'permission_callback' => [ $this, 'check_logged_in' ],
-            'args'                => [
-                'theme' => [
-                    'type'              => 'string',
-                    'required'          => true,
-                    'sanitize_callback' => 'sanitize_text_field',
-                    'enum'              => [ 'dark', 'light' ],
-                ],
-            ],
-        ] );
-
-        // Bot Analytics (v4.5).
-        register_rest_route( self::NAMESPACE, '/bot-analytics/summary', [
-            'methods'             => 'GET',
-            'callback'            => [ $this, 'bot_analytics_summary' ],
-            'permission_callback' => [ $this, 'check_permissions' ],
-            'args'                => [
-                'days' => [ 'type' => 'integer', 'default' => 30, 'sanitize_callback' => 'absint' ],
-            ],
-        ] );
-
-        register_rest_route( self::NAMESPACE, '/bot-analytics/top-pages', [
-            'methods'             => 'GET',
-            'callback'            => [ $this, 'bot_analytics_top_pages' ],
-            'permission_callback' => [ $this, 'check_permissions' ],
-            'args'                => [
-                'days'  => [ 'type' => 'integer', 'default' => 30, 'sanitize_callback' => 'absint' ],
-                'limit' => [ 'type' => 'integer', 'default' => 20, 'sanitize_callback' => 'absint' ],
-                'bot'   => [ 'type' => 'string', 'default' => '', 'sanitize_callback' => 'sanitize_key' ],
-            ],
-        ] );
-
-        register_rest_route( self::NAMESPACE, '/bot-analytics/gaps', [
-            'methods'             => 'GET',
-            'callback'            => [ $this, 'bot_analytics_gaps' ],
-            'permission_callback' => [ $this, 'check_permissions' ],
-            'args'                => [
-                'days'  => [ 'type' => 'integer', 'default' => 30, 'sanitize_callback' => 'absint' ],
-                'limit' => [ 'type' => 'integer', 'default' => 25, 'sanitize_callback' => 'absint' ],
-            ],
-        ] );
-
-        // Modules registry — toggle a module on/off.
-        register_rest_route( self::NAMESPACE, '/modules/(?P<slug>[a-z0-9-]+)/toggle', [
-            'methods'             => 'POST',
-            'callback'            => [ $this, 'toggle_module' ],
-            'permission_callback' => [ $this, 'check_permissions' ],
-            'args'                => [
-                'slug'    => [ 'type' => 'string', 'required' => true, 'sanitize_callback' => 'sanitize_key' ],
-                'enabled' => [ 'type' => 'boolean', 'required' => true ],
-            ],
-        ] );
-    }
-
-    /**
-     * Looser permission check for per-user preferences — any logged-in user.
-     */
-    public function check_logged_in(): bool|WP_Error {
-        if ( ! is_user_logged_in() ) {
-            return new WP_Error( 'rest_forbidden', __( 'You must be logged in.', 'stratawp-seo' ), [ 'status' => 401 ] );
-        }
-        return true;
-    }
-
-    /**
-     * POST /user-prefs/theme — set the current user's admin theme.
-     */
-    public function update_theme( WP_REST_Request $request ): WP_REST_Response {
-        $theme = $request->get_param( 'theme' );
-        $prefs = stratawp_seo()->user_prefs;
-        $ok    = $prefs->set_theme( $theme );
-
-        return new WP_REST_Response( [
-            'success' => $ok,
-            'theme'   => $prefs->get_theme(),
-        ], $ok ? 200 : 400 );
-    }
-
-    /**
-     * POST /modules/{slug}/toggle — enable or disable a module.
-     */
-    public function toggle_module( WP_REST_Request $request ): WP_REST_Response {
-        $slug    = $request->get_param( 'slug' );
-        $enabled = (bool) $request->get_param( 'enabled' );
-        $modules = stratawp_seo()->modules;
-
-        $ok = $modules->set_enabled( $slug, $enabled );
-        if ( ! $ok ) {
-            return new WP_REST_Response( [
-                'success' => false,
-                'message' => 'Unknown or locked module.',
-            ], 400 );
-        }
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'slug'    => $slug,
-            'enabled' => $modules->is_enabled( $slug ),
-        ] );
-    }
-
-    /**
-     * Permission check — requires manage_options.
-     *
-     * @return bool|WP_Error
-     */
-    public function check_permissions(): bool|WP_Error {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            return new WP_Error(
-                'rest_forbidden',
-                __( 'You do not have permission to access this endpoint.', 'stratawp-seo' ),
-                [ 'status' => 403 ]
-            );
-        }
-        return true;
-    }
-
-    /**
-     * POST /generate - Generate a blog post.
-     *
-     * @param WP_REST_Request $request Request object.
-     * @return WP_REST_Response
-     */
-    public function generate_post( WP_REST_Request $request ): WP_REST_Response {
-        $topic    = $request->get_param( 'topic' );
-        $template = $request->get_param( 'template' );
-
-        $plugin = stratawp_seo();
-        $result = $plugin->generator->generate_post( $topic, $template );
-
-        if ( is_wp_error( $result ) ) {
-            return new WP_REST_Response( [
-                'success' => false,
-                'message' => $result->get_error_message(),
-            ], 500 );
-        }
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'data'    => $result,
-        ], 201 );
-    }
-
-    /**
-     * GET /status - Get plugin status.
-     *
-     * @return WP_REST_Response
-     */
-    public function get_status(): WP_REST_Response {
-        $schedule = SWPS_Cron::get_schedule_info();
-
-        $data = [
-            'version'     => SWPS_VERSION,
-            'ai_provider' => get_option( 'swps_ai_provider', 'anthropic' ),
-            'model'       => get_option( 'swps_model', '' ),
-            'schedule'    => $schedule,
-        ];
-
-        if ( get_option( 'swps_cost_tracking', false ) ) {
-            $tracker = new SWPS_Cost_Tracker();
-            $data['costs'] = $tracker->get_monthly_stats();
-        }
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'data'    => $data,
-        ] );
-    }
-
-    /**
-     * GET /queue - List queued topics.
-     *
-     * @return WP_REST_Response
-     */
-    public function get_queue(): WP_REST_Response {
-        $queue  = new SWPS_Topic_Queue();
-        $topics = $queue->get_queued_topics();
-
-        $data = array_map( function ( $topic ) {
-            return [
-                'id'       => $topic->ID,
-                'title'    => $topic->post_title,
-                'date'     => $topic->post_date,
-                'status'   => $topic->post_status,
-                'template' => get_post_meta( $topic->ID, '_swps_template', true ) ?: 'auto',
-                'notes'    => $topic->post_content,
-            ];
-        }, $topics );
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'data'    => $data,
-            'count'   => count( $data ),
-        ] );
-    }
-
-    /**
-     * POST /queue - Add a topic to the queue.
-     *
-     * @param WP_REST_Request $request Request object.
-     * @return WP_REST_Response
-     */
-    public function add_to_queue( WP_REST_Request $request ): WP_REST_Response {
-        $queue = new SWPS_Topic_Queue();
-
-        $result = $queue->create_topic(
-            $request->get_param( 'title' ),
-            $request->get_param( 'date' ),
-            $request->get_param( 'template' ),
-            $request->get_param( 'notes' )
-        );
-
-        if ( is_wp_error( $result ) ) {
-            return new WP_REST_Response( [
-                'success' => false,
-                'message' => $result->get_error_message(),
-            ], 500 );
-        }
-
-        return new WP_REST_Response( [
-            'success'  => true,
-            'topic_id' => $result,
-        ], 201 );
-    }
-
-    /**
-     * DELETE /queue/{id} - Remove a topic from the queue.
-     *
-     * @param WP_REST_Request $request Request object.
-     * @return WP_REST_Response
-     */
-    public function delete_from_queue( WP_REST_Request $request ): WP_REST_Response {
-        $queue    = new SWPS_Topic_Queue();
-        $topic_id = $request->get_param( 'id' );
-
-        $success = $queue->delete_topic( $topic_id );
-
-        return new WP_REST_Response( [
-            'success' => $success,
-        ] );
-    }
-
-    /**
-     * GET /score/{id} - Get stored score for a post.
-     */
-    public function get_score( WP_REST_Request $request ): WP_REST_Response {
-        $post_id = $request->get_param( 'id' );
-
-        $score   = get_post_meta( $post_id, '_swps_content_score', true );
-        $details = get_post_meta( $post_id, '_swps_score_details', true );
-        $recs    = get_post_meta( $post_id, '_swps_score_recommendations', true );
-
-        if ( '' === $score ) {
-            return new WP_REST_Response( [
-                'success' => false,
-                'message' => 'No score found for this post.',
-            ], 404 );
-        }
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'data'    => [
-                'overall_score'   => (int) $score,
-                'details'         => $details ?: [],
-                'recommendations' => $recs ?: [],
-            ],
-        ] );
-    }
-
-    /**
-     * POST /score/{id} - Score an existing post.
-     */
-    public function score_post( WP_REST_Request $request ): WP_REST_Response {
-        $post_id = $request->get_param( 'id' );
-        $post    = get_post( $post_id );
-
-        if ( ! $post || 'post' !== $post->post_type ) {
-            return new WP_REST_Response( [
-                'success' => false,
-                'message' => 'Post not found or not a blog post.',
-            ], 404 );
-        }
-
-        // Build a minimal ai_result from the existing post.
-        $ai_result = [
-            'title'               => $post->post_title,
-            'content_html'        => $post->post_content,
-            'meta_description'    => get_post_meta( $post_id, '_yoast_wpseo_metadesc', true )
-                                  ?: get_post_meta( $post_id, 'rank_math_description', true )
-                                  ?: '',
-            'focus_keyword'       => get_post_meta( $post_id, '_swps_focus_keyword', true )
-                                  ?: get_post_meta( $post_id, '_yoast_wpseo_focuskw', true )
-                                  ?: get_post_meta( $post_id, 'rank_math_focus_keyword', true )
-                                  ?: '',
-            'secondary_keywords'  => get_post_meta( $post_id, '_swps_secondary_keywords', true ) ?: [],
-            'internal_links_used' => get_post_meta( $post_id, '_swps_internal_links', true ) ?: [],
-            'estimated_word_count' => str_word_count( wp_strip_all_tags( $post->post_content ) ),
-        ];
-
-        $scorer  = stratawp_seo()->content_scorer;
-        $results = $scorer->score( $post_id, $ai_result );
-
-        update_post_meta( $post_id, '_swps_content_score', $results['overall_score'] );
-        update_post_meta( $post_id, '_swps_score_details', $results['details'] );
-        update_post_meta( $post_id, '_swps_score_recommendations', $results['recommendations'] );
-
-        SWPS_Hooks::do_score_complete( $results, $post_id );
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'data'    => $results,
-        ] );
-    }
-
-    /**
-     * GET /voice-profiles - List all voice profiles.
-     */
-    public function get_voice_profiles(): WP_REST_Response {
-        $profiles = stratawp_seo()->voice_profile->get_all();
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'data'    => $profiles,
-            'count'   => count( $profiles ),
-        ] );
-    }
-
-    /**
-     * POST /voice-profiles - Create a voice profile.
-     */
-    public function create_voice_profile( WP_REST_Request $request ): WP_REST_Response {
-        $vp     = stratawp_seo()->voice_profile;
-        $result = $vp->create( $request->get_param( 'name' ), $request->get_params() );
-
-        if ( is_wp_error( $result ) ) {
-            return new WP_REST_Response( [
-                'success' => false,
-                'message' => $result->get_error_message(),
-            ], 500 );
-        }
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'data'    => $vp->get( $result ),
-        ], 201 );
-    }
-
-    /**
-     * PUT /voice-profiles/{id} - Update a voice profile.
-     */
-    public function update_voice_profile( WP_REST_Request $request ): WP_REST_Response {
-        $vp     = stratawp_seo()->voice_profile;
-        $result = $vp->update( $request->get_param( 'id' ), $request->get_param( 'name' ), $request->get_params() );
-
-        if ( is_wp_error( $result ) ) {
-            return new WP_REST_Response( [
-                'success' => false,
-                'message' => $result->get_error_message(),
-            ], 500 );
-        }
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'data'    => $vp->get( $result ),
-        ] );
-    }
-
-    /**
-     * DELETE /voice-profiles/{id} - Delete a voice profile.
-     */
-    public function delete_voice_profile( WP_REST_Request $request ): WP_REST_Response {
-        $vp      = stratawp_seo()->voice_profile;
-        $success = $vp->delete( $request->get_param( 'id' ) );
-
-        return new WP_REST_Response( [
-            'success' => $success,
-        ] );
-    }
-
-    /**
-     * GET /audit - Get cached audit results.
-     */
-    public function get_audit(): WP_REST_Response {
-        $audit = stratawp_seo()->seo_audit;
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'data'    => $audit->get_cached_results(),
-            'last_run' => $audit->get_last_run(),
-        ] );
-    }
-
-    /**
-     * POST /audit - Run a fresh audit.
-     */
-    public function run_audit(): WP_REST_Response {
-        $audit   = stratawp_seo()->seo_audit;
-        $results = $audit->run_all();
-
-        return new WP_REST_Response( [
-            'success'  => true,
-            'data'     => $results,
-            'last_run' => $audit->get_last_run(),
-        ] );
-    }
-
-    /**
-     * GET /bot-analytics/summary - Headline totals + per-bot summary.
-     */
-    public function bot_analytics_summary( WP_REST_Request $request ): WP_REST_Response {
-        $days    = max( 1, min( 365, (int) $request->get_param( 'days' ) ) );
-        $tracker = stratawp_seo()->bot_analytics_tracker;
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'data'    => [
-                'totals' => $tracker->get_totals( $days ),
-                'bots'   => $tracker->get_bot_summary( $days ),
-            ],
-        ] );
-    }
-
-    /**
-     * GET /bot-analytics/top-pages - Top crawled pages.
-     */
-    public function bot_analytics_top_pages( WP_REST_Request $request ): WP_REST_Response {
-        $days    = max( 1, min( 365, (int) $request->get_param( 'days' ) ) );
-        $limit   = max( 1, min( 100, (int) $request->get_param( 'limit' ) ) );
-        $bot     = (string) $request->get_param( 'bot' );
-        $tracker = stratawp_seo()->bot_analytics_tracker;
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'data'    => $tracker->get_top_pages( $days, $limit, '' !== $bot ? $bot : null ),
-        ] );
-    }
-
-    /**
-     * GET /bot-analytics/gaps - Posts never crawled in the window.
-     */
-    public function bot_analytics_gaps( WP_REST_Request $request ): WP_REST_Response {
-        $days    = max( 1, min( 365, (int) $request->get_param( 'days' ) ) );
-        $limit   = max( 1, min( 100, (int) $request->get_param( 'limit' ) ) );
-        $tracker = stratawp_seo()->bot_analytics_tracker;
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'data'    => $tracker->get_gap_posts( $days, $limit ),
-        ] );
-    }
-
-    /**
-     * POST /audit/fix/{module_id} - Auto-fix a specific module.
-     */
-    public function fix_audit_module( WP_REST_Request $request ): WP_REST_Response {
-        $audit     = stratawp_seo()->seo_audit;
-        $module_id = $request->get_param( 'module_id' );
-
-        $fix_result = $audit->fix_module( $module_id );
-
-        if ( null === $fix_result ) {
-            return new WP_REST_Response( [
-                'success' => false,
-                'message' => 'Module not found or does not support auto-fix.',
-            ], 404 );
-        }
-
-        return new WP_REST_Response( [
-            'success' => true,
-            'data'    => [
-                'fix'     => $fix_result,
-                'results' => $audit->get_cached_results(),
-            ],
-        ] );
-    }
+	private const NAMESPACE = 'swps/v1';
+
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register REST API routes.
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			'/generate',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'generate_post' ),
+				'permission_callback' => array( $this, 'check_permissions' ),
+				'args'                => array(
+					'topic'    => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+						'default'           => '',
+					),
+					'template' => array(
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+						'default'           => 'auto',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/status',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'get_status' ),
+				'permission_callback' => array( $this, 'check_permissions' ),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/queue',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'get_queue' ),
+					'permission_callback' => array( $this, 'check_permissions' ),
+				),
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'add_to_queue' ),
+					'permission_callback' => array( $this, 'check_permissions' ),
+					'args'                => array(
+						'title'    => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'date'     => array(
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+							'default'           => '',
+						),
+						'template' => array(
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+							'default'           => 'auto',
+						),
+						'notes'    => array(
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_textarea_field',
+							'default'           => '',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/queue/(?P<id>\d+)',
+			array(
+				'methods'             => 'DELETE',
+				'callback'            => array( $this, 'delete_from_queue' ),
+				'permission_callback' => array( $this, 'check_permissions' ),
+				'args'                => array(
+					'id' => array(
+						'type'              => 'integer',
+						'required'          => true,
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		// Score endpoints.
+		register_rest_route(
+			self::NAMESPACE,
+			'/score/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'get_score' ),
+					'permission_callback' => array( $this, 'check_permissions' ),
+					'args'                => array(
+						'id' => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'score_post' ),
+					'permission_callback' => array( $this, 'check_permissions' ),
+					'args'                => array(
+						'id' => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+			)
+		);
+
+		// Voice profile endpoints.
+		register_rest_route(
+			self::NAMESPACE,
+			'/voice-profiles',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'get_voice_profiles' ),
+					'permission_callback' => array( $this, 'check_permissions' ),
+				),
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'create_voice_profile' ),
+					'permission_callback' => array( $this, 'check_permissions' ),
+					'args'                => array(
+						'name'              => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'tone'              => array(
+							'type'              => 'string',
+							'default'           => 'professional',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'formality'         => array(
+							'type'              => 'integer',
+							'default'           => 5,
+							'sanitize_callback' => 'absint',
+						),
+						'sentence_length'   => array(
+							'type'              => 'string',
+							'default'           => 'varied',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'vocabulary_level'  => array(
+							'type'              => 'string',
+							'default'           => 'moderate',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'person'            => array(
+							'type'              => 'string',
+							'default'           => 'second',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'example_content'   => array(
+							'type'              => 'string',
+							'default'           => '',
+							'sanitize_callback' => 'sanitize_textarea_field',
+						),
+						'avoid_phrases'     => array(
+							'type'              => 'string',
+							'default'           => '',
+							'sanitize_callback' => 'sanitize_textarea_field',
+						),
+						'preferred_phrases' => array(
+							'type'              => 'string',
+							'default'           => '',
+							'sanitize_callback' => 'sanitize_textarea_field',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/voice-profiles/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => 'PUT',
+					'callback'            => array( $this, 'update_voice_profile' ),
+					'permission_callback' => array( $this, 'check_permissions' ),
+					'args'                => array(
+						'id'   => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+						),
+						'name' => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+				array(
+					'methods'             => 'DELETE',
+					'callback'            => array( $this, 'delete_voice_profile' ),
+					'permission_callback' => array( $this, 'check_permissions' ),
+					'args'                => array(
+						'id' => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+			)
+		);
+
+		// Audit endpoints.
+		register_rest_route(
+			self::NAMESPACE,
+			'/audit',
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'get_audit' ),
+					'permission_callback' => array( $this, 'check_permissions' ),
+				),
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( $this, 'run_audit' ),
+					'permission_callback' => array( $this, 'check_permissions' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/audit/fix/(?P<module_id>[a-z_]+)',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'fix_audit_module' ),
+				'permission_callback' => array( $this, 'check_permissions' ),
+				'args'                => array(
+					'module_id' => array(
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
+
+		// User preferences (v4.0 — theme toggle).
+		register_rest_route(
+			self::NAMESPACE,
+			'/user-prefs/theme',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'update_theme' ),
+				'permission_callback' => array( $this, 'check_logged_in' ),
+				'args'                => array(
+					'theme' => array(
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+						'enum'              => array( 'dark', 'light' ),
+					),
+				),
+			)
+		);
+
+		// Bot Analytics (v4.5).
+		register_rest_route(
+			self::NAMESPACE,
+			'/bot-analytics/summary',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'bot_analytics_summary' ),
+				'permission_callback' => array( $this, 'check_permissions' ),
+				'args'                => array(
+					'days' => array(
+						'type'              => 'integer',
+						'default'           => 30,
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/bot-analytics/top-pages',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'bot_analytics_top_pages' ),
+				'permission_callback' => array( $this, 'check_permissions' ),
+				'args'                => array(
+					'days'  => array(
+						'type'              => 'integer',
+						'default'           => 30,
+						'sanitize_callback' => 'absint',
+					),
+					'limit' => array(
+						'type'              => 'integer',
+						'default'           => 20,
+						'sanitize_callback' => 'absint',
+					),
+					'bot'   => array(
+						'type'              => 'string',
+						'default'           => '',
+						'sanitize_callback' => 'sanitize_key',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			self::NAMESPACE,
+			'/bot-analytics/gaps',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'bot_analytics_gaps' ),
+				'permission_callback' => array( $this, 'check_permissions' ),
+				'args'                => array(
+					'days'  => array(
+						'type'              => 'integer',
+						'default'           => 30,
+						'sanitize_callback' => 'absint',
+					),
+					'limit' => array(
+						'type'              => 'integer',
+						'default'           => 25,
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		// Modules registry — toggle a module on/off.
+		register_rest_route(
+			self::NAMESPACE,
+			'/modules/(?P<slug>[a-z0-9-]+)/toggle',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'toggle_module' ),
+				'permission_callback' => array( $this, 'check_permissions' ),
+				'args'                => array(
+					'slug'    => array(
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_key',
+					),
+					'enabled' => array(
+						'type'     => 'boolean',
+						'required' => true,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Looser permission check for per-user preferences — any logged-in user.
+	 */
+	public function check_logged_in(): bool|WP_Error {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error( 'rest_forbidden', __( 'You must be logged in.', 'stratawp-seo' ), array( 'status' => 401 ) );
+		}
+		return true;
+	}
+
+	/**
+	 * POST /user-prefs/theme — set the current user's admin theme.
+	 */
+	public function update_theme( WP_REST_Request $request ): WP_REST_Response {
+		$theme = $request->get_param( 'theme' );
+		$prefs = stratawp_seo()->user_prefs;
+		$ok    = $prefs->set_theme( $theme );
+
+		return new WP_REST_Response(
+			array(
+				'success' => $ok,
+				'theme'   => $prefs->get_theme(),
+			),
+			$ok ? 200 : 400
+		);
+	}
+
+	/**
+	 * POST /modules/{slug}/toggle — enable or disable a module.
+	 */
+	public function toggle_module( WP_REST_Request $request ): WP_REST_Response {
+		$slug    = $request->get_param( 'slug' );
+		$enabled = (bool) $request->get_param( 'enabled' );
+		$modules = stratawp_seo()->modules;
+
+		$ok = $modules->set_enabled( $slug, $enabled );
+		if ( ! $ok ) {
+			return new WP_REST_Response(
+				array(
+					'success' => false,
+					'message' => 'Unknown or locked module.',
+				),
+				400
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'slug'    => $slug,
+				'enabled' => $modules->is_enabled( $slug ),
+			)
+		);
+	}
+
+	/**
+	 * Permission check — requires manage_options.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function check_permissions(): bool|WP_Error {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to access this endpoint.', 'stratawp-seo' ),
+				array( 'status' => 403 )
+			);
+		}
+		return true;
+	}
+
+	/**
+	 * POST /generate - Generate a blog post.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function generate_post( WP_REST_Request $request ): WP_REST_Response {
+		$topic    = $request->get_param( 'topic' );
+		$template = $request->get_param( 'template' );
+
+		$plugin = stratawp_seo();
+		$result = $plugin->generator->generate_post( $topic, $template );
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_REST_Response(
+				array(
+					'success' => false,
+					'message' => $result->get_error_message(),
+				),
+				500
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'data'    => $result,
+			),
+			201
+		);
+	}
+
+	/**
+	 * GET /status - Get plugin status.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_status(): WP_REST_Response {
+		$schedule = SWPS_Cron::get_schedule_info();
+
+		$data = array(
+			'version'     => SWPS_VERSION,
+			'ai_provider' => get_option( 'swps_ai_provider', 'anthropic' ),
+			'model'       => get_option( 'swps_model', '' ),
+			'schedule'    => $schedule,
+		);
+
+		if ( get_option( 'swps_cost_tracking', false ) ) {
+			$tracker       = new SWPS_Cost_Tracker();
+			$data['costs'] = $tracker->get_monthly_stats();
+		}
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'data'    => $data,
+			)
+		);
+	}
+
+	/**
+	 * GET /queue - List queued topics.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_queue(): WP_REST_Response {
+		$queue  = new SWPS_Topic_Queue();
+		$topics = $queue->get_queued_topics();
+
+		$data = array_map(
+			function ( $topic ) {
+				return array(
+					'id'       => $topic->ID,
+					'title'    => $topic->post_title,
+					'date'     => $topic->post_date,
+					'status'   => $topic->post_status,
+					'template' => get_post_meta( $topic->ID, '_swps_template', true ) ?: 'auto',
+					'notes'    => $topic->post_content,
+				);
+			},
+			$topics
+		);
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'data'    => $data,
+				'count'   => count( $data ),
+			)
+		);
+	}
+
+	/**
+	 * POST /queue - Add a topic to the queue.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function add_to_queue( WP_REST_Request $request ): WP_REST_Response {
+		$queue = new SWPS_Topic_Queue();
+
+		$result = $queue->create_topic(
+			$request->get_param( 'title' ),
+			$request->get_param( 'date' ),
+			$request->get_param( 'template' ),
+			$request->get_param( 'notes' )
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_REST_Response(
+				array(
+					'success' => false,
+					'message' => $result->get_error_message(),
+				),
+				500
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'success'  => true,
+				'topic_id' => $result,
+			),
+			201
+		);
+	}
+
+	/**
+	 * DELETE /queue/{id} - Remove a topic from the queue.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function delete_from_queue( WP_REST_Request $request ): WP_REST_Response {
+		$queue    = new SWPS_Topic_Queue();
+		$topic_id = $request->get_param( 'id' );
+
+		$success = $queue->delete_topic( $topic_id );
+
+		return new WP_REST_Response(
+			array(
+				'success' => $success,
+			)
+		);
+	}
+
+	/**
+	 * GET /score/{id} - Get stored score for a post.
+	 */
+	public function get_score( WP_REST_Request $request ): WP_REST_Response {
+		$post_id = $request->get_param( 'id' );
+
+		$score   = get_post_meta( $post_id, '_swps_content_score', true );
+		$details = get_post_meta( $post_id, '_swps_score_details', true );
+		$recs    = get_post_meta( $post_id, '_swps_score_recommendations', true );
+
+		if ( '' === $score ) {
+			return new WP_REST_Response(
+				array(
+					'success' => false,
+					'message' => 'No score found for this post.',
+				),
+				404
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'data'    => array(
+					'overall_score'   => (int) $score,
+					'details'         => $details ?: array(),
+					'recommendations' => $recs ?: array(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * POST /score/{id} - Score an existing post.
+	 */
+	public function score_post( WP_REST_Request $request ): WP_REST_Response {
+		$post_id = $request->get_param( 'id' );
+		$post    = get_post( $post_id );
+
+		if ( ! $post || 'post' !== $post->post_type ) {
+			return new WP_REST_Response(
+				array(
+					'success' => false,
+					'message' => 'Post not found or not a blog post.',
+				),
+				404
+			);
+		}
+
+		// Build a minimal ai_result from the existing post.
+		$ai_result = array(
+			'title'                => $post->post_title,
+			'content_html'         => $post->post_content,
+			'meta_description'     => get_post_meta( $post_id, '_yoast_wpseo_metadesc', true )
+									?: get_post_meta( $post_id, 'rank_math_description', true )
+									?: '',
+			'focus_keyword'        => get_post_meta( $post_id, '_swps_focus_keyword', true )
+									?: get_post_meta( $post_id, '_yoast_wpseo_focuskw', true )
+									?: get_post_meta( $post_id, 'rank_math_focus_keyword', true )
+									?: '',
+			'secondary_keywords'   => get_post_meta( $post_id, '_swps_secondary_keywords', true ) ?: array(),
+			'internal_links_used'  => get_post_meta( $post_id, '_swps_internal_links', true ) ?: array(),
+			'estimated_word_count' => str_word_count( wp_strip_all_tags( $post->post_content ) ),
+		);
+
+		$scorer  = stratawp_seo()->content_scorer;
+		$results = $scorer->score( $post_id, $ai_result );
+
+		update_post_meta( $post_id, '_swps_content_score', $results['overall_score'] );
+		update_post_meta( $post_id, '_swps_score_details', $results['details'] );
+		update_post_meta( $post_id, '_swps_score_recommendations', $results['recommendations'] );
+
+		SWPS_Hooks::do_score_complete( $results, $post_id );
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'data'    => $results,
+			)
+		);
+	}
+
+	/**
+	 * GET /voice-profiles - List all voice profiles.
+	 */
+	public function get_voice_profiles(): WP_REST_Response {
+		$profiles = stratawp_seo()->voice_profile->get_all();
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'data'    => $profiles,
+				'count'   => count( $profiles ),
+			)
+		);
+	}
+
+	/**
+	 * POST /voice-profiles - Create a voice profile.
+	 */
+	public function create_voice_profile( WP_REST_Request $request ): WP_REST_Response {
+		$vp     = stratawp_seo()->voice_profile;
+		$result = $vp->create( $request->get_param( 'name' ), $request->get_params() );
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_REST_Response(
+				array(
+					'success' => false,
+					'message' => $result->get_error_message(),
+				),
+				500
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'data'    => $vp->get( $result ),
+			),
+			201
+		);
+	}
+
+	/**
+	 * PUT /voice-profiles/{id} - Update a voice profile.
+	 */
+	public function update_voice_profile( WP_REST_Request $request ): WP_REST_Response {
+		$vp     = stratawp_seo()->voice_profile;
+		$result = $vp->update( $request->get_param( 'id' ), $request->get_param( 'name' ), $request->get_params() );
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_REST_Response(
+				array(
+					'success' => false,
+					'message' => $result->get_error_message(),
+				),
+				500
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'data'    => $vp->get( $result ),
+			)
+		);
+	}
+
+	/**
+	 * DELETE /voice-profiles/{id} - Delete a voice profile.
+	 */
+	public function delete_voice_profile( WP_REST_Request $request ): WP_REST_Response {
+		$vp      = stratawp_seo()->voice_profile;
+		$success = $vp->delete( $request->get_param( 'id' ) );
+
+		return new WP_REST_Response(
+			array(
+				'success' => $success,
+			)
+		);
+	}
+
+	/**
+	 * GET /audit - Get cached audit results.
+	 */
+	public function get_audit(): WP_REST_Response {
+		$audit = stratawp_seo()->seo_audit;
+
+		return new WP_REST_Response(
+			array(
+				'success'  => true,
+				'data'     => $audit->get_cached_results(),
+				'last_run' => $audit->get_last_run(),
+			)
+		);
+	}
+
+	/**
+	 * POST /audit - Run a fresh audit.
+	 */
+	public function run_audit(): WP_REST_Response {
+		$audit   = stratawp_seo()->seo_audit;
+		$results = $audit->run_all();
+
+		return new WP_REST_Response(
+			array(
+				'success'  => true,
+				'data'     => $results,
+				'last_run' => $audit->get_last_run(),
+			)
+		);
+	}
+
+	/**
+	 * GET /bot-analytics/summary - Headline totals + per-bot summary.
+	 */
+	public function bot_analytics_summary( WP_REST_Request $request ): WP_REST_Response {
+		$days    = max( 1, min( 365, (int) $request->get_param( 'days' ) ) );
+		$tracker = stratawp_seo()->bot_analytics_tracker;
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'data'    => array(
+					'totals' => $tracker->get_totals( $days ),
+					'bots'   => $tracker->get_bot_summary( $days ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * GET /bot-analytics/top-pages - Top crawled pages.
+	 */
+	public function bot_analytics_top_pages( WP_REST_Request $request ): WP_REST_Response {
+		$days    = max( 1, min( 365, (int) $request->get_param( 'days' ) ) );
+		$limit   = max( 1, min( 100, (int) $request->get_param( 'limit' ) ) );
+		$bot     = (string) $request->get_param( 'bot' );
+		$tracker = stratawp_seo()->bot_analytics_tracker;
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'data'    => $tracker->get_top_pages( $days, $limit, '' !== $bot ? $bot : null ),
+			)
+		);
+	}
+
+	/**
+	 * GET /bot-analytics/gaps - Posts never crawled in the window.
+	 */
+	public function bot_analytics_gaps( WP_REST_Request $request ): WP_REST_Response {
+		$days    = max( 1, min( 365, (int) $request->get_param( 'days' ) ) );
+		$limit   = max( 1, min( 100, (int) $request->get_param( 'limit' ) ) );
+		$tracker = stratawp_seo()->bot_analytics_tracker;
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'data'    => $tracker->get_gap_posts( $days, $limit ),
+			)
+		);
+	}
+
+	/**
+	 * POST /audit/fix/{module_id} - Auto-fix a specific module.
+	 */
+	public function fix_audit_module( WP_REST_Request $request ): WP_REST_Response {
+		$audit     = stratawp_seo()->seo_audit;
+		$module_id = $request->get_param( 'module_id' );
+
+		$fix_result = $audit->fix_module( $module_id );
+
+		if ( null === $fix_result ) {
+			return new WP_REST_Response(
+				array(
+					'success' => false,
+					'message' => 'Module not found or does not support auto-fix.',
+				),
+				404
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'success' => true,
+				'data'    => array(
+					'fix'     => $fix_result,
+					'results' => $audit->get_cached_results(),
+				),
+			)
+		);
+	}
 }

--- a/includes/class-rss-optimizer.php
+++ b/includes/class-rss-optimizer.php
@@ -6,46 +6,46 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_RSS_Optimizer {
 
-    public function __construct() {
-        $before = get_option( 'swps_rss_before', '' );
-        $after  = get_option( 'swps_rss_after', '' );
+	public function __construct() {
+		$before = get_option( 'swps_rss_before', '' );
+		$after  = get_option( 'swps_rss_after', '' );
 
-        if ( empty( $before ) && empty( $after ) ) {
-            return;
-        }
+		if ( empty( $before ) && empty( $after ) ) {
+			return;
+		}
 
-        add_filter( 'the_content_feed', [ $this, 'filter_feed_content' ] );
-    }
+		add_filter( 'the_content_feed', array( $this, 'filter_feed_content' ) );
+	}
 
-    public function filter_feed_content( string $content ): string {
-        $before = get_option( 'swps_rss_before', '' );
-        $after  = get_option( 'swps_rss_after', '' );
+	public function filter_feed_content( string $content ): string {
+		$before = get_option( 'swps_rss_before', '' );
+		$after  = get_option( 'swps_rss_after', '' );
 
-        if ( ! empty( $before ) ) {
-            $content = '<p>' . $this->replace_variables( $before ) . '</p>' . $content;
-        }
+		if ( ! empty( $before ) ) {
+			$content = '<p>' . $this->replace_variables( $before ) . '</p>' . $content;
+		}
 
-        if ( ! empty( $after ) ) {
-            $content .= '<p>' . $this->replace_variables( $after ) . '</p>';
-        }
+		if ( ! empty( $after ) ) {
+			$content .= '<p>' . $this->replace_variables( $after ) . '</p>';
+		}
 
-        return $content;
-    }
+		return $content;
+	}
 
-    private function replace_variables( string $text ): string {
-        $post_link = '<a href="' . esc_url( get_permalink() ) . '">' . esc_html( get_the_title() ) . '</a>';
-        $blog_link = '<a href="' . esc_url( home_url( '/' ) ) . '">' . esc_html( get_bloginfo( 'name' ) ) . '</a>';
-        $blog_name = esc_html( get_bloginfo( 'name' ) );
+	private function replace_variables( string $text ): string {
+		$post_link = '<a href="' . esc_url( get_permalink() ) . '">' . esc_html( get_the_title() ) . '</a>';
+		$blog_link = '<a href="' . esc_url( home_url( '/' ) ) . '">' . esc_html( get_bloginfo( 'name' ) ) . '</a>';
+		$blog_name = esc_html( get_bloginfo( 'name' ) );
 
-        return str_replace(
-            [ '%%post_link%%', '%%blog_link%%', '%%blog_name%%' ],
-            [ $post_link, $blog_link, $blog_name ],
-            $text
-        );
-    }
+		return str_replace(
+			array( '%%post_link%%', '%%blog_link%%', '%%blog_name%%' ),
+			array( $post_link, $blog_link, $blog_name ),
+			$text
+		);
+	}
 }

--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -9,7 +9,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /**
@@ -20,349 +20,349 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class SWPS_Schema {
 
-    /**
-     * Constructor — bail if schema is disabled or another SEO plugin handles it.
-     */
-    public function __construct() {
-        if ( is_admin() ) {
-            return;
-        }
+	/**
+	 * Constructor — bail if schema is disabled or another SEO plugin handles it.
+	 */
+	public function __construct() {
+		if ( is_admin() ) {
+			return;
+		}
 
-        if ( ! get_option( 'swps_schema_enabled', 1 ) ) {
-            return;
-        }
+		if ( ! get_option( 'swps_schema_enabled', 1 ) ) {
+			return;
+		}
 
-        // Defer to other SEO plugins that output their own schema.
-        if ( defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' ) ) {
-            return;
-        }
+		// Defer to other SEO plugins that output their own schema.
+		if ( defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' ) ) {
+			return;
+		}
 
-        add_action( 'wp_head', [ $this, 'output_schema' ], 1 );
-    }
+		add_action( 'wp_head', array( $this, 'output_schema' ), 1 );
+	}
 
-    /**
-     * Main wp_head callback — dispatches to individual schema methods.
-     */
-    public function output_schema(): void {
-        if ( is_front_page() ) {
-            $this->website_schema();
-            $this->organization_schema();
-        }
+	/**
+	 * Main wp_head callback — dispatches to individual schema methods.
+	 */
+	public function output_schema(): void {
+		if ( is_front_page() ) {
+			$this->website_schema();
+			$this->organization_schema();
+		}
 
-        if ( is_singular( 'post' ) ) {
-            $this->article_schema();
-        }
+		if ( is_singular( 'post' ) ) {
+			$this->article_schema();
+		}
 
-        // Output JSON-LD breadcrumbs only when the HTML breadcrumbs feature is disabled.
-        // When enabled, SWPS_Breadcrumbs outputs inline microdata schema instead.
-        if ( ! is_front_page() && ! get_option( 'swps_breadcrumbs_enabled', 1 ) ) {
-            $this->breadcrumb_schema();
-        }
-    }
+		// Output JSON-LD breadcrumbs only when the HTML breadcrumbs feature is disabled.
+		// When enabled, SWPS_Breadcrumbs outputs inline microdata schema instead.
+		if ( ! is_front_page() && ! get_option( 'swps_breadcrumbs_enabled', 1 ) ) {
+			$this->breadcrumb_schema();
+		}
+	}
 
-    /**
-     * Output a JSON-LD script tag from a schema array.
-     *
-     * @param array $schema Schema data array.
-     */
-    private function output_jsonld( array $schema ): void {
-        if ( empty( $schema ) ) {
-            return;
-        }
+	/**
+	 * Output a JSON-LD script tag from a schema array.
+	 *
+	 * @param array $schema Schema data array.
+	 */
+	private function output_jsonld( array $schema ): void {
+		if ( empty( $schema ) ) {
+			return;
+		}
 
         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON-LD script tag.
-        echo '<script type="application/ld+json">'
-           . wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT )
-           . '</script>' . "\n";
-    }
+		echo '<script type="application/ld+json">'
+			. wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT )
+			. '</script>' . "\n";
+	}
 
-    /**
-     * Output Article schema on single posts.
-     */
-    private function article_schema(): void {
-        $post = get_post();
+	/**
+	 * Output Article schema on single posts.
+	 */
+	private function article_schema(): void {
+		$post = get_post();
 
-        if ( ! $post ) {
-            return;
-        }
+		if ( ! $post ) {
+			return;
+		}
 
-        $article_type = get_option( 'swps_schema_article_type', 'Article' );
-        $author       = get_userdata( $post->post_author );
-        $excerpt      = get_the_excerpt( $post );
+		$article_type = get_option( 'swps_schema_article_type', 'Article' );
+		$author       = get_userdata( $post->post_author );
+		$excerpt      = get_the_excerpt( $post );
 
-        if ( empty( $excerpt ) ) {
-            $excerpt = wp_trim_words( wp_strip_all_tags( $post->post_content ), 25, '...' );
-        }
+		if ( empty( $excerpt ) ) {
+			$excerpt = wp_trim_words( wp_strip_all_tags( $post->post_content ), 25, '...' );
+		}
 
-        $schema = [
-            '@context'         => 'https://schema.org',
-            '@type'            => $article_type,
-            'headline'         => get_the_title( $post ),
-            'description'      => $excerpt,
-            'datePublished'    => get_the_date( 'c', $post ),
-            'dateModified'     => get_the_modified_date( 'c', $post ),
-            'mainEntityOfPage' => [
-                '@type' => 'WebPage',
-                '@id'   => get_permalink( $post ),
-            ],
-            'wordCount'        => str_word_count( wp_strip_all_tags( $post->post_content ) ),
-        ];
+		$schema = array(
+			'@context'         => 'https://schema.org',
+			'@type'            => $article_type,
+			'headline'         => get_the_title( $post ),
+			'description'      => $excerpt,
+			'datePublished'    => get_the_date( 'c', $post ),
+			'dateModified'     => get_the_modified_date( 'c', $post ),
+			'mainEntityOfPage' => array(
+				'@type' => 'WebPage',
+				'@id'   => get_permalink( $post ),
+			),
+			'wordCount'        => str_word_count( wp_strip_all_tags( $post->post_content ) ),
+		);
 
-        // Author.
-        if ( $author ) {
-            $schema['author'] = [
-                '@type' => 'Person',
-                'name'  => $author->display_name,
-                'url'   => get_author_posts_url( $author->ID ),
-            ];
-        }
+		// Author.
+		if ( $author ) {
+			$schema['author'] = array(
+				'@type' => 'Person',
+				'name'  => $author->display_name,
+				'url'   => get_author_posts_url( $author->ID ),
+			);
+		}
 
-        // Featured image.
-        $thumb_id = get_post_thumbnail_id( $post );
+		// Featured image.
+		$thumb_id = get_post_thumbnail_id( $post );
 
-        if ( $thumb_id ) {
-            $img_data = wp_get_attachment_image_src( $thumb_id, 'full' );
+		if ( $thumb_id ) {
+			$img_data = wp_get_attachment_image_src( $thumb_id, 'full' );
 
-            if ( $img_data ) {
-                $schema['image'] = [
-                    '@type'  => 'ImageObject',
-                    'url'    => $img_data[0],
-                    'width'  => $img_data[1],
-                    'height' => $img_data[2],
-                ];
-            }
-        }
+			if ( $img_data ) {
+				$schema['image'] = array(
+					'@type'  => 'ImageObject',
+					'url'    => $img_data[0],
+					'width'  => $img_data[1],
+					'height' => $img_data[2],
+				);
+			}
+		}
 
-        // Publisher — references Organization settings.
-        $org_name = get_option( 'swps_schema_name', '' );
+		// Publisher — references Organization settings.
+		$org_name = get_option( 'swps_schema_name', '' );
 
-        if ( empty( $org_name ) ) {
-            $org_name = get_bloginfo( 'name' );
-        }
+		if ( empty( $org_name ) ) {
+			$org_name = get_bloginfo( 'name' );
+		}
 
-        $publisher = [
-            '@type' => 'Organization',
-            'name'  => $org_name,
-        ];
+		$publisher = array(
+			'@type' => 'Organization',
+			'name'  => $org_name,
+		);
 
-        $logo_url = get_option( 'swps_schema_logo', '' );
+		$logo_url = get_option( 'swps_schema_logo', '' );
 
-        if ( ! empty( $logo_url ) ) {
-            $publisher['logo'] = [
-                '@type' => 'ImageObject',
-                'url'   => $logo_url,
-            ];
-        }
+		if ( ! empty( $logo_url ) ) {
+			$publisher['logo'] = array(
+				'@type' => 'ImageObject',
+				'url'   => $logo_url,
+			);
+		}
 
-        $schema['publisher'] = $publisher;
+		$schema['publisher'] = $publisher;
 
-        /**
-         * Filter the Article schema before output.
-         *
-         * @param array $schema  Article schema array.
-         * @param int   $post_id Post ID.
-         */
-        $schema = SWPS_Hooks::filter_schema_article( $schema, $post->ID );
+		/**
+		 * Filter the Article schema before output.
+		 *
+		 * @param array $schema  Article schema array.
+		 * @param int   $post_id Post ID.
+		 */
+		$schema = SWPS_Hooks::filter_schema_article( $schema, $post->ID );
 
-        $this->output_jsonld( $schema );
-    }
+		$this->output_jsonld( $schema );
+	}
 
-    /**
-     * Output BreadcrumbList schema on all pages except homepage.
-     */
-    private function breadcrumb_schema(): void {
-        $items = [];
+	/**
+	 * Output BreadcrumbList schema on all pages except homepage.
+	 */
+	private function breadcrumb_schema(): void {
+		$items = array();
 
-        // Home is always first.
-        $items[] = [
-            'name' => get_bloginfo( 'name' ),
-            'url'  => home_url( '/' ),
-        ];
+		// Home is always first.
+		$items[] = array(
+			'name' => get_bloginfo( 'name' ),
+			'url'  => home_url( '/' ),
+		);
 
-        if ( is_singular( 'post' ) ) {
-            $post       = get_post();
-            $category   = $this->get_primary_category( $post );
+		if ( is_singular( 'post' ) ) {
+			$post     = get_post();
+			$category = $this->get_primary_category( $post );
 
-            if ( $category ) {
-                $items[] = [
-                    'name' => $category->name,
-                    'url'  => get_category_link( $category->term_id ),
-                ];
-            }
+			if ( $category ) {
+				$items[] = array(
+					'name' => $category->name,
+					'url'  => get_category_link( $category->term_id ),
+				);
+			}
 
-            $items[] = [
-                'name' => get_the_title( $post ),
-                'url'  => get_permalink( $post ),
-            ];
-        } elseif ( is_page() ) {
-            $post      = get_post();
-            $ancestors = array_reverse( get_post_ancestors( $post ) );
+			$items[] = array(
+				'name' => get_the_title( $post ),
+				'url'  => get_permalink( $post ),
+			);
+		} elseif ( is_page() ) {
+			$post      = get_post();
+			$ancestors = array_reverse( get_post_ancestors( $post ) );
 
-            foreach ( $ancestors as $ancestor_id ) {
-                $items[] = [
-                    'name' => get_the_title( $ancestor_id ),
-                    'url'  => get_permalink( $ancestor_id ),
-                ];
-            }
+			foreach ( $ancestors as $ancestor_id ) {
+				$items[] = array(
+					'name' => get_the_title( $ancestor_id ),
+					'url'  => get_permalink( $ancestor_id ),
+				);
+			}
 
-            $items[] = [
-                'name' => get_the_title( $post ),
-                'url'  => get_permalink( $post ),
-            ];
-        } elseif ( is_category() || is_tag() || is_tax() ) {
-            $term = get_queried_object();
+			$items[] = array(
+				'name' => get_the_title( $post ),
+				'url'  => get_permalink( $post ),
+			);
+		} elseif ( is_category() || is_tag() || is_tax() ) {
+			$term = get_queried_object();
 
-            if ( $term ) {
-                $items[] = [
-                    'name' => $term->name,
-                    'url'  => get_term_link( $term ),
-                ];
-            }
-        } elseif ( is_author() ) {
-            $author = get_queried_object();
+			if ( $term ) {
+				$items[] = array(
+					'name' => $term->name,
+					'url'  => get_term_link( $term ),
+				);
+			}
+		} elseif ( is_author() ) {
+			$author = get_queried_object();
 
-            if ( $author ) {
-                $items[] = [
-                    'name' => $author->display_name,
-                    'url'  => get_author_posts_url( $author->ID ),
-                ];
-            }
-        }
+			if ( $author ) {
+				$items[] = array(
+					'name' => $author->display_name,
+					'url'  => get_author_posts_url( $author->ID ),
+				);
+			}
+		}
 
-        // Need at least 2 items (Home + something) for a valid breadcrumb.
-        if ( count( $items ) < 2 ) {
-            return;
-        }
+		// Need at least 2 items (Home + something) for a valid breadcrumb.
+		if ( count( $items ) < 2 ) {
+			return;
+		}
 
-        $list_items = [];
+		$list_items = array();
 
-        foreach ( $items as $position => $item ) {
-            $list_items[] = [
-                '@type'    => 'ListItem',
-                'position' => $position + 1,
-                'name'     => $item['name'],
-                'item'     => $item['url'],
-            ];
-        }
+		foreach ( $items as $position => $item ) {
+			$list_items[] = array(
+				'@type'    => 'ListItem',
+				'position' => $position + 1,
+				'name'     => $item['name'],
+				'item'     => $item['url'],
+			);
+		}
 
-        $schema = [
-            '@context'        => 'https://schema.org',
-            '@type'           => 'BreadcrumbList',
-            'itemListElement' => $list_items,
-        ];
+		$schema = array(
+			'@context'        => 'https://schema.org',
+			'@type'           => 'BreadcrumbList',
+			'itemListElement' => $list_items,
+		);
 
-        /** Filter the Breadcrumb schema before output. */
-        $schema = SWPS_Hooks::filter_schema_breadcrumb( $schema );
+		/** Filter the Breadcrumb schema before output. */
+		$schema = SWPS_Hooks::filter_schema_breadcrumb( $schema );
 
-        $this->output_jsonld( $schema );
-    }
+		$this->output_jsonld( $schema );
+	}
 
-    /**
-     * Get the primary category for a post.
-     *
-     * Uses Yoast primary category if set, otherwise falls back to first category.
-     *
-     * @param WP_Post $post Post object.
-     * @return WP_Term|null Category term or null.
-     */
-    private function get_primary_category( WP_Post $post ): ?WP_Term {
-        // Check Yoast primary category first.
-        $primary_id = get_post_meta( $post->ID, '_yoast_wpseo_primary_category', true );
+	/**
+	 * Get the primary category for a post.
+	 *
+	 * Uses Yoast primary category if set, otherwise falls back to first category.
+	 *
+	 * @param WP_Post $post Post object.
+	 * @return WP_Term|null Category term or null.
+	 */
+	private function get_primary_category( WP_Post $post ): ?WP_Term {
+		// Check Yoast primary category first.
+		$primary_id = get_post_meta( $post->ID, '_yoast_wpseo_primary_category', true );
 
-        if ( $primary_id ) {
-            $term = get_term( (int) $primary_id, 'category' );
+		if ( $primary_id ) {
+			$term = get_term( (int) $primary_id, 'category' );
 
-            if ( $term && ! is_wp_error( $term ) ) {
-                return $term;
-            }
-        }
+			if ( $term && ! is_wp_error( $term ) ) {
+				return $term;
+			}
+		}
 
-        // Fall back to first assigned category.
-        $categories = get_the_category( $post->ID );
+		// Fall back to first assigned category.
+		$categories = get_the_category( $post->ID );
 
-        if ( ! empty( $categories ) ) {
-            return $categories[0];
-        }
+		if ( ! empty( $categories ) ) {
+			return $categories[0];
+		}
 
-        return null;
-    }
+		return null;
+	}
 
-    /**
-     * Output WebSite schema on the homepage.
-     */
-    private function website_schema(): void {
-        $name = get_option( 'swps_schema_name', '' );
+	/**
+	 * Output WebSite schema on the homepage.
+	 */
+	private function website_schema(): void {
+		$name = get_option( 'swps_schema_name', '' );
 
-        if ( empty( $name ) ) {
-            $name = get_bloginfo( 'name' );
-        }
+		if ( empty( $name ) ) {
+			$name = get_bloginfo( 'name' );
+		}
 
-        $schema = [
-            '@context' => 'https://schema.org',
-            '@type'    => 'WebSite',
-            'name'     => $name,
-            'url'      => home_url( '/' ),
-        ];
+		$schema = array(
+			'@context' => 'https://schema.org',
+			'@type'    => 'WebSite',
+			'name'     => $name,
+			'url'      => home_url( '/' ),
+		);
 
-        // Optional sitelinks searchbox.
-        if ( get_option( 'swps_schema_searchbox', 1 ) ) {
-            $schema['potentialAction'] = [
-                '@type'       => 'SearchAction',
-                'target'      => [
-                    '@type'       => 'EntryPoint',
-                    'urlTemplate' => home_url( '/?s={search_term_string}' ),
-                ],
-                'query-input' => 'required name=search_term_string',
-            ];
-        }
+		// Optional sitelinks searchbox.
+		if ( get_option( 'swps_schema_searchbox', 1 ) ) {
+			$schema['potentialAction'] = array(
+				'@type'       => 'SearchAction',
+				'target'      => array(
+					'@type'       => 'EntryPoint',
+					'urlTemplate' => home_url( '/?s={search_term_string}' ),
+				),
+				'query-input' => 'required name=search_term_string',
+			);
+		}
 
-        $this->output_jsonld( $schema );
-    }
+		$this->output_jsonld( $schema );
+	}
 
-    /**
-     * Output Organization or Person schema on the homepage.
-     */
-    private function organization_schema(): void {
-        $entity_type = get_option( 'swps_schema_entity_type', 'Organization' );
-        $name        = get_option( 'swps_schema_name', '' );
+	/**
+	 * Output Organization or Person schema on the homepage.
+	 */
+	private function organization_schema(): void {
+		$entity_type = get_option( 'swps_schema_entity_type', 'Organization' );
+		$name        = get_option( 'swps_schema_name', '' );
 
-        if ( empty( $name ) ) {
-            $name = get_bloginfo( 'name' );
-        }
+		if ( empty( $name ) ) {
+			$name = get_bloginfo( 'name' );
+		}
 
-        $schema = [
-            '@context' => 'https://schema.org',
-            '@type'    => $entity_type,
-            'name'     => $name,
-            'url'      => home_url( '/' ),
-        ];
+		$schema = array(
+			'@context' => 'https://schema.org',
+			'@type'    => $entity_type,
+			'name'     => $name,
+			'url'      => home_url( '/' ),
+		);
 
-        // Logo (Organization only, per Google spec).
-        if ( 'Organization' === $entity_type ) {
-            $logo_url = get_option( 'swps_schema_logo', '' );
+		// Logo (Organization only, per Google spec).
+		if ( 'Organization' === $entity_type ) {
+			$logo_url = get_option( 'swps_schema_logo', '' );
 
-            if ( ! empty( $logo_url ) ) {
-                $schema['logo'] = [
-                    '@type' => 'ImageObject',
-                    'url'   => $logo_url,
-                ];
-            }
-        }
+			if ( ! empty( $logo_url ) ) {
+				$schema['logo'] = array(
+					'@type' => 'ImageObject',
+					'url'   => $logo_url,
+				);
+			}
+		}
 
-        // Social profiles.
-        $social_raw = get_option( 'swps_schema_social_profiles', '' );
+		// Social profiles.
+		$social_raw = get_option( 'swps_schema_social_profiles', '' );
 
-        if ( ! empty( $social_raw ) ) {
-            $urls = array_filter( array_map( 'trim', explode( "\n", $social_raw ) ) );
+		if ( ! empty( $social_raw ) ) {
+			$urls = array_filter( array_map( 'trim', explode( "\n", $social_raw ) ) );
 
-            if ( ! empty( $urls ) ) {
-                $schema['sameAs'] = array_values( $urls );
-            }
-        }
+			if ( ! empty( $urls ) ) {
+				$schema['sameAs'] = array_values( $urls );
+			}
+		}
 
-        /** Filter the Organization/Person schema before output. */
-        $schema = SWPS_Hooks::filter_schema_organization( $schema );
+		/** Filter the Organization/Person schema before output. */
+		$schema = SWPS_Hooks::filter_schema_organization( $schema );
 
-        $this->output_jsonld( $schema );
-    }
+		$this->output_jsonld( $schema );
+	}
 }

--- a/includes/class-search-appearance.php
+++ b/includes/class-search-appearance.php
@@ -11,323 +11,332 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Search_Appearance {
 
-    /**
-     * Supported template variables.
-     */
-    private const VARIABLES = [
-        '%%title%%', '%%sitename%%', '%%sep%%', '%%excerpt%%',
-        '%%category%%', '%%tag%%', '%%author%%', '%%date%%',
-        '%%page%%', '%%searchphrase%%', '%%pt_single%%', '%%pt_plural%%',
-    ];
+	/**
+	 * Supported template variables.
+	 */
+	private const VARIABLES = array(
+		'%%title%%',
+		'%%sitename%%',
+		'%%sep%%',
+		'%%excerpt%%',
+		'%%category%%',
+		'%%tag%%',
+		'%%author%%',
+		'%%date%%',
+		'%%page%%',
+		'%%searchphrase%%',
+		'%%pt_single%%',
+		'%%pt_plural%%',
+	);
 
-    public function __construct() {
-        if ( is_admin() ) {
-            return;
-        }
+	public function __construct() {
+		if ( is_admin() ) {
+			return;
+		}
 
-        // Conflict detection — defer when competing plugins active.
-        if ( defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' ) ) {
-            return;
-        }
+		// Conflict detection — defer when competing plugins active.
+		if ( defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' ) ) {
+			return;
+		}
 
-        // Title template — priority 10 (Meta Editor overrides at 20).
-        add_filter( 'document_title_parts', [ $this, 'filter_title_parts' ], 10 );
-        add_filter( 'document_title_separator', [ $this, 'filter_separator' ], 10 );
+		// Title template — priority 10 (Meta Editor overrides at 20).
+		add_filter( 'document_title_parts', array( $this, 'filter_title_parts' ), 10 );
+		add_filter( 'document_title_separator', array( $this, 'filter_separator' ), 10 );
 
-        // Meta description for non-singular pages — priority 2 (same as Meta Editor).
-        add_action( 'wp_head', [ $this, 'output_meta_description' ], 2 );
+		// Meta description for non-singular pages — priority 2 (same as Meta Editor).
+		add_action( 'wp_head', array( $this, 'output_meta_description' ), 2 );
 
-        // Robots directives from Search Appearance noindex controls.
-        add_action( 'wp_head', [ $this, 'output_robots_directives' ], 2 );
-    }
+		// Robots directives from Search Appearance noindex controls.
+		add_action( 'wp_head', array( $this, 'output_robots_directives' ), 2 );
+	}
 
-    /**
-     * Filter the document title parts array.
-     */
-    public function filter_title_parts( array $title_parts ): array {
-        $template = $this->get_title_template();
+	/**
+	 * Filter the document title parts array.
+	 */
+	public function filter_title_parts( array $title_parts ): array {
+		$template = $this->get_title_template();
 
-        if ( empty( $template ) ) {
-            return $title_parts;
-        }
+		if ( empty( $template ) ) {
+			return $title_parts;
+		}
 
-        $resolved = $this->resolve_variables( $template );
-        $title_parts['title'] = $resolved;
+		$resolved             = $this->resolve_variables( $template );
+		$title_parts['title'] = $resolved;
 
-        // Remove site name from parts since template includes it.
-        unset( $title_parts['site'], $title_parts['tagline'] );
+		// Remove site name from parts since template includes it.
+		unset( $title_parts['site'], $title_parts['tagline'] );
 
-        return $title_parts;
-    }
+		return $title_parts;
+	}
 
-    /**
-     * Filter the title separator.
-     */
-    public function filter_separator( string $sep ): string {
-        $custom = get_option( 'swps_title_separator', '-' );
-        return ! empty( $custom ) ? $custom : $sep;
-    }
+	/**
+	 * Filter the title separator.
+	 */
+	public function filter_separator( string $sep ): string {
+		$custom = get_option( 'swps_title_separator', '-' );
+		return ! empty( $custom ) ? $custom : $sep;
+	}
 
-    /**
-     * Output meta description for non-singular pages.
-     * Singular pages are handled by SWPS_Meta_Editor.
-     */
-    public function output_meta_description(): void {
-        // Singular pages: only output if Meta Editor hasn't set one.
-        if ( is_singular() ) {
-            $post_desc = get_post_meta( get_the_ID(), '_swps_meta_description', true );
-            if ( ! empty( $post_desc ) ) {
-                return; // Meta Editor handles it.
-            }
-        }
+	/**
+	 * Output meta description for non-singular pages.
+	 * Singular pages are handled by SWPS_Meta_Editor.
+	 */
+	public function output_meta_description(): void {
+		// Singular pages: only output if Meta Editor hasn't set one.
+		if ( is_singular() ) {
+			$post_desc = get_post_meta( get_the_ID(), '_swps_meta_description', true );
+			if ( ! empty( $post_desc ) ) {
+				return; // Meta Editor handles it.
+			}
+		}
 
-        $description = $this->get_description();
+		$description = $this->get_description();
 
-        if ( ! empty( $description ) ) {
-            printf(
-                '<meta name="description" content="%s" />' . "\n",
-                esc_attr( wp_strip_all_tags( $description ) )
-            );
-        }
-    }
+		if ( ! empty( $description ) ) {
+			printf(
+				'<meta name="description" content="%s" />' . "\n",
+				esc_attr( wp_strip_all_tags( $description ) )
+			);
+		}
+	}
 
-    /**
-     * Output robots meta tags for Search Appearance visibility settings.
-     */
-    public function output_robots_directives(): void {
-        $robots = $this->get_robots_directives();
+	/**
+	 * Output robots meta tags for Search Appearance visibility settings.
+	 */
+	public function output_robots_directives(): void {
+		$robots = $this->get_robots_directives();
 
-        if ( empty( $robots ) ) {
-            return;
-        }
+		if ( empty( $robots ) ) {
+			return;
+		}
 
-        printf(
-            '<meta name="robots" content="%s" />' . "\n",
-            esc_attr( implode( ', ', $robots ) )
-        );
-    }
+		printf(
+			'<meta name="robots" content="%s" />' . "\n",
+			esc_attr( implode( ', ', $robots ) )
+		);
+	}
 
-    /**
-     * Resolve robots directives for the current request.
-     *
-     * Per-post and per-term explicit robots settings win; this method only fills
-     * in the global noindex controls from Search Appearance to avoid duplicate
-     * meta tags from the Meta Editor or Taxonomy Meta modules.
-     */
-    private function get_robots_directives(): array {
-        if ( is_singular() ) {
-            $post_id = get_the_ID();
-            if ( ! $post_id ) {
-                return [];
-            }
+	/**
+	 * Resolve robots directives for the current request.
+	 *
+	 * Per-post and per-term explicit robots settings win; this method only fills
+	 * in the global noindex controls from Search Appearance to avoid duplicate
+	 * meta tags from the Meta Editor or Taxonomy Meta modules.
+	 */
+	private function get_robots_directives(): array {
+		if ( is_singular() ) {
+			$post_id = get_the_ID();
+			if ( ! $post_id ) {
+				return array();
+			}
 
-            $explicit = get_post_meta( $post_id, '_swps_robots', true );
-            if ( ! empty( $explicit ) ) {
-                return [];
-            }
+			$explicit = get_post_meta( $post_id, '_swps_robots', true );
+			if ( ! empty( $explicit ) ) {
+				return array();
+			}
 
-            $post_type = get_post_type( $post_id );
-            if ( $post_type && get_option( "swps_noindex_{$post_type}", 0 ) ) {
-                return [ 'noindex', 'follow' ];
-            }
+			$post_type = get_post_type( $post_id );
+			if ( $post_type && get_option( "swps_noindex_{$post_type}", 0 ) ) {
+				return array( 'noindex', 'follow' );
+			}
 
-            return [];
-        }
+			return array();
+		}
 
-        if ( is_category() || is_tag() || is_tax() ) {
-            $term = get_queried_object();
-            if ( ! $term instanceof WP_Term ) {
-                return [];
-            }
+		if ( is_category() || is_tag() || is_tax() ) {
+			$term = get_queried_object();
+			if ( ! $term instanceof WP_Term ) {
+				return array();
+			}
 
-            $explicit = get_term_meta( $term->term_id, '_swps_robots', true );
-            if ( ! empty( $explicit ) ) {
-                return [];
-            }
+			$explicit = get_term_meta( $term->term_id, '_swps_robots', true );
+			if ( ! empty( $explicit ) ) {
+				return array();
+			}
 
-            if ( get_option( "swps_noindex_{$term->taxonomy}", 0 ) ) {
-                return [ 'noindex', 'follow' ];
-            }
+			if ( get_option( "swps_noindex_{$term->taxonomy}", 0 ) ) {
+				return array( 'noindex', 'follow' );
+			}
 
-            return [];
-        }
+			return array();
+		}
 
-        if ( is_post_type_archive() ) {
-            $post_type = get_query_var( 'post_type' );
-            if ( is_array( $post_type ) ) {
-                $post_type = reset( $post_type );
-            }
+		if ( is_post_type_archive() ) {
+			$post_type = get_query_var( 'post_type' );
+			if ( is_array( $post_type ) ) {
+				$post_type = reset( $post_type );
+			}
 
-            if ( is_string( $post_type ) && get_option( "swps_noindex_{$post_type}", 0 ) ) {
-                return [ 'noindex', 'follow' ];
-            }
-        }
+			if ( is_string( $post_type ) && get_option( "swps_noindex_{$post_type}", 0 ) ) {
+				return array( 'noindex', 'follow' );
+			}
+		}
 
-        return [];
-    }
+		return array();
+	}
 
-    /**
-     * Get the title template for the current page context.
-     */
-    private function get_title_template(): string {
-        if ( is_front_page() && is_home() ) {
-            return get_option( 'swps_title_template_homepage', '%%sitename%%' );
-        }
+	/**
+	 * Get the title template for the current page context.
+	 */
+	private function get_title_template(): string {
+		if ( is_front_page() && is_home() ) {
+			return get_option( 'swps_title_template_homepage', '%%sitename%%' );
+		}
 
-        if ( is_singular() ) {
-            $post_type = get_post_type();
-            return get_option( "swps_title_template_{$post_type}", '%%title%% %%sep%% %%sitename%%' );
-        }
+		if ( is_singular() ) {
+			$post_type = get_post_type();
+			return get_option( "swps_title_template_{$post_type}", '%%title%% %%sep%% %%sitename%%' );
+		}
 
-        if ( is_category() ) {
-            return get_option( 'swps_title_template_category', '%%title%% Archives %%sep%% %%sitename%%' );
-        }
+		if ( is_category() ) {
+			return get_option( 'swps_title_template_category', '%%title%% Archives %%sep%% %%sitename%%' );
+		}
 
-        if ( is_tag() ) {
-            return get_option( 'swps_title_template_post_tag', '%%title%% %%sep%% %%sitename%%' );
-        }
+		if ( is_tag() ) {
+			return get_option( 'swps_title_template_post_tag', '%%title%% %%sep%% %%sitename%%' );
+		}
 
-        if ( is_tax() ) {
-            $taxonomy = get_queried_object()->taxonomy ?? '';
-            return get_option( "swps_title_template_{$taxonomy}", '%%title%% %%sep%% %%sitename%%' );
-        }
+		if ( is_tax() ) {
+			$taxonomy = get_queried_object()->taxonomy ?? '';
+			return get_option( "swps_title_template_{$taxonomy}", '%%title%% %%sep%% %%sitename%%' );
+		}
 
-        if ( is_author() ) {
-            return get_option( 'swps_title_template_author', '%%author%% %%sep%% %%sitename%%' );
-        }
+		if ( is_author() ) {
+			return get_option( 'swps_title_template_author', '%%author%% %%sep%% %%sitename%%' );
+		}
 
-        if ( is_post_type_archive() ) {
-            $post_type = get_query_var( 'post_type' );
-            if ( is_array( $post_type ) ) {
-                $post_type = reset( $post_type );
-            }
-            return get_option( "swps_title_template_{$post_type}_archive", '%%pt_plural%% %%sep%% %%sitename%%' );
-        }
+		if ( is_post_type_archive() ) {
+			$post_type = get_query_var( 'post_type' );
+			if ( is_array( $post_type ) ) {
+				$post_type = reset( $post_type );
+			}
+			return get_option( "swps_title_template_{$post_type}_archive", '%%pt_plural%% %%sep%% %%sitename%%' );
+		}
 
-        if ( is_date() ) {
-            return get_option( 'swps_title_template_date', '%%title%% %%sep%% %%sitename%%' );
-        }
+		if ( is_date() ) {
+			return get_option( 'swps_title_template_date', '%%title%% %%sep%% %%sitename%%' );
+		}
 
-        if ( is_search() ) {
-            return get_option( 'swps_title_template_search', 'Search: %%searchphrase%% %%sep%% %%sitename%%' );
-        }
+		if ( is_search() ) {
+			return get_option( 'swps_title_template_search', 'Search: %%searchphrase%% %%sep%% %%sitename%%' );
+		}
 
-        if ( is_404() ) {
-            return get_option( 'swps_title_template_404', 'Page Not Found %%sep%% %%sitename%%' );
-        }
+		if ( is_404() ) {
+			return get_option( 'swps_title_template_404', 'Page Not Found %%sep%% %%sitename%%' );
+		}
 
-        return '';
-    }
+		return '';
+	}
 
-    /**
-     * Get the meta description for the current page context.
-     */
-    private function get_description(): string {
-        if ( is_singular() ) {
-            $post_type = get_post_type();
-            $template  = get_option( "swps_desc_template_{$post_type}", '%%excerpt%%' );
-            return $this->resolve_variables( $template );
-        }
+	/**
+	 * Get the meta description for the current page context.
+	 */
+	private function get_description(): string {
+		if ( is_singular() ) {
+			$post_type = get_post_type();
+			$template  = get_option( "swps_desc_template_{$post_type}", '%%excerpt%%' );
+			return $this->resolve_variables( $template );
+		}
 
-        if ( is_category() || is_tag() || is_tax() ) {
-            $term = get_queried_object();
-            if ( $term && ! empty( $term->description ) ) {
-                return wp_trim_words( $term->description, 30 );
-            }
-            // Check for per-term meta description (from Taxonomy Meta).
-            if ( $term ) {
-                $meta_desc = get_term_meta( $term->term_id, '_swps_meta_description', true );
-                if ( ! empty( $meta_desc ) ) {
-                    return $meta_desc;
-                }
-            }
-        }
+		if ( is_category() || is_tag() || is_tax() ) {
+			$term = get_queried_object();
+			if ( $term && ! empty( $term->description ) ) {
+				return wp_trim_words( $term->description, 30 );
+			}
+			// Check for per-term meta description (from Taxonomy Meta).
+			if ( $term ) {
+				$meta_desc = get_term_meta( $term->term_id, '_swps_meta_description', true );
+				if ( ! empty( $meta_desc ) ) {
+					return $meta_desc;
+				}
+			}
+		}
 
-        if ( is_author() ) {
-            $author = get_queried_object();
-            if ( $author ) {
-                return wp_trim_words( get_the_author_meta( 'description', $author->ID ), 30 );
-            }
-        }
+		if ( is_author() ) {
+			$author = get_queried_object();
+			if ( $author ) {
+				return wp_trim_words( get_the_author_meta( 'description', $author->ID ), 30 );
+			}
+		}
 
-        return '';
-    }
+		return '';
+	}
 
-    /**
-     * Resolve template variables to their current values.
-     */
-    public function resolve_variables( string $template ): string {
-        $sep      = get_option( 'swps_title_separator', '-' );
-        $sitename = get_bloginfo( 'name' );
+	/**
+	 * Resolve template variables to their current values.
+	 */
+	public function resolve_variables( string $template ): string {
+		$sep      = get_option( 'swps_title_separator', '-' );
+		$sitename = get_bloginfo( 'name' );
 
-        $replacements = [
-            '%%sitename%%'     => $sitename,
-            '%%sep%%'          => $sep,
-            '%%searchphrase%%' => get_search_query(),
-        ];
+		$replacements = array(
+			'%%sitename%%'     => $sitename,
+			'%%sep%%'          => $sep,
+			'%%searchphrase%%' => get_search_query(),
+		);
 
-        // Context-specific replacements.
-        if ( is_singular() ) {
-            $post = get_queried_object();
-            if ( $post ) {
-                $replacements['%%title%%']    = $post->post_title;
-                $replacements['%%excerpt%%']  = wp_trim_words( $post->post_excerpt ?: wp_strip_all_tags( $post->post_content ), 30 );
-                $replacements['%%author%%']   = get_the_author_meta( 'display_name', $post->post_author );
-                $replacements['%%date%%']     = get_the_date( '', $post );
+		// Context-specific replacements.
+		if ( is_singular() ) {
+			$post = get_queried_object();
+			if ( $post ) {
+				$replacements['%%title%%']   = $post->post_title;
+				$replacements['%%excerpt%%'] = wp_trim_words( $post->post_excerpt ?: wp_strip_all_tags( $post->post_content ), 30 );
+				$replacements['%%author%%']  = get_the_author_meta( 'display_name', $post->post_author );
+				$replacements['%%date%%']    = get_the_date( '', $post );
 
-                $categories = get_the_category( $post->ID );
-                $replacements['%%category%%'] = ! empty( $categories ) ? $categories[0]->name : '';
+				$categories                   = get_the_category( $post->ID );
+				$replacements['%%category%%'] = ! empty( $categories ) ? $categories[0]->name : '';
 
-                $tags = get_the_tags( $post->ID );
-                $replacements['%%tag%%']      = ! empty( $tags ) ? $tags[0]->name : '';
-            }
-        } elseif ( is_category() || is_tag() || is_tax() ) {
-            $term = get_queried_object();
-            if ( $term ) {
-                $replacements['%%title%%'] = $term->name;
-            }
-        } elseif ( is_author() ) {
-            $author = get_queried_object();
-            if ( $author ) {
-                $replacements['%%title%%']  = $author->display_name;
-                $replacements['%%author%%'] = $author->display_name;
-            }
-        } elseif ( is_post_type_archive() ) {
-            $post_type = get_query_var( 'post_type' );
-            if ( is_array( $post_type ) ) {
-                $post_type = reset( $post_type );
-            }
-            $pto = get_post_type_object( $post_type );
-            if ( $pto ) {
-                $replacements['%%title%%']     = $pto->labels->name;
-                $replacements['%%pt_single%%'] = $pto->labels->singular_name;
-                $replacements['%%pt_plural%%'] = $pto->labels->name;
-            }
-        } elseif ( is_date() ) {
-            if ( is_year() ) {
-                $replacements['%%title%%'] = get_the_date( 'Y' );
-            } elseif ( is_month() ) {
-                $replacements['%%title%%'] = get_the_date( 'F Y' );
-            } else {
-                $replacements['%%title%%'] = get_the_date();
-            }
-        }
+				$tags                    = get_the_tags( $post->ID );
+				$replacements['%%tag%%'] = ! empty( $tags ) ? $tags[0]->name : '';
+			}
+		} elseif ( is_category() || is_tag() || is_tax() ) {
+			$term = get_queried_object();
+			if ( $term ) {
+				$replacements['%%title%%'] = $term->name;
+			}
+		} elseif ( is_author() ) {
+			$author = get_queried_object();
+			if ( $author ) {
+				$replacements['%%title%%']  = $author->display_name;
+				$replacements['%%author%%'] = $author->display_name;
+			}
+		} elseif ( is_post_type_archive() ) {
+			$post_type = get_query_var( 'post_type' );
+			if ( is_array( $post_type ) ) {
+				$post_type = reset( $post_type );
+			}
+			$pto = get_post_type_object( $post_type );
+			if ( $pto ) {
+				$replacements['%%title%%']     = $pto->labels->name;
+				$replacements['%%pt_single%%'] = $pto->labels->singular_name;
+				$replacements['%%pt_plural%%'] = $pto->labels->name;
+			}
+		} elseif ( is_date() ) {
+			if ( is_year() ) {
+				$replacements['%%title%%'] = get_the_date( 'Y' );
+			} elseif ( is_month() ) {
+				$replacements['%%title%%'] = get_the_date( 'F Y' );
+			} else {
+				$replacements['%%title%%'] = get_the_date();
+			}
+		}
 
-        // Pagination.
-        $paged = get_query_var( 'paged', 0 );
-        $replacements['%%page%%'] = $paged > 1 ? sprintf( __( 'Page %d', 'stratawp-seo' ), $paged ) : '';
+		// Pagination.
+		$paged                    = get_query_var( 'paged', 0 );
+		$replacements['%%page%%'] = $paged > 1 ? sprintf( __( 'Page %d', 'stratawp-seo' ), $paged ) : '';
 
-        $result = str_replace( array_keys( $replacements ), array_values( $replacements ), $template );
+		$result = str_replace( array_keys( $replacements ), array_values( $replacements ), $template );
 
-        // Clean up empty variables and double separators.
-        $result = preg_replace( '/%%\w+%%/', '', $result );
-        $result = preg_replace( '/\s+/', ' ', trim( $result ) );
+		// Clean up empty variables and double separators.
+		$result = preg_replace( '/%%\w+%%/', '', $result );
+		$result = preg_replace( '/\s+/', ' ', trim( $result ) );
 
-        return $result;
-    }
+		return $result;
+	}
 }

--- a/includes/class-search-console.php
+++ b/includes/class-search-console.php
@@ -8,442 +8,448 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Search_Console {
 
-    private const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
-    private const AUTH_ENDPOINT  = 'https://accounts.google.com/o/oauth2/v2/auth';
-    private const API_BASE       = 'https://www.googleapis.com/webmasters/v3';
-    private const SCOPE          = 'https://www.googleapis.com/auth/webmasters.readonly';
-    private const CACHE_PREFIX   = 'swps_gsc_';
-    private const CACHE_TTL      = 43200; // 12 hours.
-    private const CRON_HOOK      = 'swps_gsc_refresh_data';
+	private const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
+	private const AUTH_ENDPOINT  = 'https://accounts.google.com/o/oauth2/v2/auth';
+	private const API_BASE       = 'https://www.googleapis.com/webmasters/v3';
+	private const SCOPE          = 'https://www.googleapis.com/auth/webmasters.readonly';
+	private const CACHE_PREFIX   = 'swps_gsc_';
+	private const CACHE_TTL      = 43200; // 12 hours.
+	private const CRON_HOOK      = 'swps_gsc_refresh_data';
 
-    public function __construct() {
-        add_action( 'admin_init', [ $this, 'handle_oauth_callback' ] );
-        add_action( self::CRON_HOOK, [ $this, 'refresh_cached_data' ] );
-    }
+	public function __construct() {
+		add_action( 'admin_init', array( $this, 'handle_oauth_callback' ) );
+		add_action( self::CRON_HOOK, array( $this, 'refresh_cached_data' ) );
+	}
 
-    /**
-     * Check if GSC is connected.
-     */
-    public function is_connected(): bool {
-        return (bool) get_option( 'swps_gsc_connected', false );
-    }
+	/**
+	 * Check if GSC is connected.
+	 */
+	public function is_connected(): bool {
+		return (bool) get_option( 'swps_gsc_connected', false );
+	}
 
-    /**
-     * Get the OAuth authorization URL.
-     */
-    public function get_auth_url(): string {
-        $client_id = get_option( 'swps_gsc_client_id', '' );
+	/**
+	 * Get the OAuth authorization URL.
+	 */
+	public function get_auth_url(): string {
+		$client_id = get_option( 'swps_gsc_client_id', '' );
 
-        if ( empty( $client_id ) ) {
-            return '';
-        }
+		if ( empty( $client_id ) ) {
+			return '';
+		}
 
-        $state = wp_create_nonce( 'swps_gsc_oauth' );
-        update_option( 'swps_gsc_oauth_state', $state );
+		$state = wp_create_nonce( 'swps_gsc_oauth' );
+		update_option( 'swps_gsc_oauth_state', $state );
 
-        $params = [
-            'client_id'     => $client_id,
-            'redirect_uri'  => $this->get_redirect_uri(),
-            'response_type' => 'code',
-            'scope'         => self::SCOPE,
-            'access_type'   => 'offline',
-            'prompt'        => 'consent',
-            'state'         => $state,
-        ];
+		$params = array(
+			'client_id'     => $client_id,
+			'redirect_uri'  => $this->get_redirect_uri(),
+			'response_type' => 'code',
+			'scope'         => self::SCOPE,
+			'access_type'   => 'offline',
+			'prompt'        => 'consent',
+			'state'         => $state,
+		);
 
-        return self::AUTH_ENDPOINT . '?' . http_build_query( $params );
-    }
+		return self::AUTH_ENDPOINT . '?' . http_build_query( $params );
+	}
 
-    /**
-     * Handle the OAuth callback from Google.
-     */
-    public function handle_oauth_callback(): void {
-        if ( ! isset( $_GET['swps_gsc_callback'] ) || ! current_user_can( 'manage_options' ) ) {
-            return;
-        }
+	/**
+	 * Handle the OAuth callback from Google.
+	 */
+	public function handle_oauth_callback(): void {
+		if ( ! isset( $_GET['swps_gsc_callback'] ) || ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
 
-        $state = sanitize_text_field( $_GET['state'] ?? '' );
-        $saved = get_option( 'swps_gsc_oauth_state', '' );
+		$state = sanitize_text_field( $_GET['state'] ?? '' );
+		$saved = get_option( 'swps_gsc_oauth_state', '' );
 
-        if ( empty( $state ) || $state !== $saved ) {
-            add_settings_error( 'stratawp-seo', 'gsc_oauth', __( 'Invalid OAuth state. Please try again.', 'stratawp-seo' ) );
-            return;
-        }
+		if ( empty( $state ) || $state !== $saved ) {
+			add_settings_error( 'stratawp-seo', 'gsc_oauth', __( 'Invalid OAuth state. Please try again.', 'stratawp-seo' ) );
+			return;
+		}
 
-        delete_option( 'swps_gsc_oauth_state' );
+		delete_option( 'swps_gsc_oauth_state' );
 
-        if ( isset( $_GET['error'] ) ) {
-            add_settings_error( 'stratawp-seo', 'gsc_oauth', __( 'Google authorization denied.', 'stratawp-seo' ) );
-            return;
-        }
+		if ( isset( $_GET['error'] ) ) {
+			add_settings_error( 'stratawp-seo', 'gsc_oauth', __( 'Google authorization denied.', 'stratawp-seo' ) );
+			return;
+		}
 
-        $code = sanitize_text_field( $_GET['code'] ?? '' );
+		$code = sanitize_text_field( $_GET['code'] ?? '' );
 
-        if ( empty( $code ) ) {
-            add_settings_error( 'stratawp-seo', 'gsc_oauth', __( 'No authorization code received.', 'stratawp-seo' ) );
-            return;
-        }
+		if ( empty( $code ) ) {
+			add_settings_error( 'stratawp-seo', 'gsc_oauth', __( 'No authorization code received.', 'stratawp-seo' ) );
+			return;
+		}
 
-        $tokens = $this->exchange_code( $code );
+		$tokens = $this->exchange_code( $code );
 
-        if ( is_wp_error( $tokens ) ) {
-            add_settings_error( 'stratawp-seo', 'gsc_oauth', $tokens->get_error_message() );
-            return;
-        }
+		if ( is_wp_error( $tokens ) ) {
+			add_settings_error( 'stratawp-seo', 'gsc_oauth', $tokens->get_error_message() );
+			return;
+		}
 
-        update_option( 'swps_gsc_access_token', SWPS_Encryption::encrypt( $tokens['access_token'] ) );
-        update_option( 'swps_gsc_refresh_token', SWPS_Encryption::encrypt( $tokens['refresh_token'] ) );
-        update_option( 'swps_gsc_token_expiry', time() + (int) $tokens['expires_in'] );
-        update_option( 'swps_gsc_connected', 1 );
+		update_option( 'swps_gsc_access_token', SWPS_Encryption::encrypt( $tokens['access_token'] ) );
+		update_option( 'swps_gsc_refresh_token', SWPS_Encryption::encrypt( $tokens['refresh_token'] ) );
+		update_option( 'swps_gsc_token_expiry', time() + (int) $tokens['expires_in'] );
+		update_option( 'swps_gsc_connected', 1 );
 
-        // Redirect to settings page.
-        wp_safe_redirect( admin_url( 'admin.php?page=swps-settings&gsc_connected=1' ) );
-        exit;
-    }
+		// Redirect to settings page.
+		wp_safe_redirect( admin_url( 'admin.php?page=swps-settings&gsc_connected=1' ) );
+		exit;
+	}
 
-    /**
-     * Disconnect from GSC — clear all tokens and cached data.
-     */
-    public function disconnect(): void {
-        delete_option( 'swps_gsc_access_token' );
-        delete_option( 'swps_gsc_refresh_token' );
-        delete_option( 'swps_gsc_token_expiry' );
-        delete_option( 'swps_gsc_connected' );
-        delete_option( 'swps_gsc_property' );
-        delete_option( 'swps_gsc_oauth_state' );
+	/**
+	 * Disconnect from GSC — clear all tokens and cached data.
+	 */
+	public function disconnect(): void {
+		delete_option( 'swps_gsc_access_token' );
+		delete_option( 'swps_gsc_refresh_token' );
+		delete_option( 'swps_gsc_token_expiry' );
+		delete_option( 'swps_gsc_connected' );
+		delete_option( 'swps_gsc_property' );
+		delete_option( 'swps_gsc_oauth_state' );
 
-        $this->clear_cache();
-    }
+		$this->clear_cache();
+	}
 
-    /**
-     * Get the list of verified GSC properties.
-     *
-     * @return array Site URLs.
-     */
-    public function get_properties(): array {
-        $response = $this->api_request( '/sites' );
+	/**
+	 * Get the list of verified GSC properties.
+	 *
+	 * @return array Site URLs.
+	 */
+	public function get_properties(): array {
+		$response = $this->api_request( '/sites' );
 
-        if ( is_wp_error( $response ) ) {
-            return [];
-        }
+		if ( is_wp_error( $response ) ) {
+			return array();
+		}
 
-        $sites = [];
+		$sites = array();
 
-        foreach ( $response['siteEntry'] ?? [] as $site ) {
-            $sites[] = $site['siteUrl'];
-        }
+		foreach ( $response['siteEntry'] ?? array() as $site ) {
+			$sites[] = $site['siteUrl'];
+		}
 
-        return $sites;
-    }
+		return $sites;
+	}
 
-    /**
-     * Fetch search analytics data (queries + pages).
-     *
-     * @param int $days Number of days to fetch.
-     * @return array Search data with 'queries', 'pages', 'daily' keys.
-     */
-    public function get_search_data( int $days = 90 ): array {
-        $cache_key = self::CACHE_PREFIX . 'search_data_' . $days;
-        $cached    = get_transient( $cache_key );
+	/**
+	 * Fetch search analytics data (queries + pages).
+	 *
+	 * @param int $days Number of days to fetch.
+	 * @return array Search data with 'queries', 'pages', 'daily' keys.
+	 */
+	public function get_search_data( int $days = 90 ): array {
+		$cache_key = self::CACHE_PREFIX . 'search_data_' . $days;
+		$cached    = get_transient( $cache_key );
 
-        if ( false !== $cached ) {
-            return SWPS_Hooks::filter_gsc_data( $cached, $this->get_property() );
-        }
+		if ( false !== $cached ) {
+			return SWPS_Hooks::filter_gsc_data( $cached, $this->get_property() );
+		}
 
-        $property  = $this->get_property();
-        $start     = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
-        $end       = gmdate( 'Y-m-d', strtotime( '-2 days' ) ); // GSC data has 2-day delay.
+		$property = $this->get_property();
+		$start    = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+		$end      = gmdate( 'Y-m-d', strtotime( '-2 days' ) ); // GSC data has 2-day delay.
 
-        $data = [
-            'queries' => $this->fetch_analytics( $property, $start, $end, ['query'] ),
-            'pages'   => $this->fetch_analytics( $property, $start, $end, ['page'] ),
-            'daily'   => $this->fetch_analytics( $property, $start, $end, ['date'] ),
-        ];
+		$data = array(
+			'queries' => $this->fetch_analytics( $property, $start, $end, array( 'query' ) ),
+			'pages'   => $this->fetch_analytics( $property, $start, $end, array( 'page' ) ),
+			'daily'   => $this->fetch_analytics( $property, $start, $end, array( 'date' ) ),
+		);
 
-        set_transient( $cache_key, $data, self::CACHE_TTL );
+		set_transient( $cache_key, $data, self::CACHE_TTL );
 
-        return SWPS_Hooks::filter_gsc_data( $data, $property );
-    }
+		return SWPS_Hooks::filter_gsc_data( $data, $property );
+	}
 
-    /**
-     * Get search data for a specific page URL.
-     *
-     * @param string $url  Page URL.
-     * @param int    $days Days to look back.
-     * @return array Query data for this page.
-     */
-    public function get_page_queries( string $url, int $days = 90 ): array {
-        $property = $this->get_property();
-        $start    = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
-        $end      = gmdate( 'Y-m-d', strtotime( '-2 days' ) );
+	/**
+	 * Get search data for a specific page URL.
+	 *
+	 * @param string $url  Page URL.
+	 * @param int    $days Days to look back.
+	 * @return array Query data for this page.
+	 */
+	public function get_page_queries( string $url, int $days = 90 ): array {
+		$property = $this->get_property();
+		$start    = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+		$end      = gmdate( 'Y-m-d', strtotime( '-2 days' ) );
 
-        $body = [
-            'startDate'  => $start,
-            'endDate'    => $end,
-            'dimensions' => ['query'],
-            'dimensionFilterGroups' => [
-                [
-                    'filters' => [
-                        [
-                            'dimension'  => 'page',
-                            'expression' => $url,
-                        ],
-                    ],
-                ],
-            ],
-            'rowLimit' => 10,
-        ];
+		$body = array(
+			'startDate'             => $start,
+			'endDate'               => $end,
+			'dimensions'            => array( 'query' ),
+			'dimensionFilterGroups' => array(
+				array(
+					'filters' => array(
+						array(
+							'dimension'  => 'page',
+							'expression' => $url,
+						),
+					),
+				),
+			),
+			'rowLimit'              => 10,
+		);
 
-        $encoded_property = rawurlencode( $property );
-        $response = $this->api_request(
-            "/sites/{$encoded_property}/searchAnalytics/query",
-            'POST',
-            $body
-        );
+		$encoded_property = rawurlencode( $property );
+		$response         = $this->api_request(
+			"/sites/{$encoded_property}/searchAnalytics/query",
+			'POST',
+			$body
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return [];
-        }
+		if ( is_wp_error( $response ) ) {
+			return array();
+		}
 
-        return $response['rows'] ?? [];
-    }
+		return $response['rows'] ?? array();
+	}
 
-    /**
-     * Clear all GSC cached data.
-     */
-    public function clear_cache(): void {
-        global $wpdb;
+	/**
+	 * Clear all GSC cached data.
+	 */
+	public function clear_cache(): void {
+		global $wpdb;
 
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
-        $wpdb->query(
-            $wpdb->prepare(
-                "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
-                $wpdb->esc_like( '_transient_' . self::CACHE_PREFIX ) . '%'
-            )
-        );
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+				$wpdb->esc_like( '_transient_' . self::CACHE_PREFIX ) . '%'
+			)
+		);
 
-        // Also delete timeout transients.
-        $wpdb->query(
-            $wpdb->prepare(
-                "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
-                $wpdb->esc_like( '_transient_timeout_' . self::CACHE_PREFIX ) . '%'
-            )
-        );
-    }
+		// Also delete timeout transients.
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+				$wpdb->esc_like( '_transient_timeout_' . self::CACHE_PREFIX ) . '%'
+			)
+		);
+	}
 
-    /**
-     * Cron: Refresh cached data in background.
-     */
-    public function refresh_cached_data(): void {
-        if ( ! $this->is_connected() ) {
-            return;
-        }
+	/**
+	 * Cron: Refresh cached data in background.
+	 */
+	public function refresh_cached_data(): void {
+		if ( ! $this->is_connected() ) {
+			return;
+		}
 
-        $this->clear_cache();
-        $this->get_search_data( 90 );
-    }
+		$this->clear_cache();
+		$this->get_search_data( 90 );
+	}
 
-    /**
-     * Schedule the data refresh cron.
-     */
-    public static function schedule_cron(): void {
-        if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-            wp_schedule_event( time(), 'twicedaily', self::CRON_HOOK );
-        }
-    }
+	/**
+	 * Schedule the data refresh cron.
+	 */
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'twicedaily', self::CRON_HOOK );
+		}
+	}
 
-    /**
-     * Unschedule the data refresh cron.
-     */
-    public static function unschedule_cron(): void {
-        $timestamp = wp_next_scheduled( self::CRON_HOOK );
+	/**
+	 * Unschedule the data refresh cron.
+	 */
+	public static function unschedule_cron(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
 
-        if ( $timestamp ) {
-            wp_unschedule_event( $timestamp, self::CRON_HOOK );
-        }
-    }
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
 
-    /**
-     * Get the selected GSC property.
-     */
-    private function get_property(): string {
-        return get_option( 'swps_gsc_property', '' );
-    }
+	/**
+	 * Get the selected GSC property.
+	 */
+	private function get_property(): string {
+		return get_option( 'swps_gsc_property', '' );
+	}
 
-    /**
-     * Get the OAuth redirect URI.
-     */
-    private function get_redirect_uri(): string {
-        return admin_url( 'admin.php?swps_gsc_callback=1' );
-    }
+	/**
+	 * Get the OAuth redirect URI.
+	 */
+	private function get_redirect_uri(): string {
+		return admin_url( 'admin.php?swps_gsc_callback=1' );
+	}
 
-    /**
-     * Exchange authorization code for tokens.
-     *
-     * @param string $code Authorization code.
-     * @return array|WP_Error Token data or error.
-     */
-    private function exchange_code( string $code ): array|WP_Error {
-        $response = wp_remote_post( self::TOKEN_ENDPOINT, [
-            'body' => [
-                'code'          => $code,
-                'client_id'     => get_option( 'swps_gsc_client_id', '' ),
-                'client_secret' => SWPS_Encryption::decrypt( get_option( 'swps_gsc_client_secret', '' ) ),
-                'redirect_uri'  => $this->get_redirect_uri(),
-                'grant_type'    => 'authorization_code',
-            ],
-        ] );
+	/**
+	 * Exchange authorization code for tokens.
+	 *
+	 * @param string $code Authorization code.
+	 * @return array|WP_Error Token data or error.
+	 */
+	private function exchange_code( string $code ): array|WP_Error {
+		$response = wp_remote_post(
+			self::TOKEN_ENDPOINT,
+			array(
+				'body' => array(
+					'code'          => $code,
+					'client_id'     => get_option( 'swps_gsc_client_id', '' ),
+					'client_secret' => SWPS_Encryption::decrypt( get_option( 'swps_gsc_client_secret', '' ) ),
+					'redirect_uri'  => $this->get_redirect_uri(),
+					'grant_type'    => 'authorization_code',
+				),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
-        $body = json_decode( wp_remote_retrieve_body( $response ), true );
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
 
-        if ( isset( $body['error'] ) ) {
-            return new WP_Error( 'gsc_token_error', $body['error_description'] ?? $body['error'] );
-        }
+		if ( isset( $body['error'] ) ) {
+			return new WP_Error( 'gsc_token_error', $body['error_description'] ?? $body['error'] );
+		}
 
-        if ( empty( $body['access_token'] ) || empty( $body['refresh_token'] ) ) {
-            return new WP_Error( 'gsc_token_error', __( 'Invalid token response from Google.', 'stratawp-seo' ) );
-        }
+		if ( empty( $body['access_token'] ) || empty( $body['refresh_token'] ) ) {
+			return new WP_Error( 'gsc_token_error', __( 'Invalid token response from Google.', 'stratawp-seo' ) );
+		}
 
-        return $body;
-    }
+		return $body;
+	}
 
-    /**
-     * Refresh the access token using the refresh token.
-     *
-     * @return bool True if refreshed successfully.
-     */
-    private function refresh_token(): bool {
-        $refresh_token = SWPS_Encryption::decrypt( get_option( 'swps_gsc_refresh_token', '' ) );
+	/**
+	 * Refresh the access token using the refresh token.
+	 *
+	 * @return bool True if refreshed successfully.
+	 */
+	private function refresh_token(): bool {
+		$refresh_token = SWPS_Encryption::decrypt( get_option( 'swps_gsc_refresh_token', '' ) );
 
-        if ( empty( $refresh_token ) ) {
-            $this->disconnect();
-            return false;
-        }
+		if ( empty( $refresh_token ) ) {
+			$this->disconnect();
+			return false;
+		}
 
-        $response = wp_remote_post( self::TOKEN_ENDPOINT, [
-            'body' => [
-                'refresh_token' => $refresh_token,
-                'client_id'     => get_option( 'swps_gsc_client_id', '' ),
-                'client_secret' => SWPS_Encryption::decrypt( get_option( 'swps_gsc_client_secret', '' ) ),
-                'grant_type'    => 'refresh_token',
-            ],
-        ] );
+		$response = wp_remote_post(
+			self::TOKEN_ENDPOINT,
+			array(
+				'body' => array(
+					'refresh_token' => $refresh_token,
+					'client_id'     => get_option( 'swps_gsc_client_id', '' ),
+					'client_secret' => SWPS_Encryption::decrypt( get_option( 'swps_gsc_client_secret', '' ) ),
+					'grant_type'    => 'refresh_token',
+				),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return false;
-        }
+		if ( is_wp_error( $response ) ) {
+			return false;
+		}
 
-        $body = json_decode( wp_remote_retrieve_body( $response ), true );
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
 
-        if ( isset( $body['error'] ) || empty( $body['access_token'] ) ) {
-            $this->disconnect();
-            return false;
-        }
+		if ( isset( $body['error'] ) || empty( $body['access_token'] ) ) {
+			$this->disconnect();
+			return false;
+		}
 
-        update_option( 'swps_gsc_access_token', SWPS_Encryption::encrypt( $body['access_token'] ) );
-        update_option( 'swps_gsc_token_expiry', time() + (int) $body['expires_in'] );
+		update_option( 'swps_gsc_access_token', SWPS_Encryption::encrypt( $body['access_token'] ) );
+		update_option( 'swps_gsc_token_expiry', time() + (int) $body['expires_in'] );
 
-        return true;
-    }
+		return true;
+	}
 
-    /**
-     * Get a valid access token, refreshing if needed.
-     *
-     * @return string|null Access token or null.
-     */
-    private function get_access_token(): ?string {
-        $expiry = (int) get_option( 'swps_gsc_token_expiry', 0 );
+	/**
+	 * Get a valid access token, refreshing if needed.
+	 *
+	 * @return string|null Access token or null.
+	 */
+	private function get_access_token(): ?string {
+		$expiry = (int) get_option( 'swps_gsc_token_expiry', 0 );
 
-        if ( $expiry < time() + 60 ) {
-            if ( ! $this->refresh_token() ) {
-                return null;
-            }
-        }
+		if ( $expiry < time() + 60 ) {
+			if ( ! $this->refresh_token() ) {
+				return null;
+			}
+		}
 
-        return SWPS_Encryption::decrypt( get_option( 'swps_gsc_access_token', '' ) );
-    }
+		return SWPS_Encryption::decrypt( get_option( 'swps_gsc_access_token', '' ) );
+	}
 
-    /**
-     * Make an authenticated API request to GSC.
-     *
-     * @param string $endpoint API endpoint path.
-     * @param string $method   HTTP method.
-     * @param array  $body     Request body for POST.
-     * @return array|WP_Error Response data or error.
-     */
-    private function api_request( string $endpoint, string $method = 'GET', array $body = [] ): array|WP_Error {
-        $token = $this->get_access_token();
+	/**
+	 * Make an authenticated API request to GSC.
+	 *
+	 * @param string $endpoint API endpoint path.
+	 * @param string $method   HTTP method.
+	 * @param array  $body     Request body for POST.
+	 * @return array|WP_Error Response data or error.
+	 */
+	private function api_request( string $endpoint, string $method = 'GET', array $body = array() ): array|WP_Error {
+		$token = $this->get_access_token();
 
-        if ( ! $token ) {
-            return new WP_Error( 'gsc_no_token', __( 'Not connected to Google Search Console.', 'stratawp-seo' ) );
-        }
+		if ( ! $token ) {
+			return new WP_Error( 'gsc_no_token', __( 'Not connected to Google Search Console.', 'stratawp-seo' ) );
+		}
 
-        $args = [
-            'method'  => $method,
-            'headers' => [
-                'Authorization' => 'Bearer ' . $token,
-                'Content-Type'  => 'application/json',
-            ],
-            'timeout' => 30,
-        ];
+		$args = array(
+			'method'  => $method,
+			'headers' => array(
+				'Authorization' => 'Bearer ' . $token,
+				'Content-Type'  => 'application/json',
+			),
+			'timeout' => 30,
+		);
 
-        if ( ! empty( $body ) ) {
-            $args['body'] = wp_json_encode( $body );
-        }
+		if ( ! empty( $body ) ) {
+			$args['body'] = wp_json_encode( $body );
+		}
 
-        $response = wp_remote_request( self::API_BASE . $endpoint, $args );
+		$response = wp_remote_request( self::API_BASE . $endpoint, $args );
 
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
-        $code = wp_remote_retrieve_response_code( $response );
+		$code = wp_remote_retrieve_response_code( $response );
 
-        if ( $code >= 400 ) {
-            $decoded = json_decode( wp_remote_retrieve_body( $response ), true );
-            $message = $decoded['error']['message'] ?? "HTTP {$code}";
-            return new WP_Error( 'gsc_api_error', $message );
-        }
+		if ( $code >= 400 ) {
+			$decoded = json_decode( wp_remote_retrieve_body( $response ), true );
+			$message = $decoded['error']['message'] ?? "HTTP {$code}";
+			return new WP_Error( 'gsc_api_error', $message );
+		}
 
-        return json_decode( wp_remote_retrieve_body( $response ), true ) ?: [];
-    }
+		return json_decode( wp_remote_retrieve_body( $response ), true ) ?: array();
+	}
 
-    /**
-     * Fetch search analytics from GSC API.
-     *
-     * @param string $property   Site URL.
-     * @param string $start_date Start date (Y-m-d).
-     * @param string $end_date   End date (Y-m-d).
-     * @param array  $dimensions Dimensions to group by.
-     * @return array Rows of analytics data.
-     */
-    private function fetch_analytics( string $property, string $start_date, string $end_date, array $dimensions ): array {
-        $encoded_property = rawurlencode( $property );
+	/**
+	 * Fetch search analytics from GSC API.
+	 *
+	 * @param string $property   Site URL.
+	 * @param string $start_date Start date (Y-m-d).
+	 * @param string $end_date   End date (Y-m-d).
+	 * @param array  $dimensions Dimensions to group by.
+	 * @return array Rows of analytics data.
+	 */
+	private function fetch_analytics( string $property, string $start_date, string $end_date, array $dimensions ): array {
+		$encoded_property = rawurlencode( $property );
 
-        $response = $this->api_request(
-            "/sites/{$encoded_property}/searchAnalytics/query",
-            'POST',
-            [
-                'startDate'  => $start_date,
-                'endDate'    => $end_date,
-                'dimensions' => $dimensions,
-                'rowLimit'   => 100,
-            ]
-        );
+		$response = $this->api_request(
+			"/sites/{$encoded_property}/searchAnalytics/query",
+			'POST',
+			array(
+				'startDate'  => $start_date,
+				'endDate'    => $end_date,
+				'dimensions' => $dimensions,
+				'rowLimit'   => 100,
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return [];
-        }
+		if ( is_wp_error( $response ) ) {
+			return array();
+		}
 
-        return $response['rows'] ?? [];
-    }
+		return $response['rows'] ?? array();
+	}
 }

--- a/includes/class-seo-audit.php
+++ b/includes/class-seo-audit.php
@@ -18,7 +18,7 @@ class SWPS_SEO_Audit {
 	/**
 	 * Default weights per module ID for overall score.
 	 */
-	private const WEIGHTS = [
+	private const WEIGHTS = array(
 		'canonical'   => 15,
 		'sitemap'     => 15,
 		'opengraph'   => 12,
@@ -27,15 +27,15 @@ class SWPS_SEO_Audit {
 		'meta_robots' => 15,
 		'image_seo'   => 15,
 		'pagespeed'   => 10,
-	];
+	);
 
 	/** @var SWPS_Audit_Module[] */
-	private array $modules = [];
+	private array $modules = array();
 
 	public function __construct() {
-		add_action( 'init', [ $this, 'register_default_modules' ], 20 );
-		add_action( self::CRON_HOOK, [ $this, 'run_all' ] );
-		add_filter( 'cron_schedules', [ $this, 'register_custom_schedules' ] );
+		add_action( 'init', array( $this, 'register_default_modules' ), 20 );
+		add_action( self::CRON_HOOK, array( $this, 'run_all' ) );
+		add_filter( 'cron_schedules', array( $this, 'register_custom_schedules' ) );
 	}
 
 	/**
@@ -43,10 +43,10 @@ class SWPS_SEO_Audit {
 	 */
 	public function register_custom_schedules( array $schedules ): array {
 		if ( ! isset( $schedules['swps_monthly'] ) ) {
-			$schedules['swps_monthly'] = [
+			$schedules['swps_monthly'] = array(
 				'interval' => 30 * DAY_IN_SECONDS,
 				'display'  => __( 'Monthly', 'stratawp-seo' ),
-			];
+			);
 		}
 		return $schedules;
 	}
@@ -55,7 +55,7 @@ class SWPS_SEO_Audit {
 	 * Register the 8 built-in audit modules.
 	 */
 	public function register_default_modules(): void {
-		$defaults = [
+		$defaults = array(
 			new SWPS_Canonical_Module(),
 			new SWPS_Sitemap_Module(),
 			new SWPS_OpenGraph_Module(),
@@ -64,7 +64,7 @@ class SWPS_SEO_Audit {
 			new SWPS_Meta_Robots_Module(),
 			new SWPS_Image_SEO_Module(),
 			new SWPS_PageSpeed_Module(),
-		];
+		);
 
 		foreach ( $defaults as $module ) {
 			$this->modules[ $module->get_id() ] = $module;
@@ -84,19 +84,19 @@ class SWPS_SEO_Audit {
 	 * @return array { @type int $overall_score, @type array $modules keyed by ID }
 	 */
 	public function run_all(): array {
-		$results = [];
+		$results = array();
 
 		foreach ( $this->modules as $id => $module ) {
-			$result          = $module->run();
-			$results[ $id ]  = apply_filters( 'swps_audit_result', $result, $id );
+			$result         = $module->run();
+			$results[ $id ] = apply_filters( 'swps_audit_result', $result, $id );
 		}
 
 		$overall = $this->calculate_overall_score( $results );
 
-		$data = [
+		$data = array(
 			'overall_score' => $overall,
 			'modules'       => $results,
-		];
+		);
 
 		update_option( self::RESULTS_OPTION, $data, false );
 		update_option( self::LAST_RUN_OPTION, current_time( 'mysql' ), false );
@@ -121,7 +121,7 @@ class SWPS_SEO_Audit {
 		$result = apply_filters( 'swps_audit_result', $result, $id );
 
 		// Update the cached results for this module.
-		$cached                    = $this->get_cached_results();
+		$cached                   = $this->get_cached_results();
 		$cached['modules'][ $id ] = $result;
 		$cached['overall_score']  = $this->calculate_overall_score( $cached['modules'] );
 
@@ -142,7 +142,7 @@ class SWPS_SEO_Audit {
 		}
 
 		$cached = $this->get_cached_results();
-		$issues = $cached['modules'][ $id ]['issues'] ?? [];
+		$issues = $cached['modules'][ $id ]['issues'] ?? array();
 
 		$fix_result = $this->modules[ $id ]->auto_fix( $issues );
 
@@ -158,10 +158,13 @@ class SWPS_SEO_Audit {
 	 * @return array { @type int $overall_score, @type array $modules }
 	 */
 	public function get_cached_results(): array {
-		return get_option( self::RESULTS_OPTION, [
-			'overall_score' => 0,
-			'modules'       => [],
-		] );
+		return get_option(
+			self::RESULTS_OPTION,
+			array(
+				'overall_score' => 0,
+				'modules'       => array(),
+			)
+		);
 	}
 
 	/**
@@ -213,11 +216,11 @@ class SWPS_SEO_Audit {
 
 		$schedule = get_option( 'swps_audit_cron_schedule', 'weekly' );
 
-		$recurrence_map = [
+		$recurrence_map = array(
 			'daily'   => 'daily',
 			'weekly'  => 'weekly',
 			'monthly' => 'swps_monthly',
-		];
+		);
 
 		$recurrence = $recurrence_map[ $schedule ] ?? 'weekly';
 		$next_run   = time() + DAY_IN_SECONDS; // Start tomorrow.

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -6,1130 +6,1567 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Settings {
 
-    public function __construct() {
-        add_action( 'admin_menu', [ $this, 'register_menu' ] );
-        add_action( 'admin_init', [ $this, 'register_settings' ] );
-        add_action( 'admin_notices', [ $this, 'admin_notices' ] );
-    }
-
-    /**
-     * Register admin menu pages.
-     *
-     * v4.0: SWPS_Dashboard now owns the top-level menu (registered at
-     * admin_menu priority 5). Settings registers itself as a submenu with
-     * the new slug 'swps-settings' so /admin.php?page=stratawp-seo lands
-     * on the Dashboard, not Settings. Old bookmarks to ?page=stratawp-seo
-     * continue to resolve — they show Dashboard.
-     */
-    public function register_menu(): void {
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Settings', 'stratawp-seo' ),
-            __( 'Settings', 'stratawp-seo' ),
-            'manage_options',
-            'swps-settings',
-            [ $this, 'render_settings_page' ]
-        );
-
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Generate Content', 'stratawp-seo' ),
-            __( 'Generate Content', 'stratawp-seo' ),
-            'edit_posts',
-            'swps-generate',
-            [ $this, 'render_generate_page' ]
-        );
-
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Voice Profiles', 'stratawp-seo' ),
-            __( 'Voice Profiles', 'stratawp-seo' ),
-            'manage_options',
-            'swps-voice-profiles',
-            [ $this, 'render_voice_profiles_page' ]
-        );
-
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'SEO Audit', 'stratawp-seo' ),
-            __( 'SEO Audit', 'stratawp-seo' ),
-            'manage_options',
-            'swps-seo-audit',
-            [ $this, 'render_audit_page' ]
-        );
-
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Search Appearance', 'stratawp-seo' ),
-            __( 'Search Appearance', 'stratawp-seo' ),
-            'manage_options',
-            'swps-search-appearance',
-            [ $this, 'render_search_appearance_page' ]
-        );
-
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Redirects', 'stratawp-seo' ),
-            __( 'Redirects', 'stratawp-seo' ),
-            'manage_options',
-            'swps-redirects',
-            [ SWPS_Redirect_Admin::class, 'render' ]
-        );
-
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Migrate from Yoast / Rank Math', 'stratawp-seo' ),
-            __( 'Migrate', 'stratawp-seo' ),
-            'manage_options',
-            'swps-migration',
-            [ $this, 'render_migration_page' ]
-        );
-
-        add_submenu_page(
-            'stratawp-seo',
-            __( 'Debug — Last AI Failure', 'stratawp-seo' ),
-            __( 'Debug', 'stratawp-seo' ),
-            'manage_options',
-            'swps-debug',
-            [ $this, 'render_debug_page' ]
-        );
-    }
-
-    /**
-     * Render the migration tool page.
-     */
-    public function render_migration_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have permission to view this page.', 'stratawp-seo' ) );
-        }
-        include SWPS_PLUGIN_DIR . 'templates/migration-page.php';
-    }
-
-    /**
-     * Render the debug page showing the last failed AI response.
-     */
-    public function render_debug_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_die( esc_html__( 'You do not have permission to view this page.', 'stratawp-seo' ) );
-        }
-
-        if ( isset( $_POST['swps_clear_failure'] ) && check_admin_referer( 'swps_clear_failure' ) ) {
-            delete_transient( 'swps_last_ai_failure' );
-            echo '<div class="notice notice-success"><p>' . esc_html__( 'Cleared.', 'stratawp-seo' ) . '</p></div>';
-        }
-
-        $failure = get_transient( 'swps_last_ai_failure' );
-
-        echo '<div class="wrap swps-debug-wrap">';
-
-        $title    = __( 'Debug', 'stratawp-seo' );
-        $subtitle = __( 'Last failed AI response captured by the JSON parser. Use this to diagnose generation errors.', 'stratawp-seo' );
-        $actions  = [];
-        require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-
-        if ( empty( $failure ) ) {
-            echo '<div class="swps-tile" style="text-align:center;padding:48px 24px">';
-            echo '<div style="font-size:48px;line-height:1;margin-bottom:16px;color:var(--swps-success)">✓</div>';
-            echo '<p style="color:var(--swps-text-muted);margin:0">' . esc_html__( 'No recent failures.', 'stratawp-seo' ) . '</p>';
-            echo '</div></div>';
-            return;
-        }
-
-        echo '<div class="swps-tile">';
-        echo '<table style="width:100%;border-collapse:collapse">';
-        echo '<tr><td style="padding:6px 0;color:var(--swps-text-muted);font-size:12px;width:80px">' . esc_html__( 'Time', 'stratawp-seo' ) . '</td><td style="padding:6px 0;color:var(--swps-text-primary)">' . esc_html( $failure['time'] ?? '' ) . '</td></tr>';
-        echo '<tr><td style="padding:6px 0;color:var(--swps-text-muted);font-size:12px">' . esc_html__( 'Error', 'stratawp-seo' ) . '</td><td style="padding:6px 0;color:var(--swps-crit)">' . esc_html( $failure['error'] ?? '' ) . '</td></tr>';
-        echo '<tr><td style="padding:6px 0;color:var(--swps-text-muted);font-size:12px">' . esc_html__( 'Length', 'stratawp-seo' ) . '</td><td style="padding:6px 0;color:var(--swps-text-primary)">' . esc_html( number_format( strlen( (string) ( $failure['raw'] ?? '' ) ) ) ) . ' ' . esc_html__( 'chars', 'stratawp-seo' ) . '</td></tr>';
-        echo '</table>';
-
-        echo '<form method="post" style="margin: 16px 0 0;">';
-        wp_nonce_field( 'swps_clear_failure' );
-        echo '<button type="submit" name="swps_clear_failure" class="swps-btn swps-btn-secondary">' . esc_html__( 'Clear', 'stratawp-seo' ) . '</button>';
-        echo '</form>';
-        echo '</div>';
-
-        echo '<div class="swps-section-h" style="margin-top:24px"><h3>' . esc_html__( 'Raw response', 'stratawp-seo' ) . '</h3></div>';
-        echo '<textarea readonly rows="24" style="width:100%;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;background:var(--swps-bg-input);color:var(--swps-text-body);border:1px solid var(--swps-border-strong);border-radius:var(--swps-radius-sm);padding:14px;line-height:1.5">' . esc_textarea( (string) ( $failure['raw'] ?? '' ) ) . '</textarea>';
-
-        echo '</div>';
-    }
-
-    /**
-     * Register all settings.
-     */
-    public function register_settings(): void {
-        // --- AI Provider Section ---
-        add_settings_section( 'swps_ai_section', __( 'AI Provider', 'stratawp-seo' ), [ $this, 'render_ai_section' ], 'stratawp-seo' );
-
-        $this->add_field( 'ai_provider', __( 'AI Provider', 'stratawp-seo' ), 'select', 'swps_ai_section', [
-            'options' => SWPS_Provider_Factory::get_ai_provider_options(),
-        ] );
-
-        $this->add_field( 'anthropic_api_key', __( 'Anthropic API Key', 'stratawp-seo' ), 'password', 'swps_ai_section', [
-            'description' => __( 'Get your API key from <a href="https://console.anthropic.com/" target="_blank">console.anthropic.com</a>', 'stratawp-seo' ),
-            'row_class'   => 'swps-ai-key-row swps-provider-anthropic',
-        ] );
-
-        $this->add_field( 'openai_api_key', __( 'OpenAI API Key', 'stratawp-seo' ), 'password', 'swps_ai_section', [
-            'description' => __( 'Get your API key from <a href="https://platform.openai.com/api-keys" target="_blank">platform.openai.com</a>', 'stratawp-seo' ),
-            'row_class'   => 'swps-ai-key-row swps-provider-openai',
-        ] );
-
-        $this->add_field( 'google_api_key', __( 'Google API Key', 'stratawp-seo' ), 'password', 'swps_ai_section', [
-            'description' => __( 'Get your API key from <a href="https://aistudio.google.com/apikey" target="_blank">Google AI Studio</a>', 'stratawp-seo' ),
-            'row_class'   => 'swps-ai-key-row swps-provider-google',
-        ] );
-
-        $this->add_field( 'xai_api_key', __( 'xAI API Key', 'stratawp-seo' ), 'password', 'swps_ai_section', [
-            'description' => __( 'Get your API key from <a href="https://console.x.ai/" target="_blank">console.x.ai</a>', 'stratawp-seo' ),
-            'row_class'   => 'swps-ai-key-row swps-provider-xai',
-        ] );
-
-        $this->add_field( 'model', __( 'AI Model', 'stratawp-seo' ), 'select', 'swps_ai_section', [
-            'options'     => $this->get_current_model_options(),
-            'description' => __( 'Model list updates automatically when you change providers.', 'stratawp-seo' ),
-        ] );
-
-        // --- Featured Images Section ---
-        add_settings_section( 'swps_images_section', __( 'Featured Images', 'stratawp-seo' ), [ $this, 'render_images_section' ], 'stratawp-seo' );
-
-        $this->add_field( 'featured_images', __( 'Auto Featured Images', 'stratawp-seo' ), 'checkbox', 'swps_images_section', [
-            'label' => __( 'Automatically fetch a relevant featured image for each generated post', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'image_provider', __( 'Image Provider', 'stratawp-seo' ), 'select', 'swps_images_section', [
-            'options' => SWPS_Provider_Factory::get_image_provider_options(),
-        ] );
-
-        $this->add_field( 'unsplash_api_key', __( 'Unsplash API Key', 'stratawp-seo' ), 'password', 'swps_images_section', [
-            'description' => __( 'Get a free API key from <a href="https://unsplash.com/developers" target="_blank">unsplash.com/developers</a>', 'stratawp-seo' ),
-            'row_class'   => 'swps-image-key-row swps-image-provider-unsplash',
-        ] );
-
-        $this->add_field( 'pexels_api_key', __( 'Pexels API Key', 'stratawp-seo' ), 'password', 'swps_images_section', [
-            'description' => __( 'Get a free API key from <a href="https://www.pexels.com/api/" target="_blank">pexels.com/api</a>', 'stratawp-seo' ),
-            'row_class'   => 'swps-image-key-row swps-image-provider-pexels',
-        ] );
-
-        $this->add_field( 'pixabay_api_key', __( 'Pixabay API Key', 'stratawp-seo' ), 'password', 'swps_images_section', [
-            'description' => __( 'Get a free API key from <a href="https://pixabay.com/api/docs/" target="_blank">pixabay.com/api</a>', 'stratawp-seo' ),
-            'row_class'   => 'swps-image-key-row swps-image-provider-pixabay',
-        ] );
-
-        // Note: Gemini image generation reuses the Google API key from the AI Provider
-        // section above. We intentionally do NOT register another input for
-        // `swps_google_api_key` here — duplicate inputs with the same name cause the
-        // hidden row's empty value to clobber the visible row's value on save (see #24).
-        add_settings_field(
-            'swps_gemini_image_key_info',
-            __( 'Google API Key', 'stratawp-seo' ),
-            function () {
-                echo '<p class="description">' . wp_kses_post( __( 'Gemini image generation uses the Google API Key set in the <strong>AI Provider</strong> section above.', 'stratawp-seo' ) ) . '</p>';
-            },
-            'stratawp-seo',
-            'swps_images_section',
-            [ 'class' => 'swps-image-key-row swps-image-provider-gemini' ]
-        );
-
-        $this->add_field( 'insert_content_images', __( 'In-Content Images', 'stratawp-seo' ), 'checkbox', 'swps_images_section', [
-            'label' => __( 'Insert contextual images within the post body (in addition to featured image)', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'content_images_count', __( 'Images Per Post', 'stratawp-seo' ), 'number', 'swps_images_section', [
-            'min'         => 1,
-            'max'         => 4,
-            'description' => __( 'Maximum number of in-content images to insert (1-4).', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'image_max_width', __( 'Image Max Width', 'stratawp-seo' ), 'number', 'swps_images_section', [
-            'min'         => 600,
-            'max'         => 2400,
-            'step'        => 100,
-            'description' => __( 'Maximum width in pixels for content images.', 'stratawp-seo' ),
-        ] );
-
-        // --- Site Details Section ---
-        add_settings_section( 'swps_site_section', __( 'Site Details', 'stratawp-seo' ), [ $this, 'render_site_section' ], 'stratawp-seo' );
-
-        $this->add_field( 'site_niche', __( 'Site Niche / Industry', 'stratawp-seo' ), 'text', 'swps_site_section', [
-            'placeholder'  => 'e.g., Home Renovation, Digital Marketing, Pet Care',
-            'description'  => __( 'What is your site about? Be specific.', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'site_description', __( 'Site Description', 'stratawp-seo' ), 'textarea', 'swps_site_section', [
-            'placeholder'  => 'Describe your site, target audience, and what makes it unique...',
-            'description'  => __( 'Give the AI context about your site and audience. The more detail, the better the content.', 'stratawp-seo' ),
-            'rows'         => 4,
-        ] );
-
-        // --- AI Crawlers Section ---
-        add_settings_section( 'swps_ai_crawlers_section', __( 'AI Crawlers', 'stratawp-seo' ), [ $this, 'render_ai_crawlers_section' ], 'stratawp-seo' );
-
-        $bot_options = [];
-        foreach ( SWPS_AI_Bots::KNOWN_BOTS as $key => $token ) {
-            $bot_options[ $key ] = $token;
-        }
-        $this->add_field( 'ai_bots_allowed', __( 'Allowed AI Bots', 'stratawp-seo' ), 'multi_checkbox', 'swps_ai_crawlers_section', [
-            'options'     => $bot_options,
-            'default'     => array_keys( $bot_options ),
-            'description' => __( 'Allowed bots get an explicit Allow rule in robots.txt; unchecked known bots get a Disallow. View the result at <code>/robots.txt</code>.', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'llms_txt_enabled', __( 'Generate llms.txt', 'stratawp-seo' ), 'checkbox', 'swps_ai_crawlers_section', [
-            'default'     => 1,
-            'label'       => __( 'Serve a dynamic llms.txt at /llms.txt', 'stratawp-seo' ),
-            'description' => sprintf(
-                /* translators: %s: link to /llms.txt */
-                __( 'Built from your site description and most recent posts (with one-line summaries). Overrides Yoast or other plugin output. <a href="%s" target="_blank">View live</a>.', 'stratawp-seo' ),
-                esc_url( home_url( '/llms.txt' ) )
-            ),
-        ] );
-
-        // --- Writing Preferences Section ---
-        add_settings_section( 'swps_writing_section', __( 'Writing Preferences', 'stratawp-seo' ), [ $this, 'render_writing_section' ], 'stratawp-seo' );
-
-        $this->add_field( 'tone', __( 'Tone of Voice', 'stratawp-seo' ), 'select', 'swps_writing_section', [
-            'options' => [
-                'professional'    => __( 'Professional', 'stratawp-seo' ),
-                'conversational'  => __( 'Conversational', 'stratawp-seo' ),
-                'friendly'        => __( 'Friendly & Approachable', 'stratawp-seo' ),
-                'authoritative'   => __( 'Authoritative & Expert', 'stratawp-seo' ),
-                'casual'          => __( 'Casual & Relaxed', 'stratawp-seo' ),
-                'formal'          => __( 'Formal & Academic', 'stratawp-seo' ),
-                'witty'           => __( 'Witty & Entertaining', 'stratawp-seo' ),
-            ],
-        ] );
-
-        $this->add_field( 'voice_profile', __( 'Voice Profile', 'stratawp-seo' ), 'select', 'swps_writing_section', [
-            'options'     => stratawp_seo()->voice_profile->get_options(),
-            'description' => __( 'Select a voice profile to override tone/style settings. <a href="' . admin_url( 'admin.php?page=swps-voice-profiles' ) . '">Manage profiles</a>', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'writing_style', __( 'Custom Style Notes', 'stratawp-seo' ), 'textarea', 'swps_writing_section', [
-            'placeholder' => 'e.g., Use short paragraphs, include real-world examples, avoid jargon, write for beginners...',
-            'description' => __( 'Any specific instructions about how content should be written.', 'stratawp-seo' ),
-            'rows'        => 3,
-        ] );
-
-        $this->add_field( 'target_keywords', __( 'Target Keywords', 'stratawp-seo' ), 'textarea', 'swps_writing_section', [
-            'placeholder' => 'kitchen remodeling tips, bathroom renovation cost, home improvement ideas',
-            'description' => __( 'Comma-separated list of keywords you want to target across your content.', 'stratawp-seo' ),
-            'rows'        => 3,
-        ] );
-
-        // --- Content Settings Section ---
-        add_settings_section( 'swps_content_section', __( 'Content Settings', 'stratawp-seo' ), [ $this, 'render_content_section' ], 'stratawp-seo' );
-
-        $this->add_field( 'post_status', __( 'Default Post Status', 'stratawp-seo' ), 'select', 'swps_content_section', [
-            'options' => [
-                'draft'   => __( 'Draft (review before publishing)', 'stratawp-seo' ),
-                'pending' => __( 'Pending Review', 'stratawp-seo' ),
-                'publish' => __( 'Published (use with caution)', 'stratawp-seo' ),
-            ],
-        ] );
-
-        $this->add_field( 'post_author', __( 'Post Author', 'stratawp-seo' ), 'author_select', 'swps_content_section' );
-
-        $this->add_field( 'post_category', __( 'Default Category', 'stratawp-seo' ), 'category_select', 'swps_content_section', [
-            'description' => __( 'Default category. The AI may also suggest a better category per post.', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'word_count_min', __( 'Minimum Word Count', 'stratawp-seo' ), 'number', 'swps_content_section', [
-            'min' => 300, 'max' => 5000, 'step' => 100,
-        ] );
-
-        $this->add_field( 'word_count_max', __( 'Maximum Word Count', 'stratawp-seo' ), 'number', 'swps_content_section', [
-            'min' => 500, 'max' => 8000, 'step' => 100,
-        ] );
-
-        $this->add_field( 'internal_links_min', __( 'Min Internal Links', 'stratawp-seo' ), 'number', 'swps_content_section', [
-            'min' => 0, 'max' => 20,
-        ] );
-
-        $this->add_field( 'internal_links_max', __( 'Max Internal Links', 'stratawp-seo' ), 'number', 'swps_content_section', [
-            'min' => 1, 'max' => 30,
-        ] );
-
-        $this->add_field( 'include_faq_schema', __( 'Include FAQ Section + Schema', 'stratawp-seo' ), 'checkbox', 'swps_content_section', [
-            'label' => __( 'Add a FAQ section with structured data (great for rich snippets)', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'include_toc', __( 'Include Table of Contents', 'stratawp-seo' ), 'checkbox', 'swps_content_section', [
-            'label' => __( 'Add a linked table of contents at the top of each post', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'include_takeaways', __( 'Include Key Takeaways', 'stratawp-seo' ), 'checkbox', 'swps_content_section', [
-            'label' => __( 'Add a key takeaways section after the intro (concise bullet points summarizing the post)', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'takeaways_count', __( 'Takeaway Count', 'stratawp-seo' ), 'number', 'swps_content_section', [
-            'min'         => 3,
-            'max'         => 7,
-            'description' => __( 'Number of key takeaway bullet points to generate (3-7).', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'takeaways_schema', __( 'Takeaways Schema Markup', 'stratawp-seo' ), 'checkbox', 'swps_content_section', [
-            'label' => __( 'Output ItemList JSON-LD structured data for key takeaways (for rich snippets)', 'stratawp-seo' ),
-        ] );
-
-        // --- Schedule Section ---
-        add_settings_section( 'swps_schedule_section', __( 'Auto-Publishing Schedule', 'stratawp-seo' ), [ $this, 'render_schedule_section' ], 'stratawp-seo' );
-
-        $this->add_field( 'cron_enabled', __( 'Enable Scheduled Generation', 'stratawp-seo' ), 'checkbox', 'swps_schedule_section', [
-            'label' => __( 'Automatically generate posts on a schedule', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'cron_frequency', __( 'Frequency', 'stratawp-seo' ), 'select', 'swps_schedule_section', [
-            'options' => [
-                'daily'        => __( 'Daily', 'stratawp-seo' ),
-                'twice_weekly' => __( 'Twice a Week', 'stratawp-seo' ),
-                'three_weekly' => __( 'Three Times a Week', 'stratawp-seo' ),
-                'weekly'       => __( 'Weekly', 'stratawp-seo' ),
-                'biweekly'     => __( 'Every Two Weeks', 'stratawp-seo' ),
-                'monthly'      => __( 'Monthly', 'stratawp-seo' ),
-            ],
-        ] );
-
-        $this->add_field( 'cron_day', __( 'Day of Week', 'stratawp-seo' ), 'select', 'swps_schedule_section', [
-            'options' => [
-                'monday'    => __( 'Monday', 'stratawp-seo' ),
-                'tuesday'   => __( 'Tuesday', 'stratawp-seo' ),
-                'wednesday' => __( 'Wednesday', 'stratawp-seo' ),
-                'thursday'  => __( 'Thursday', 'stratawp-seo' ),
-                'friday'    => __( 'Friday', 'stratawp-seo' ),
-                'saturday'  => __( 'Saturday', 'stratawp-seo' ),
-                'sunday'    => __( 'Sunday', 'stratawp-seo' ),
-            ],
-            'description' => __( 'Starting day for the schedule.', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'cron_time', __( 'Time', 'stratawp-seo' ), 'time', 'swps_schedule_section' );
-
-        $this->add_field( 'cron_posts_per_run', __( 'Posts Per Run', 'stratawp-seo' ), 'number', 'swps_schedule_section', [
-            'min'         => 1,
-            'max'         => 5,
-            'description' => __( 'Number of posts to generate each time (max 5).', 'stratawp-seo' ),
-        ] );
-
-        // --- SEO Audit Section ---
-        add_settings_section( 'swps_audit_section', __( 'SEO Audit', 'stratawp-seo' ), [ $this, 'render_audit_section' ], 'stratawp-seo' );
-
-        $this->add_field( 'audit_auto_canonical', __( 'Auto Canonical Tags', 'stratawp-seo' ), 'checkbox', 'swps_audit_section', [
-            'label' => __( 'Automatically add canonical tags to posts/pages missing them', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'audit_auto_og', __( 'Auto OG/Twitter Tags', 'stratawp-seo' ), 'checkbox', 'swps_audit_section', [
-            'label' => __( 'Automatically output Open Graph and Twitter Card meta tags', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'audit_auto_sitemap', __( 'Sitemap Generation', 'stratawp-seo' ), 'checkbox', 'swps_audit_section', [
-            'label' => __( 'Generate XML sitemap (only when no other sitemap plugin is active)', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'audit_cron_schedule', __( 'Audit Schedule', 'stratawp-seo' ), 'select', 'swps_audit_section', [
-            'options' => [
-                'daily'   => __( 'Daily', 'stratawp-seo' ),
-                'weekly'  => __( 'Weekly', 'stratawp-seo' ),
-                'monthly' => __( 'Monthly', 'stratawp-seo' ),
-            ],
-            'description' => __( 'How often to run the automated SEO audit.', 'stratawp-seo' ),
-        ] );
-
-        // --- Schema / Structured Data Section ---
-        add_settings_section( 'swps_schema_section', __( 'Schema / Structured Data', 'stratawp-seo' ), [ $this, 'render_schema_section' ], 'stratawp-seo' );
-
-        $this->add_field( 'schema_enabled', __( 'Enable Schema Markup', 'stratawp-seo' ), 'checkbox', 'swps_schema_section', [
-            'label' => __( 'Output JSON-LD structured data on all posts and pages (auto-disabled when Yoast, RankMath, or AIOSEO is active)', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'schema_article_type', __( 'Article Type', 'stratawp-seo' ), 'select', 'swps_schema_section', [
-            'options' => [
-                'Article'      => __( 'Article', 'stratawp-seo' ),
-                'BlogPosting'  => __( 'BlogPosting', 'stratawp-seo' ),
-                'NewsArticle'  => __( 'NewsArticle', 'stratawp-seo' ),
-            ],
-            'description' => __( 'Schema type for blog posts. Most sites should use Article.', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'schema_searchbox', __( 'Sitelinks Searchbox', 'stratawp-seo' ), 'checkbox', 'swps_schema_section', [
-            'label' => __( 'Add SearchAction to enable Google sitelinks search box on your homepage', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'schema_entity_type', __( 'Site Represents', 'stratawp-seo' ), 'select', 'swps_schema_section', [
-            'options' => [
-                'Organization' => __( 'Organization', 'stratawp-seo' ),
-                'Person'       => __( 'Person', 'stratawp-seo' ),
-            ],
-            'description' => __( 'Does this website represent an organization or an individual?', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'schema_name', __( 'Name', 'stratawp-seo' ), 'text', 'swps_schema_section', [
-            'placeholder' => get_bloginfo( 'name' ),
-            'description' => __( 'Organization or person name. Leave blank to use your site name.', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'schema_logo', __( 'Logo URL', 'stratawp-seo' ), 'text', 'swps_schema_section', [
-            'placeholder' => 'https://example.com/logo.png',
-            'description' => __( 'Full URL to your logo image (minimum 112x112px). Used for Organization schema and Article publisher.', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'schema_social_profiles', __( 'Social Profiles', 'stratawp-seo' ), 'textarea', 'swps_schema_section', [
-            'rows'        => 4,
-            'placeholder' => "https://facebook.com/yourpage\nhttps://twitter.com/yourhandle\nhttps://linkedin.com/company/yourcompany",
-            'description' => __( 'One social profile URL per line. Populates the sameAs property.', 'stratawp-seo' ),
-        ] );
-
-        // --- SEO Meta Section ---
-        add_settings_section( 'swps_meta_section', __( 'SEO Meta', 'stratawp-seo' ), [ $this, 'render_meta_section' ], 'stratawp-seo' );
-
-        $this->add_field( 'meta_editor_enabled', __( 'Enable Meta Editor', 'stratawp-seo' ), 'checkbox', 'swps_meta_section', [
-            'label' => __( 'Show SEO meta fields (title, description, social, robots) on post and page editors', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'meta_editor_post_types', __( 'Post Types', 'stratawp-seo' ), 'text', 'swps_meta_section', [
-            'placeholder' => 'post,page',
-            'description' => __( 'Comma-separated post types to show the meta editor on. Default: post,page', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'meta_auto_generate', __( 'Auto-Generate Meta', 'stratawp-seo' ), 'checkbox', 'swps_meta_section', [
-            'label' => __( 'Automatically generate meta title and description via AI when publishing a post without them', 'stratawp-seo' ),
-        ] );
-
-        // --- Analytics Section ---
-        add_settings_section( 'swps_analytics_section', __( 'Analytics', 'stratawp-seo' ), [ $this, 'render_analytics_section' ], 'stratawp-seo' );
-
-        $this->add_field( 'analytics_enabled', __( 'Enable On-Site Tracking', 'stratawp-seo' ), 'checkbox', 'swps_analytics_section', [
-            'label' => __( 'Track page views, time on page, scroll depth, and bounce rate (cookie-free, GDPR-friendly)', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'analytics_retention', __( 'Data Retention', 'stratawp-seo' ), 'select', 'swps_analytics_section', [
-            'options' => [
-                '30'  => __( '30 days', 'stratawp-seo' ),
-                '90'  => __( '90 days', 'stratawp-seo' ),
-                '180' => __( '180 days', 'stratawp-seo' ),
-                '365' => __( '365 days', 'stratawp-seo' ),
-            ],
-            'description' => __( 'How long to keep analytics data. Older data is automatically pruned.', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'analytics_exclude_admins', __( 'Exclude Admins', 'stratawp-seo' ), 'checkbox', 'swps_analytics_section', [
-            'label' => __( 'Don\'t track visits from logged-in administrators', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'gsc_client_id', __( 'Google OAuth Client ID', 'stratawp-seo' ), 'text', 'swps_analytics_section', [
-            'placeholder' => 'xxxx.apps.googleusercontent.com',
-            'description' => __( 'Create OAuth credentials in your <a href="https://console.cloud.google.com/apis/credentials" target="_blank">Google Cloud Console</a>. Set the redirect URI to: <code>' . admin_url( 'admin.php?swps_gsc_callback=1' ) . '</code>', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'gsc_client_secret', __( 'Google OAuth Client Secret', 'stratawp-seo' ), 'password', 'swps_analytics_section', [
-            'description' => __( 'Stored encrypted. After saving, connect via the Analytics page.', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'keyword_tracking_frequency', __( 'Keyword Sync Frequency', 'stratawp-seo' ), 'select', 'swps_analytics_section', [
-            'options' => [
-                'daily'   => __( 'Daily', 'stratawp-seo' ),
-                'weekly'  => __( 'Weekly', 'stratawp-seo' ),
-                'monthly' => __( 'Monthly', 'stratawp-seo' ),
-            ],
-            'description' => __( 'How often to sync tracked keyword positions from Google Search Console.', 'stratawp-seo' ),
-        ] );
-
-        // --- Advanced Section (v2.0) ---
-        add_settings_section( 'swps_advanced_section', __( 'Advanced Settings', 'stratawp-seo' ), [ $this, 'render_advanced_section' ], 'stratawp-seo' );
-
-        $this->add_field( 'default_template', __( 'Default Content Template', 'stratawp-seo' ), 'select', 'swps_advanced_section', [
-            'options'     => SWPS_Templates::get_options(),
-            'description' => __( 'Default template for generated content. Can be overridden per generation.', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'rate_limit', __( 'Rate Limit Cooldown', 'stratawp-seo' ), 'number', 'swps_advanced_section', [
-            'min'         => 0,
-            'max'         => 600,
-            'description' => __( 'Seconds to wait between generations (prevents accidental double-clicks). 0 to disable.', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'duplicate_check', __( 'Duplicate Detection', 'stratawp-seo' ), 'checkbox', 'swps_advanced_section', [
-            'label' => __( 'Check for duplicate titles before creating posts (85% similarity threshold)', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'cost_tracking', __( 'Cost Tracking', 'stratawp-seo' ), 'checkbox', 'swps_advanced_section', [
-            'label' => __( 'Track token usage and estimated costs per generation', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'min_content_score', __( 'Minimum Content Score', 'stratawp-seo' ), 'number', 'swps_advanced_section', [
-            'min'         => 0,
-            'max'         => 100,
-            'description' => __( 'Posts scoring below this threshold are saved as drafts. Set to 0 to disable.', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'jon_ai_endpoint', __( 'Remote Content Endpoint', 'stratawp-seo' ), 'text', 'swps_advanced_section', [
-            'placeholder' => 'https://example.com/wp-json/jon-ai/v1/create-posts',
-            'description' => __( 'Optional: Remote endpoint for duplicate checking against an external site.', 'stratawp-seo' ),
-        ] );
-
-        $this->add_field( 'jon_ai_secret', __( 'Remote Content Secret', 'stratawp-seo' ), 'password', 'swps_advanced_section', [
-            'description' => __( 'Authentication secret for the remote content endpoint. Stored encrypted.', 'stratawp-seo' ),
-        ] );
-
-        // --- Head Cleanup Section ---
-        add_settings_section( 'swps_cleanup_section', __( 'Head Cleanup', 'stratawp-seo' ), [ $this, 'render_cleanup_section' ], 'stratawp-seo' );
-
-        $cleanup_fields = [
-            'cleanup_generator' => __( 'Remove WP Generator Tag', 'stratawp-seo' ),
-            'cleanup_rsd'       => __( 'Remove RSD/EditURI Link', 'stratawp-seo' ),
-            'cleanup_wlw'       => __( 'Remove Windows Live Writer Link', 'stratawp-seo' ),
-            'cleanup_shortlink' => __( 'Remove Shortlink', 'stratawp-seo' ),
-            'cleanup_rest_api'  => __( 'Remove REST API Link', 'stratawp-seo' ),
-            'cleanup_oembed'    => __( 'Remove oEmbed Discovery', 'stratawp-seo' ),
-            'cleanup_emoji'     => __( 'Remove Emoji Scripts & Styles', 'stratawp-seo' ),
-        ];
-
-        foreach ( $cleanup_fields as $key => $label ) {
-            $this->add_field( $key, $label, 'checkbox', 'swps_cleanup_section' );
-        }
-
-        // --- RSS Optimization Section ---
-        add_settings_section( 'swps_rss_section', __( 'RSS Feed', 'stratawp-seo' ), [ $this, 'render_rss_section' ], 'stratawp-seo' );
-
-        $this->add_field( 'rss_before', __( 'Content Before Post in RSS', 'stratawp-seo' ), 'textarea', 'swps_rss_section' );
-        $this->add_field( 'rss_after', __( 'Content After Post in RSS', 'stratawp-seo' ), 'textarea', 'swps_rss_section' );
-
-        // --- Search Appearance Settings (separate options group) ---
-        register_setting( 'swps_search_appearance', 'swps_title_separator', [ 'sanitize_callback' => 'sanitize_text_field' ] );
-
-        foreach ( get_post_types( [ 'public' => true ] ) as $pt ) {
-            if ( 'attachment' === $pt ) continue;
-            register_setting( 'swps_search_appearance', "swps_title_template_{$pt}", [ 'sanitize_callback' => 'sanitize_text_field' ] );
-            register_setting( 'swps_search_appearance', "swps_desc_template_{$pt}", [ 'sanitize_callback' => 'sanitize_textarea_field' ] );
-            register_setting( 'swps_search_appearance', "swps_noindex_{$pt}", [ 'sanitize_callback' => 'absint' ] );
-        }
-
-        foreach ( get_taxonomies( [ 'public' => true ] ) as $tax ) {
-            if ( 'post_format' === $tax ) continue;
-            register_setting( 'swps_search_appearance', "swps_title_template_{$tax}", [ 'sanitize_callback' => 'sanitize_text_field' ] );
-            register_setting( 'swps_search_appearance', "swps_noindex_{$tax}", [ 'sanitize_callback' => 'absint' ] );
-        }
-
-        register_setting( 'swps_search_appearance', 'swps_title_template_search', [ 'sanitize_callback' => 'sanitize_text_field' ] );
-        register_setting( 'swps_search_appearance', 'swps_title_template_404', [ 'sanitize_callback' => 'sanitize_text_field' ] );
-        register_setting( 'swps_search_appearance', 'swps_title_template_author', [ 'sanitize_callback' => 'sanitize_text_field' ] );
-        register_setting( 'swps_search_appearance', 'swps_title_template_date', [ 'sanitize_callback' => 'sanitize_text_field' ] );
-
-        // Breadcrumb settings.
-        register_setting( 'swps_search_appearance', 'swps_breadcrumbs_enabled', [ 'sanitize_callback' => 'absint' ] );
-        register_setting( 'swps_search_appearance', 'swps_breadcrumbs_separator', [ 'sanitize_callback' => 'sanitize_text_field' ] );
-        register_setting( 'swps_search_appearance', 'swps_breadcrumbs_home_label', [ 'sanitize_callback' => 'sanitize_text_field' ] );
-
-        // SEO Column settings.
-        register_setting( 'swps_search_appearance', 'swps_seo_column_post_types', [
-            'sanitize_callback' => function ( $value ) {
-                return is_array( $value ) ? array_map( 'sanitize_text_field', $value ) : [ 'post', 'page' ];
-            },
-            'default' => [ 'post', 'page' ],
-        ] );
-        register_setting( 'swps_search_appearance', 'swps_seo_score_content_min', [
-            'sanitize_callback' => 'absint',
-            'default' => 300,
-        ] );
-
-        // Internal Links settings.
-        register_setting( 'swps_settings', 'swps_internal_links_enabled', [
-            'type'    => 'boolean',
-            'default' => true,
-        ] );
-        register_setting( 'swps_settings', 'swps_internal_links_post_types', [
-            'type'    => 'array',
-            'default' => [ 'post', 'page' ],
-        ] );
-        register_setting( 'swps_settings', 'swps_link_relevance_threshold', [
-            'type'    => 'number',
-            'default' => 0.3,
-        ] );
-        register_setting( 'swps_settings', 'swps_link_max_suggestions', [
-            'type'    => 'integer',
-            'default' => 10,
-        ] );
-        register_setting( 'swps_settings', 'swps_internal_links_in_generation', [
-            'type'    => 'boolean',
-            'default' => true,
-        ] );
-        register_setting( 'swps_settings', 'swps_link_ai_batch_size', [
-            'type'    => 'integer',
-            'default' => 10,
-        ] );
-    }
-
-    /**
-     * Get model options for the currently active AI provider.
-     */
-    private function get_current_model_options(): array {
-        $slug = get_option( 'swps_ai_provider', 'anthropic' );
-        return SWPS_Provider_Factory::get_models_for_provider( $slug );
-    }
-
-    /**
-     * Helper to register a setting field.
-     */
-    private function add_field( string $key, string $title, string $type, string $section, array $args = [] ): void {
-        $option_name = "swps_{$key}";
-
-        register_setting( 'stratawp-seo', $option_name, [
-            'sanitize_callback' => $this->get_sanitize_callback( $type, $key ),
-        ] );
-
-        $field_args = array_merge( $args, [
-            'key'  => $key,
-            'type' => $type,
-            'name' => $option_name,
-        ] );
-
-        $extra = [];
-        if ( ! empty( $args['row_class'] ) ) {
-            $extra['class'] = $args['row_class'];
-        }
-
-        add_settings_field(
-            $option_name,
-            $title,
-            [ $this, 'render_field' ],
-            'stratawp-seo',
-            $section,
-            array_merge( $field_args, $extra )
-        );
-    }
-
-    /**
-     * Get the appropriate sanitize callback for a field type.
-     */
-    private function get_sanitize_callback( string $type, string $key = '' ): callable {
-        // Encrypt the jon_ai_secret on save.
-        if ( $key === 'jon_ai_secret' || $key === 'gsc_client_secret' ) {
-            $option_name = "swps_{$key}";
-            return function ( $value ) use ( $option_name ) {
-                if ( empty( $value ) ) {
-                    // Preserve existing encrypted value when field submitted empty.
-                    return get_option( $option_name, '' );
-                }
-                return SWPS_Encryption::encrypt( sanitize_text_field( $value ) );
-            };
-        }
-
-        return match ( $type ) {
-            'checkbox' => function ( $value ) {
-                return $value ? 1 : 0;
-            },
-            'multi_checkbox' => function ( $value ) {
-                if ( ! is_array( $value ) ) {
-                    return [];
-                }
-                return array_values( array_map( 'sanitize_key', $value ) );
-            },
-            'number'   => 'absint',
-            'textarea' => 'sanitize_textarea_field',
-            'password' => function ( $value ) {
-                return sanitize_text_field( $value );
-            },
-            default    => 'sanitize_text_field',
-        };
-    }
-
-    /**
-     * Render a settings field.
-     */
-    public function render_field( array $args ): void {
-        $name    = $args['name'];
-        $type    = $args['type'];
-        $default = $args['default'] ?? '';
-        $value   = get_option( $name, $default );
-        $desc    = $args['description'] ?? '';
-
-        // Don't display encrypted values — show empty field with saved indicator.
-        $has_encrypted_value = false;
-        if ( in_array( $args['key'], [ 'jon_ai_secret', 'gsc_client_secret' ], true ) && ! empty( $value ) && SWPS_Encryption::is_encrypted( $value ) ) {
-            $has_encrypted_value = true;
-            $value = '';
-        }
-
-        switch ( $type ) {
-            case 'text':
-            case 'password':
-                printf(
-                    '<input type="%s" name="%s" value="%s" class="regular-text" placeholder="%s" />',
-                    esc_attr( $type ),
-                    esc_attr( $name ),
-                    esc_attr( $value ),
-                    esc_attr( $args['placeholder'] ?? '' )
-                );
-                break;
-
-            case 'number':
-                printf(
-                    '<input type="number" name="%s" value="%s" class="small-text" min="%s" max="%s" step="%s" />',
-                    esc_attr( $name ),
-                    esc_attr( $value ),
-                    esc_attr( $args['min'] ?? 0 ),
-                    esc_attr( $args['max'] ?? 99999 ),
-                    esc_attr( $args['step'] ?? 1 )
-                );
-                break;
-
-            case 'textarea':
-                printf(
-                    '<textarea name="%s" class="large-text" rows="%d" placeholder="%s">%s</textarea>',
-                    esc_attr( $name ),
-                    $args['rows'] ?? 4,
-                    esc_attr( $args['placeholder'] ?? '' ),
-                    esc_textarea( $value )
-                );
-                break;
-
-            case 'select':
-                printf( '<select name="%s" id="%s">', esc_attr( $name ), esc_attr( $name ) );
-                foreach ( ( $args['options'] ?? [] ) as $val => $label ) {
-                    printf(
-                        '<option value="%s" %s>%s</option>',
-                        esc_attr( $val ),
-                        selected( $value, $val, false ),
-                        esc_html( $label )
-                    );
-                }
-                echo '</select>';
-                break;
-
-            case 'checkbox':
-                printf(
-                    '<label><input type="checkbox" name="%s" value="1" %s /> %s</label>',
-                    esc_attr( $name ),
-                    checked( $value, 1, false ),
-                    esc_html( $args['label'] ?? '' )
-                );
-                break;
-
-            case 'multi_checkbox':
-                $stored  = is_array( $value ) ? $value : ( $args['default'] ?? [] );
-                $options = $args['options'] ?? [];
-                echo '<fieldset style="display:grid;grid-template-columns:repeat(2,minmax(180px,1fr));gap:4px 16px;">';
-                foreach ( $options as $val => $label ) {
-                    printf(
-                        '<label><input type="checkbox" name="%s[]" value="%s" %s /> %s</label>',
-                        esc_attr( $name ),
-                        esc_attr( $val ),
-                        checked( in_array( $val, $stored, true ), true, false ),
-                        esc_html( $label )
-                    );
-                }
-                echo '</fieldset>';
-                break;
-
-            case 'time':
-                printf(
-                    '<input type="time" name="%s" value="%s" />',
-                    esc_attr( $name ),
-                    esc_attr( $value ?: '09:00' )
-                );
-                break;
-
-            case 'author_select':
-                wp_dropdown_users( [
-                    'name'     => $name,
-                    'selected' => $value ?: get_current_user_id(),
-                    'who'      => 'authors',
-                ] );
-                break;
-
-            case 'category_select':
-                wp_dropdown_categories( [
-                    'name'             => $name,
-                    'selected'         => $value,
-                    'show_option_none' => __( '— AI Decides —', 'stratawp-seo' ),
-                    'option_none_value' => 0,
-                    'hide_empty'       => false,
-                ] );
-                break;
-        }
-
-        if ( $has_encrypted_value ) {
-            echo '<span class="dashicons dashicons-yes" style="color:#00a32a;vertical-align:middle;"></span> ';
-            echo '<span style="color:#00a32a;">' . esc_html__( 'Saved (encrypted). Leave blank to keep current value.', 'stratawp-seo' ) . '</span>';
-        }
-
-        if ( $desc ) {
-            printf( '<p class="description">%s</p>', wp_kses_post( $desc ) );
-        }
-    }
-
-    // --- Section descriptions ---
-
-    public function render_ai_section(): void {
-        echo '<p>' . esc_html__( 'Choose your AI provider and enter your API key.', 'stratawp-seo' ) . '</p>';
-    }
-
-    public function render_images_section(): void {
-        echo '<p>' . esc_html__( 'Configure automatic featured images for generated posts.', 'stratawp-seo' ) . '</p>';
-    }
-
-    public function render_site_section(): void {
-        echo '<p>' . esc_html__( 'Tell the AI about your site so it can generate relevant, targeted content.', 'stratawp-seo' ) . '</p>';
-    }
-
-    public function render_ai_crawlers_section(): void {
-        echo '<p>' . esc_html__( 'Control which AI crawlers can access your site and serve a dynamic llms.txt index at /llms.txt.', 'stratawp-seo' ) . '</p>';
-    }
-
-    public function render_writing_section(): void {
-        echo '<p>' . esc_html__( 'Configure how the AI writes content for your site.', 'stratawp-seo' ) . '</p>';
-    }
-
-    public function render_content_section(): void {
-        echo '<p>' . esc_html__( 'Control the output format and WordPress post settings.', 'stratawp-seo' ) . '</p>';
-    }
-
-    public function render_schedule_section(): void {
-        $schedule = SWPS_Cron::get_schedule_info();
-        echo '<p>' . esc_html__( 'Set up automatic content generation on a schedule.', 'stratawp-seo' ) . '</p>';
-        if ( $schedule['enabled'] ) {
-            printf(
-                '<div class="notice notice-info inline"><p><strong>%s</strong> %s</p></div>',
-                esc_html__( 'Next scheduled run:', 'stratawp-seo' ),
-                esc_html( $schedule['next_run'] )
-            );
-        }
-    }
-
-    public function render_audit_section(): void {
-        echo '<p>' . esc_html__( 'Configure automatic SEO audit checks and fixes.', 'stratawp-seo' ) . '</p>';
-    }
-
-    /**
-     * Render the Schema settings section description.
-     */
-    public function render_schema_section(): void {
-        echo '<p>' . esc_html__( 'Automatic JSON-LD structured data for rich results in Google. Disabled automatically when Yoast SEO, RankMath, or All in One SEO is active.', 'stratawp-seo' ) . '</p>';
-    }
-
-    public function render_meta_section(): void {
-        echo '<p>' . esc_html__( 'Per-post SEO meta fields for titles, descriptions, social previews, and robots directives. Auto-disabled when Yoast, RankMath, or AIOSEO is active.', 'stratawp-seo' ) . '</p>';
-    }
-
-    public function render_analytics_section(): void {
-        echo '<p>' . esc_html__( 'On-site analytics tracking and Google Search Console integration.', 'stratawp-seo' ) . '</p>';
-    }
-
-    public function render_advanced_section(): void {
-        echo '<p>' . esc_html__( 'Advanced features for duplicate detection, rate limiting, cost tracking, and remote integration.', 'stratawp-seo' ) . '</p>';
-
-        // Show encryption status.
-        $secret = get_option( 'swps_jon_ai_secret', '' );
-        if ( ! empty( $secret ) ) {
-            $is_encrypted = SWPS_Encryption::is_encrypted( $secret );
-            printf(
-                '<div class="notice notice-%s inline"><p>%s %s</p></div>',
-                $is_encrypted ? 'success' : 'warning',
-                esc_html__( 'Remote secret:', 'stratawp-seo' ),
-                $is_encrypted
-                    ? esc_html__( 'Stored encrypted.', 'stratawp-seo' )
-                    : esc_html__( 'Not encrypted — save settings to encrypt.', 'stratawp-seo' )
-            );
-        }
-    }
-
-    public function render_cleanup_section(): void {
-        echo '<p>' . esc_html__( 'Remove unnecessary items from your site\'s <head> section to reduce page size.', 'stratawp-seo' ) . '</p>';
-    }
-
-    public function render_rss_section(): void {
-        echo '<p>' . esc_html__( 'Add content before or after posts in your RSS feed. Available variables: %%post_link%%, %%blog_link%%, %%blog_name%%', 'stratawp-seo' ) . '</p>';
-    }
-
-    public function render_sitemap_section(): void {
-        $index_url = home_url( '/sitemap_index.xml' );
-        echo '<p>' . sprintf(
-            esc_html__( 'Your sitemap index: %s', 'stratawp-seo' ),
-            '<a href="' . esc_url( $index_url ) . '" target="_blank">' . esc_url( $index_url ) . '</a>'
-        ) . '</p>';
-    }
-
-    /**
-     * Tab groups for the settings page. Each tab lists the section IDs it contains.
-     */
-    public function get_settings_tabs(): array {
-        return [
-            'ai-content' => [
-                'label'    => __( 'AI & Content', 'stratawp-seo' ),
-                'sections' => [
-                    'swps_ai_section',
-                    'swps_site_section',
-                    'swps_writing_section',
-                    'swps_content_section',
-                    'swps_images_section',
-                ],
-            ],
-            'schedule' => [
-                'label'    => __( 'Schedule', 'stratawp-seo' ),
-                'sections' => [
-                    'swps_schedule_section',
-                ],
-            ],
-            'seo' => [
-                'label'    => __( 'SEO', 'stratawp-seo' ),
-                'sections' => [
-                    'swps_audit_section',
-                    'swps_schema_section',
-                    'swps_meta_section',
-                    'swps_cleanup_section',
-                    'swps_rss_section',
-                ],
-            ],
-            'discoverability' => [
-                'label'    => __( 'AI Crawlers', 'stratawp-seo' ),
-                'sections' => [
-                    'swps_ai_crawlers_section',
-                ],
-            ],
-            'analytics' => [
-                'label'    => __( 'Analytics', 'stratawp-seo' ),
-                'sections' => [
-                    'swps_analytics_section',
-                ],
-            ],
-            'advanced' => [
-                'label'    => __( 'Advanced', 'stratawp-seo' ),
-                'sections' => [
-                    'swps_advanced_section',
-                ],
-            ],
-        ];
-    }
-
-    /**
-     * Render a subset of settings sections — same output as do_settings_sections()
-     * but scoped to a specific list of section IDs.
-     */
-    public function render_sections_for_tab( array $section_ids ): void {
-        global $wp_settings_sections, $wp_settings_fields;
-
-        $page = 'stratawp-seo';
-        if ( empty( $wp_settings_sections[ $page ] ) ) {
-            return;
-        }
-
-        foreach ( $section_ids as $section_id ) {
-            if ( ! isset( $wp_settings_sections[ $page ][ $section_id ] ) ) {
-                continue;
-            }
-
-            $section = $wp_settings_sections[ $page ][ $section_id ];
-
-            if ( ! empty( $section['title'] ) ) {
-                echo '<h2>' . esc_html( $section['title'] ) . '</h2>' . "\n";
-            }
-
-            if ( ! empty( $section['callback'] ) ) {
-                call_user_func( $section['callback'], $section );
-            }
-
-            if ( empty( $wp_settings_fields[ $page ][ $section_id ] ) ) {
-                continue;
-            }
-
-            echo '<table class="form-table" role="presentation">';
-            do_settings_fields( $page, $section_id );
-            echo '</table>';
-        }
-    }
-
-    /**
-     * Render the main settings page.
-     */
-    public function render_settings_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            return;
-        }
-
-        if ( isset( $_GET['settings-updated'] ) && $_GET['settings-updated'] ) {
-            if ( get_option( 'swps_cron_enabled' ) ) {
-                SWPS_Cron::schedule();
-            } else {
-                SWPS_Cron::unschedule();
-            }
-        }
-
-        include SWPS_PLUGIN_DIR . 'templates/settings-page.php';
-    }
-
-    /**
-     * Render the generate content page.
-     */
-    public function render_generate_page(): void {
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            return;
-        }
-
-        include SWPS_PLUGIN_DIR . 'templates/generate-page.php';
-    }
-
-    /**
-     * Show admin notices.
-     */
-    public function admin_notices(): void {
-        $screen = get_current_screen();
-
-        if ( ! $screen || strpos( $screen->id, 'stratawp-seo' ) === false ) {
-            return;
-        }
-
-        $ai_provider = SWPS_Provider_Factory::create_ai_provider();
-        if ( empty( $ai_provider->get_api_key() ) ) {
-            printf(
-                '<div class="notice notice-warning"><p><strong>%s</strong> %s</p></div>',
-                esc_html__( 'StrataWP SEO:', 'stratawp-seo' ),
-                sprintf(
-                    esc_html__( 'Please enter your %s API key to get started.', 'stratawp-seo' ),
-                    esc_html( $ai_provider->get_name() )
-                )
-            );
-        }
-
-        if ( empty( get_option( 'swps_site_niche' ) ) ) {
-            printf(
-                '<div class="notice notice-info"><p><strong>%s</strong> %s</p></div>',
-                esc_html__( 'StrataWP SEO:', 'stratawp-seo' ),
-                esc_html__( 'Enter your site niche and description for better content generation.', 'stratawp-seo' )
-            );
-        }
-    }
-
-    /**
-     * Render the voice profiles page (list or edit).
-     */
-    public function render_voice_profiles_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            return;
-        }
-
-        $action = sanitize_text_field( $_GET['action'] ?? 'list' );
-
-        if ( in_array( $action, [ 'new', 'edit' ], true ) ) {
-            include SWPS_PLUGIN_DIR . 'templates/voice-profile-edit.php';
-        } else {
-            include SWPS_PLUGIN_DIR . 'templates/voice-profiles-page.php';
-        }
-    }
-
-    public function render_audit_page(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            return;
-        }
-
-        include SWPS_PLUGIN_DIR . 'templates/audit-page.php';
-    }
-
-    public function render_search_appearance_page(): void {
-        include SWPS_PLUGIN_DIR . 'templates/search-appearance-page.php';
-    }
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'register_menu' ) );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
+	}
+
+	/**
+	 * Register admin menu pages.
+	 *
+	 * v4.0: SWPS_Dashboard now owns the top-level menu (registered at
+	 * admin_menu priority 5). Settings registers itself as a submenu with
+	 * the new slug 'swps-settings' so /admin.php?page=stratawp-seo lands
+	 * on the Dashboard, not Settings. Old bookmarks to ?page=stratawp-seo
+	 * continue to resolve — they show Dashboard.
+	 */
+	public function register_menu(): void {
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Settings', 'stratawp-seo' ),
+			__( 'Settings', 'stratawp-seo' ),
+			'manage_options',
+			'swps-settings',
+			array( $this, 'render_settings_page' )
+		);
+
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Generate Content', 'stratawp-seo' ),
+			__( 'Generate Content', 'stratawp-seo' ),
+			'edit_posts',
+			'swps-generate',
+			array( $this, 'render_generate_page' )
+		);
+
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Voice Profiles', 'stratawp-seo' ),
+			__( 'Voice Profiles', 'stratawp-seo' ),
+			'manage_options',
+			'swps-voice-profiles',
+			array( $this, 'render_voice_profiles_page' )
+		);
+
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'SEO Audit', 'stratawp-seo' ),
+			__( 'SEO Audit', 'stratawp-seo' ),
+			'manage_options',
+			'swps-seo-audit',
+			array( $this, 'render_audit_page' )
+		);
+
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Search Appearance', 'stratawp-seo' ),
+			__( 'Search Appearance', 'stratawp-seo' ),
+			'manage_options',
+			'swps-search-appearance',
+			array( $this, 'render_search_appearance_page' )
+		);
+
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Redirects', 'stratawp-seo' ),
+			__( 'Redirects', 'stratawp-seo' ),
+			'manage_options',
+			'swps-redirects',
+			array( SWPS_Redirect_Admin::class, 'render' )
+		);
+
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Migrate from Yoast / Rank Math', 'stratawp-seo' ),
+			__( 'Migrate', 'stratawp-seo' ),
+			'manage_options',
+			'swps-migration',
+			array( $this, 'render_migration_page' )
+		);
+
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Debug — Last AI Failure', 'stratawp-seo' ),
+			__( 'Debug', 'stratawp-seo' ),
+			'manage_options',
+			'swps-debug',
+			array( $this, 'render_debug_page' )
+		);
+	}
+
+	/**
+	 * Render the migration tool page.
+	 */
+	public function render_migration_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to view this page.', 'stratawp-seo' ) );
+		}
+		include SWPS_PLUGIN_DIR . 'templates/migration-page.php';
+	}
+
+	/**
+	 * Render the debug page showing the last failed AI response.
+	 */
+	public function render_debug_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to view this page.', 'stratawp-seo' ) );
+		}
+
+		if ( isset( $_POST['swps_clear_failure'] ) && check_admin_referer( 'swps_clear_failure' ) ) {
+			delete_transient( 'swps_last_ai_failure' );
+			echo '<div class="notice notice-success"><p>' . esc_html__( 'Cleared.', 'stratawp-seo' ) . '</p></div>';
+		}
+
+		$failure = get_transient( 'swps_last_ai_failure' );
+
+		echo '<div class="wrap swps-debug-wrap">';
+
+		$title    = __( 'Debug', 'stratawp-seo' );
+		$subtitle = __( 'Last failed AI response captured by the JSON parser. Use this to diagnose generation errors.', 'stratawp-seo' );
+		$actions  = array();
+		require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+
+		if ( empty( $failure ) ) {
+			echo '<div class="swps-tile" style="text-align:center;padding:48px 24px">';
+			echo '<div style="font-size:48px;line-height:1;margin-bottom:16px;color:var(--swps-success)">✓</div>';
+			echo '<p style="color:var(--swps-text-muted);margin:0">' . esc_html__( 'No recent failures.', 'stratawp-seo' ) . '</p>';
+			echo '</div></div>';
+			return;
+		}
+
+		echo '<div class="swps-tile">';
+		echo '<table style="width:100%;border-collapse:collapse">';
+		echo '<tr><td style="padding:6px 0;color:var(--swps-text-muted);font-size:12px;width:80px">' . esc_html__( 'Time', 'stratawp-seo' ) . '</td><td style="padding:6px 0;color:var(--swps-text-primary)">' . esc_html( $failure['time'] ?? '' ) . '</td></tr>';
+		echo '<tr><td style="padding:6px 0;color:var(--swps-text-muted);font-size:12px">' . esc_html__( 'Error', 'stratawp-seo' ) . '</td><td style="padding:6px 0;color:var(--swps-crit)">' . esc_html( $failure['error'] ?? '' ) . '</td></tr>';
+		echo '<tr><td style="padding:6px 0;color:var(--swps-text-muted);font-size:12px">' . esc_html__( 'Length', 'stratawp-seo' ) . '</td><td style="padding:6px 0;color:var(--swps-text-primary)">' . esc_html( number_format( strlen( (string) ( $failure['raw'] ?? '' ) ) ) ) . ' ' . esc_html__( 'chars', 'stratawp-seo' ) . '</td></tr>';
+		echo '</table>';
+
+		echo '<form method="post" style="margin: 16px 0 0;">';
+		wp_nonce_field( 'swps_clear_failure' );
+		echo '<button type="submit" name="swps_clear_failure" class="swps-btn swps-btn-secondary">' . esc_html__( 'Clear', 'stratawp-seo' ) . '</button>';
+		echo '</form>';
+		echo '</div>';
+
+		echo '<div class="swps-section-h" style="margin-top:24px"><h3>' . esc_html__( 'Raw response', 'stratawp-seo' ) . '</h3></div>';
+		echo '<textarea readonly rows="24" style="width:100%;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;background:var(--swps-bg-input);color:var(--swps-text-body);border:1px solid var(--swps-border-strong);border-radius:var(--swps-radius-sm);padding:14px;line-height:1.5">' . esc_textarea( (string) ( $failure['raw'] ?? '' ) ) . '</textarea>';
+
+		echo '</div>';
+	}
+
+	/**
+	 * Register all settings.
+	 */
+	public function register_settings(): void {
+		// --- AI Provider Section ---
+		add_settings_section( 'swps_ai_section', __( 'AI Provider', 'stratawp-seo' ), array( $this, 'render_ai_section' ), 'stratawp-seo' );
+
+		$this->add_field(
+			'ai_provider',
+			__( 'AI Provider', 'stratawp-seo' ),
+			'select',
+			'swps_ai_section',
+			array(
+				'options' => SWPS_Provider_Factory::get_ai_provider_options(),
+			)
+		);
+
+		$this->add_field(
+			'anthropic_api_key',
+			__( 'Anthropic API Key', 'stratawp-seo' ),
+			'password',
+			'swps_ai_section',
+			array(
+				'description' => __( 'Get your API key from <a href="https://console.anthropic.com/" target="_blank">console.anthropic.com</a>', 'stratawp-seo' ),
+				'row_class'   => 'swps-ai-key-row swps-provider-anthropic',
+			)
+		);
+
+		$this->add_field(
+			'openai_api_key',
+			__( 'OpenAI API Key', 'stratawp-seo' ),
+			'password',
+			'swps_ai_section',
+			array(
+				'description' => __( 'Get your API key from <a href="https://platform.openai.com/api-keys" target="_blank">platform.openai.com</a>', 'stratawp-seo' ),
+				'row_class'   => 'swps-ai-key-row swps-provider-openai',
+			)
+		);
+
+		$this->add_field(
+			'google_api_key',
+			__( 'Google API Key', 'stratawp-seo' ),
+			'password',
+			'swps_ai_section',
+			array(
+				'description' => __( 'Get your API key from <a href="https://aistudio.google.com/apikey" target="_blank">Google AI Studio</a>', 'stratawp-seo' ),
+				'row_class'   => 'swps-ai-key-row swps-provider-google',
+			)
+		);
+
+		$this->add_field(
+			'xai_api_key',
+			__( 'xAI API Key', 'stratawp-seo' ),
+			'password',
+			'swps_ai_section',
+			array(
+				'description' => __( 'Get your API key from <a href="https://console.x.ai/" target="_blank">console.x.ai</a>', 'stratawp-seo' ),
+				'row_class'   => 'swps-ai-key-row swps-provider-xai',
+			)
+		);
+
+		$this->add_field(
+			'model',
+			__( 'AI Model', 'stratawp-seo' ),
+			'select',
+			'swps_ai_section',
+			array(
+				'options'     => $this->get_current_model_options(),
+				'description' => __( 'Model list updates automatically when you change providers.', 'stratawp-seo' ),
+			)
+		);
+
+		// --- Featured Images Section ---
+		add_settings_section( 'swps_images_section', __( 'Featured Images', 'stratawp-seo' ), array( $this, 'render_images_section' ), 'stratawp-seo' );
+
+		$this->add_field(
+			'featured_images',
+			__( 'Auto Featured Images', 'stratawp-seo' ),
+			'checkbox',
+			'swps_images_section',
+			array(
+				'label' => __( 'Automatically fetch a relevant featured image for each generated post', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'image_provider',
+			__( 'Image Provider', 'stratawp-seo' ),
+			'select',
+			'swps_images_section',
+			array(
+				'options' => SWPS_Provider_Factory::get_image_provider_options(),
+			)
+		);
+
+		$this->add_field(
+			'unsplash_api_key',
+			__( 'Unsplash API Key', 'stratawp-seo' ),
+			'password',
+			'swps_images_section',
+			array(
+				'description' => __( 'Get a free API key from <a href="https://unsplash.com/developers" target="_blank">unsplash.com/developers</a>', 'stratawp-seo' ),
+				'row_class'   => 'swps-image-key-row swps-image-provider-unsplash',
+			)
+		);
+
+		$this->add_field(
+			'pexels_api_key',
+			__( 'Pexels API Key', 'stratawp-seo' ),
+			'password',
+			'swps_images_section',
+			array(
+				'description' => __( 'Get a free API key from <a href="https://www.pexels.com/api/" target="_blank">pexels.com/api</a>', 'stratawp-seo' ),
+				'row_class'   => 'swps-image-key-row swps-image-provider-pexels',
+			)
+		);
+
+		$this->add_field(
+			'pixabay_api_key',
+			__( 'Pixabay API Key', 'stratawp-seo' ),
+			'password',
+			'swps_images_section',
+			array(
+				'description' => __( 'Get a free API key from <a href="https://pixabay.com/api/docs/" target="_blank">pixabay.com/api</a>', 'stratawp-seo' ),
+				'row_class'   => 'swps-image-key-row swps-image-provider-pixabay',
+			)
+		);
+
+		// Note: Gemini image generation reuses the Google API key from the AI Provider
+		// section above. We intentionally do NOT register another input for
+		// `swps_google_api_key` here — duplicate inputs with the same name cause the
+		// hidden row's empty value to clobber the visible row's value on save (see #24).
+		add_settings_field(
+			'swps_gemini_image_key_info',
+			__( 'Google API Key', 'stratawp-seo' ),
+			function () {
+				echo '<p class="description">' . wp_kses_post( __( 'Gemini image generation uses the Google API Key set in the <strong>AI Provider</strong> section above.', 'stratawp-seo' ) ) . '</p>';
+			},
+			'stratawp-seo',
+			'swps_images_section',
+			array( 'class' => 'swps-image-key-row swps-image-provider-gemini' )
+		);
+
+		$this->add_field(
+			'insert_content_images',
+			__( 'In-Content Images', 'stratawp-seo' ),
+			'checkbox',
+			'swps_images_section',
+			array(
+				'label' => __( 'Insert contextual images within the post body (in addition to featured image)', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'content_images_count',
+			__( 'Images Per Post', 'stratawp-seo' ),
+			'number',
+			'swps_images_section',
+			array(
+				'min'         => 1,
+				'max'         => 4,
+				'description' => __( 'Maximum number of in-content images to insert (1-4).', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'image_max_width',
+			__( 'Image Max Width', 'stratawp-seo' ),
+			'number',
+			'swps_images_section',
+			array(
+				'min'         => 600,
+				'max'         => 2400,
+				'step'        => 100,
+				'description' => __( 'Maximum width in pixels for content images.', 'stratawp-seo' ),
+			)
+		);
+
+		// --- Site Details Section ---
+		add_settings_section( 'swps_site_section', __( 'Site Details', 'stratawp-seo' ), array( $this, 'render_site_section' ), 'stratawp-seo' );
+
+		$this->add_field(
+			'site_niche',
+			__( 'Site Niche / Industry', 'stratawp-seo' ),
+			'text',
+			'swps_site_section',
+			array(
+				'placeholder' => 'e.g., Home Renovation, Digital Marketing, Pet Care',
+				'description' => __( 'What is your site about? Be specific.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'site_description',
+			__( 'Site Description', 'stratawp-seo' ),
+			'textarea',
+			'swps_site_section',
+			array(
+				'placeholder' => 'Describe your site, target audience, and what makes it unique...',
+				'description' => __( 'Give the AI context about your site and audience. The more detail, the better the content.', 'stratawp-seo' ),
+				'rows'        => 4,
+			)
+		);
+
+		// --- AI Crawlers Section ---
+		add_settings_section( 'swps_ai_crawlers_section', __( 'AI Crawlers', 'stratawp-seo' ), array( $this, 'render_ai_crawlers_section' ), 'stratawp-seo' );
+
+		$bot_options = array();
+		foreach ( SWPS_AI_Bots::KNOWN_BOTS as $key => $token ) {
+			$bot_options[ $key ] = $token;
+		}
+		$this->add_field(
+			'ai_bots_allowed',
+			__( 'Allowed AI Bots', 'stratawp-seo' ),
+			'multi_checkbox',
+			'swps_ai_crawlers_section',
+			array(
+				'options'     => $bot_options,
+				'default'     => array_keys( $bot_options ),
+				'description' => __( 'Allowed bots get an explicit Allow rule in robots.txt; unchecked known bots get a Disallow. View the result at <code>/robots.txt</code>.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'llms_txt_enabled',
+			__( 'Generate llms.txt', 'stratawp-seo' ),
+			'checkbox',
+			'swps_ai_crawlers_section',
+			array(
+				'default'     => 1,
+				'label'       => __( 'Serve a dynamic llms.txt at /llms.txt', 'stratawp-seo' ),
+				'description' => sprintf(
+					/* translators: %s: link to /llms.txt */
+					__( 'Built from your site description and most recent posts (with one-line summaries). Overrides Yoast or other plugin output. <a href="%s" target="_blank">View live</a>.', 'stratawp-seo' ),
+					esc_url( home_url( '/llms.txt' ) )
+				),
+			)
+		);
+
+		// --- Writing Preferences Section ---
+		add_settings_section( 'swps_writing_section', __( 'Writing Preferences', 'stratawp-seo' ), array( $this, 'render_writing_section' ), 'stratawp-seo' );
+
+		$this->add_field(
+			'tone',
+			__( 'Tone of Voice', 'stratawp-seo' ),
+			'select',
+			'swps_writing_section',
+			array(
+				'options' => array(
+					'professional'   => __( 'Professional', 'stratawp-seo' ),
+					'conversational' => __( 'Conversational', 'stratawp-seo' ),
+					'friendly'       => __( 'Friendly & Approachable', 'stratawp-seo' ),
+					'authoritative'  => __( 'Authoritative & Expert', 'stratawp-seo' ),
+					'casual'         => __( 'Casual & Relaxed', 'stratawp-seo' ),
+					'formal'         => __( 'Formal & Academic', 'stratawp-seo' ),
+					'witty'          => __( 'Witty & Entertaining', 'stratawp-seo' ),
+				),
+			)
+		);
+
+		$this->add_field(
+			'voice_profile',
+			__( 'Voice Profile', 'stratawp-seo' ),
+			'select',
+			'swps_writing_section',
+			array(
+				'options'     => stratawp_seo()->voice_profile->get_options(),
+				'description' => __( 'Select a voice profile to override tone/style settings. <a href="' . admin_url( 'admin.php?page=swps-voice-profiles' ) . '">Manage profiles</a>', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'writing_style',
+			__( 'Custom Style Notes', 'stratawp-seo' ),
+			'textarea',
+			'swps_writing_section',
+			array(
+				'placeholder' => 'e.g., Use short paragraphs, include real-world examples, avoid jargon, write for beginners...',
+				'description' => __( 'Any specific instructions about how content should be written.', 'stratawp-seo' ),
+				'rows'        => 3,
+			)
+		);
+
+		$this->add_field(
+			'target_keywords',
+			__( 'Target Keywords', 'stratawp-seo' ),
+			'textarea',
+			'swps_writing_section',
+			array(
+				'placeholder' => 'kitchen remodeling tips, bathroom renovation cost, home improvement ideas',
+				'description' => __( 'Comma-separated list of keywords you want to target across your content.', 'stratawp-seo' ),
+				'rows'        => 3,
+			)
+		);
+
+		// --- Content Settings Section ---
+		add_settings_section( 'swps_content_section', __( 'Content Settings', 'stratawp-seo' ), array( $this, 'render_content_section' ), 'stratawp-seo' );
+
+		$this->add_field(
+			'post_status',
+			__( 'Default Post Status', 'stratawp-seo' ),
+			'select',
+			'swps_content_section',
+			array(
+				'options' => array(
+					'draft'   => __( 'Draft (review before publishing)', 'stratawp-seo' ),
+					'pending' => __( 'Pending Review', 'stratawp-seo' ),
+					'publish' => __( 'Published (use with caution)', 'stratawp-seo' ),
+				),
+			)
+		);
+
+		$this->add_field( 'post_author', __( 'Post Author', 'stratawp-seo' ), 'author_select', 'swps_content_section' );
+
+		$this->add_field(
+			'post_category',
+			__( 'Default Category', 'stratawp-seo' ),
+			'category_select',
+			'swps_content_section',
+			array(
+				'description' => __( 'Default category. The AI may also suggest a better category per post.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'word_count_min',
+			__( 'Minimum Word Count', 'stratawp-seo' ),
+			'number',
+			'swps_content_section',
+			array(
+				'min'  => 300,
+				'max'  => 5000,
+				'step' => 100,
+			)
+		);
+
+		$this->add_field(
+			'word_count_max',
+			__( 'Maximum Word Count', 'stratawp-seo' ),
+			'number',
+			'swps_content_section',
+			array(
+				'min'  => 500,
+				'max'  => 8000,
+				'step' => 100,
+			)
+		);
+
+		$this->add_field(
+			'internal_links_min',
+			__( 'Min Internal Links', 'stratawp-seo' ),
+			'number',
+			'swps_content_section',
+			array(
+				'min' => 0,
+				'max' => 20,
+			)
+		);
+
+		$this->add_field(
+			'internal_links_max',
+			__( 'Max Internal Links', 'stratawp-seo' ),
+			'number',
+			'swps_content_section',
+			array(
+				'min' => 1,
+				'max' => 30,
+			)
+		);
+
+		$this->add_field(
+			'include_faq_schema',
+			__( 'Include FAQ Section + Schema', 'stratawp-seo' ),
+			'checkbox',
+			'swps_content_section',
+			array(
+				'label' => __( 'Add a FAQ section with structured data (great for rich snippets)', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'include_toc',
+			__( 'Include Table of Contents', 'stratawp-seo' ),
+			'checkbox',
+			'swps_content_section',
+			array(
+				'label' => __( 'Add a linked table of contents at the top of each post', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'include_takeaways',
+			__( 'Include Key Takeaways', 'stratawp-seo' ),
+			'checkbox',
+			'swps_content_section',
+			array(
+				'label' => __( 'Add a key takeaways section after the intro (concise bullet points summarizing the post)', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'takeaways_count',
+			__( 'Takeaway Count', 'stratawp-seo' ),
+			'number',
+			'swps_content_section',
+			array(
+				'min'         => 3,
+				'max'         => 7,
+				'description' => __( 'Number of key takeaway bullet points to generate (3-7).', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'takeaways_schema',
+			__( 'Takeaways Schema Markup', 'stratawp-seo' ),
+			'checkbox',
+			'swps_content_section',
+			array(
+				'label' => __( 'Output ItemList JSON-LD structured data for key takeaways (for rich snippets)', 'stratawp-seo' ),
+			)
+		);
+
+		// --- Schedule Section ---
+		add_settings_section( 'swps_schedule_section', __( 'Auto-Publishing Schedule', 'stratawp-seo' ), array( $this, 'render_schedule_section' ), 'stratawp-seo' );
+
+		$this->add_field(
+			'cron_enabled',
+			__( 'Enable Scheduled Generation', 'stratawp-seo' ),
+			'checkbox',
+			'swps_schedule_section',
+			array(
+				'label' => __( 'Automatically generate posts on a schedule', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'cron_frequency',
+			__( 'Frequency', 'stratawp-seo' ),
+			'select',
+			'swps_schedule_section',
+			array(
+				'options' => array(
+					'daily'        => __( 'Daily', 'stratawp-seo' ),
+					'twice_weekly' => __( 'Twice a Week', 'stratawp-seo' ),
+					'three_weekly' => __( 'Three Times a Week', 'stratawp-seo' ),
+					'weekly'       => __( 'Weekly', 'stratawp-seo' ),
+					'biweekly'     => __( 'Every Two Weeks', 'stratawp-seo' ),
+					'monthly'      => __( 'Monthly', 'stratawp-seo' ),
+				),
+			)
+		);
+
+		$this->add_field(
+			'cron_day',
+			__( 'Day of Week', 'stratawp-seo' ),
+			'select',
+			'swps_schedule_section',
+			array(
+				'options'     => array(
+					'monday'    => __( 'Monday', 'stratawp-seo' ),
+					'tuesday'   => __( 'Tuesday', 'stratawp-seo' ),
+					'wednesday' => __( 'Wednesday', 'stratawp-seo' ),
+					'thursday'  => __( 'Thursday', 'stratawp-seo' ),
+					'friday'    => __( 'Friday', 'stratawp-seo' ),
+					'saturday'  => __( 'Saturday', 'stratawp-seo' ),
+					'sunday'    => __( 'Sunday', 'stratawp-seo' ),
+				),
+				'description' => __( 'Starting day for the schedule.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field( 'cron_time', __( 'Time', 'stratawp-seo' ), 'time', 'swps_schedule_section' );
+
+		$this->add_field(
+			'cron_posts_per_run',
+			__( 'Posts Per Run', 'stratawp-seo' ),
+			'number',
+			'swps_schedule_section',
+			array(
+				'min'         => 1,
+				'max'         => 5,
+				'description' => __( 'Number of posts to generate each time (max 5).', 'stratawp-seo' ),
+			)
+		);
+
+		// --- SEO Audit Section ---
+		add_settings_section( 'swps_audit_section', __( 'SEO Audit', 'stratawp-seo' ), array( $this, 'render_audit_section' ), 'stratawp-seo' );
+
+		$this->add_field(
+			'audit_auto_canonical',
+			__( 'Auto Canonical Tags', 'stratawp-seo' ),
+			'checkbox',
+			'swps_audit_section',
+			array(
+				'label' => __( 'Automatically add canonical tags to posts/pages missing them', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'audit_auto_og',
+			__( 'Auto OG/Twitter Tags', 'stratawp-seo' ),
+			'checkbox',
+			'swps_audit_section',
+			array(
+				'label' => __( 'Automatically output Open Graph and Twitter Card meta tags', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'audit_auto_sitemap',
+			__( 'Sitemap Generation', 'stratawp-seo' ),
+			'checkbox',
+			'swps_audit_section',
+			array(
+				'label' => __( 'Generate XML sitemap (only when no other sitemap plugin is active)', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'audit_cron_schedule',
+			__( 'Audit Schedule', 'stratawp-seo' ),
+			'select',
+			'swps_audit_section',
+			array(
+				'options'     => array(
+					'daily'   => __( 'Daily', 'stratawp-seo' ),
+					'weekly'  => __( 'Weekly', 'stratawp-seo' ),
+					'monthly' => __( 'Monthly', 'stratawp-seo' ),
+				),
+				'description' => __( 'How often to run the automated SEO audit.', 'stratawp-seo' ),
+			)
+		);
+
+		// --- Schema / Structured Data Section ---
+		add_settings_section( 'swps_schema_section', __( 'Schema / Structured Data', 'stratawp-seo' ), array( $this, 'render_schema_section' ), 'stratawp-seo' );
+
+		$this->add_field(
+			'schema_enabled',
+			__( 'Enable Schema Markup', 'stratawp-seo' ),
+			'checkbox',
+			'swps_schema_section',
+			array(
+				'label' => __( 'Output JSON-LD structured data on all posts and pages (auto-disabled when Yoast, RankMath, or AIOSEO is active)', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'schema_article_type',
+			__( 'Article Type', 'stratawp-seo' ),
+			'select',
+			'swps_schema_section',
+			array(
+				'options'     => array(
+					'Article'     => __( 'Article', 'stratawp-seo' ),
+					'BlogPosting' => __( 'BlogPosting', 'stratawp-seo' ),
+					'NewsArticle' => __( 'NewsArticle', 'stratawp-seo' ),
+				),
+				'description' => __( 'Schema type for blog posts. Most sites should use Article.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'schema_searchbox',
+			__( 'Sitelinks Searchbox', 'stratawp-seo' ),
+			'checkbox',
+			'swps_schema_section',
+			array(
+				'label' => __( 'Add SearchAction to enable Google sitelinks search box on your homepage', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'schema_entity_type',
+			__( 'Site Represents', 'stratawp-seo' ),
+			'select',
+			'swps_schema_section',
+			array(
+				'options'     => array(
+					'Organization' => __( 'Organization', 'stratawp-seo' ),
+					'Person'       => __( 'Person', 'stratawp-seo' ),
+				),
+				'description' => __( 'Does this website represent an organization or an individual?', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'schema_name',
+			__( 'Name', 'stratawp-seo' ),
+			'text',
+			'swps_schema_section',
+			array(
+				'placeholder' => get_bloginfo( 'name' ),
+				'description' => __( 'Organization or person name. Leave blank to use your site name.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'schema_logo',
+			__( 'Logo URL', 'stratawp-seo' ),
+			'text',
+			'swps_schema_section',
+			array(
+				'placeholder' => 'https://example.com/logo.png',
+				'description' => __( 'Full URL to your logo image (minimum 112x112px). Used for Organization schema and Article publisher.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'schema_social_profiles',
+			__( 'Social Profiles', 'stratawp-seo' ),
+			'textarea',
+			'swps_schema_section',
+			array(
+				'rows'        => 4,
+				'placeholder' => "https://facebook.com/yourpage\nhttps://twitter.com/yourhandle\nhttps://linkedin.com/company/yourcompany",
+				'description' => __( 'One social profile URL per line. Populates the sameAs property.', 'stratawp-seo' ),
+			)
+		);
+
+		// --- SEO Meta Section ---
+		add_settings_section( 'swps_meta_section', __( 'SEO Meta', 'stratawp-seo' ), array( $this, 'render_meta_section' ), 'stratawp-seo' );
+
+		$this->add_field(
+			'meta_editor_enabled',
+			__( 'Enable Meta Editor', 'stratawp-seo' ),
+			'checkbox',
+			'swps_meta_section',
+			array(
+				'label' => __( 'Show SEO meta fields (title, description, social, robots) on post and page editors', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'meta_editor_post_types',
+			__( 'Post Types', 'stratawp-seo' ),
+			'text',
+			'swps_meta_section',
+			array(
+				'placeholder' => 'post,page',
+				'description' => __( 'Comma-separated post types to show the meta editor on. Default: post,page', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'meta_auto_generate',
+			__( 'Auto-Generate Meta', 'stratawp-seo' ),
+			'checkbox',
+			'swps_meta_section',
+			array(
+				'label' => __( 'Automatically generate meta title and description via AI when publishing a post without them', 'stratawp-seo' ),
+			)
+		);
+
+		// --- Analytics Section ---
+		add_settings_section( 'swps_analytics_section', __( 'Analytics', 'stratawp-seo' ), array( $this, 'render_analytics_section' ), 'stratawp-seo' );
+
+		$this->add_field(
+			'analytics_enabled',
+			__( 'Enable On-Site Tracking', 'stratawp-seo' ),
+			'checkbox',
+			'swps_analytics_section',
+			array(
+				'label' => __( 'Track page views, time on page, scroll depth, and bounce rate (cookie-free, GDPR-friendly)', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'analytics_retention',
+			__( 'Data Retention', 'stratawp-seo' ),
+			'select',
+			'swps_analytics_section',
+			array(
+				'options'     => array(
+					'30'  => __( '30 days', 'stratawp-seo' ),
+					'90'  => __( '90 days', 'stratawp-seo' ),
+					'180' => __( '180 days', 'stratawp-seo' ),
+					'365' => __( '365 days', 'stratawp-seo' ),
+				),
+				'description' => __( 'How long to keep analytics data. Older data is automatically pruned.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'analytics_exclude_admins',
+			__( 'Exclude Admins', 'stratawp-seo' ),
+			'checkbox',
+			'swps_analytics_section',
+			array(
+				'label' => __( 'Don\'t track visits from logged-in administrators', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'gsc_client_id',
+			__( 'Google OAuth Client ID', 'stratawp-seo' ),
+			'text',
+			'swps_analytics_section',
+			array(
+				'placeholder' => 'xxxx.apps.googleusercontent.com',
+				'description' => __( 'Create OAuth credentials in your <a href="https://console.cloud.google.com/apis/credentials" target="_blank">Google Cloud Console</a>. Set the redirect URI to: <code>' . admin_url( 'admin.php?swps_gsc_callback=1' ) . '</code>', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'gsc_client_secret',
+			__( 'Google OAuth Client Secret', 'stratawp-seo' ),
+			'password',
+			'swps_analytics_section',
+			array(
+				'description' => __( 'Stored encrypted. After saving, connect via the Analytics page.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'keyword_tracking_frequency',
+			__( 'Keyword Sync Frequency', 'stratawp-seo' ),
+			'select',
+			'swps_analytics_section',
+			array(
+				'options'     => array(
+					'daily'   => __( 'Daily', 'stratawp-seo' ),
+					'weekly'  => __( 'Weekly', 'stratawp-seo' ),
+					'monthly' => __( 'Monthly', 'stratawp-seo' ),
+				),
+				'description' => __( 'How often to sync tracked keyword positions from Google Search Console.', 'stratawp-seo' ),
+			)
+		);
+
+		// --- Advanced Section (v2.0) ---
+		add_settings_section( 'swps_advanced_section', __( 'Advanced Settings', 'stratawp-seo' ), array( $this, 'render_advanced_section' ), 'stratawp-seo' );
+
+		$this->add_field(
+			'default_template',
+			__( 'Default Content Template', 'stratawp-seo' ),
+			'select',
+			'swps_advanced_section',
+			array(
+				'options'     => SWPS_Templates::get_options(),
+				'description' => __( 'Default template for generated content. Can be overridden per generation.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'rate_limit',
+			__( 'Rate Limit Cooldown', 'stratawp-seo' ),
+			'number',
+			'swps_advanced_section',
+			array(
+				'min'         => 0,
+				'max'         => 600,
+				'description' => __( 'Seconds to wait between generations (prevents accidental double-clicks). 0 to disable.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'duplicate_check',
+			__( 'Duplicate Detection', 'stratawp-seo' ),
+			'checkbox',
+			'swps_advanced_section',
+			array(
+				'label' => __( 'Check for duplicate titles before creating posts (85% similarity threshold)', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'cost_tracking',
+			__( 'Cost Tracking', 'stratawp-seo' ),
+			'checkbox',
+			'swps_advanced_section',
+			array(
+				'label' => __( 'Track token usage and estimated costs per generation', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'min_content_score',
+			__( 'Minimum Content Score', 'stratawp-seo' ),
+			'number',
+			'swps_advanced_section',
+			array(
+				'min'         => 0,
+				'max'         => 100,
+				'description' => __( 'Posts scoring below this threshold are saved as drafts. Set to 0 to disable.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'jon_ai_endpoint',
+			__( 'Remote Content Endpoint', 'stratawp-seo' ),
+			'text',
+			'swps_advanced_section',
+			array(
+				'placeholder' => 'https://example.com/wp-json/jon-ai/v1/create-posts',
+				'description' => __( 'Optional: Remote endpoint for duplicate checking against an external site.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'jon_ai_secret',
+			__( 'Remote Content Secret', 'stratawp-seo' ),
+			'password',
+			'swps_advanced_section',
+			array(
+				'description' => __( 'Authentication secret for the remote content endpoint. Stored encrypted.', 'stratawp-seo' ),
+			)
+		);
+
+		// --- Head Cleanup Section ---
+		add_settings_section( 'swps_cleanup_section', __( 'Head Cleanup', 'stratawp-seo' ), array( $this, 'render_cleanup_section' ), 'stratawp-seo' );
+
+		$cleanup_fields = array(
+			'cleanup_generator' => __( 'Remove WP Generator Tag', 'stratawp-seo' ),
+			'cleanup_rsd'       => __( 'Remove RSD/EditURI Link', 'stratawp-seo' ),
+			'cleanup_wlw'       => __( 'Remove Windows Live Writer Link', 'stratawp-seo' ),
+			'cleanup_shortlink' => __( 'Remove Shortlink', 'stratawp-seo' ),
+			'cleanup_rest_api'  => __( 'Remove REST API Link', 'stratawp-seo' ),
+			'cleanup_oembed'    => __( 'Remove oEmbed Discovery', 'stratawp-seo' ),
+			'cleanup_emoji'     => __( 'Remove Emoji Scripts & Styles', 'stratawp-seo' ),
+		);
+
+		foreach ( $cleanup_fields as $key => $label ) {
+			$this->add_field( $key, $label, 'checkbox', 'swps_cleanup_section' );
+		}
+
+		// --- RSS Optimization Section ---
+		add_settings_section( 'swps_rss_section', __( 'RSS Feed', 'stratawp-seo' ), array( $this, 'render_rss_section' ), 'stratawp-seo' );
+
+		$this->add_field( 'rss_before', __( 'Content Before Post in RSS', 'stratawp-seo' ), 'textarea', 'swps_rss_section' );
+		$this->add_field( 'rss_after', __( 'Content After Post in RSS', 'stratawp-seo' ), 'textarea', 'swps_rss_section' );
+
+		// --- Search Appearance Settings (separate options group) ---
+		register_setting( 'swps_search_appearance', 'swps_title_separator', array( 'sanitize_callback' => 'sanitize_text_field' ) );
+
+		foreach ( get_post_types( array( 'public' => true ) ) as $pt ) {
+			if ( 'attachment' === $pt ) {
+				continue;
+			}
+			register_setting( 'swps_search_appearance', "swps_title_template_{$pt}", array( 'sanitize_callback' => 'sanitize_text_field' ) );
+			register_setting( 'swps_search_appearance', "swps_desc_template_{$pt}", array( 'sanitize_callback' => 'sanitize_textarea_field' ) );
+			register_setting( 'swps_search_appearance', "swps_noindex_{$pt}", array( 'sanitize_callback' => 'absint' ) );
+		}
+
+		foreach ( get_taxonomies( array( 'public' => true ) ) as $tax ) {
+			if ( 'post_format' === $tax ) {
+				continue;
+			}
+			register_setting( 'swps_search_appearance', "swps_title_template_{$tax}", array( 'sanitize_callback' => 'sanitize_text_field' ) );
+			register_setting( 'swps_search_appearance', "swps_noindex_{$tax}", array( 'sanitize_callback' => 'absint' ) );
+		}
+
+		register_setting( 'swps_search_appearance', 'swps_title_template_search', array( 'sanitize_callback' => 'sanitize_text_field' ) );
+		register_setting( 'swps_search_appearance', 'swps_title_template_404', array( 'sanitize_callback' => 'sanitize_text_field' ) );
+		register_setting( 'swps_search_appearance', 'swps_title_template_author', array( 'sanitize_callback' => 'sanitize_text_field' ) );
+		register_setting( 'swps_search_appearance', 'swps_title_template_date', array( 'sanitize_callback' => 'sanitize_text_field' ) );
+
+		// Breadcrumb settings.
+		register_setting( 'swps_search_appearance', 'swps_breadcrumbs_enabled', array( 'sanitize_callback' => 'absint' ) );
+		register_setting( 'swps_search_appearance', 'swps_breadcrumbs_separator', array( 'sanitize_callback' => 'sanitize_text_field' ) );
+		register_setting( 'swps_search_appearance', 'swps_breadcrumbs_home_label', array( 'sanitize_callback' => 'sanitize_text_field' ) );
+
+		// SEO Column settings.
+		register_setting(
+			'swps_search_appearance',
+			'swps_seo_column_post_types',
+			array(
+				'sanitize_callback' => function ( $value ) {
+					return is_array( $value ) ? array_map( 'sanitize_text_field', $value ) : array( 'post', 'page' );
+				},
+				'default'           => array( 'post', 'page' ),
+			)
+		);
+		register_setting(
+			'swps_search_appearance',
+			'swps_seo_score_content_min',
+			array(
+				'sanitize_callback' => 'absint',
+				'default'           => 300,
+			)
+		);
+
+		// Internal Links settings.
+		register_setting(
+			'swps_settings',
+			'swps_internal_links_enabled',
+			array(
+				'type'    => 'boolean',
+				'default' => true,
+			)
+		);
+		register_setting(
+			'swps_settings',
+			'swps_internal_links_post_types',
+			array(
+				'type'    => 'array',
+				'default' => array( 'post', 'page' ),
+			)
+		);
+		register_setting(
+			'swps_settings',
+			'swps_link_relevance_threshold',
+			array(
+				'type'    => 'number',
+				'default' => 0.3,
+			)
+		);
+		register_setting(
+			'swps_settings',
+			'swps_link_max_suggestions',
+			array(
+				'type'    => 'integer',
+				'default' => 10,
+			)
+		);
+		register_setting(
+			'swps_settings',
+			'swps_internal_links_in_generation',
+			array(
+				'type'    => 'boolean',
+				'default' => true,
+			)
+		);
+		register_setting(
+			'swps_settings',
+			'swps_link_ai_batch_size',
+			array(
+				'type'    => 'integer',
+				'default' => 10,
+			)
+		);
+	}
+
+	/**
+	 * Get model options for the currently active AI provider.
+	 */
+	private function get_current_model_options(): array {
+		$slug = get_option( 'swps_ai_provider', 'anthropic' );
+		return SWPS_Provider_Factory::get_models_for_provider( $slug );
+	}
+
+	/**
+	 * Helper to register a setting field.
+	 */
+	private function add_field( string $key, string $title, string $type, string $section, array $args = array() ): void {
+		$option_name = "swps_{$key}";
+
+		register_setting(
+			'stratawp-seo',
+			$option_name,
+			array(
+				'sanitize_callback' => $this->get_sanitize_callback( $type, $key ),
+			)
+		);
+
+		$field_args = array_merge(
+			$args,
+			array(
+				'key'  => $key,
+				'type' => $type,
+				'name' => $option_name,
+			)
+		);
+
+		$extra = array();
+		if ( ! empty( $args['row_class'] ) ) {
+			$extra['class'] = $args['row_class'];
+		}
+
+		add_settings_field(
+			$option_name,
+			$title,
+			array( $this, 'render_field' ),
+			'stratawp-seo',
+			$section,
+			array_merge( $field_args, $extra )
+		);
+	}
+
+	/**
+	 * Get the appropriate sanitize callback for a field type.
+	 */
+	private function get_sanitize_callback( string $type, string $key = '' ): callable {
+		// Encrypt the jon_ai_secret on save.
+		if ( $key === 'jon_ai_secret' || $key === 'gsc_client_secret' ) {
+			$option_name = "swps_{$key}";
+			return function ( $value ) use ( $option_name ) {
+				if ( empty( $value ) ) {
+					// Preserve existing encrypted value when field submitted empty.
+					return get_option( $option_name, '' );
+				}
+				return SWPS_Encryption::encrypt( sanitize_text_field( $value ) );
+			};
+		}
+
+		return match ( $type ) {
+			'checkbox' => function ( $value ) {
+				return $value ? 1 : 0;
+			},
+			'multi_checkbox' => function ( $value ) {
+				if ( ! is_array( $value ) ) {
+					return array();
+				}
+				return array_values( array_map( 'sanitize_key', $value ) );
+			},
+			'number'   => 'absint',
+			'textarea' => 'sanitize_textarea_field',
+			'password' => function ( $value ) {
+				return sanitize_text_field( $value );
+			},
+			default    => 'sanitize_text_field',
+		};
+	}
+
+	/**
+	 * Render a settings field.
+	 */
+	public function render_field( array $args ): void {
+		$name    = $args['name'];
+		$type    = $args['type'];
+		$default = $args['default'] ?? '';
+		$value   = get_option( $name, $default );
+		$desc    = $args['description'] ?? '';
+
+		// Don't display encrypted values — show empty field with saved indicator.
+		$has_encrypted_value = false;
+		if ( in_array( $args['key'], array( 'jon_ai_secret', 'gsc_client_secret' ), true ) && ! empty( $value ) && SWPS_Encryption::is_encrypted( $value ) ) {
+			$has_encrypted_value = true;
+			$value               = '';
+		}
+
+		switch ( $type ) {
+			case 'text':
+			case 'password':
+				printf(
+					'<input type="%s" name="%s" value="%s" class="regular-text" placeholder="%s" />',
+					esc_attr( $type ),
+					esc_attr( $name ),
+					esc_attr( $value ),
+					esc_attr( $args['placeholder'] ?? '' )
+				);
+				break;
+
+			case 'number':
+				printf(
+					'<input type="number" name="%s" value="%s" class="small-text" min="%s" max="%s" step="%s" />',
+					esc_attr( $name ),
+					esc_attr( $value ),
+					esc_attr( $args['min'] ?? 0 ),
+					esc_attr( $args['max'] ?? 99999 ),
+					esc_attr( $args['step'] ?? 1 )
+				);
+				break;
+
+			case 'textarea':
+				printf(
+					'<textarea name="%s" class="large-text" rows="%d" placeholder="%s">%s</textarea>',
+					esc_attr( $name ),
+					$args['rows'] ?? 4,
+					esc_attr( $args['placeholder'] ?? '' ),
+					esc_textarea( $value )
+				);
+				break;
+
+			case 'select':
+				printf( '<select name="%s" id="%s">', esc_attr( $name ), esc_attr( $name ) );
+				foreach ( ( $args['options'] ?? array() ) as $val => $label ) {
+					printf(
+						'<option value="%s" %s>%s</option>',
+						esc_attr( $val ),
+						selected( $value, $val, false ),
+						esc_html( $label )
+					);
+				}
+				echo '</select>';
+				break;
+
+			case 'checkbox':
+				printf(
+					'<label><input type="checkbox" name="%s" value="1" %s /> %s</label>',
+					esc_attr( $name ),
+					checked( $value, 1, false ),
+					esc_html( $args['label'] ?? '' )
+				);
+				break;
+
+			case 'multi_checkbox':
+				$stored  = is_array( $value ) ? $value : ( $args['default'] ?? array() );
+				$options = $args['options'] ?? array();
+				echo '<fieldset style="display:grid;grid-template-columns:repeat(2,minmax(180px,1fr));gap:4px 16px;">';
+				foreach ( $options as $val => $label ) {
+					printf(
+						'<label><input type="checkbox" name="%s[]" value="%s" %s /> %s</label>',
+						esc_attr( $name ),
+						esc_attr( $val ),
+						checked( in_array( $val, $stored, true ), true, false ),
+						esc_html( $label )
+					);
+				}
+				echo '</fieldset>';
+				break;
+
+			case 'time':
+				printf(
+					'<input type="time" name="%s" value="%s" />',
+					esc_attr( $name ),
+					esc_attr( $value ?: '09:00' )
+				);
+				break;
+
+			case 'author_select':
+				wp_dropdown_users(
+					array(
+						'name'     => $name,
+						'selected' => $value ?: get_current_user_id(),
+						'who'      => 'authors',
+					)
+				);
+				break;
+
+			case 'category_select':
+				wp_dropdown_categories(
+					array(
+						'name'              => $name,
+						'selected'          => $value,
+						'show_option_none'  => __( '— AI Decides —', 'stratawp-seo' ),
+						'option_none_value' => 0,
+						'hide_empty'        => false,
+					)
+				);
+				break;
+		}
+
+		if ( $has_encrypted_value ) {
+			echo '<span class="dashicons dashicons-yes" style="color:#00a32a;vertical-align:middle;"></span> ';
+			echo '<span style="color:#00a32a;">' . esc_html__( 'Saved (encrypted). Leave blank to keep current value.', 'stratawp-seo' ) . '</span>';
+		}
+
+		if ( $desc ) {
+			printf( '<p class="description">%s</p>', wp_kses_post( $desc ) );
+		}
+	}
+
+	// --- Section descriptions ---
+
+	public function render_ai_section(): void {
+		echo '<p>' . esc_html__( 'Choose your AI provider and enter your API key.', 'stratawp-seo' ) . '</p>';
+	}
+
+	public function render_images_section(): void {
+		echo '<p>' . esc_html__( 'Configure automatic featured images for generated posts.', 'stratawp-seo' ) . '</p>';
+	}
+
+	public function render_site_section(): void {
+		echo '<p>' . esc_html__( 'Tell the AI about your site so it can generate relevant, targeted content.', 'stratawp-seo' ) . '</p>';
+	}
+
+	public function render_ai_crawlers_section(): void {
+		echo '<p>' . esc_html__( 'Control which AI crawlers can access your site and serve a dynamic llms.txt index at /llms.txt.', 'stratawp-seo' ) . '</p>';
+	}
+
+	public function render_writing_section(): void {
+		echo '<p>' . esc_html__( 'Configure how the AI writes content for your site.', 'stratawp-seo' ) . '</p>';
+	}
+
+	public function render_content_section(): void {
+		echo '<p>' . esc_html__( 'Control the output format and WordPress post settings.', 'stratawp-seo' ) . '</p>';
+	}
+
+	public function render_schedule_section(): void {
+		$schedule = SWPS_Cron::get_schedule_info();
+		echo '<p>' . esc_html__( 'Set up automatic content generation on a schedule.', 'stratawp-seo' ) . '</p>';
+		if ( $schedule['enabled'] ) {
+			printf(
+				'<div class="notice notice-info inline"><p><strong>%s</strong> %s</p></div>',
+				esc_html__( 'Next scheduled run:', 'stratawp-seo' ),
+				esc_html( $schedule['next_run'] )
+			);
+		}
+	}
+
+	public function render_audit_section(): void {
+		echo '<p>' . esc_html__( 'Configure automatic SEO audit checks and fixes.', 'stratawp-seo' ) . '</p>';
+	}
+
+	/**
+	 * Render the Schema settings section description.
+	 */
+	public function render_schema_section(): void {
+		echo '<p>' . esc_html__( 'Automatic JSON-LD structured data for rich results in Google. Disabled automatically when Yoast SEO, RankMath, or All in One SEO is active.', 'stratawp-seo' ) . '</p>';
+	}
+
+	public function render_meta_section(): void {
+		echo '<p>' . esc_html__( 'Per-post SEO meta fields for titles, descriptions, social previews, and robots directives. Auto-disabled when Yoast, RankMath, or AIOSEO is active.', 'stratawp-seo' ) . '</p>';
+	}
+
+	public function render_analytics_section(): void {
+		echo '<p>' . esc_html__( 'On-site analytics tracking and Google Search Console integration.', 'stratawp-seo' ) . '</p>';
+	}
+
+	public function render_advanced_section(): void {
+		echo '<p>' . esc_html__( 'Advanced features for duplicate detection, rate limiting, cost tracking, and remote integration.', 'stratawp-seo' ) . '</p>';
+
+		// Show encryption status.
+		$secret = get_option( 'swps_jon_ai_secret', '' );
+		if ( ! empty( $secret ) ) {
+			$is_encrypted = SWPS_Encryption::is_encrypted( $secret );
+			printf(
+				'<div class="notice notice-%s inline"><p>%s %s</p></div>',
+				$is_encrypted ? 'success' : 'warning',
+				esc_html__( 'Remote secret:', 'stratawp-seo' ),
+				$is_encrypted
+					? esc_html__( 'Stored encrypted.', 'stratawp-seo' )
+					: esc_html__( 'Not encrypted — save settings to encrypt.', 'stratawp-seo' )
+			);
+		}
+	}
+
+	public function render_cleanup_section(): void {
+		echo '<p>' . esc_html__( 'Remove unnecessary items from your site\'s <head> section to reduce page size.', 'stratawp-seo' ) . '</p>';
+	}
+
+	public function render_rss_section(): void {
+		echo '<p>' . esc_html__( 'Add content before or after posts in your RSS feed. Available variables: %%post_link%%, %%blog_link%%, %%blog_name%%', 'stratawp-seo' ) . '</p>';
+	}
+
+	public function render_sitemap_section(): void {
+		$index_url = home_url( '/sitemap_index.xml' );
+		echo '<p>' . sprintf(
+			esc_html__( 'Your sitemap index: %s', 'stratawp-seo' ),
+			'<a href="' . esc_url( $index_url ) . '" target="_blank">' . esc_url( $index_url ) . '</a>'
+		) . '</p>';
+	}
+
+	/**
+	 * Tab groups for the settings page. Each tab lists the section IDs it contains.
+	 */
+	public function get_settings_tabs(): array {
+		return array(
+			'ai-content'      => array(
+				'label'    => __( 'AI & Content', 'stratawp-seo' ),
+				'sections' => array(
+					'swps_ai_section',
+					'swps_site_section',
+					'swps_writing_section',
+					'swps_content_section',
+					'swps_images_section',
+				),
+			),
+			'schedule'        => array(
+				'label'    => __( 'Schedule', 'stratawp-seo' ),
+				'sections' => array(
+					'swps_schedule_section',
+				),
+			),
+			'seo'             => array(
+				'label'    => __( 'SEO', 'stratawp-seo' ),
+				'sections' => array(
+					'swps_audit_section',
+					'swps_schema_section',
+					'swps_meta_section',
+					'swps_cleanup_section',
+					'swps_rss_section',
+				),
+			),
+			'discoverability' => array(
+				'label'    => __( 'AI Crawlers', 'stratawp-seo' ),
+				'sections' => array(
+					'swps_ai_crawlers_section',
+				),
+			),
+			'analytics'       => array(
+				'label'    => __( 'Analytics', 'stratawp-seo' ),
+				'sections' => array(
+					'swps_analytics_section',
+				),
+			),
+			'advanced'        => array(
+				'label'    => __( 'Advanced', 'stratawp-seo' ),
+				'sections' => array(
+					'swps_advanced_section',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Render a subset of settings sections — same output as do_settings_sections()
+	 * but scoped to a specific list of section IDs.
+	 */
+	public function render_sections_for_tab( array $section_ids ): void {
+		global $wp_settings_sections, $wp_settings_fields;
+
+		$page = 'stratawp-seo';
+		if ( empty( $wp_settings_sections[ $page ] ) ) {
+			return;
+		}
+
+		foreach ( $section_ids as $section_id ) {
+			if ( ! isset( $wp_settings_sections[ $page ][ $section_id ] ) ) {
+				continue;
+			}
+
+			$section = $wp_settings_sections[ $page ][ $section_id ];
+
+			if ( ! empty( $section['title'] ) ) {
+				echo '<h2>' . esc_html( $section['title'] ) . '</h2>' . "\n";
+			}
+
+			if ( ! empty( $section['callback'] ) ) {
+				call_user_func( $section['callback'], $section );
+			}
+
+			if ( empty( $wp_settings_fields[ $page ][ $section_id ] ) ) {
+				continue;
+			}
+
+			echo '<table class="form-table" role="presentation">';
+			do_settings_fields( $page, $section_id );
+			echo '</table>';
+		}
+	}
+
+	/**
+	 * Render the main settings page.
+	 */
+	public function render_settings_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( isset( $_GET['settings-updated'] ) && $_GET['settings-updated'] ) {
+			if ( get_option( 'swps_cron_enabled' ) ) {
+				SWPS_Cron::schedule();
+			} else {
+				SWPS_Cron::unschedule();
+			}
+		}
+
+		include SWPS_PLUGIN_DIR . 'templates/settings-page.php';
+	}
+
+	/**
+	 * Render the generate content page.
+	 */
+	public function render_generate_page(): void {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return;
+		}
+
+		include SWPS_PLUGIN_DIR . 'templates/generate-page.php';
+	}
+
+	/**
+	 * Show admin notices.
+	 */
+	public function admin_notices(): void {
+		$screen = get_current_screen();
+
+		if ( ! $screen || strpos( $screen->id, 'stratawp-seo' ) === false ) {
+			return;
+		}
+
+		$ai_provider = SWPS_Provider_Factory::create_ai_provider();
+		if ( empty( $ai_provider->get_api_key() ) ) {
+			printf(
+				'<div class="notice notice-warning"><p><strong>%s</strong> %s</p></div>',
+				esc_html__( 'StrataWP SEO:', 'stratawp-seo' ),
+				sprintf(
+					esc_html__( 'Please enter your %s API key to get started.', 'stratawp-seo' ),
+					esc_html( $ai_provider->get_name() )
+				)
+			);
+		}
+
+		if ( empty( get_option( 'swps_site_niche' ) ) ) {
+			printf(
+				'<div class="notice notice-info"><p><strong>%s</strong> %s</p></div>',
+				esc_html__( 'StrataWP SEO:', 'stratawp-seo' ),
+				esc_html__( 'Enter your site niche and description for better content generation.', 'stratawp-seo' )
+			);
+		}
+	}
+
+	/**
+	 * Render the voice profiles page (list or edit).
+	 */
+	public function render_voice_profiles_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$action = sanitize_text_field( $_GET['action'] ?? 'list' );
+
+		if ( in_array( $action, array( 'new', 'edit' ), true ) ) {
+			include SWPS_PLUGIN_DIR . 'templates/voice-profile-edit.php';
+		} else {
+			include SWPS_PLUGIN_DIR . 'templates/voice-profiles-page.php';
+		}
+	}
+
+	public function render_audit_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		include SWPS_PLUGIN_DIR . 'templates/audit-page.php';
+	}
+
+	public function render_search_appearance_page(): void {
+		include SWPS_PLUGIN_DIR . 'templates/search-appearance-page.php';
+	}
 }

--- a/includes/class-sitemap-admin.php
+++ b/includes/class-sitemap-admin.php
@@ -14,10 +14,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 class SWPS_Sitemap_Admin {
 
 	public function __construct() {
-		add_action( 'admin_menu', [ $this, 'register_menu' ], 20 );
-		add_action( 'admin_init', [ $this, 'register_settings' ] );
-		add_action( 'wp_ajax_swps_get_sitemaps', [ $this, 'ajax_get_sitemaps' ] );
-		add_action( 'wp_ajax_swps_toggle_sitemap', [ $this, 'ajax_toggle_sitemap' ] );
+		add_action( 'admin_menu', array( $this, 'register_menu' ), 20 );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'wp_ajax_swps_get_sitemaps', array( $this, 'ajax_get_sitemaps' ) );
+		add_action( 'wp_ajax_swps_toggle_sitemap', array( $this, 'ajax_toggle_sitemap' ) );
 	}
 
 	/**
@@ -30,7 +30,7 @@ class SWPS_Sitemap_Admin {
 			__( 'Sitemaps', 'stratawp-seo' ),
 			'manage_options',
 			'swps-sitemaps',
-			[ $this, 'render' ]
+			array( $this, 'render' )
 		);
 	}
 
@@ -41,37 +41,37 @@ class SWPS_Sitemap_Admin {
 		register_setting(
 			'swps_sitemap_settings',
 			'swps_sitemap_exclude_images',
-			[
+			array(
 				'sanitize_callback' => function ( $value ) {
 					return $value ? 1 : 0;
 				},
-			]
+			)
 		);
 
 		register_setting(
 			'swps_sitemap_settings',
 			'swps_sitemap_exclude_author',
-			[
+			array(
 				'sanitize_callback' => function ( $value ) {
 					return $value ? 1 : 0;
 				},
-			]
+			)
 		);
 
 		register_setting(
 			'swps_sitemap_settings',
 			'swps_auto_redirect_slug_change',
-			[
+			array(
 				'sanitize_callback' => function ( $value ) {
 					return $value ? 1 : 0;
 				},
-			]
+			)
 		);
 
 		register_setting(
 			'swps_sitemap_settings',
 			'swps_sitemap_urls_per_page',
-			[
+			array(
 				'sanitize_callback' => function ( $value ) {
 					$value = absint( $value );
 					if ( $value < 100 ) {
@@ -82,7 +82,7 @@ class SWPS_Sitemap_Admin {
 					}
 					return $value;
 				},
-			]
+			)
 		);
 	}
 
@@ -104,43 +104,49 @@ class SWPS_Sitemap_Admin {
 		check_ajax_referer( 'swps_nonce', 'nonce' );
 
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
 		}
 
-		$sitemaps = [];
+		$sitemaps = array();
 
 		// Post type sitemaps.
-		$post_types = get_post_types( [ 'public' => true ] );
+		$post_types = get_post_types( array( 'public' => true ) );
 		foreach ( $post_types as $pt ) {
 			if ( 'attachment' === $pt ) {
 				continue;
 			}
 
-			$count      = $this->get_post_type_count( $pt );
-			$lastmod    = $this->get_post_type_lastmod( $pt );
-			$excluded   = (bool) get_option( "swps_sitemap_exclude_{$pt}", 0 );
+			$count         = $this->get_post_type_count( $pt );
+			$lastmod       = $this->get_post_type_lastmod( $pt );
+			$excluded      = (bool) get_option( "swps_sitemap_exclude_{$pt}", 0 );
 			$post_type_obj = get_post_type_object( $pt );
-			$label      = $post_type_obj ? $post_type_obj->label : $pt;
+			$label         = $post_type_obj ? $post_type_obj->label : $pt;
 
-			$sitemaps[] = [
-				'key'       => $pt,
-				'name'      => $label,
-				'type'      => 'post_type',
-				'url'       => home_url( "/{$pt}-sitemap.xml" ),
-				'count'     => $count,
-				'lastmod'   => $lastmod,
-				'excluded'  => $excluded,
-			];
+			$sitemaps[] = array(
+				'key'      => $pt,
+				'name'     => $label,
+				'type'     => 'post_type',
+				'url'      => home_url( "/{$pt}-sitemap.xml" ),
+				'count'    => $count,
+				'lastmod'  => $lastmod,
+				'excluded' => $excluded,
+			);
 		}
 
 		// Taxonomy sitemaps.
-		$taxonomies = get_taxonomies( [ 'public' => true ] );
+		$taxonomies = get_taxonomies( array( 'public' => true ) );
 		foreach ( $taxonomies as $tax ) {
 			if ( 'post_format' === $tax ) {
 				continue;
 			}
 
-			$terms = get_terms( [ 'taxonomy' => $tax, 'hide_empty' => true, 'number' => 1 ] );
+			$terms = get_terms(
+				array(
+					'taxonomy'   => $tax,
+					'hide_empty' => true,
+					'number'     => 1,
+				)
+			);
 			if ( empty( $terms ) || is_wp_error( $terms ) ) {
 				continue;
 			}
@@ -148,39 +154,53 @@ class SWPS_Sitemap_Admin {
 			$excluded   = (bool) get_option( "swps_sitemap_exclude_{$tax}", 0 );
 			$tax_obj    = get_taxonomy( $tax );
 			$label      = $tax_obj ? $tax_obj->label : $tax;
-			$term_count = wp_count_terms( [ 'taxonomy' => $tax, 'hide_empty' => true ] );
+			$term_count = wp_count_terms(
+				array(
+					'taxonomy'   => $tax,
+					'hide_empty' => true,
+				)
+			);
 
-			$sitemaps[] = [
-				'key'       => $tax,
-				'name'      => $label,
-				'type'      => 'taxonomy',
-				'url'       => home_url( "/{$tax}-sitemap.xml" ),
-				'count'     => is_wp_error( $term_count ) ? 0 : (int) $term_count,
-				'lastmod'   => gmdate( 'Y-m-d\TH:i:s+00:00' ),
-				'excluded'  => $excluded,
-			];
+			$sitemaps[] = array(
+				'key'      => $tax,
+				'name'     => $label,
+				'type'     => 'taxonomy',
+				'url'      => home_url( "/{$tax}-sitemap.xml" ),
+				'count'    => is_wp_error( $term_count ) ? 0 : (int) $term_count,
+				'lastmod'  => gmdate( 'Y-m-d\TH:i:s+00:00' ),
+				'excluded' => $excluded,
+			);
 		}
 
 		// Author sitemap.
 		$author_excluded = (bool) get_option( 'swps_sitemap_exclude_author', 0 );
-		$author_count    = count( get_users( [ 'has_published_posts' => true, 'fields' => 'ID' ] ) );
+		$author_count    = count(
+			get_users(
+				array(
+					'has_published_posts' => true,
+					'fields'              => 'ID',
+				)
+			)
+		);
 
-		$sitemaps[] = [
-			'key'       => 'author',
-			'name'      => __( 'Authors', 'stratawp-seo' ),
-			'type'      => 'author',
-			'url'       => home_url( '/author-sitemap.xml' ),
-			'count'     => $author_count,
-			'lastmod'   => gmdate( 'Y-m-d\TH:i:s+00:00' ),
-			'excluded'  => $author_excluded,
-		];
+		$sitemaps[] = array(
+			'key'      => 'author',
+			'name'     => __( 'Authors', 'stratawp-seo' ),
+			'type'     => 'author',
+			'url'      => home_url( '/author-sitemap.xml' ),
+			'count'    => $author_count,
+			'lastmod'  => gmdate( 'Y-m-d\TH:i:s+00:00' ),
+			'excluded' => $author_excluded,
+		);
 
 		$index_url = home_url( '/sitemap_index.xml' );
 
-		wp_send_json_success( [
-			'sitemaps'  => $sitemaps,
-			'index_url' => $index_url,
-		] );
+		wp_send_json_success(
+			array(
+				'sitemaps'  => $sitemaps,
+				'index_url' => $index_url,
+			)
+		);
 	}
 
 	/**
@@ -190,24 +210,26 @@ class SWPS_Sitemap_Admin {
 		check_ajax_referer( 'swps_nonce', 'nonce' );
 
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
 		}
 
 		$key = sanitize_text_field( $_POST['key'] ?? '' );
 		if ( empty( $key ) ) {
-			wp_send_json_error( [ 'message' => 'Missing sitemap key.' ] );
+			wp_send_json_error( array( 'message' => 'Missing sitemap key.' ) );
 		}
 
 		$option_name = "swps_sitemap_exclude_{$key}";
-		$current      = (bool) get_option( $option_name, 0 );
-		$new_value    = $current ? 0 : 1;
+		$current     = (bool) get_option( $option_name, 0 );
+		$new_value   = $current ? 0 : 1;
 
 		update_option( $option_name, $new_value );
 
-		wp_send_json_success( [
-			'key'      => $key,
-			'excluded' => (bool) $new_value,
-		] );
+		wp_send_json_success(
+			array(
+				'key'      => $key,
+				'excluded' => (bool) $new_value,
+			)
+		);
 	}
 
 	/**
@@ -215,10 +237,12 @@ class SWPS_Sitemap_Admin {
 	 */
 	private function get_post_type_count( string $post_type ): int {
 		global $wpdb;
-		return (int) $wpdb->get_var( $wpdb->prepare(
-			"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s AND post_status = 'publish'",
-			$post_type
-		) );
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s AND post_status = 'publish'",
+				$post_type
+			)
+		);
 	}
 
 	/**
@@ -226,10 +250,12 @@ class SWPS_Sitemap_Admin {
 	 */
 	private function get_post_type_lastmod( string $post_type ): string {
 		global $wpdb;
-		$date = $wpdb->get_var( $wpdb->prepare(
-			"SELECT MAX(post_modified_gmt) FROM {$wpdb->posts} WHERE post_type = %s AND post_status = 'publish'",
-			$post_type
-		) );
+		$date = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT MAX(post_modified_gmt) FROM {$wpdb->posts} WHERE post_type = %s AND post_status = 'publish'",
+				$post_type
+			)
+		);
 		return $date ? gmdate( 'Y-m-d\TH:i:s+00:00', strtotime( $date ) ) : gmdate( 'Y-m-d\TH:i:s+00:00' );
 	}
 }

--- a/includes/class-sitemap-manager.php
+++ b/includes/class-sitemap-manager.php
@@ -9,374 +9,393 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Sitemap_Manager {
 
-    private function get_urls_per_sitemap(): int {
-        return max( 100, min( 50000, (int) get_option( 'swps_sitemap_urls_per_page', 1000 ) ) );
-    }
-    private function is_post_type_hidden_from_sitemap( string $post_type ): bool {
-        return 'attachment' === $post_type
-            || (bool) get_option( "swps_sitemap_exclude_{$post_type}", 0 )
-            || (bool) get_option( "swps_noindex_{$post_type}", 0 );
-    }
+	private function get_urls_per_sitemap(): int {
+		return max( 100, min( 50000, (int) get_option( 'swps_sitemap_urls_per_page', 1000 ) ) );
+	}
+	private function is_post_type_hidden_from_sitemap( string $post_type ): bool {
+		return 'attachment' === $post_type
+			|| (bool) get_option( "swps_sitemap_exclude_{$post_type}", 0 )
+			|| (bool) get_option( "swps_noindex_{$post_type}", 0 );
+	}
 
-    private function is_taxonomy_hidden_from_sitemap( string $taxonomy ): bool {
-        return 'post_format' === $taxonomy
-            || (bool) get_option( "swps_sitemap_exclude_{$taxonomy}", 0 )
-            || (bool) get_option( "swps_noindex_{$taxonomy}", 0 );
-    }
+	private function is_taxonomy_hidden_from_sitemap( string $taxonomy ): bool {
+		return 'post_format' === $taxonomy
+			|| (bool) get_option( "swps_sitemap_exclude_{$taxonomy}", 0 )
+			|| (bool) get_option( "swps_noindex_{$taxonomy}", 0 );
+	}
 
-    public function __construct() {
-        // Disable WP core sitemaps to prevent conflict detection from blocking us.
-        add_filter( 'wp_sitemaps_enabled', '__return_false' );
+	public function __construct() {
+		// Disable WP core sitemaps to prevent conflict detection from blocking us.
+		add_filter( 'wp_sitemaps_enabled', '__return_false' );
 
-        // Rewrite rules.
-        add_action( 'init', [ $this, 'register_rewrite_rules' ] );
+		// Rewrite rules.
+		add_action( 'init', array( $this, 'register_rewrite_rules' ) );
 
-        // Auto-flush after a plugin upgrade so cached rewrite_rules pick up
-        // new sitemap URLs without the user manually visiting Settings →
-        // Permalinks. Runs once per version change.
-        add_action( 'wp_loaded', [ $this, 'maybe_flush_rewrites' ] );
+		// Auto-flush after a plugin upgrade so cached rewrite_rules pick up
+		// new sitemap URLs without the user manually visiting Settings →
+		// Permalinks. Runs once per version change.
+		add_action( 'wp_loaded', array( $this, 'maybe_flush_rewrites' ) );
 
-        // Serve sitemaps.
-        add_action( 'template_redirect', [ $this, 'serve_sitemap' ], 1 );
-    }
+		// Serve sitemaps.
+		add_action( 'template_redirect', array( $this, 'serve_sitemap' ), 1 );
+	}
 
-    /**
-     * Register rewrite rules for all sitemap URLs.
-     */
-    public function register_rewrite_rules(): void {
-        // Sitemap index.
-        add_rewrite_rule( 'sitemap_index\.xml$', 'index.php?swps_sitemap=index', 'top' );
+	/**
+	 * Register rewrite rules for all sitemap URLs.
+	 */
+	public function register_rewrite_rules(): void {
+		// Sitemap index.
+		add_rewrite_rule( 'sitemap_index\.xml$', 'index.php?swps_sitemap=index', 'top' );
 
-        // Post type sitemaps.
-        add_rewrite_rule( '([a-z0-9_-]+)-sitemap(\d*)\.xml$', 'index.php?swps_sitemap=$matches[1]&swps_sitemap_page=$matches[2]', 'top' );
+		// Post type sitemaps.
+		add_rewrite_rule( '([a-z0-9_-]+)-sitemap(\d*)\.xml$', 'index.php?swps_sitemap=$matches[1]&swps_sitemap_page=$matches[2]', 'top' );
 
-        // Author sitemap.
-        add_rewrite_rule( 'author-sitemap\.xml$', 'index.php?swps_sitemap=author', 'top' );
+		// Author sitemap.
+		add_rewrite_rule( 'author-sitemap\.xml$', 'index.php?swps_sitemap=author', 'top' );
 
-        // Legacy URL redirect.
-        add_rewrite_rule( 'swps-sitemap\.xml$', 'index.php?swps_sitemap=legacy_redirect', 'top' );
+		// Legacy URL redirect.
+		add_rewrite_rule( 'swps-sitemap\.xml$', 'index.php?swps_sitemap=legacy_redirect', 'top' );
 
-        add_filter( 'query_vars', function ( array $vars ): array {
-            $vars[] = 'swps_sitemap';
-            $vars[] = 'swps_sitemap_page';
-            return $vars;
-        } );
-    }
+		add_filter(
+			'query_vars',
+			function ( array $vars ): array {
+				$vars[] = 'swps_sitemap';
+				$vars[] = 'swps_sitemap_page';
+				return $vars;
+			}
+		);
+	}
 
-    /**
-     * Flush rewrite rules once per plugin version so users do not have to
-     * manually re-save permalinks after every upgrade.
-     */
-    public function maybe_flush_rewrites(): void {
-        if ( get_option( 'swps_rewrite_version' ) === SWPS_VERSION ) {
-            return;
-        }
-        update_option( 'swps_rewrite_version', SWPS_VERSION, false );
-        flush_rewrite_rules( false );
-    }
+	/**
+	 * Flush rewrite rules once per plugin version so users do not have to
+	 * manually re-save permalinks after every upgrade.
+	 */
+	public function maybe_flush_rewrites(): void {
+		if ( get_option( 'swps_rewrite_version' ) === SWPS_VERSION ) {
+			return;
+		}
+		update_option( 'swps_rewrite_version', SWPS_VERSION, false );
+		flush_rewrite_rules( false );
+	}
 
-    /**
-     * Serve the appropriate sitemap based on the query var.
-     */
-    public function serve_sitemap(): void {
-        $type = get_query_var( 'swps_sitemap', '' );
-        if ( empty( $type ) ) {
-            return;
-        }
+	/**
+	 * Serve the appropriate sitemap based on the query var.
+	 */
+	public function serve_sitemap(): void {
+		$type = get_query_var( 'swps_sitemap', '' );
+		if ( empty( $type ) ) {
+			return;
+		}
 
-        // Skip if another SEO plugin is actively handling sitemaps.
-        if ( defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' ) ) {
-            return;
-        }
+		// Skip if another SEO plugin is actively handling sitemaps.
+		if ( defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' ) ) {
+			return;
+		}
 
-        // Legacy redirect.
-        if ( 'legacy_redirect' === $type ) {
-            wp_redirect( home_url( '/sitemap_index.xml' ), 301 );
-            exit;
-        }
+		// Legacy redirect.
+		if ( 'legacy_redirect' === $type ) {
+			wp_redirect( home_url( '/sitemap_index.xml' ), 301 );
+			exit;
+		}
 
-        $page = (int) get_query_var( 'swps_sitemap_page', 1 );
-        if ( $page < 1 ) {
-            $page = 1;
-        }
+		$page = (int) get_query_var( 'swps_sitemap_page', 1 );
+		if ( $page < 1 ) {
+			$page = 1;
+		}
 
-        header( 'Content-Type: application/xml; charset=UTF-8' );
-        header( 'X-Robots-Tag: noindex' );
+		header( 'Content-Type: application/xml; charset=UTF-8' );
+		header( 'X-Robots-Tag: noindex' );
 
-        if ( 'index' === $type ) {
-            $this->render_sitemap_index();
-        } elseif ( 'author' === $type ) {
-            $this->render_author_sitemap();
-        } else {
-            // Check if it's a taxonomy.
-            $taxonomies = get_taxonomies( [ 'public' => true ] );
-            if ( in_array( $type, $taxonomies, true ) && ! $this->is_taxonomy_hidden_from_sitemap( $type ) ) {
-                $this->render_taxonomy_sitemap( $type );
-            } else {
-                // Post type sitemap.
-                $post_types = get_post_types( [ 'public' => true ] );
-                if ( in_array( $type, $post_types, true ) && ! $this->is_post_type_hidden_from_sitemap( $type ) ) {
-                    $this->render_post_type_sitemap( $type, $page );
-                } else {
-                    status_header( 404 );
-                    exit;
-                }
-            }
-        }
+		if ( 'index' === $type ) {
+			$this->render_sitemap_index();
+		} elseif ( 'author' === $type ) {
+			$this->render_author_sitemap();
+		} else {
+			// Check if it's a taxonomy.
+			$taxonomies = get_taxonomies( array( 'public' => true ) );
+			if ( in_array( $type, $taxonomies, true ) && ! $this->is_taxonomy_hidden_from_sitemap( $type ) ) {
+				$this->render_taxonomy_sitemap( $type );
+			} else {
+				// Post type sitemap.
+				$post_types = get_post_types( array( 'public' => true ) );
+				if ( in_array( $type, $post_types, true ) && ! $this->is_post_type_hidden_from_sitemap( $type ) ) {
+					$this->render_post_type_sitemap( $type, $page );
+				} else {
+					status_header( 404 );
+					exit;
+				}
+			}
+		}
 
-        exit;
-    }
+		exit;
+	}
 
-    /**
-     * Render the sitemap index.
-     */
-    private function render_sitemap_index(): void {
-        echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
-        echo '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+	/**
+	 * Render the sitemap index.
+	 */
+	private function render_sitemap_index(): void {
+		echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
+		echo '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
 
-        // Post type sitemaps.
-        $post_types = get_post_types( [ 'public' => true ] );
-        foreach ( $post_types as $pt ) {
-            if ( $this->is_post_type_hidden_from_sitemap( $pt ) ) {
-                continue;
-            }
+		// Post type sitemaps.
+		$post_types = get_post_types( array( 'public' => true ) );
+		foreach ( $post_types as $pt ) {
+			if ( $this->is_post_type_hidden_from_sitemap( $pt ) ) {
+				continue;
+			}
 
-            $count = $this->get_post_type_count( $pt );
-            $pages = max( 1, (int) ceil( $count / $this->get_urls_per_sitemap() ) );
+			$count = $this->get_post_type_count( $pt );
+			$pages = max( 1, (int) ceil( $count / $this->get_urls_per_sitemap() ) );
 
-            for ( $i = 1; $i <= $pages; $i++ ) {
-                $suffix = $i > 1 ? $i : '';
-                printf(
-                    "<sitemap>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n</sitemap>\n",
-                    esc_url( home_url( "/{$pt}-sitemap{$suffix}.xml" ) ),
-                    $this->get_post_type_lastmod( $pt )
-                );
-            }
-        }
+			for ( $i = 1; $i <= $pages; $i++ ) {
+				$suffix = $i > 1 ? $i : '';
+				printf(
+					"<sitemap>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n</sitemap>\n",
+					esc_url( home_url( "/{$pt}-sitemap{$suffix}.xml" ) ),
+					$this->get_post_type_lastmod( $pt )
+				);
+			}
+		}
 
-        // Taxonomy sitemaps.
-        $taxonomies = get_taxonomies( [ 'public' => true ] );
-        foreach ( $taxonomies as $tax ) {
-            if ( $this->is_taxonomy_hidden_from_sitemap( $tax ) ) {
-                continue;
-            }
+		// Taxonomy sitemaps.
+		$taxonomies = get_taxonomies( array( 'public' => true ) );
+		foreach ( $taxonomies as $tax ) {
+			if ( $this->is_taxonomy_hidden_from_sitemap( $tax ) ) {
+				continue;
+			}
 
-            $terms = get_terms( [ 'taxonomy' => $tax, 'hide_empty' => true, 'number' => 1 ] );
-            if ( empty( $terms ) || is_wp_error( $terms ) ) {
-                continue;
-            }
+			$terms = get_terms(
+				array(
+					'taxonomy'   => $tax,
+					'hide_empty' => true,
+					'number'     => 1,
+				)
+			);
+			if ( empty( $terms ) || is_wp_error( $terms ) ) {
+				continue;
+			}
 
-            printf(
-                "<sitemap>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n</sitemap>\n",
-                esc_url( home_url( "/{$tax}-sitemap.xml" ) ),
-                gmdate( 'Y-m-d\TH:i:s+00:00' )
-            );
-        }
+			printf(
+				"<sitemap>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n</sitemap>\n",
+				esc_url( home_url( "/{$tax}-sitemap.xml" ) ),
+				gmdate( 'Y-m-d\TH:i:s+00:00' )
+			);
+		}
 
-        // Author sitemap.
-        if ( ! get_option( 'swps_sitemap_exclude_author', 0 ) ) {
-            printf(
-                "<sitemap>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n</sitemap>\n",
-                esc_url( home_url( '/author-sitemap.xml' ) ),
-                gmdate( 'Y-m-d\TH:i:s+00:00' )
-            );
-        }
+		// Author sitemap.
+		if ( ! get_option( 'swps_sitemap_exclude_author', 0 ) ) {
+			printf(
+				"<sitemap>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n</sitemap>\n",
+				esc_url( home_url( '/author-sitemap.xml' ) ),
+				gmdate( 'Y-m-d\TH:i:s+00:00' )
+			);
+		}
 
-        echo '</sitemapindex>';
-    }
+		echo '</sitemapindex>';
+	}
 
-    /**
-     * Render a post type sub-sitemap.
-     */
-    private function render_post_type_sitemap( string $post_type, int $page ): void {
-        if ( $this->is_post_type_hidden_from_sitemap( $post_type ) ) {
-            return;
-        }
+	/**
+	 * Render a post type sub-sitemap.
+	 */
+	private function render_post_type_sitemap( string $post_type, int $page ): void {
+		if ( $this->is_post_type_hidden_from_sitemap( $post_type ) ) {
+			return;
+		}
 
-        $offset = ( $page - 1 ) * $this->get_urls_per_sitemap();
+		$offset = ( $page - 1 ) * $this->get_urls_per_sitemap();
 
-        $posts = get_posts( [
-            'post_type'      => $post_type,
-            'post_status'    => 'publish',
-            'posts_per_page' => $this->get_urls_per_sitemap(),
-            'offset'         => $offset,
-            'orderby'        => 'modified',
-            'order'          => 'DESC',
-            'no_found_rows'  => true,
-        ] );
+		$posts = get_posts(
+			array(
+				'post_type'      => $post_type,
+				'post_status'    => 'publish',
+				'posts_per_page' => $this->get_urls_per_sitemap(),
+				'offset'         => $offset,
+				'orderby'        => 'modified',
+				'order'          => 'DESC',
+				'no_found_rows'  => true,
+			)
+		);
 
-        echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
-        echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"' . "\n";
-        echo '        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">' . "\n";
+		echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
+		echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"' . "\n";
+		echo '        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">' . "\n";
 
-        // Include homepage on first page of 'page' sitemap.
-        if ( 'page' === $post_type && 1 === $page ) {
-            printf(
-                "<url>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n  <priority>1.0</priority>\n</url>\n",
-                esc_url( home_url( '/' ) ),
-                gmdate( 'Y-m-d\TH:i:s+00:00' )
-            );
-        }
+		// Include homepage on first page of 'page' sitemap.
+		if ( 'page' === $post_type && 1 === $page ) {
+			printf(
+				"<url>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n  <priority>1.0</priority>\n</url>\n",
+				esc_url( home_url( '/' ) ),
+				gmdate( 'Y-m-d\TH:i:s+00:00' )
+			);
+		}
 
-        foreach ( $posts as $post ) {
-            // Respect exclusions.
-            if ( get_post_meta( $post->ID, '_swps_sitemap_exclude', true ) ) {
-                continue;
-            }
+		foreach ( $posts as $post ) {
+			// Respect exclusions.
+			if ( get_post_meta( $post->ID, '_swps_sitemap_exclude', true ) ) {
+				continue;
+			}
 
-            // Respect noindex.
-            $robots = get_post_meta( $post->ID, '_swps_robots', true );
-            if ( ! empty( $robots ) && str_contains( (string) $robots, 'noindex' ) ) {
-                continue;
-            }
+			// Respect noindex.
+			$robots = get_post_meta( $post->ID, '_swps_robots', true );
+			if ( ! empty( $robots ) && str_contains( (string) $robots, 'noindex' ) ) {
+				continue;
+			}
 
-            $modified = get_post_modified_time( 'U', true, $post );
-            $priority = get_post_meta( $post->ID, '_swps_sitemap_priority', true );
-            if ( empty( $priority ) ) {
-                $priority = 'page' === $post_type ? '0.8' : '0.6';
-            }
-            $changefreq = get_post_meta( $post->ID, '_swps_sitemap_changefreq', true ) ?: 'weekly';
+			$modified = get_post_modified_time( 'U', true, $post );
+			$priority = get_post_meta( $post->ID, '_swps_sitemap_priority', true );
+			if ( empty( $priority ) ) {
+				$priority = 'page' === $post_type ? '0.8' : '0.6';
+			}
+			$changefreq = get_post_meta( $post->ID, '_swps_sitemap_changefreq', true ) ?: 'weekly';
 
-            echo "<url>\n";
-            printf( "  <loc>%s</loc>\n", esc_url( get_permalink( $post ) ) );
-            printf( "  <lastmod>%s</lastmod>\n", gmdate( 'Y-m-d\TH:i:s+00:00', $modified ) );
-            printf( "  <changefreq>%s</changefreq>\n", esc_xml( $changefreq ) );
-            printf( "  <priority>%s</priority>\n", esc_attr( $priority ) );
+			echo "<url>\n";
+			printf( "  <loc>%s</loc>\n", esc_url( get_permalink( $post ) ) );
+			printf( "  <lastmod>%s</lastmod>\n", gmdate( 'Y-m-d\TH:i:s+00:00', $modified ) );
+			printf( "  <changefreq>%s</changefreq>\n", esc_xml( $changefreq ) );
+			printf( "  <priority>%s</priority>\n", esc_attr( $priority ) );
 
-            // Image entries.
-            if ( ! get_option( 'swps_sitemap_exclude_images', 0 ) ) {
-                $this->render_image_entries( $post->ID );
-            }
+			// Image entries.
+			if ( ! get_option( 'swps_sitemap_exclude_images', 0 ) ) {
+				$this->render_image_entries( $post->ID );
+			}
 
-            echo "</url>\n";
-        }
+			echo "</url>\n";
+		}
 
-        echo '</urlset>';
-    }
+		echo '</urlset>';
+	}
 
-    /**
-     * Render a taxonomy sub-sitemap.
-     */
-    private function render_taxonomy_sitemap( string $taxonomy ): void {
-        if ( $this->is_taxonomy_hidden_from_sitemap( $taxonomy ) ) {
-            return;
-        }
+	/**
+	 * Render a taxonomy sub-sitemap.
+	 */
+	private function render_taxonomy_sitemap( string $taxonomy ): void {
+		if ( $this->is_taxonomy_hidden_from_sitemap( $taxonomy ) ) {
+			return;
+		}
 
-        $terms = get_terms( [
-            'taxonomy'   => $taxonomy,
-            'hide_empty' => true,
-            'number'     => $this->get_urls_per_sitemap(),
-        ] );
+		$terms = get_terms(
+			array(
+				'taxonomy'   => $taxonomy,
+				'hide_empty' => true,
+				'number'     => $this->get_urls_per_sitemap(),
+			)
+		);
 
-        echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
-        echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+		echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
+		echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
 
-        if ( ! is_wp_error( $terms ) ) {
-            foreach ( $terms as $term ) {
-                // Respect exclusions.
-                if ( get_term_meta( $term->term_id, '_swps_sitemap_exclude', true ) ) {
-                    continue;
-                }
+		if ( ! is_wp_error( $terms ) ) {
+			foreach ( $terms as $term ) {
+				// Respect exclusions.
+				if ( get_term_meta( $term->term_id, '_swps_sitemap_exclude', true ) ) {
+					continue;
+				}
 
-                $robots = get_term_meta( $term->term_id, '_swps_robots', true );
-                if ( ! empty( $robots ) && str_contains( (string) $robots, 'noindex' ) ) {
-                    continue;
-                }
+				$robots = get_term_meta( $term->term_id, '_swps_robots', true );
+				if ( ! empty( $robots ) && str_contains( (string) $robots, 'noindex' ) ) {
+					continue;
+				}
 
-                echo "<url>\n";
-                printf( "  <loc>%s</loc>\n", esc_url( get_term_link( $term ) ) );
-                printf( "  <changefreq>weekly</changefreq>\n" );
-                printf( "  <priority>0.4</priority>\n" );
-                echo "</url>\n";
-            }
-        }
+				echo "<url>\n";
+				printf( "  <loc>%s</loc>\n", esc_url( get_term_link( $term ) ) );
+				printf( "  <changefreq>weekly</changefreq>\n" );
+				printf( "  <priority>0.4</priority>\n" );
+				echo "</url>\n";
+			}
+		}
 
-        echo '</urlset>';
-    }
+		echo '</urlset>';
+	}
 
-    /**
-     * Render author sub-sitemap.
-     */
-    private function render_author_sitemap(): void {
-        $authors = get_users( [
-            'has_published_posts' => true,
-            'fields'             => [ 'ID', 'user_nicename' ],
-        ] );
+	/**
+	 * Render author sub-sitemap.
+	 */
+	private function render_author_sitemap(): void {
+		$authors = get_users(
+			array(
+				'has_published_posts' => true,
+				'fields'              => array( 'ID', 'user_nicename' ),
+			)
+		);
 
-        echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
-        echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
+		echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
+		echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
 
-        foreach ( $authors as $author ) {
-            echo "<url>\n";
-            printf( "  <loc>%s</loc>\n", esc_url( get_author_posts_url( $author->ID ) ) );
-            printf( "  <changefreq>weekly</changefreq>\n" );
-            printf( "  <priority>0.3</priority>\n" );
-            echo "</url>\n";
-        }
+		foreach ( $authors as $author ) {
+			echo "<url>\n";
+			printf( "  <loc>%s</loc>\n", esc_url( get_author_posts_url( $author->ID ) ) );
+			printf( "  <changefreq>weekly</changefreq>\n" );
+			printf( "  <priority>0.3</priority>\n" );
+			echo "</url>\n";
+		}
 
-        echo '</urlset>';
-    }
+		echo '</urlset>';
+	}
 
-    /**
-     * Render image entries for a post.
-     */
-    private function render_image_entries( int $post_id ): void {
-        // Featured image.
-        $thumb_id = get_post_thumbnail_id( $post_id );
-        if ( $thumb_id ) {
-            $img_url = wp_get_attachment_url( $thumb_id );
-            if ( $img_url ) {
-                echo "  <image:image>\n";
-                printf( "    <image:loc>%s</image:loc>\n", esc_url( $img_url ) );
-                $alt = get_post_meta( $thumb_id, '_wp_attachment_image_alt', true );
-                if ( $alt ) {
-                    printf( "    <image:title>%s</image:title>\n", esc_xml( $alt ) );
-                }
-                echo "  </image:image>\n";
-            }
-        }
+	/**
+	 * Render image entries for a post.
+	 */
+	private function render_image_entries( int $post_id ): void {
+		// Featured image.
+		$thumb_id = get_post_thumbnail_id( $post_id );
+		if ( $thumb_id ) {
+			$img_url = wp_get_attachment_url( $thumb_id );
+			if ( $img_url ) {
+				echo "  <image:image>\n";
+				printf( "    <image:loc>%s</image:loc>\n", esc_url( $img_url ) );
+				$alt = get_post_meta( $thumb_id, '_wp_attachment_image_alt', true );
+				if ( $alt ) {
+					printf( "    <image:title>%s</image:title>\n", esc_xml( $alt ) );
+				}
+				echo "  </image:image>\n";
+			}
+		}
 
-        // In-content images.
-        $post = get_post( $post_id );
-        if ( $post && preg_match_all( '/<img[^>]+src=["\']([^"\']+)["\'][^>]*>/i', $post->post_content, $matches ) ) {
-            $seen = [ $thumb_id ? wp_get_attachment_url( $thumb_id ) : '' ];
-            foreach ( $matches[1] as $img_url ) {
-                if ( in_array( $img_url, $seen, true ) ) {
-                    continue;
-                }
-                $seen[] = $img_url;
-                echo "  <image:image>\n";
-                printf( "    <image:loc>%s</image:loc>\n", esc_url( $img_url ) );
-                echo "  </image:image>\n";
-            }
-        }
-    }
+		// In-content images.
+		$post = get_post( $post_id );
+		if ( $post && preg_match_all( '/<img[^>]+src=["\']([^"\']+)["\'][^>]*>/i', $post->post_content, $matches ) ) {
+			$seen = array( $thumb_id ? wp_get_attachment_url( $thumb_id ) : '' );
+			foreach ( $matches[1] as $img_url ) {
+				if ( in_array( $img_url, $seen, true ) ) {
+					continue;
+				}
+				$seen[] = $img_url;
+				echo "  <image:image>\n";
+				printf( "    <image:loc>%s</image:loc>\n", esc_url( $img_url ) );
+				echo "  </image:image>\n";
+			}
+		}
+	}
 
-    /**
-     * Get post count for a post type (excluding sitemap-excluded posts).
-     */
-    private function get_post_type_count( string $post_type ): int {
-        global $wpdb;
-        return (int) $wpdb->get_var( $wpdb->prepare(
-            "SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s AND post_status = 'publish'",
-            $post_type
-        ) );
-    }
+	/**
+	 * Get post count for a post type (excluding sitemap-excluded posts).
+	 */
+	private function get_post_type_count( string $post_type ): int {
+		global $wpdb;
+		return (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(*) FROM {$wpdb->posts} WHERE post_type = %s AND post_status = 'publish'",
+				$post_type
+			)
+		);
+	}
 
-    /**
-     * Get the most recent lastmod for a post type.
-     */
-    private function get_post_type_lastmod( string $post_type ): string {
-        global $wpdb;
-        $date = $wpdb->get_var( $wpdb->prepare(
-            "SELECT MAX(post_modified_gmt) FROM {$wpdb->posts} WHERE post_type = %s AND post_status = 'publish'",
-            $post_type
-        ) );
-        return $date ? gmdate( 'Y-m-d\TH:i:s+00:00', strtotime( $date ) ) : gmdate( 'Y-m-d\TH:i:s+00:00' );
-    }
+	/**
+	 * Get the most recent lastmod for a post type.
+	 */
+	private function get_post_type_lastmod( string $post_type ): string {
+		global $wpdb;
+		$date = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT MAX(post_modified_gmt) FROM {$wpdb->posts} WHERE post_type = %s AND post_status = 'publish'",
+				$post_type
+			)
+		);
+		return $date ? gmdate( 'Y-m-d\TH:i:s+00:00', strtotime( $date ) ) : gmdate( 'Y-m-d\TH:i:s+00:00' );
+	}
 }

--- a/includes/class-taxonomy-meta.php
+++ b/includes/class-taxonomy-meta.php
@@ -6,183 +6,183 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Taxonomy_Meta {
 
-    private const META_FIELDS = [
-        '_swps_meta_title',
-        '_swps_meta_description',
-        '_swps_canonical_url',
-        '_swps_robots',
-        '_swps_og_title',
-        '_swps_og_description',
-        '_swps_og_image',
-        '_swps_focus_keyword',
-    ];
+	private const META_FIELDS = array(
+		'_swps_meta_title',
+		'_swps_meta_description',
+		'_swps_canonical_url',
+		'_swps_robots',
+		'_swps_og_title',
+		'_swps_og_description',
+		'_swps_og_image',
+		'_swps_focus_keyword',
+	);
 
-    public function __construct() {
-        // Register fields on all public taxonomy edit screens.
-        $taxonomies = get_taxonomies( [ 'public' => true ] );
-        foreach ( $taxonomies as $taxonomy ) {
-            if ( 'post_format' === $taxonomy ) {
-                continue;
-            }
-            add_action( "{$taxonomy}_edit_form_fields", [ $this, 'render_fields' ], 10, 2 );
-            add_action( "edited_{$taxonomy}", [ $this, 'save_fields' ], 10, 2 );
-        }
+	public function __construct() {
+		// Register fields on all public taxonomy edit screens.
+		$taxonomies = get_taxonomies( array( 'public' => true ) );
+		foreach ( $taxonomies as $taxonomy ) {
+			if ( 'post_format' === $taxonomy ) {
+				continue;
+			}
+			add_action( "{$taxonomy}_edit_form_fields", array( $this, 'render_fields' ), 10, 2 );
+			add_action( "edited_{$taxonomy}", array( $this, 'save_fields' ), 10, 2 );
+		}
 
-        // Frontend meta output for archive pages (only when no conflict).
-        if ( ! is_admin() && ! defined( 'WPSEO_VERSION' ) && ! defined( 'RANK_MATH_VERSION' ) && ! defined( 'AIOSEO_VERSION' ) ) {
-            add_action( 'wp_head', [ $this, 'output_archive_meta' ], 3 );
-        }
-    }
+		// Frontend meta output for archive pages (only when no conflict).
+		if ( ! is_admin() && ! defined( 'WPSEO_VERSION' ) && ! defined( 'RANK_MATH_VERSION' ) && ! defined( 'AIOSEO_VERSION' ) ) {
+			add_action( 'wp_head', array( $this, 'output_archive_meta' ), 3 );
+		}
+	}
 
-    /**
-     * Render SEO fields on the term edit screen.
-     */
-    public function render_fields( \WP_Term $term ): void {
-        wp_nonce_field( 'swps_taxonomy_meta', 'swps_taxonomy_meta_nonce' );
-        ?>
-        <tr class="form-field">
-            <th colspan="2"><h2><?php esc_html_e( 'StrataWP SEO', 'stratawp-seo' ); ?></h2></th>
-        </tr>
-        <tr class="form-field">
-            <th scope="row"><label for="swps-tax-meta-title"><?php esc_html_e( 'Meta Title', 'stratawp-seo' ); ?></label></th>
-            <td>
-                <input type="text" id="swps-tax-meta-title" name="_swps_meta_title" class="large-text"
-                    value="<?php echo esc_attr( get_term_meta( $term->term_id, '_swps_meta_title', true ) ); ?>">
-                <p class="description"><?php esc_html_e( 'Leave blank to use the Search Appearance template.', 'stratawp-seo' ); ?></p>
-            </td>
-        </tr>
-        <tr class="form-field">
-            <th scope="row"><label for="swps-tax-meta-desc"><?php esc_html_e( 'Meta Description', 'stratawp-seo' ); ?></label></th>
-            <td>
-                <textarea id="swps-tax-meta-desc" name="_swps_meta_description" rows="3" class="large-text"
-                ><?php echo esc_textarea( get_term_meta( $term->term_id, '_swps_meta_description', true ) ); ?></textarea>
-            </td>
-        </tr>
-        <tr class="form-field">
-            <th scope="row"><label for="swps-tax-canonical"><?php esc_html_e( 'Canonical URL', 'stratawp-seo' ); ?></label></th>
-            <td>
-                <input type="url" id="swps-tax-canonical" name="_swps_canonical_url" class="large-text"
-                    value="<?php echo esc_url( get_term_meta( $term->term_id, '_swps_canonical_url', true ) ); ?>">
-            </td>
-        </tr>
-        <tr class="form-field">
-            <th scope="row"><?php esc_html_e( 'Robots', 'stratawp-seo' ); ?></th>
-            <td>
-                <?php $robots = get_term_meta( $term->term_id, '_swps_robots', true ); ?>
-                <label>
-                    <input type="checkbox" name="_swps_robots_noindex" value="1"
-                        <?php checked( str_contains( (string) $robots, 'noindex' ) ); ?>>
-                    <?php esc_html_e( 'noindex', 'stratawp-seo' ); ?>
-                </label>
-                <label style="margin-left: 15px;">
-                    <input type="checkbox" name="_swps_robots_nofollow" value="1"
-                        <?php checked( str_contains( (string) $robots, 'nofollow' ) ); ?>>
-                    <?php esc_html_e( 'nofollow', 'stratawp-seo' ); ?>
-                </label>
-            </td>
-        </tr>
-        <tr class="form-field">
-            <th scope="row"><label for="swps-tax-og-title"><?php esc_html_e( 'OG Title', 'stratawp-seo' ); ?></label></th>
-            <td>
-                <input type="text" id="swps-tax-og-title" name="_swps_og_title" class="large-text"
-                    value="<?php echo esc_attr( get_term_meta( $term->term_id, '_swps_og_title', true ) ); ?>">
-            </td>
-        </tr>
-        <tr class="form-field">
-            <th scope="row"><label for="swps-tax-og-desc"><?php esc_html_e( 'OG Description', 'stratawp-seo' ); ?></label></th>
-            <td>
-                <textarea id="swps-tax-og-desc" name="_swps_og_description" rows="2" class="large-text"
-                ><?php echo esc_textarea( get_term_meta( $term->term_id, '_swps_og_description', true ) ); ?></textarea>
-            </td>
-        </tr>
-        <tr class="form-field">
-            <th scope="row"><label for="swps-tax-focus-kw"><?php esc_html_e( 'Focus Keyword', 'stratawp-seo' ); ?></label></th>
-            <td>
-                <input type="text" id="swps-tax-focus-kw" name="_swps_focus_keyword" class="large-text"
-                    value="<?php echo esc_attr( get_term_meta( $term->term_id, '_swps_focus_keyword', true ) ); ?>">
-            </td>
-        </tr>
-        <?php
-    }
+	/**
+	 * Render SEO fields on the term edit screen.
+	 */
+	public function render_fields( \WP_Term $term ): void {
+		wp_nonce_field( 'swps_taxonomy_meta', 'swps_taxonomy_meta_nonce' );
+		?>
+		<tr class="form-field">
+			<th colspan="2"><h2><?php esc_html_e( 'StrataWP SEO', 'stratawp-seo' ); ?></h2></th>
+		</tr>
+		<tr class="form-field">
+			<th scope="row"><label for="swps-tax-meta-title"><?php esc_html_e( 'Meta Title', 'stratawp-seo' ); ?></label></th>
+			<td>
+				<input type="text" id="swps-tax-meta-title" name="_swps_meta_title" class="large-text"
+					value="<?php echo esc_attr( get_term_meta( $term->term_id, '_swps_meta_title', true ) ); ?>">
+				<p class="description"><?php esc_html_e( 'Leave blank to use the Search Appearance template.', 'stratawp-seo' ); ?></p>
+			</td>
+		</tr>
+		<tr class="form-field">
+			<th scope="row"><label for="swps-tax-meta-desc"><?php esc_html_e( 'Meta Description', 'stratawp-seo' ); ?></label></th>
+			<td>
+				<textarea id="swps-tax-meta-desc" name="_swps_meta_description" rows="3" class="large-text"
+				><?php echo esc_textarea( get_term_meta( $term->term_id, '_swps_meta_description', true ) ); ?></textarea>
+			</td>
+		</tr>
+		<tr class="form-field">
+			<th scope="row"><label for="swps-tax-canonical"><?php esc_html_e( 'Canonical URL', 'stratawp-seo' ); ?></label></th>
+			<td>
+				<input type="url" id="swps-tax-canonical" name="_swps_canonical_url" class="large-text"
+					value="<?php echo esc_url( get_term_meta( $term->term_id, '_swps_canonical_url', true ) ); ?>">
+			</td>
+		</tr>
+		<tr class="form-field">
+			<th scope="row"><?php esc_html_e( 'Robots', 'stratawp-seo' ); ?></th>
+			<td>
+				<?php $robots = get_term_meta( $term->term_id, '_swps_robots', true ); ?>
+				<label>
+					<input type="checkbox" name="_swps_robots_noindex" value="1"
+						<?php checked( str_contains( (string) $robots, 'noindex' ) ); ?>>
+					<?php esc_html_e( 'noindex', 'stratawp-seo' ); ?>
+				</label>
+				<label style="margin-left: 15px;">
+					<input type="checkbox" name="_swps_robots_nofollow" value="1"
+						<?php checked( str_contains( (string) $robots, 'nofollow' ) ); ?>>
+					<?php esc_html_e( 'nofollow', 'stratawp-seo' ); ?>
+				</label>
+			</td>
+		</tr>
+		<tr class="form-field">
+			<th scope="row"><label for="swps-tax-og-title"><?php esc_html_e( 'OG Title', 'stratawp-seo' ); ?></label></th>
+			<td>
+				<input type="text" id="swps-tax-og-title" name="_swps_og_title" class="large-text"
+					value="<?php echo esc_attr( get_term_meta( $term->term_id, '_swps_og_title', true ) ); ?>">
+			</td>
+		</tr>
+		<tr class="form-field">
+			<th scope="row"><label for="swps-tax-og-desc"><?php esc_html_e( 'OG Description', 'stratawp-seo' ); ?></label></th>
+			<td>
+				<textarea id="swps-tax-og-desc" name="_swps_og_description" rows="2" class="large-text"
+				><?php echo esc_textarea( get_term_meta( $term->term_id, '_swps_og_description', true ) ); ?></textarea>
+			</td>
+		</tr>
+		<tr class="form-field">
+			<th scope="row"><label for="swps-tax-focus-kw"><?php esc_html_e( 'Focus Keyword', 'stratawp-seo' ); ?></label></th>
+			<td>
+				<input type="text" id="swps-tax-focus-kw" name="_swps_focus_keyword" class="large-text"
+					value="<?php echo esc_attr( get_term_meta( $term->term_id, '_swps_focus_keyword', true ) ); ?>">
+			</td>
+		</tr>
+		<?php
+	}
 
-    /**
-     * Save taxonomy SEO fields.
-     */
-    public function save_fields( int $term_id ): void {
-        if ( ! isset( $_POST['swps_taxonomy_meta_nonce'] ) ||
-             ! wp_verify_nonce( $_POST['swps_taxonomy_meta_nonce'], 'swps_taxonomy_meta' ) ) {
-            return;
-        }
+	/**
+	 * Save taxonomy SEO fields.
+	 */
+	public function save_fields( int $term_id ): void {
+		if ( ! isset( $_POST['swps_taxonomy_meta_nonce'] ) ||
+			! wp_verify_nonce( $_POST['swps_taxonomy_meta_nonce'], 'swps_taxonomy_meta' ) ) {
+			return;
+		}
 
-        if ( ! current_user_can( 'manage_categories' ) ) {
-            return;
-        }
+		if ( ! current_user_can( 'manage_categories' ) ) {
+			return;
+		}
 
-        // Text fields.
-        $text_fields = [ '_swps_meta_title', '_swps_meta_description', '_swps_canonical_url', '_swps_og_title', '_swps_og_description', '_swps_focus_keyword' ];
-        foreach ( $text_fields as $field ) {
-            $value = isset( $_POST[ $field ] ) ? sanitize_text_field( wp_unslash( $_POST[ $field ] ) ) : '';
-            if ( ! empty( $value ) ) {
-                update_term_meta( $term_id, $field, $value );
-            } else {
-                delete_term_meta( $term_id, $field );
-            }
-        }
+		// Text fields.
+		$text_fields = array( '_swps_meta_title', '_swps_meta_description', '_swps_canonical_url', '_swps_og_title', '_swps_og_description', '_swps_focus_keyword' );
+		foreach ( $text_fields as $field ) {
+			$value = isset( $_POST[ $field ] ) ? sanitize_text_field( wp_unslash( $_POST[ $field ] ) ) : '';
+			if ( ! empty( $value ) ) {
+				update_term_meta( $term_id, $field, $value );
+			} else {
+				delete_term_meta( $term_id, $field );
+			}
+		}
 
-        // Robots directives.
-        $robots = [];
-        if ( ! empty( $_POST['_swps_robots_noindex'] ) ) {
-            $robots[] = 'noindex';
-        }
-        if ( ! empty( $_POST['_swps_robots_nofollow'] ) ) {
-            $robots[] = 'nofollow';
-        }
-        if ( ! empty( $robots ) ) {
-            update_term_meta( $term_id, '_swps_robots', implode( ',', $robots ) );
-        } else {
-            delete_term_meta( $term_id, '_swps_robots' );
-        }
-    }
+		// Robots directives.
+		$robots = array();
+		if ( ! empty( $_POST['_swps_robots_noindex'] ) ) {
+			$robots[] = 'noindex';
+		}
+		if ( ! empty( $_POST['_swps_robots_nofollow'] ) ) {
+			$robots[] = 'nofollow';
+		}
+		if ( ! empty( $robots ) ) {
+			update_term_meta( $term_id, '_swps_robots', implode( ',', $robots ) );
+		} else {
+			delete_term_meta( $term_id, '_swps_robots' );
+		}
+	}
 
-    /**
-     * Output meta tags on archive pages using term meta overrides.
-     */
-    public function output_archive_meta(): void {
-        if ( ! is_category() && ! is_tag() && ! is_tax() ) {
-            return;
-        }
+	/**
+	 * Output meta tags on archive pages using term meta overrides.
+	 */
+	public function output_archive_meta(): void {
+		if ( ! is_category() && ! is_tag() && ! is_tax() ) {
+			return;
+		}
 
-        $term = get_queried_object();
-        if ( ! $term instanceof \WP_Term ) {
-            return;
-        }
+		$term = get_queried_object();
+		if ( ! $term instanceof \WP_Term ) {
+			return;
+		}
 
-        // Canonical URL.
-        $canonical = get_term_meta( $term->term_id, '_swps_canonical_url', true );
-        if ( ! empty( $canonical ) ) {
-            printf( '<link rel="canonical" href="%s" />' . "\n", esc_url( $canonical ) );
-        }
+		// Canonical URL.
+		$canonical = get_term_meta( $term->term_id, '_swps_canonical_url', true );
+		if ( ! empty( $canonical ) ) {
+			printf( '<link rel="canonical" href="%s" />' . "\n", esc_url( $canonical ) );
+		}
 
-        // Robots.
-        $robots = get_term_meta( $term->term_id, '_swps_robots', true );
-        if ( ! empty( $robots ) ) {
-            printf( '<meta name="robots" content="%s" />' . "\n", esc_attr( $robots ) );
-        }
+		// Robots.
+		$robots = get_term_meta( $term->term_id, '_swps_robots', true );
+		if ( ! empty( $robots ) ) {
+			printf( '<meta name="robots" content="%s" />' . "\n", esc_attr( $robots ) );
+		}
 
-        // OG tags.
-        $og_title = get_term_meta( $term->term_id, '_swps_og_title', true );
-        $og_desc  = get_term_meta( $term->term_id, '_swps_og_description', true );
+		// OG tags.
+		$og_title = get_term_meta( $term->term_id, '_swps_og_title', true );
+		$og_desc  = get_term_meta( $term->term_id, '_swps_og_description', true );
 
-        if ( ! empty( $og_title ) ) {
-            printf( '<meta property="og:title" content="%s" />' . "\n", esc_attr( $og_title ) );
-        }
-        if ( ! empty( $og_desc ) ) {
-            printf( '<meta property="og:description" content="%s" />' . "\n", esc_attr( $og_desc ) );
-        }
-    }
+		if ( ! empty( $og_title ) ) {
+			printf( '<meta property="og:title" content="%s" />' . "\n", esc_attr( $og_title ) );
+		}
+		if ( ! empty( $og_desc ) ) {
+			printf( '<meta property="og:description" content="%s" />' . "\n", esc_attr( $og_desc ) );
+		}
+	}
 }

--- a/includes/class-templates.php
+++ b/includes/class-templates.php
@@ -8,103 +8,103 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Templates {
 
-    /**
-     * Available content templates.
-     *
-     * @return array Template definitions [slug => [name, system_modifier, user_modifier]].
-     */
-    public static function get_templates(): array {
-        return [
-            'auto' => [
-                'name'            => __( 'Auto (AI Decides)', 'stratawp-seo' ),
-                'system_modifier' => '',
-                'user_modifier'   => '',
-            ],
-            'listicle' => [
-                'name'            => __( 'Listicle', 'stratawp-seo' ),
-                'system_modifier' => "\nCONTENT FORMAT: Write this as a numbered listicle (e.g., \"7 Ways to...\", \"10 Best...\"). Each list item should have its own H2 heading with a number, followed by 2-3 paragraphs of detail.",
-                'user_modifier'   => "\n- Format as a numbered listicle with 7-15 items\n- Each item gets its own H2 heading\n- Include a brief intro and conclusion",
-            ],
-            'how-to' => [
-                'name'            => __( 'How-To Guide', 'stratawp-seo' ),
-                'system_modifier' => "\nCONTENT FORMAT: Write this as a step-by-step how-to guide. Use numbered steps as H2 headings (\"Step 1: ...\"). Include prerequisites, tools needed, and expected outcomes.",
-                'user_modifier'   => "\n- Format as a step-by-step how-to guide\n- Include a prerequisites/what you'll need section\n- Number each step clearly\n- Add tips and warnings where relevant\n- Include an expected results section",
-            ],
-            'comparison' => [
-                'name'            => __( 'Comparison / Vs', 'stratawp-seo' ),
-                'system_modifier' => "\nCONTENT FORMAT: Write this as a detailed comparison article. Compare 2-4 options/products/approaches side by side. Include a comparison table in HTML, pros and cons for each, and a clear recommendation.",
-                'user_modifier'   => "\n- Format as a comparison article\n- Include an HTML comparison table with key features\n- List pros and cons for each option\n- Provide a clear winner/recommendation with reasoning\n- Add a \"Who should choose what\" section",
-            ],
-            'case-study' => [
-                'name'            => __( 'Case Study', 'stratawp-seo' ),
-                'system_modifier' => "\nCONTENT FORMAT: Write this as a case study with clear sections: Challenge/Problem, Solution/Approach, Results/Outcomes, and Key Takeaways. Use specific (but realistic fictional) data points and metrics.",
-                'user_modifier'   => "\n- Format as a case study\n- Include sections: Background, Challenge, Solution, Results, Key Takeaways\n- Use specific metrics and data points (realistic examples)\n- Include quotes or testimonials (fictional but realistic)\n- End with actionable lessons readers can apply",
-            ],
-            'news' => [
-                'name'            => __( 'News / Trend Analysis', 'stratawp-seo' ),
-                'system_modifier' => "\nCONTENT FORMAT: Write this as a news analysis or trend piece. Cover the who/what/when/where/why. Include expert perspectives, industry impact, and future predictions.",
-                'user_modifier'   => "\n- Format as a news/trend analysis article\n- Lead with the most important information (inverted pyramid)\n- Include industry context and background\n- Add expert perspectives and analysis\n- Discuss implications and future predictions\n- Keep a journalistic, balanced tone",
-            ],
-            'tutorial' => [
-                'name'            => __( 'Tutorial / Deep Dive', 'stratawp-seo' ),
-                'system_modifier' => "\nCONTENT FORMAT: Write this as an in-depth tutorial or technical deep dive. Include code examples where relevant (in <pre><code> blocks), detailed explanations, and practical examples.",
-                'user_modifier'   => "\n- Format as a detailed tutorial or deep dive\n- Include code examples in <pre><code> blocks where relevant\n- Explain concepts from basics to advanced\n- Add practical, real-world examples\n- Include troubleshooting tips and common pitfalls\n- Provide references for further learning",
-            ],
-        ];
-    }
+	/**
+	 * Available content templates.
+	 *
+	 * @return array Template definitions [slug => [name, system_modifier, user_modifier]].
+	 */
+	public static function get_templates(): array {
+		return array(
+			'auto'       => array(
+				'name'            => __( 'Auto (AI Decides)', 'stratawp-seo' ),
+				'system_modifier' => '',
+				'user_modifier'   => '',
+			),
+			'listicle'   => array(
+				'name'            => __( 'Listicle', 'stratawp-seo' ),
+				'system_modifier' => "\nCONTENT FORMAT: Write this as a numbered listicle (e.g., \"7 Ways to...\", \"10 Best...\"). Each list item should have its own H2 heading with a number, followed by 2-3 paragraphs of detail.",
+				'user_modifier'   => "\n- Format as a numbered listicle with 7-15 items\n- Each item gets its own H2 heading\n- Include a brief intro and conclusion",
+			),
+			'how-to'     => array(
+				'name'            => __( 'How-To Guide', 'stratawp-seo' ),
+				'system_modifier' => "\nCONTENT FORMAT: Write this as a step-by-step how-to guide. Use numbered steps as H2 headings (\"Step 1: ...\"). Include prerequisites, tools needed, and expected outcomes.",
+				'user_modifier'   => "\n- Format as a step-by-step how-to guide\n- Include a prerequisites/what you'll need section\n- Number each step clearly\n- Add tips and warnings where relevant\n- Include an expected results section",
+			),
+			'comparison' => array(
+				'name'            => __( 'Comparison / Vs', 'stratawp-seo' ),
+				'system_modifier' => "\nCONTENT FORMAT: Write this as a detailed comparison article. Compare 2-4 options/products/approaches side by side. Include a comparison table in HTML, pros and cons for each, and a clear recommendation.",
+				'user_modifier'   => "\n- Format as a comparison article\n- Include an HTML comparison table with key features\n- List pros and cons for each option\n- Provide a clear winner/recommendation with reasoning\n- Add a \"Who should choose what\" section",
+			),
+			'case-study' => array(
+				'name'            => __( 'Case Study', 'stratawp-seo' ),
+				'system_modifier' => "\nCONTENT FORMAT: Write this as a case study with clear sections: Challenge/Problem, Solution/Approach, Results/Outcomes, and Key Takeaways. Use specific (but realistic fictional) data points and metrics.",
+				'user_modifier'   => "\n- Format as a case study\n- Include sections: Background, Challenge, Solution, Results, Key Takeaways\n- Use specific metrics and data points (realistic examples)\n- Include quotes or testimonials (fictional but realistic)\n- End with actionable lessons readers can apply",
+			),
+			'news'       => array(
+				'name'            => __( 'News / Trend Analysis', 'stratawp-seo' ),
+				'system_modifier' => "\nCONTENT FORMAT: Write this as a news analysis or trend piece. Cover the who/what/when/where/why. Include expert perspectives, industry impact, and future predictions.",
+				'user_modifier'   => "\n- Format as a news/trend analysis article\n- Lead with the most important information (inverted pyramid)\n- Include industry context and background\n- Add expert perspectives and analysis\n- Discuss implications and future predictions\n- Keep a journalistic, balanced tone",
+			),
+			'tutorial'   => array(
+				'name'            => __( 'Tutorial / Deep Dive', 'stratawp-seo' ),
+				'system_modifier' => "\nCONTENT FORMAT: Write this as an in-depth tutorial or technical deep dive. Include code examples where relevant (in <pre><code> blocks), detailed explanations, and practical examples.",
+				'user_modifier'   => "\n- Format as a detailed tutorial or deep dive\n- Include code examples in <pre><code> blocks where relevant\n- Explain concepts from basics to advanced\n- Add practical, real-world examples\n- Include troubleshooting tips and common pitfalls\n- Provide references for further learning",
+			),
+		);
+	}
 
-    /**
-     * Get template options for a select dropdown.
-     *
-     * @return array [slug => name].
-     */
-    public static function get_options(): array {
-        $options = [];
-        foreach ( self::get_templates() as $slug => $template ) {
-            $options[ $slug ] = $template['name'];
-        }
-        return $options;
-    }
+	/**
+	 * Get template options for a select dropdown.
+	 *
+	 * @return array [slug => name].
+	 */
+	public static function get_options(): array {
+		$options = array();
+		foreach ( self::get_templates() as $slug => $template ) {
+			$options[ $slug ] = $template['name'];
+		}
+		return $options;
+	}
 
-    /**
-     * Get a specific template's modifiers.
-     *
-     * @param string $slug Template slug.
-     * @return array|null Template data or null if not found.
-     */
-    public static function get_template( string $slug ): ?array {
-        $templates = self::get_templates();
-        return $templates[ $slug ] ?? null;
-    }
+	/**
+	 * Get a specific template's modifiers.
+	 *
+	 * @param string $slug Template slug.
+	 * @return array|null Template data or null if not found.
+	 */
+	public static function get_template( string $slug ): ?array {
+		$templates = self::get_templates();
+		return $templates[ $slug ] ?? null;
+	}
 
-    /**
-     * Apply template modifiers to prompts.
-     *
-     * @param string $system_prompt The system prompt.
-     * @param string $user_prompt   The user prompt.
-     * @param string $template_slug The template to apply.
-     * @return array [system_prompt, user_prompt].
-     */
-    public static function apply( string $system_prompt, string $user_prompt, string $template_slug ): array {
-        $template = self::get_template( $template_slug );
+	/**
+	 * Apply template modifiers to prompts.
+	 *
+	 * @param string $system_prompt The system prompt.
+	 * @param string $user_prompt   The user prompt.
+	 * @param string $template_slug The template to apply.
+	 * @return array [system_prompt, user_prompt].
+	 */
+	public static function apply( string $system_prompt, string $user_prompt, string $template_slug ): array {
+		$template = self::get_template( $template_slug );
 
-        if ( ! $template || $template_slug === 'auto' ) {
-            return [ $system_prompt, $user_prompt ];
-        }
+		if ( ! $template || $template_slug === 'auto' ) {
+			return array( $system_prompt, $user_prompt );
+		}
 
-        if ( ! empty( $template['system_modifier'] ) ) {
-            $system_prompt .= $template['system_modifier'];
-        }
+		if ( ! empty( $template['system_modifier'] ) ) {
+			$system_prompt .= $template['system_modifier'];
+		}
 
-        if ( ! empty( $template['user_modifier'] ) ) {
-            $user_prompt .= $template['user_modifier'];
-        }
+		if ( ! empty( $template['user_modifier'] ) ) {
+			$user_prompt .= $template['user_modifier'];
+		}
 
-        return [ $system_prompt, $user_prompt ];
-    }
+		return array( $system_prompt, $user_prompt );
+	}
 }

--- a/includes/class-topic-queue.php
+++ b/includes/class-topic-queue.php
@@ -8,265 +8,289 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Topic_Queue {
 
-    public const POST_TYPE = 'swps_topic';
+	public const POST_TYPE = 'swps_topic';
 
-    /**
-     * Register the custom post type.
-     */
-    public static function register_post_type(): void {
-        register_post_type( self::POST_TYPE, [
-            'labels'       => [
-                'name'          => __( 'Topics', 'stratawp-seo' ),
-                'singular_name' => __( 'Topic', 'stratawp-seo' ),
-            ],
-            'public'       => false,
-            'show_ui'      => false,
-            'show_in_rest' => false,
-            'supports'     => [ 'title', 'editor' ],
-            'capabilities' => [
-                'create_posts' => 'manage_options',
-            ],
-        ] );
+	/**
+	 * Register the custom post type.
+	 */
+	public static function register_post_type(): void {
+		register_post_type(
+			self::POST_TYPE,
+			array(
+				'labels'       => array(
+					'name'          => __( 'Topics', 'stratawp-seo' ),
+					'singular_name' => __( 'Topic', 'stratawp-seo' ),
+				),
+				'public'       => false,
+				'show_ui'      => false,
+				'show_in_rest' => false,
+				'supports'     => array( 'title', 'editor' ),
+				'capabilities' => array(
+					'create_posts' => 'manage_options',
+				),
+			)
+		);
 
-        // Register custom statuses.
-        register_post_status( 'queued', [
-            'label'       => __( 'Queued', 'stratawp-seo' ),
-            'public'      => false,
-            'internal'    => true,
-            'label_count' => _n_noop( 'Queued <span class="count">(%s)</span>', 'Queued <span class="count">(%s)</span>', 'stratawp-seo' ),
-        ] );
+		// Register custom statuses.
+		register_post_status(
+			'queued',
+			array(
+				'label'       => __( 'Queued', 'stratawp-seo' ),
+				'public'      => false,
+				'internal'    => true,
+				'label_count' => _n_noop( 'Queued <span class="count">(%s)</span>', 'Queued <span class="count">(%s)</span>', 'stratawp-seo' ),
+			)
+		);
 
-        register_post_status( 'generating', [
-            'label'       => __( 'Generating', 'stratawp-seo' ),
-            'public'      => false,
-            'internal'    => true,
-            'label_count' => _n_noop( 'Generating <span class="count">(%s)</span>', 'Generating <span class="count">(%s)</span>', 'stratawp-seo' ),
-        ] );
+		register_post_status(
+			'generating',
+			array(
+				'label'       => __( 'Generating', 'stratawp-seo' ),
+				'public'      => false,
+				'internal'    => true,
+				'label_count' => _n_noop( 'Generating <span class="count">(%s)</span>', 'Generating <span class="count">(%s)</span>', 'stratawp-seo' ),
+			)
+		);
 
-        register_post_status( 'failed', [
-            'label'       => __( 'Failed', 'stratawp-seo' ),
-            'public'      => false,
-            'internal'    => true,
-            'label_count' => _n_noop( 'Failed <span class="count">(%s)</span>', 'Failed <span class="count">(%s)</span>', 'stratawp-seo' ),
-        ] );
-    }
+		register_post_status(
+			'failed',
+			array(
+				'label'       => __( 'Failed', 'stratawp-seo' ),
+				'public'      => false,
+				'internal'    => true,
+				'label_count' => _n_noop( 'Failed <span class="count">(%s)</span>', 'Failed <span class="count">(%s)</span>', 'stratawp-seo' ),
+			)
+		);
+	}
 
-    /**
-     * Create a new topic in the queue.
-     *
-     * @param string $title    Topic title/headline.
-     * @param string $date     Scheduled date (Y-m-d H:i:s).
-     * @param string $template Template slug.
-     * @param string $notes    Optional notes.
-     * @param int    $priority Priority (1=highest).
-     * @return int|WP_Error Post ID or error.
-     */
-    public function create_topic( string $title, string $date = '', string $template = 'auto', string $notes = '', int $priority = 10 ): int|WP_Error {
-        $post_data = [
-            'post_type'    => self::POST_TYPE,
-            'post_title'   => sanitize_text_field( $title ),
-            'post_content' => sanitize_textarea_field( $notes ),
-            'post_status'  => 'queued',
-        ];
+	/**
+	 * Create a new topic in the queue.
+	 *
+	 * @param string $title    Topic title/headline.
+	 * @param string $date     Scheduled date (Y-m-d H:i:s).
+	 * @param string $template Template slug.
+	 * @param string $notes    Optional notes.
+	 * @param int    $priority Priority (1=highest).
+	 * @return int|WP_Error Post ID or error.
+	 */
+	public function create_topic( string $title, string $date = '', string $template = 'auto', string $notes = '', int $priority = 10 ): int|WP_Error {
+		$post_data = array(
+			'post_type'    => self::POST_TYPE,
+			'post_title'   => sanitize_text_field( $title ),
+			'post_content' => sanitize_textarea_field( $notes ),
+			'post_status'  => 'queued',
+		);
 
-        if ( ! empty( $date ) ) {
-            $post_data['post_date']     = $date;
-            $post_data['post_date_gmt'] = get_gmt_from_date( $date );
-        }
+		if ( ! empty( $date ) ) {
+			$post_data['post_date']     = $date;
+			$post_data['post_date_gmt'] = get_gmt_from_date( $date );
+		}
 
-        $post_id = wp_insert_post( $post_data, true );
+		$post_id = wp_insert_post( $post_data, true );
 
-        if ( is_wp_error( $post_id ) ) {
-            return $post_id;
-        }
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
 
-        update_post_meta( $post_id, '_swps_template', sanitize_text_field( $template ) );
-        update_post_meta( $post_id, '_swps_priority', $priority );
+		update_post_meta( $post_id, '_swps_template', sanitize_text_field( $template ) );
+		update_post_meta( $post_id, '_swps_priority', $priority );
 
-        return $post_id;
-    }
+		return $post_id;
+	}
 
-    /**
-     * Get all queued topics, ordered by date then priority.
-     *
-     * @param int $limit Max topics to return.
-     * @return array Array of topic post objects.
-     */
-    public function get_queued_topics( int $limit = 50 ): array {
-        return get_posts( [
-            'post_type'      => self::POST_TYPE,
-            'post_status'    => 'queued',
-            'posts_per_page' => $limit,
-            'orderby'        => [ 'date' => 'ASC' ],
-            'meta_key'       => '_swps_priority',
-        ] );
-    }
+	/**
+	 * Get all queued topics, ordered by date then priority.
+	 *
+	 * @param int $limit Max topics to return.
+	 * @return array Array of topic post objects.
+	 */
+	public function get_queued_topics( int $limit = 50 ): array {
+		return get_posts(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => 'queued',
+				'posts_per_page' => $limit,
+				'orderby'        => array( 'date' => 'ASC' ),
+				'meta_key'       => '_swps_priority',
+			)
+		);
+	}
 
-    /**
-     * Get the next topic due for generation.
-     *
-     * @return WP_Post|null Next topic or null.
-     */
-    public function get_next_topic(): ?WP_Post {
-        $topics = get_posts( [
-            'post_type'      => self::POST_TYPE,
-            'post_status'    => 'queued',
-            'posts_per_page' => 1,
-            'orderby'        => 'date',
-            'order'          => 'ASC',
-            'date_query'     => [
-                [
-                    'before'    => 'now',
-                    'inclusive' => true,
-                ],
-            ],
-        ] );
+	/**
+	 * Get the next topic due for generation.
+	 *
+	 * @return WP_Post|null Next topic or null.
+	 */
+	public function get_next_topic(): ?WP_Post {
+		$topics = get_posts(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => 'queued',
+				'posts_per_page' => 1,
+				'orderby'        => 'date',
+				'order'          => 'ASC',
+				'date_query'     => array(
+					array(
+						'before'    => 'now',
+						'inclusive' => true,
+					),
+				),
+			)
+		);
 
-        return $topics[0] ?? null;
-    }
+		return $topics[0] ?? null;
+	}
 
-    /**
-     * Update a topic's status.
-     *
-     * @param int    $topic_id Topic post ID.
-     * @param string $status   New status (queued, generating, published, failed).
-     * @param string $error    Error message (for failed status).
-     * @param int    $post_id  Generated post ID (for published status).
-     */
-    public function update_status( int $topic_id, string $status, string $error = '', int $post_id = 0 ): void {
-        wp_update_post( [
-            'ID'          => $topic_id,
-            'post_status' => $status,
-        ] );
+	/**
+	 * Update a topic's status.
+	 *
+	 * @param int    $topic_id Topic post ID.
+	 * @param string $status   New status (queued, generating, published, failed).
+	 * @param string $error    Error message (for failed status).
+	 * @param int    $post_id  Generated post ID (for published status).
+	 */
+	public function update_status( int $topic_id, string $status, string $error = '', int $post_id = 0 ): void {
+		wp_update_post(
+			array(
+				'ID'          => $topic_id,
+				'post_status' => $status,
+			)
+		);
 
-        if ( ! empty( $error ) ) {
-            update_post_meta( $topic_id, '_swps_error_message', $error );
-        }
+		if ( ! empty( $error ) ) {
+			update_post_meta( $topic_id, '_swps_error_message', $error );
+		}
 
-        if ( $post_id > 0 ) {
-            update_post_meta( $topic_id, '_swps_generated_post_id', $post_id );
-        }
-    }
+		if ( $post_id > 0 ) {
+			update_post_meta( $topic_id, '_swps_generated_post_id', $post_id );
+		}
+	}
 
-    /**
-     * Update a topic's scheduled date.
-     *
-     * @param int    $topic_id Topic post ID.
-     * @param string $date     New date (Y-m-d H:i:s).
-     */
-    public function update_date( int $topic_id, string $date ): void {
-        wp_update_post( [
-            'ID'            => $topic_id,
-            'post_date'     => $date,
-            'post_date_gmt' => get_gmt_from_date( $date ),
-        ] );
-    }
+	/**
+	 * Update a topic's scheduled date.
+	 *
+	 * @param int    $topic_id Topic post ID.
+	 * @param string $date     New date (Y-m-d H:i:s).
+	 */
+	public function update_date( int $topic_id, string $date ): void {
+		wp_update_post(
+			array(
+				'ID'            => $topic_id,
+				'post_date'     => $date,
+				'post_date_gmt' => get_gmt_from_date( $date ),
+			)
+		);
+	}
 
-    /**
-     * Delete a topic.
-     *
-     * @param int $topic_id Topic post ID.
-     * @return bool True on success.
-     */
-    public function delete_topic( int $topic_id ): bool {
-        $result = wp_delete_post( $topic_id, true );
-        return false !== $result;
-    }
+	/**
+	 * Delete a topic.
+	 *
+	 * @param int $topic_id Topic post ID.
+	 * @return bool True on success.
+	 */
+	public function delete_topic( int $topic_id ): bool {
+		$result = wp_delete_post( $topic_id, true );
+		return false !== $result;
+	}
 
-    /**
-     * Get all topics for calendar display.
-     *
-     * @param string $start Start date (Y-m-d).
-     * @param string $end   End date (Y-m-d).
-     * @return array Array of topic data for FullCalendar.
-     */
-    public function get_calendar_events( string $start, string $end ): array {
-        $topics = get_posts( [
-            'post_type'      => self::POST_TYPE,
-            'post_status'    => [ 'queued', 'generating', 'published', 'failed' ],
-            'posts_per_page' => 200,
-            'date_query'     => [
-                [
-                    'after'     => $start,
-                    'before'    => $end,
-                    'inclusive' => true,
-                ],
-            ],
-        ] );
+	/**
+	 * Get all topics for calendar display.
+	 *
+	 * @param string $start Start date (Y-m-d).
+	 * @param string $end   End date (Y-m-d).
+	 * @return array Array of topic data for FullCalendar.
+	 */
+	public function get_calendar_events( string $start, string $end ): array {
+		$topics = get_posts(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => array( 'queued', 'generating', 'published', 'failed' ),
+				'posts_per_page' => 200,
+				'date_query'     => array(
+					array(
+						'after'     => $start,
+						'before'    => $end,
+						'inclusive' => true,
+					),
+				),
+			)
+		);
 
-        $events = [];
-        foreach ( $topics as $topic ) {
-            $template = get_post_meta( $topic->ID, '_swps_template', true ) ?: 'auto';
-            $color    = match ( $topic->post_status ) {
-                'queued'     => '#dba617',
-                'generating' => '#2271b1',
-                'published'  => '#00a32a',
-                'failed'     => '#d63638',
-                default      => '#646970',
-            };
+		$events = array();
+		foreach ( $topics as $topic ) {
+			$template = get_post_meta( $topic->ID, '_swps_template', true ) ?: 'auto';
+			$color    = match ( $topic->post_status ) {
+				'queued'     => '#dba617',
+				'generating' => '#2271b1',
+				'published'  => '#00a32a',
+				'failed'     => '#d63638',
+				default      => '#646970',
+			};
 
-            $events[] = [
-                'id'              => $topic->ID,
-                'title'           => $topic->post_title,
-                'start'           => $topic->post_date,
-                'backgroundColor' => $color,
-                'borderColor'     => $color,
-                'extendedProps'   => [
-                    'status'   => $topic->post_status,
-                    'template' => $template,
-                    'notes'    => $topic->post_content,
-                    'type'     => 'topic',
-                ],
-            ];
-        }
+			$events[] = array(
+				'id'              => $topic->ID,
+				'title'           => $topic->post_title,
+				'start'           => $topic->post_date,
+				'backgroundColor' => $color,
+				'borderColor'     => $color,
+				'extendedProps'   => array(
+					'status'   => $topic->post_status,
+					'template' => $template,
+					'notes'    => $topic->post_content,
+					'type'     => 'topic',
+				),
+			);
+		}
 
-        return $events;
-    }
+		return $events;
+	}
 
-    /**
-     * Get published posts for calendar display.
-     *
-     * @param string $start Start date (Y-m-d).
-     * @param string $end   End date (Y-m-d).
-     * @return array Array of post data for FullCalendar.
-     */
-    public function get_published_events( string $start, string $end ): array {
-        $posts = get_posts( [
-            'post_type'      => 'post',
-            'post_status'    => 'publish',
-            'posts_per_page' => 200,
-            'date_query'     => [
-                [
-                    'after'     => $start,
-                    'before'    => $end,
-                    'inclusive' => true,
-                ],
-            ],
-        ] );
+	/**
+	 * Get published posts for calendar display.
+	 *
+	 * @param string $start Start date (Y-m-d).
+	 * @param string $end   End date (Y-m-d).
+	 * @return array Array of post data for FullCalendar.
+	 */
+	public function get_published_events( string $start, string $end ): array {
+		$posts = get_posts(
+			array(
+				'post_type'      => 'post',
+				'post_status'    => 'publish',
+				'posts_per_page' => 200,
+				'date_query'     => array(
+					array(
+						'after'     => $start,
+						'before'    => $end,
+						'inclusive' => true,
+					),
+				),
+			)
+		);
 
-        $events = [];
-        foreach ( $posts as $post ) {
-            $is_generated = get_post_meta( $post->ID, '_swps_generated', true );
+		$events = array();
+		foreach ( $posts as $post ) {
+			$is_generated = get_post_meta( $post->ID, '_swps_generated', true );
 
-            $events[] = [
-                'id'              => 'post_' . $post->ID,
-                'title'           => $post->post_title,
-                'start'           => $post->post_date,
-                'backgroundColor' => $is_generated ? '#00a32a' : '#8c8f94',
-                'borderColor'     => $is_generated ? '#00a32a' : '#8c8f94',
-                'url'             => get_edit_post_link( $post->ID, 'raw' ),
-                'extendedProps'   => [
-                    'status' => 'published',
-                    'type'   => 'post',
-                ],
-            ];
-        }
+			$events[] = array(
+				'id'              => 'post_' . $post->ID,
+				'title'           => $post->post_title,
+				'start'           => $post->post_date,
+				'backgroundColor' => $is_generated ? '#00a32a' : '#8c8f94',
+				'borderColor'     => $is_generated ? '#00a32a' : '#8c8f94',
+				'url'             => get_edit_post_link( $post->ID, 'raw' ),
+				'extendedProps'   => array(
+					'status' => 'published',
+					'type'   => 'post',
+				),
+			);
+		}
 
-        return $events;
-    }
+		return $events;
+	}
 }

--- a/includes/class-user-prefs.php
+++ b/includes/class-user-prefs.php
@@ -6,47 +6,47 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_User_Prefs {
 
-    public const META_THEME = '_swps_theme';
+	public const META_THEME = '_swps_theme';
 
-    public const THEME_DARK  = 'dark';
-    public const THEME_LIGHT = 'light';
+	public const THEME_DARK  = 'dark';
+	public const THEME_LIGHT = 'light';
 
-    /**
-     * Get the active theme for a user. Defaults to dark.
-     */
-    public function get_theme( int $user_id = 0 ): string {
-        if ( 0 === $user_id ) {
-            $user_id = get_current_user_id();
-        }
-        if ( 0 === $user_id ) {
-            return self::THEME_DARK;
-        }
-        $stored = get_user_meta( $user_id, self::META_THEME, true );
-        if ( in_array( $stored, [ self::THEME_DARK, self::THEME_LIGHT ], true ) ) {
-            return $stored;
-        }
-        return self::THEME_DARK;
-    }
+	/**
+	 * Get the active theme for a user. Defaults to dark.
+	 */
+	public function get_theme( int $user_id = 0 ): string {
+		if ( 0 === $user_id ) {
+			$user_id = get_current_user_id();
+		}
+		if ( 0 === $user_id ) {
+			return self::THEME_DARK;
+		}
+		$stored = get_user_meta( $user_id, self::META_THEME, true );
+		if ( in_array( $stored, array( self::THEME_DARK, self::THEME_LIGHT ), true ) ) {
+			return $stored;
+		}
+		return self::THEME_DARK;
+	}
 
-    /**
-     * Set the theme for a user.
-     */
-    public function set_theme( string $theme, int $user_id = 0 ): bool {
-        if ( ! in_array( $theme, [ self::THEME_DARK, self::THEME_LIGHT ], true ) ) {
-            return false;
-        }
-        if ( 0 === $user_id ) {
-            $user_id = get_current_user_id();
-        }
-        if ( 0 === $user_id ) {
-            return false;
-        }
-        update_user_meta( $user_id, self::META_THEME, $theme );
-        return true;
-    }
+	/**
+	 * Set the theme for a user.
+	 */
+	public function set_theme( string $theme, int $user_id = 0 ): bool {
+		if ( ! in_array( $theme, array( self::THEME_DARK, self::THEME_LIGHT ), true ) ) {
+			return false;
+		}
+		if ( 0 === $user_id ) {
+			$user_id = get_current_user_id();
+		}
+		if ( 0 === $user_id ) {
+			return false;
+		}
+		update_user_meta( $user_id, self::META_THEME, $theme );
+		return true;
+	}
 }

--- a/includes/class-voice-profile.php
+++ b/includes/class-voice-profile.php
@@ -9,328 +9,339 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Voice_Profile {
 
-    public const POST_TYPE = 'swps_voice_profile';
+	public const POST_TYPE = 'swps_voice_profile';
 
-    /**
-     * Register hooks.
-     */
-    public function __construct() {
-        add_action( 'init', [ self::class, 'register_post_type' ] );
-        add_filter( 'swps_system_prompt', [ $this, 'inject_voice_profile' ], 5, 3 );
-    }
+	/**
+	 * Register hooks.
+	 */
+	public function __construct() {
+		add_action( 'init', array( self::class, 'register_post_type' ) );
+		add_filter( 'swps_system_prompt', array( $this, 'inject_voice_profile' ), 5, 3 );
+	}
 
-    /**
-     * Register the custom post type.
-     */
-    public static function register_post_type(): void {
-        register_post_type( self::POST_TYPE, [
-            'labels'       => [
-                'name'               => __( 'Voice Profiles', 'stratawp-seo' ),
-                'singular_name'      => __( 'Voice Profile', 'stratawp-seo' ),
-                'add_new_item'       => __( 'Add New Voice Profile', 'stratawp-seo' ),
-                'edit_item'          => __( 'Edit Voice Profile', 'stratawp-seo' ),
-                'new_item'           => __( 'New Voice Profile', 'stratawp-seo' ),
-                'all_items'          => __( 'All Voice Profiles', 'stratawp-seo' ),
-                'not_found'          => __( 'No voice profiles found.', 'stratawp-seo' ),
-                'not_found_in_trash' => __( 'No voice profiles found in Trash.', 'stratawp-seo' ),
-            ],
-            'public'       => false,
-            'show_ui'      => false,
-            'show_in_rest' => false,
-            'supports'     => [ 'title' ],
-            'capabilities' => [
-                'create_posts' => 'manage_options',
-            ],
-        ] );
-    }
+	/**
+	 * Register the custom post type.
+	 */
+	public static function register_post_type(): void {
+		register_post_type(
+			self::POST_TYPE,
+			array(
+				'labels'       => array(
+					'name'               => __( 'Voice Profiles', 'stratawp-seo' ),
+					'singular_name'      => __( 'Voice Profile', 'stratawp-seo' ),
+					'add_new_item'       => __( 'Add New Voice Profile', 'stratawp-seo' ),
+					'edit_item'          => __( 'Edit Voice Profile', 'stratawp-seo' ),
+					'new_item'           => __( 'New Voice Profile', 'stratawp-seo' ),
+					'all_items'          => __( 'All Voice Profiles', 'stratawp-seo' ),
+					'not_found'          => __( 'No voice profiles found.', 'stratawp-seo' ),
+					'not_found_in_trash' => __( 'No voice profiles found in Trash.', 'stratawp-seo' ),
+				),
+				'public'       => false,
+				'show_ui'      => false,
+				'show_in_rest' => false,
+				'supports'     => array( 'title' ),
+				'capabilities' => array(
+					'create_posts' => 'manage_options',
+				),
+			)
+		);
+	}
 
-    /**
-     * Create a voice profile.
-     *
-     * @param string $name Profile name.
-     * @param array  $meta Profile settings.
-     * @return int|WP_Error Post ID or error.
-     */
-    public function create( string $name, array $meta ): int|WP_Error {
-        $post_id = wp_insert_post( [
-            'post_type'   => self::POST_TYPE,
-            'post_title'  => sanitize_text_field( $name ),
-            'post_status' => 'publish',
-        ], true );
+	/**
+	 * Create a voice profile.
+	 *
+	 * @param string $name Profile name.
+	 * @param array  $meta Profile settings.
+	 * @return int|WP_Error Post ID or error.
+	 */
+	public function create( string $name, array $meta ): int|WP_Error {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => self::POST_TYPE,
+				'post_title'  => sanitize_text_field( $name ),
+				'post_status' => 'publish',
+			),
+			true
+		);
 
-        if ( is_wp_error( $post_id ) ) {
-            return $post_id;
-        }
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
 
-        $this->save_meta( $post_id, $meta );
-        return $post_id;
-    }
+		$this->save_meta( $post_id, $meta );
+		return $post_id;
+	}
 
-    /**
-     * Update a voice profile.
-     *
-     * @param int    $profile_id Profile post ID.
-     * @param string $name       Profile name.
-     * @param array  $meta       Profile settings.
-     * @return int|WP_Error Post ID or error.
-     */
-    public function update( int $profile_id, string $name, array $meta ): int|WP_Error {
-        $post = get_post( $profile_id );
-        if ( ! $post || self::POST_TYPE !== $post->post_type ) {
-            return new WP_Error( 'invalid_profile', __( 'Voice profile not found.', 'stratawp-seo' ) );
-        }
+	/**
+	 * Update a voice profile.
+	 *
+	 * @param int    $profile_id Profile post ID.
+	 * @param string $name       Profile name.
+	 * @param array  $meta       Profile settings.
+	 * @return int|WP_Error Post ID or error.
+	 */
+	public function update( int $profile_id, string $name, array $meta ): int|WP_Error {
+		$post = get_post( $profile_id );
+		if ( ! $post || self::POST_TYPE !== $post->post_type ) {
+			return new WP_Error( 'invalid_profile', __( 'Voice profile not found.', 'stratawp-seo' ) );
+		}
 
-        $result = wp_update_post( [
-            'ID'         => $profile_id,
-            'post_title' => sanitize_text_field( $name ),
-        ], true );
+		$result = wp_update_post(
+			array(
+				'ID'         => $profile_id,
+				'post_title' => sanitize_text_field( $name ),
+			),
+			true
+		);
 
-        if ( is_wp_error( $result ) ) {
-            return $result;
-        }
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
 
-        $this->save_meta( $profile_id, $meta );
-        return $profile_id;
-    }
+		$this->save_meta( $profile_id, $meta );
+		return $profile_id;
+	}
 
-    /**
-     * Delete a voice profile.
-     *
-     * @param int $profile_id Profile post ID.
-     * @return bool
-     */
-    public function delete( int $profile_id ): bool {
-        $post = get_post( $profile_id );
-        if ( ! $post || self::POST_TYPE !== $post->post_type ) {
-            return false;
-        }
+	/**
+	 * Delete a voice profile.
+	 *
+	 * @param int $profile_id Profile post ID.
+	 * @return bool
+	 */
+	public function delete( int $profile_id ): bool {
+		$post = get_post( $profile_id );
+		if ( ! $post || self::POST_TYPE !== $post->post_type ) {
+			return false;
+		}
 
-        // If this was the active profile, clear the option.
-        if ( (int) get_option( 'swps_voice_profile', 0 ) === $profile_id ) {
-            update_option( 'swps_voice_profile', 0 );
-        }
-        return false !== wp_delete_post( $profile_id, true );
-    }
+		// If this was the active profile, clear the option.
+		if ( (int) get_option( 'swps_voice_profile', 0 ) === $profile_id ) {
+			update_option( 'swps_voice_profile', 0 );
+		}
+		return false !== wp_delete_post( $profile_id, true );
+	}
 
-    /**
-     * Get all voice profiles.
-     *
-     * @return array Array of profile data arrays.
-     */
-    public function get_all(): array {
-        $posts = get_posts( [
-            'post_type'      => self::POST_TYPE,
-            'post_status'    => 'publish',
-            'posts_per_page' => 50,
-            'orderby'        => 'title',
-            'order'          => 'ASC',
-        ] );
+	/**
+	 * Get all voice profiles.
+	 *
+	 * @return array Array of profile data arrays.
+	 */
+	public function get_all(): array {
+		$posts = get_posts(
+			array(
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => 'publish',
+				'posts_per_page' => 50,
+				'orderby'        => 'title',
+				'order'          => 'ASC',
+			)
+		);
 
-        return array_map( [ $this, 'format_profile' ], $posts );
-    }
+		return array_map( array( $this, 'format_profile' ), $posts );
+	}
 
-    /**
-     * Get a single voice profile.
-     *
-     * @param int $profile_id Profile post ID.
-     * @return array|null Profile data or null.
-     */
-    public function get( int $profile_id ): ?array {
-        $post = get_post( $profile_id );
-        if ( ! $post || $post->post_type !== self::POST_TYPE ) {
-            return null;
-        }
-        return $this->format_profile( $post );
-    }
+	/**
+	 * Get a single voice profile.
+	 *
+	 * @param int $profile_id Profile post ID.
+	 * @return array|null Profile data or null.
+	 */
+	public function get( int $profile_id ): ?array {
+		$post = get_post( $profile_id );
+		if ( ! $post || $post->post_type !== self::POST_TYPE ) {
+			return null;
+		}
+		return $this->format_profile( $post );
+	}
 
-    /**
-     * Get the active voice profile ID.
-     *
-     * @return int Profile ID or 0 if none.
-     */
-    public function get_active_id(): int {
-        return (int) get_option( 'swps_voice_profile', 0 );
-    }
+	/**
+	 * Get the active voice profile ID.
+	 *
+	 * @return int Profile ID or 0 if none.
+	 */
+	public function get_active_id(): int {
+		return (int) get_option( 'swps_voice_profile', 0 );
+	}
 
-    /**
-     * Compile a voice profile into a system prompt block.
-     *
-     * @param int $profile_id Profile post ID.
-     * @return string Compiled prompt text.
-     */
-    public function compile( int $profile_id ): string {
-        $profile = $this->get( $profile_id );
-        if ( ! $profile ) {
-            return '';
-        }
+	/**
+	 * Compile a voice profile into a system prompt block.
+	 *
+	 * @param int $profile_id Profile post ID.
+	 * @return string Compiled prompt text.
+	 */
+	public function compile( int $profile_id ): string {
+		$profile = $this->get( $profile_id );
+		if ( ! $profile ) {
+			return '';
+		}
 
-        // Strip newlines/control chars to prevent prompt injection.
-        $clean = static function ( string $s ): string {
-            return wp_strip_all_tags( preg_replace( '/[\r\n\t]+/', ' ', $s ) );
-        };
+		// Strip newlines/control chars to prevent prompt injection.
+		$clean = static function ( string $s ): string {
+			return wp_strip_all_tags( preg_replace( '/[\r\n\t]+/', ' ', $s ) );
+		};
 
-        $parts = [];
+		$parts = array();
 
-        if ( ! empty( $profile['tone'] ) ) {
-            $parts[] = sprintf( 'Write in a %s tone.', $clean( $profile['tone'] ) );
-        }
+		if ( ! empty( $profile['tone'] ) ) {
+			$parts[] = sprintf( 'Write in a %s tone.', $clean( $profile['tone'] ) );
+		}
 
-        if ( ! empty( $profile['formality'] ) ) {
-            $parts[] = sprintf( 'Formality level: %d/10.', $profile['formality'] );
-        }
+		if ( ! empty( $profile['formality'] ) ) {
+			$parts[] = sprintf( 'Formality level: %d/10.', $profile['formality'] );
+		}
 
-        if ( ! empty( $profile['sentence_length'] ) ) {
-            $parts[] = sprintf( 'Use %s sentences.', $clean( $profile['sentence_length'] ) );
-        }
+		if ( ! empty( $profile['sentence_length'] ) ) {
+			$parts[] = sprintf( 'Use %s sentences.', $clean( $profile['sentence_length'] ) );
+		}
 
-        if ( ! empty( $profile['vocabulary_level'] ) ) {
-            $parts[] = sprintf( 'Vocabulary: %s.', $clean( $profile['vocabulary_level'] ) );
-        }
+		if ( ! empty( $profile['vocabulary_level'] ) ) {
+			$parts[] = sprintf( 'Vocabulary: %s.', $clean( $profile['vocabulary_level'] ) );
+		}
 
-        if ( ! empty( $profile['person'] ) ) {
-            $label = match ( $profile['person'] ) {
-                'first'  => 'first person (I/we)',
-                'second' => 'second person (you)',
-                'third'  => 'third person (they/one)',
-                default  => $clean( $profile['person'] ) . ' person',
-            };
-            $parts[] = sprintf( 'Write in %s.', $label );
-        }
+		if ( ! empty( $profile['person'] ) ) {
+			$label = match ( $profile['person'] ) {
+				'first'  => 'first person (I/we)',
+				'second' => 'second person (you)',
+				'third'  => 'third person (they/one)',
+				default  => $clean( $profile['person'] ) . ' person',
+			};
+			$parts[] = sprintf( 'Write in %s.', $label );
+		}
 
-        if ( ! empty( $profile['avoid_phrases'] ) ) {
-            $sanitized = array_map( $clean, (array) $profile['avoid_phrases'] );
-            $parts[] = sprintf( 'Never use these phrases: %s.', implode( ', ', $sanitized ) );
-        }
+		if ( ! empty( $profile['avoid_phrases'] ) ) {
+			$sanitized = array_map( $clean, (array) $profile['avoid_phrases'] );
+			$parts[]   = sprintf( 'Never use these phrases: %s.', implode( ', ', $sanitized ) );
+		}
 
-        if ( ! empty( $profile['preferred_phrases'] ) ) {
-            $sanitized = array_map( $clean, (array) $profile['preferred_phrases'] );
-            $parts[] = sprintf( 'Prefer these expressions: %s.', implode( ', ', $sanitized ) );
-        }
+		if ( ! empty( $profile['preferred_phrases'] ) ) {
+			$sanitized = array_map( $clean, (array) $profile['preferred_phrases'] );
+			$parts[]   = sprintf( 'Prefer these expressions: %s.', implode( ', ', $sanitized ) );
+		}
 
-        if ( ! empty( $profile['example_content'] ) ) {
-            $excerpt = $clean( mb_substr( $profile['example_content'], 0, 500 ) );
-            $parts[] = sprintf( "Match the writing style of this sample:\n\"%s\"", $excerpt );
-        }
+		if ( ! empty( $profile['example_content'] ) ) {
+			$excerpt = $clean( mb_substr( $profile['example_content'], 0, 500 ) );
+			$parts[] = sprintf( "Match the writing style of this sample:\n\"%s\"", $excerpt );
+		}
 
-        $compiled = "VOICE PROFILE — {$clean( $profile['name'] )}:\n" . implode( "\n", $parts );
+		$compiled = "VOICE PROFILE — {$clean( $profile['name'] )}:\n" . implode( "\n", $parts );
 
-        return apply_filters( 'swps_voice_compile', $compiled, $profile_id );
-    }
+		return apply_filters( 'swps_voice_compile', $compiled, $profile_id );
+	}
 
-    /**
-     * Inject the active voice profile into the system prompt.
-     *
-     * Hooks into swps_system_prompt at priority 5 (before other filters).
-     *
-     * @param string $prompt System prompt.
-     * @param string $tone   Tone setting.
-     * @param string $style  Style setting.
-     * @return string Modified prompt.
-     */
-    public function inject_voice_profile( string $prompt, string $tone, string $style ): string {
-        $profile_id = $this->get_active_id();
-        if ( $profile_id <= 0 ) {
-            return $prompt;
-        }
+	/**
+	 * Inject the active voice profile into the system prompt.
+	 *
+	 * Hooks into swps_system_prompt at priority 5 (before other filters).
+	 *
+	 * @param string $prompt System prompt.
+	 * @param string $tone   Tone setting.
+	 * @param string $style  Style setting.
+	 * @return string Modified prompt.
+	 */
+	public function inject_voice_profile( string $prompt, string $tone, string $style ): string {
+		$profile_id = $this->get_active_id();
+		if ( $profile_id <= 0 ) {
+			return $prompt;
+		}
 
-        $voice_block = $this->compile( $profile_id );
-        if ( empty( $voice_block ) ) {
-            return $prompt;
-        }
+		$voice_block = $this->compile( $profile_id );
+		if ( empty( $voice_block ) ) {
+			return $prompt;
+		}
 
-        // Replace the generic TONE line with the compiled voice profile.
-        // Use callback to avoid backreference interpretation in replacement.
-        $replaced = false;
-        $prompt   = preg_replace_callback(
-            '/^TONE:.*$/m',
-            function () use ( $voice_block, &$replaced ) {
-                $replaced = true;
-                return $voice_block;
-            },
-            $prompt,
-            1
-        );
+		// Replace the generic TONE line with the compiled voice profile.
+		// Use callback to avoid backreference interpretation in replacement.
+		$replaced = false;
+		$prompt   = preg_replace_callback(
+			'/^TONE:.*$/m',
+			function () use ( $voice_block, &$replaced ) {
+				$replaced = true;
+				return $voice_block;
+			},
+			$prompt,
+			1
+		);
 
-        // Append if no TONE line was found.
-        if ( ! $replaced ) {
-            $prompt .= "\n\n" . $voice_block;
-        }
+		// Append if no TONE line was found.
+		if ( ! $replaced ) {
+			$prompt .= "\n\n" . $voice_block;
+		}
 
-        return $prompt;
-    }
+		return $prompt;
+	}
 
-    /**
-     * Get profile options for a select dropdown.
-     *
-     * @return array [id => name] pairs with 0 => "None".
-     */
-    public function get_options(): array {
-        $options = [ 0 => __( '— None (use tone/style settings) —', 'stratawp-seo' ) ];
+	/**
+	 * Get profile options for a select dropdown.
+	 *
+	 * @return array [id => name] pairs with 0 => "None".
+	 */
+	public function get_options(): array {
+		$options = array( 0 => __( '— None (use tone/style settings) —', 'stratawp-seo' ) );
 
-        foreach ( $this->get_all() as $profile ) {
-            $options[ $profile['id'] ] = $profile['name'];
-        }
+		foreach ( $this->get_all() as $profile ) {
+			$options[ $profile['id'] ] = $profile['name'];
+		}
 
-        return $options;
-    }
+		return $options;
+	}
 
-    /**
-     * Save profile meta fields.
-     */
-    private function save_meta( int $post_id, array $meta ): void {
-        $fields = [
-            'tone'             => 'sanitize_text_field',
-            'formality'        => 'absint',
-            'sentence_length'  => 'sanitize_text_field',
-            'vocabulary_level' => 'sanitize_text_field',
-            'person'           => 'sanitize_text_field',
-            'example_content'  => 'sanitize_textarea_field',
-            'avoid_phrases'    => null, // JSON array.
-            'preferred_phrases' => null, // JSON array.
-        ];
+	/**
+	 * Save profile meta fields.
+	 */
+	private function save_meta( int $post_id, array $meta ): void {
+		$fields = array(
+			'tone'              => 'sanitize_text_field',
+			'formality'         => 'absint',
+			'sentence_length'   => 'sanitize_text_field',
+			'vocabulary_level'  => 'sanitize_text_field',
+			'person'            => 'sanitize_text_field',
+			'example_content'   => 'sanitize_textarea_field',
+			'avoid_phrases'     => null, // JSON array.
+			'preferred_phrases' => null, // JSON array.
+		);
 
-        foreach ( $fields as $field => $sanitize ) {
-            if ( ! array_key_exists( $field, $meta ) ) {
-                continue;
-            }
+		foreach ( $fields as $field => $sanitize ) {
+			if ( ! array_key_exists( $field, $meta ) ) {
+				continue;
+			}
 
-            $value = $meta[ $field ];
+			$value = $meta[ $field ];
 
-            if ( $sanitize ) {
-                $value = call_user_func( $sanitize, $value );
-            } elseif ( is_array( $value ) ) {
-                // Sanitize array elements.
-                $value = array_filter( array_map( 'sanitize_text_field', $value ) );
-            } elseif ( is_string( $value ) ) {
-                // Normalize newlines to commas, then parse comma-separated string into array.
-                $value = str_replace( [ "\r\n", "\r", "\n" ], ',', $value );
-                $value = array_filter( array_map( 'trim', explode( ',', $value ) ) );
-            }
+			if ( $sanitize ) {
+				$value = call_user_func( $sanitize, $value );
+			} elseif ( is_array( $value ) ) {
+				// Sanitize array elements.
+				$value = array_filter( array_map( 'sanitize_text_field', $value ) );
+			} elseif ( is_string( $value ) ) {
+				// Normalize newlines to commas, then parse comma-separated string into array.
+				$value = str_replace( array( "\r\n", "\r", "\n" ), ',', $value );
+				$value = array_filter( array_map( 'trim', explode( ',', $value ) ) );
+			}
 
-            update_post_meta( $post_id, '_swps_vp_' . $field, $value );
-        }
-    }
+			update_post_meta( $post_id, '_swps_vp_' . $field, $value );
+		}
+	}
 
-    /**
-     * Format a profile post into a data array.
-     */
-    private function format_profile( WP_Post $post ): array {
-        return [
-            'id'               => $post->ID,
-            'name'             => $post->post_title,
-            'tone'             => get_post_meta( $post->ID, '_swps_vp_tone', true ) ?: '',
-            'formality'        => ( '' !== ( $f = get_post_meta( $post->ID, '_swps_vp_formality', true ) ) ) ? (int) $f : 5,
-            'sentence_length'  => get_post_meta( $post->ID, '_swps_vp_sentence_length', true ) ?: 'varied',
-            'vocabulary_level' => get_post_meta( $post->ID, '_swps_vp_vocabulary_level', true ) ?: 'moderate',
-            'person'           => get_post_meta( $post->ID, '_swps_vp_person', true ) ?: 'second',
-            'example_content'  => get_post_meta( $post->ID, '_swps_vp_example_content', true ) ?: '',
-            'avoid_phrases'    => get_post_meta( $post->ID, '_swps_vp_avoid_phrases', true ) ?: [],
-            'preferred_phrases' => get_post_meta( $post->ID, '_swps_vp_preferred_phrases', true ) ?: [],
-        ];
-    }
+	/**
+	 * Format a profile post into a data array.
+	 */
+	private function format_profile( WP_Post $post ): array {
+		return array(
+			'id'                => $post->ID,
+			'name'              => $post->post_title,
+			'tone'              => get_post_meta( $post->ID, '_swps_vp_tone', true ) ?: '',
+			'formality'         => ( '' !== ( $f = get_post_meta( $post->ID, '_swps_vp_formality', true ) ) ) ? (int) $f : 5,
+			'sentence_length'   => get_post_meta( $post->ID, '_swps_vp_sentence_length', true ) ?: 'varied',
+			'vocabulary_level'  => get_post_meta( $post->ID, '_swps_vp_vocabulary_level', true ) ?: 'moderate',
+			'person'            => get_post_meta( $post->ID, '_swps_vp_person', true ) ?: 'second',
+			'example_content'   => get_post_meta( $post->ID, '_swps_vp_example_content', true ) ?: '',
+			'avoid_phrases'     => get_post_meta( $post->ID, '_swps_vp_avoid_phrases', true ) ?: array(),
+			'preferred_phrases' => get_post_meta( $post->ID, '_swps_vp_preferred_phrases', true ) ?: array(),
+		);
+	}
 }

--- a/includes/providers/ai/class-anthropic-provider.php
+++ b/includes/providers/ai/class-anthropic-provider.php
@@ -6,152 +6,163 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Anthropic_Provider extends SWPS_AI_Provider {
 
-    private const API_URL = 'https://api.anthropic.com/v1/messages';
+	private const API_URL = 'https://api.anthropic.com/v1/messages';
 
-    public function get_slug(): string {
-        return 'anthropic';
-    }
+	public function get_slug(): string {
+		return 'anthropic';
+	}
 
-    public function get_name(): string {
-        return 'Anthropic (Claude)';
-    }
+	public function get_name(): string {
+		return 'Anthropic (Claude)';
+	}
 
-    public function get_api_key_url(): string {
-        return 'https://console.anthropic.com/';
-    }
+	public function get_api_key_url(): string {
+		return 'https://console.anthropic.com/';
+	}
 
-    public function get_available_models(): array {
-        return [
-            'claude-opus-4-7'            => 'Claude Opus 4.7 (Most powerful, higher cost)',
-            'claude-opus-4-6'            => 'Claude Opus 4.6 (Previous generation)',
-            'claude-sonnet-4-6'          => 'Claude Sonnet 4.6 (Great balance of quality & cost)',
-            'claude-sonnet-4-5-20250929' => 'Claude Sonnet 4.5 (Previous generation)',
-            'claude-haiku-4-5-20251001'  => 'Claude Haiku 4.5 (Fastest, lowest cost)',
-        ];
-    }
+	public function get_available_models(): array {
+		return array(
+			'claude-opus-4-7'            => 'Claude Opus 4.7 (Most powerful, higher cost)',
+			'claude-opus-4-6'            => 'Claude Opus 4.6 (Previous generation)',
+			'claude-sonnet-4-6'          => 'Claude Sonnet 4.6 (Great balance of quality & cost)',
+			'claude-sonnet-4-5-20250929' => 'Claude Sonnet 4.5 (Previous generation)',
+			'claude-haiku-4-5-20251001'  => 'Claude Haiku 4.5 (Fastest, lowest cost)',
+		);
+	}
 
-    public function chat( string $system_prompt, string $user_message, int $max_tokens = 4096 ): string|WP_Error {
-        $api_key = $this->get_api_key();
+	public function chat( string $system_prompt, string $user_message, int $max_tokens = 4096 ): string|WP_Error {
+		$api_key = $this->get_api_key();
 
-        if ( empty( $api_key ) ) {
-            return new WP_Error( 'swps_no_api_key', __( 'Please enter your Anthropic API key in StrataWP SEO settings.', 'stratawp-seo' ) );
-        }
+		if ( empty( $api_key ) ) {
+			return new WP_Error( 'swps_no_api_key', __( 'Please enter your Anthropic API key in StrataWP SEO settings.', 'stratawp-seo' ) );
+		}
 
-        $messages = [
-            [
-                'role'    => 'user',
-                'content' => $user_message,
-            ],
-        ];
+		$messages = array(
+			array(
+				'role'    => 'user',
+				'content' => $user_message,
+			),
+		);
 
-        // Prefill with opening brace to guide Claude toward valid JSON output.
-        // Note: Claude 4.6+ models (opus-4-6, sonnet-4-6, and newer 4-7+) do not support assistant prefill.
-        $model = $this->get_validated_model();
-        $supports_prefill = ! preg_match( '/-(4-6|4-7|4-8|4-9|5-)/', $model );
+		// Prefill with opening brace to guide Claude toward valid JSON output.
+		// Note: Claude 4.6+ models (opus-4-6, sonnet-4-6, and newer 4-7+) do not support assistant prefill.
+		$model            = $this->get_validated_model();
+		$supports_prefill = ! preg_match( '/-(4-6|4-7|4-8|4-9|5-)/', $model );
 
-        if ( $this->requesting_json && $supports_prefill ) {
-            $messages[] = [
-                'role'    => 'assistant',
-                'content' => '{',
-            ];
-        }
+		if ( $this->requesting_json && $supports_prefill ) {
+			$messages[] = array(
+				'role'    => 'assistant',
+				'content' => '{',
+			);
+		}
 
-        $body = [
-            'model'      => $this->get_validated_model(),
-            'max_tokens' => $max_tokens,
-            'system'     => $system_prompt,
-            'messages'   => $messages,
-        ];
+		$body = array(
+			'model'      => $this->get_validated_model(),
+			'max_tokens' => $max_tokens,
+			'system'     => $system_prompt,
+			'messages'   => $messages,
+		);
 
-        $response = wp_remote_post( self::API_URL, [
-            'timeout' => 180,
-            'headers' => [
-                'Content-Type'      => 'application/json',
-                'x-api-key'        => $api_key,
-                'anthropic-version' => '2023-06-01',
-            ],
-            'body' => wp_json_encode( $body ),
-        ] );
+		$response = wp_remote_post(
+			self::API_URL,
+			array(
+				'timeout' => 180,
+				'headers' => array(
+					'Content-Type'      => 'application/json',
+					'x-api-key'         => $api_key,
+					'anthropic-version' => '2023-06-01',
+				),
+				'body'    => wp_json_encode( $body ),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error(
-                'swps_api_request_failed',
-                sprintf( __( 'API request failed: %s', 'stratawp-seo' ), $response->get_error_message() )
-            );
-        }
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'swps_api_request_failed',
+				sprintf( __( 'API request failed: %s', 'stratawp-seo' ), $response->get_error_message() )
+			);
+		}
 
-        $status_code = wp_remote_retrieve_response_code( $response );
-        $body        = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
 
-        if ( 200 !== $status_code ) {
-            $error_message = $body['error']['message'] ?? __( 'Unknown API error.', 'stratawp-seo' );
-            return new WP_Error(
-                'swps_api_error',
-                sprintf( __( 'Claude API error (%d): %s', 'stratawp-seo' ), $status_code, $error_message )
-            );
-        }
+		if ( 200 !== $status_code ) {
+			$error_message = $body['error']['message'] ?? __( 'Unknown API error.', 'stratawp-seo' );
+			return new WP_Error(
+				'swps_api_error',
+				sprintf( __( 'Claude API error (%1$d): %2$s', 'stratawp-seo' ), $status_code, $error_message )
+			);
+		}
 
-        if ( empty( $body['content'][0]['text'] ) ) {
-            return new WP_Error( 'swps_empty_response', __( 'Received empty response from Claude.', 'stratawp-seo' ) );
-        }
+		if ( empty( $body['content'][0]['text'] ) ) {
+			return new WP_Error( 'swps_empty_response', __( 'Received empty response from Claude.', 'stratawp-seo' ) );
+		}
 
-        // Store usage data for cost tracking.
-        if ( ! empty( $body['usage'] ) ) {
-            $this->last_usage = [
-                'input_tokens'  => (int) ( $body['usage']['input_tokens'] ?? 0 ),
-                'output_tokens' => (int) ( $body['usage']['output_tokens'] ?? 0 ),
-            ];
-        }
+		// Store usage data for cost tracking.
+		if ( ! empty( $body['usage'] ) ) {
+			$this->last_usage = array(
+				'input_tokens'  => (int) ( $body['usage']['input_tokens'] ?? 0 ),
+				'output_tokens' => (int) ( $body['usage']['output_tokens'] ?? 0 ),
+			);
+		}
 
-        // Store stop reason for truncation detection.
-        // Anthropic: 'end_turn', 'max_tokens', 'stop_sequence'.
-        $this->last_stop_reason = $body['stop_reason'] ?? null;
+		// Store stop reason for truncation detection.
+		// Anthropic: 'end_turn', 'max_tokens', 'stop_sequence'.
+		$this->last_stop_reason = $body['stop_reason'] ?? null;
 
-        $text = $body['content'][0]['text'];
+		$text = $body['content'][0]['text'];
 
-        // When using JSON prefill, prepend the opening brace we sent as assistant content.
-        if ( $this->requesting_json && $supports_prefill ) {
-            $text = '{' . $text;
-        }
+		// When using JSON prefill, prepend the opening brace we sent as assistant content.
+		if ( $this->requesting_json && $supports_prefill ) {
+			$text = '{' . $text;
+		}
 
-        return $text;
-    }
+		return $text;
+	}
 
-    public function test_key( string $api_key ): bool|WP_Error {
-        $response = wp_remote_post( self::API_URL, [
-            'timeout' => 30,
-            'headers' => [
-                'Content-Type'      => 'application/json',
-                'x-api-key'        => $api_key,
-                'anthropic-version' => '2023-06-01',
-            ],
-            'body' => wp_json_encode( [
-                'model'      => $this->get_validated_model(),
-                'max_tokens' => 10,
-                'messages'   => [
-                    [ 'role' => 'user', 'content' => 'Say "ok"' ],
-                ],
-            ] ),
-        ] );
+	public function test_key( string $api_key ): bool|WP_Error {
+		$response = wp_remote_post(
+			self::API_URL,
+			array(
+				'timeout' => 30,
+				'headers' => array(
+					'Content-Type'      => 'application/json',
+					'x-api-key'         => $api_key,
+					'anthropic-version' => '2023-06-01',
+				),
+				'body'    => wp_json_encode(
+					array(
+						'model'      => $this->get_validated_model(),
+						'max_tokens' => 10,
+						'messages'   => array(
+							array(
+								'role'    => 'user',
+								'content' => 'Say "ok"',
+							),
+						),
+					)
+				),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
-        $status_code = wp_remote_retrieve_response_code( $response );
+		$status_code = wp_remote_retrieve_response_code( $response );
 
-        if ( 200 === $status_code ) {
-            return true;
-        }
+		if ( 200 === $status_code ) {
+			return true;
+		}
 
-        $body          = json_decode( wp_remote_retrieve_body( $response ), true );
-        $error_message = $body['error']['message'] ?? 'Invalid API key.';
+		$body          = json_decode( wp_remote_retrieve_body( $response ), true );
+		$error_message = $body['error']['message'] ?? 'Invalid API key.';
 
-        return new WP_Error( 'swps_invalid_key', $error_message );
-    }
+		return new WP_Error( 'swps_invalid_key', $error_message );
+	}
 }

--- a/includes/providers/ai/class-google-provider.php
+++ b/includes/providers/ai/class-google-provider.php
@@ -6,145 +6,153 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Google_Provider extends SWPS_AI_Provider {
 
-    private const API_BASE = 'https://generativelanguage.googleapis.com/v1beta/models/';
+	private const API_BASE = 'https://generativelanguage.googleapis.com/v1beta/models/';
 
-    public function get_slug(): string {
-        return 'google';
-    }
+	public function get_slug(): string {
+		return 'google';
+	}
 
-    public function get_name(): string {
-        return 'Google (Gemini)';
-    }
+	public function get_name(): string {
+		return 'Google (Gemini)';
+	}
 
-    public function get_api_key_url(): string {
-        return 'https://aistudio.google.com/apikey';
-    }
+	public function get_api_key_url(): string {
+		return 'https://aistudio.google.com/apikey';
+	}
 
-    public function get_available_models(): array {
-        return [
-            'gemini-2.5-pro'        => 'Gemini 2.5 Pro (Most capable)',
-            'gemini-2.5-flash'      => 'Gemini 2.5 Flash (Fast & capable)',
-            'gemini-2.0-flash'      => 'Gemini 2.0 Flash (Previous generation)',
-            'gemini-2.0-flash-lite' => 'Gemini 2.0 Flash Lite (Fastest, lowest cost)',
-        ];
-    }
+	public function get_available_models(): array {
+		return array(
+			'gemini-2.5-pro'        => 'Gemini 2.5 Pro (Most capable)',
+			'gemini-2.5-flash'      => 'Gemini 2.5 Flash (Fast & capable)',
+			'gemini-2.0-flash'      => 'Gemini 2.0 Flash (Previous generation)',
+			'gemini-2.0-flash-lite' => 'Gemini 2.0 Flash Lite (Fastest, lowest cost)',
+		);
+	}
 
-    public function chat( string $system_prompt, string $user_message, int $max_tokens = 4096 ): string|WP_Error {
-        $api_key = $this->get_api_key();
+	public function chat( string $system_prompt, string $user_message, int $max_tokens = 4096 ): string|WP_Error {
+		$api_key = $this->get_api_key();
 
-        if ( empty( $api_key ) ) {
-            return new WP_Error( 'swps_no_api_key', __( 'Please enter your Google API key in StrataWP SEO settings.', 'stratawp-seo' ) );
-        }
+		if ( empty( $api_key ) ) {
+			return new WP_Error( 'swps_no_api_key', __( 'Please enter your Google API key in StrataWP SEO settings.', 'stratawp-seo' ) );
+		}
 
-        $model = $this->get_validated_model();
-        $url   = self::API_BASE . $model . ':generateContent?key=' . $api_key;
+		$model = $this->get_validated_model();
+		$url   = self::API_BASE . $model . ':generateContent?key=' . $api_key;
 
-        $body = [
-            'system_instruction' => [
-                'parts' => [
-                    [ 'text' => $system_prompt ],
-                ],
-            ],
-            'contents' => [
-                [
-                    'parts' => [
-                        [ 'text' => $user_message ],
-                    ],
-                ],
-            ],
-            'generationConfig' => [
-                'maxOutputTokens'  => $max_tokens,
-                'responseMimeType' => $this->requesting_json ? 'application/json' : 'text/plain',
-            ],
-        ];
+		$body = array(
+			'system_instruction' => array(
+				'parts' => array(
+					array( 'text' => $system_prompt ),
+				),
+			),
+			'contents'           => array(
+				array(
+					'parts' => array(
+						array( 'text' => $user_message ),
+					),
+				),
+			),
+			'generationConfig'   => array(
+				'maxOutputTokens'  => $max_tokens,
+				'responseMimeType' => $this->requesting_json ? 'application/json' : 'text/plain',
+			),
+		);
 
-        $response = wp_remote_post( $url, [
-            'timeout' => 180,
-            'headers' => [
-                'Content-Type' => 'application/json',
-            ],
-            'body' => wp_json_encode( $body ),
-        ] );
+		$response = wp_remote_post(
+			$url,
+			array(
+				'timeout' => 180,
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+				'body'    => wp_json_encode( $body ),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error(
-                'swps_api_request_failed',
-                sprintf( __( 'API request failed: %s', 'stratawp-seo' ), $response->get_error_message() )
-            );
-        }
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'swps_api_request_failed',
+				sprintf( __( 'API request failed: %s', 'stratawp-seo' ), $response->get_error_message() )
+			);
+		}
 
-        $status_code = wp_remote_retrieve_response_code( $response );
-        $body        = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
 
-        if ( 200 !== $status_code ) {
-            $error_message = $body['error']['message'] ?? __( 'Unknown API error.', 'stratawp-seo' );
-            return new WP_Error(
-                'swps_api_error',
-                sprintf( __( 'Gemini API error (%d): %s', 'stratawp-seo' ), $status_code, $error_message )
-            );
-        }
+		if ( 200 !== $status_code ) {
+			$error_message = $body['error']['message'] ?? __( 'Unknown API error.', 'stratawp-seo' );
+			return new WP_Error(
+				'swps_api_error',
+				sprintf( __( 'Gemini API error (%1$d): %2$s', 'stratawp-seo' ), $status_code, $error_message )
+			);
+		}
 
-        if ( empty( $body['candidates'][0]['content']['parts'][0]['text'] ) ) {
-            return new WP_Error( 'swps_empty_response', __( 'Received empty response from Gemini.', 'stratawp-seo' ) );
-        }
+		if ( empty( $body['candidates'][0]['content']['parts'][0]['text'] ) ) {
+			return new WP_Error( 'swps_empty_response', __( 'Received empty response from Gemini.', 'stratawp-seo' ) );
+		}
 
-        // Store usage data for cost tracking.
-        if ( ! empty( $body['usageMetadata'] ) ) {
-            $this->last_usage = [
-                'input_tokens'  => (int) ( $body['usageMetadata']['promptTokenCount'] ?? 0 ),
-                'output_tokens' => (int) ( $body['usageMetadata']['candidatesTokenCount'] ?? 0 ),
-            ];
-        }
+		// Store usage data for cost tracking.
+		if ( ! empty( $body['usageMetadata'] ) ) {
+			$this->last_usage = array(
+				'input_tokens'  => (int) ( $body['usageMetadata']['promptTokenCount'] ?? 0 ),
+				'output_tokens' => (int) ( $body['usageMetadata']['candidatesTokenCount'] ?? 0 ),
+			);
+		}
 
-        // Store stop reason for truncation detection.
-        // Gemini: 'STOP', 'MAX_TOKENS', 'SAFETY', 'RECITATION'.
-        $finish_reason = $body['candidates'][0]['finishReason'] ?? null;
-        $this->last_stop_reason = ( $finish_reason === 'MAX_TOKENS' ) ? 'max_tokens' : $finish_reason;
+		// Store stop reason for truncation detection.
+		// Gemini: 'STOP', 'MAX_TOKENS', 'SAFETY', 'RECITATION'.
+		$finish_reason          = $body['candidates'][0]['finishReason'] ?? null;
+		$this->last_stop_reason = ( $finish_reason === 'MAX_TOKENS' ) ? 'max_tokens' : $finish_reason;
 
-        return $body['candidates'][0]['content']['parts'][0]['text'];
-    }
+		return $body['candidates'][0]['content']['parts'][0]['text'];
+	}
 
-    public function test_key( string $api_key ): bool|WP_Error {
-        $model = $this->get_validated_model();
-        $url   = self::API_BASE . $model . ':generateContent?key=' . $api_key;
+	public function test_key( string $api_key ): bool|WP_Error {
+		$model = $this->get_validated_model();
+		$url   = self::API_BASE . $model . ':generateContent?key=' . $api_key;
 
-        $response = wp_remote_post( $url, [
-            'timeout' => 30,
-            'headers' => [
-                'Content-Type' => 'application/json',
-            ],
-            'body' => wp_json_encode( [
-                'contents' => [
-                    [
-                        'parts' => [
-                            [ 'text' => 'Say "ok"' ],
-                        ],
-                    ],
-                ],
-                'generationConfig' => [
-                    'maxOutputTokens' => 10,
-                ],
-            ] ),
-        ] );
+		$response = wp_remote_post(
+			$url,
+			array(
+				'timeout' => 30,
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+				'body'    => wp_json_encode(
+					array(
+						'contents'         => array(
+							array(
+								'parts' => array(
+									array( 'text' => 'Say "ok"' ),
+								),
+							),
+						),
+						'generationConfig' => array(
+							'maxOutputTokens' => 10,
+						),
+					)
+				),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
-        $status_code = wp_remote_retrieve_response_code( $response );
+		$status_code = wp_remote_retrieve_response_code( $response );
 
-        if ( 200 === $status_code ) {
-            return true;
-        }
+		if ( 200 === $status_code ) {
+			return true;
+		}
 
-        $body          = json_decode( wp_remote_retrieve_body( $response ), true );
-        $error_message = $body['error']['message'] ?? 'Invalid API key.';
+		$body          = json_decode( wp_remote_retrieve_body( $response ), true );
+		$error_message = $body['error']['message'] ?? 'Invalid API key.';
 
-        return new WP_Error( 'swps_invalid_key', $error_message );
-    }
+		return new WP_Error( 'swps_invalid_key', $error_message );
+	}
 }

--- a/includes/providers/ai/class-openai-provider.php
+++ b/includes/providers/ai/class-openai-provider.php
@@ -6,138 +6,149 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_OpenAI_Provider extends SWPS_AI_Provider {
 
-    private const API_URL = 'https://api.openai.com/v1/chat/completions';
+	private const API_URL = 'https://api.openai.com/v1/chat/completions';
 
-    public function get_slug(): string {
-        return 'openai';
-    }
+	public function get_slug(): string {
+		return 'openai';
+	}
 
-    public function get_name(): string {
-        return 'OpenAI (GPT)';
-    }
+	public function get_name(): string {
+		return 'OpenAI (GPT)';
+	}
 
-    public function get_api_key_url(): string {
-        return 'https://platform.openai.com/api-keys';
-    }
+	public function get_api_key_url(): string {
+		return 'https://platform.openai.com/api-keys';
+	}
 
-    public function get_available_models(): array {
-        return [
-            'gpt-4.1'      => 'GPT-4.1 (Most capable)',
-            'gpt-4.1-mini' => 'GPT-4.1 Mini (Fast & affordable)',
-            'gpt-4.1-nano' => 'GPT-4.1 Nano (Fastest, lowest cost)',
-            'gpt-4o'       => 'GPT-4o (Previous generation)',
-            'gpt-4o-mini'  => 'GPT-4o Mini (Previous generation)',
-            'o3-mini'      => 'o3-mini (Reasoning model)',
-        ];
-    }
+	public function get_available_models(): array {
+		return array(
+			'gpt-4.1'      => 'GPT-4.1 (Most capable)',
+			'gpt-4.1-mini' => 'GPT-4.1 Mini (Fast & affordable)',
+			'gpt-4.1-nano' => 'GPT-4.1 Nano (Fastest, lowest cost)',
+			'gpt-4o'       => 'GPT-4o (Previous generation)',
+			'gpt-4o-mini'  => 'GPT-4o Mini (Previous generation)',
+			'o3-mini'      => 'o3-mini (Reasoning model)',
+		);
+	}
 
-    public function chat( string $system_prompt, string $user_message, int $max_tokens = 4096 ): string|WP_Error {
-        $api_key = $this->get_api_key();
+	public function chat( string $system_prompt, string $user_message, int $max_tokens = 4096 ): string|WP_Error {
+		$api_key = $this->get_api_key();
 
-        if ( empty( $api_key ) ) {
-            return new WP_Error( 'swps_no_api_key', __( 'Please enter your OpenAI API key in StrataWP SEO settings.', 'stratawp-seo' ) );
-        }
+		if ( empty( $api_key ) ) {
+			return new WP_Error( 'swps_no_api_key', __( 'Please enter your OpenAI API key in StrataWP SEO settings.', 'stratawp-seo' ) );
+		}
 
-        $body = [
-            'model'      => $this->get_validated_model(),
-            'max_tokens' => $max_tokens,
-            'messages'   => [
-                [
-                    'role'    => 'system',
-                    'content' => $system_prompt,
-                ],
-                [
-                    'role'    => 'user',
-                    'content' => $user_message,
-                ],
-            ],
-        ];
+		$body = array(
+			'model'      => $this->get_validated_model(),
+			'max_tokens' => $max_tokens,
+			'messages'   => array(
+				array(
+					'role'    => 'system',
+					'content' => $system_prompt,
+				),
+				array(
+					'role'    => 'user',
+					'content' => $user_message,
+				),
+			),
+		);
 
-        if ( $this->requesting_json ) {
-            $body['response_format'] = [ 'type' => 'json_object' ];
-        }
+		if ( $this->requesting_json ) {
+			$body['response_format'] = array( 'type' => 'json_object' );
+		}
 
-        $response = wp_remote_post( self::API_URL, [
-            'timeout' => 180,
-            'headers' => [
-                'Content-Type'  => 'application/json',
-                'Authorization' => 'Bearer ' . $api_key,
-            ],
-            'body' => wp_json_encode( $body ),
-        ] );
+		$response = wp_remote_post(
+			self::API_URL,
+			array(
+				'timeout' => 180,
+				'headers' => array(
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Bearer ' . $api_key,
+				),
+				'body'    => wp_json_encode( $body ),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error(
-                'swps_api_request_failed',
-                sprintf( __( 'API request failed: %s', 'stratawp-seo' ), $response->get_error_message() )
-            );
-        }
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'swps_api_request_failed',
+				sprintf( __( 'API request failed: %s', 'stratawp-seo' ), $response->get_error_message() )
+			);
+		}
 
-        $status_code = wp_remote_retrieve_response_code( $response );
-        $body        = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
 
-        if ( 200 !== $status_code ) {
-            $error_message = $body['error']['message'] ?? __( 'Unknown API error.', 'stratawp-seo' );
-            return new WP_Error(
-                'swps_api_error',
-                sprintf( __( 'OpenAI API error (%d): %s', 'stratawp-seo' ), $status_code, $error_message )
-            );
-        }
+		if ( 200 !== $status_code ) {
+			$error_message = $body['error']['message'] ?? __( 'Unknown API error.', 'stratawp-seo' );
+			return new WP_Error(
+				'swps_api_error',
+				sprintf( __( 'OpenAI API error (%1$d): %2$s', 'stratawp-seo' ), $status_code, $error_message )
+			);
+		}
 
-        if ( empty( $body['choices'][0]['message']['content'] ) ) {
-            return new WP_Error( 'swps_empty_response', __( 'Received empty response from OpenAI.', 'stratawp-seo' ) );
-        }
+		if ( empty( $body['choices'][0]['message']['content'] ) ) {
+			return new WP_Error( 'swps_empty_response', __( 'Received empty response from OpenAI.', 'stratawp-seo' ) );
+		}
 
-        // Store usage data for cost tracking.
-        if ( ! empty( $body['usage'] ) ) {
-            $this->last_usage = [
-                'input_tokens'  => (int) ( $body['usage']['prompt_tokens'] ?? 0 ),
-                'output_tokens' => (int) ( $body['usage']['completion_tokens'] ?? 0 ),
-            ];
-        }
+		// Store usage data for cost tracking.
+		if ( ! empty( $body['usage'] ) ) {
+			$this->last_usage = array(
+				'input_tokens'  => (int) ( $body['usage']['prompt_tokens'] ?? 0 ),
+				'output_tokens' => (int) ( $body['usage']['completion_tokens'] ?? 0 ),
+			);
+		}
 
-        // Store stop reason for truncation detection.
-        // OpenAI: 'stop', 'length' (truncated), 'content_filter'.
-        $finish_reason = $body['choices'][0]['finish_reason'] ?? null;
-        $this->last_stop_reason = ( $finish_reason === 'length' ) ? 'max_tokens' : $finish_reason;
+		// Store stop reason for truncation detection.
+		// OpenAI: 'stop', 'length' (truncated), 'content_filter'.
+		$finish_reason          = $body['choices'][0]['finish_reason'] ?? null;
+		$this->last_stop_reason = ( $finish_reason === 'length' ) ? 'max_tokens' : $finish_reason;
 
-        return $body['choices'][0]['message']['content'];
-    }
+		return $body['choices'][0]['message']['content'];
+	}
 
-    public function test_key( string $api_key ): bool|WP_Error {
-        $response = wp_remote_post( self::API_URL, [
-            'timeout' => 30,
-            'headers' => [
-                'Content-Type'  => 'application/json',
-                'Authorization' => 'Bearer ' . $api_key,
-            ],
-            'body' => wp_json_encode( [
-                'model'      => $this->get_validated_model(),
-                'max_tokens' => 10,
-                'messages'   => [
-                    [ 'role' => 'user', 'content' => 'Say "ok"' ],
-                ],
-            ] ),
-        ] );
+	public function test_key( string $api_key ): bool|WP_Error {
+		$response = wp_remote_post(
+			self::API_URL,
+			array(
+				'timeout' => 30,
+				'headers' => array(
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Bearer ' . $api_key,
+				),
+				'body'    => wp_json_encode(
+					array(
+						'model'      => $this->get_validated_model(),
+						'max_tokens' => 10,
+						'messages'   => array(
+							array(
+								'role'    => 'user',
+								'content' => 'Say "ok"',
+							),
+						),
+					)
+				),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
-        $status_code = wp_remote_retrieve_response_code( $response );
+		$status_code = wp_remote_retrieve_response_code( $response );
 
-        if ( 200 === $status_code ) {
-            return true;
-        }
+		if ( 200 === $status_code ) {
+			return true;
+		}
 
-        $body          = json_decode( wp_remote_retrieve_body( $response ), true );
-        $error_message = $body['error']['message'] ?? 'Invalid API key.';
+		$body          = json_decode( wp_remote_retrieve_body( $response ), true );
+		$error_message = $body['error']['message'] ?? 'Invalid API key.';
 
-        return new WP_Error( 'swps_invalid_key', $error_message );
-    }
+		return new WP_Error( 'swps_invalid_key', $error_message );
+	}
 }

--- a/includes/providers/ai/class-xai-provider.php
+++ b/includes/providers/ai/class-xai-provider.php
@@ -6,135 +6,146 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_XAI_Provider extends SWPS_AI_Provider {
 
-    private const API_URL = 'https://api.x.ai/v1/chat/completions';
+	private const API_URL = 'https://api.x.ai/v1/chat/completions';
 
-    public function get_slug(): string {
-        return 'xai';
-    }
+	public function get_slug(): string {
+		return 'xai';
+	}
 
-    public function get_name(): string {
-        return 'xAI (Grok)';
-    }
+	public function get_name(): string {
+		return 'xAI (Grok)';
+	}
 
-    public function get_api_key_url(): string {
-        return 'https://console.x.ai/';
-    }
+	public function get_api_key_url(): string {
+		return 'https://console.x.ai/';
+	}
 
-    public function get_available_models(): array {
-        return [
-            'grok-3'       => 'Grok 3 (Most capable)',
-            'grok-3-mini'  => 'Grok 3 Mini (Fast & efficient)',
-            'grok-3-fast'  => 'Grok 3 Fast (Balanced)',
-        ];
-    }
+	public function get_available_models(): array {
+		return array(
+			'grok-3'      => 'Grok 3 (Most capable)',
+			'grok-3-mini' => 'Grok 3 Mini (Fast & efficient)',
+			'grok-3-fast' => 'Grok 3 Fast (Balanced)',
+		);
+	}
 
-    public function chat( string $system_prompt, string $user_message, int $max_tokens = 4096 ): string|WP_Error {
-        $api_key = $this->get_api_key();
+	public function chat( string $system_prompt, string $user_message, int $max_tokens = 4096 ): string|WP_Error {
+		$api_key = $this->get_api_key();
 
-        if ( empty( $api_key ) ) {
-            return new WP_Error( 'swps_no_api_key', __( 'Please enter your xAI API key in StrataWP SEO settings.', 'stratawp-seo' ) );
-        }
+		if ( empty( $api_key ) ) {
+			return new WP_Error( 'swps_no_api_key', __( 'Please enter your xAI API key in StrataWP SEO settings.', 'stratawp-seo' ) );
+		}
 
-        $body = [
-            'model'      => $this->get_validated_model(),
-            'max_tokens' => $max_tokens,
-            'messages'   => [
-                [
-                    'role'    => 'system',
-                    'content' => $system_prompt,
-                ],
-                [
-                    'role'    => 'user',
-                    'content' => $user_message,
-                ],
-            ],
-        ];
+		$body = array(
+			'model'      => $this->get_validated_model(),
+			'max_tokens' => $max_tokens,
+			'messages'   => array(
+				array(
+					'role'    => 'system',
+					'content' => $system_prompt,
+				),
+				array(
+					'role'    => 'user',
+					'content' => $user_message,
+				),
+			),
+		);
 
-        if ( $this->requesting_json ) {
-            $body['response_format'] = [ 'type' => 'json_object' ];
-        }
+		if ( $this->requesting_json ) {
+			$body['response_format'] = array( 'type' => 'json_object' );
+		}
 
-        $response = wp_remote_post( self::API_URL, [
-            'timeout' => 180,
-            'headers' => [
-                'Content-Type'  => 'application/json',
-                'Authorization' => 'Bearer ' . $api_key,
-            ],
-            'body' => wp_json_encode( $body ),
-        ] );
+		$response = wp_remote_post(
+			self::API_URL,
+			array(
+				'timeout' => 180,
+				'headers' => array(
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Bearer ' . $api_key,
+				),
+				'body'    => wp_json_encode( $body ),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error(
-                'swps_api_request_failed',
-                sprintf( __( 'API request failed: %s', 'stratawp-seo' ), $response->get_error_message() )
-            );
-        }
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'swps_api_request_failed',
+				sprintf( __( 'API request failed: %s', 'stratawp-seo' ), $response->get_error_message() )
+			);
+		}
 
-        $status_code = wp_remote_retrieve_response_code( $response );
-        $body        = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
 
-        if ( 200 !== $status_code ) {
-            $error_message = $body['error']['message'] ?? __( 'Unknown API error.', 'stratawp-seo' );
-            return new WP_Error(
-                'swps_api_error',
-                sprintf( __( 'Grok API error (%d): %s', 'stratawp-seo' ), $status_code, $error_message )
-            );
-        }
+		if ( 200 !== $status_code ) {
+			$error_message = $body['error']['message'] ?? __( 'Unknown API error.', 'stratawp-seo' );
+			return new WP_Error(
+				'swps_api_error',
+				sprintf( __( 'Grok API error (%1$d): %2$s', 'stratawp-seo' ), $status_code, $error_message )
+			);
+		}
 
-        if ( empty( $body['choices'][0]['message']['content'] ) ) {
-            return new WP_Error( 'swps_empty_response', __( 'Received empty response from Grok.', 'stratawp-seo' ) );
-        }
+		if ( empty( $body['choices'][0]['message']['content'] ) ) {
+			return new WP_Error( 'swps_empty_response', __( 'Received empty response from Grok.', 'stratawp-seo' ) );
+		}
 
-        // Store usage data for cost tracking.
-        if ( ! empty( $body['usage'] ) ) {
-            $this->last_usage = [
-                'input_tokens'  => (int) ( $body['usage']['prompt_tokens'] ?? 0 ),
-                'output_tokens' => (int) ( $body['usage']['completion_tokens'] ?? 0 ),
-            ];
-        }
+		// Store usage data for cost tracking.
+		if ( ! empty( $body['usage'] ) ) {
+			$this->last_usage = array(
+				'input_tokens'  => (int) ( $body['usage']['prompt_tokens'] ?? 0 ),
+				'output_tokens' => (int) ( $body['usage']['completion_tokens'] ?? 0 ),
+			);
+		}
 
-        // Store stop reason for truncation detection.
-        // xAI uses OpenAI-compatible format: 'stop', 'length' (truncated).
-        $finish_reason = $body['choices'][0]['finish_reason'] ?? null;
-        $this->last_stop_reason = ( $finish_reason === 'length' ) ? 'max_tokens' : $finish_reason;
+		// Store stop reason for truncation detection.
+		// xAI uses OpenAI-compatible format: 'stop', 'length' (truncated).
+		$finish_reason          = $body['choices'][0]['finish_reason'] ?? null;
+		$this->last_stop_reason = ( $finish_reason === 'length' ) ? 'max_tokens' : $finish_reason;
 
-        return $body['choices'][0]['message']['content'];
-    }
+		return $body['choices'][0]['message']['content'];
+	}
 
-    public function test_key( string $api_key ): bool|WP_Error {
-        $response = wp_remote_post( self::API_URL, [
-            'timeout' => 30,
-            'headers' => [
-                'Content-Type'  => 'application/json',
-                'Authorization' => 'Bearer ' . $api_key,
-            ],
-            'body' => wp_json_encode( [
-                'model'      => $this->get_validated_model(),
-                'max_tokens' => 10,
-                'messages'   => [
-                    [ 'role' => 'user', 'content' => 'Say "ok"' ],
-                ],
-            ] ),
-        ] );
+	public function test_key( string $api_key ): bool|WP_Error {
+		$response = wp_remote_post(
+			self::API_URL,
+			array(
+				'timeout' => 30,
+				'headers' => array(
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Bearer ' . $api_key,
+				),
+				'body'    => wp_json_encode(
+					array(
+						'model'      => $this->get_validated_model(),
+						'max_tokens' => 10,
+						'messages'   => array(
+							array(
+								'role'    => 'user',
+								'content' => 'Say "ok"',
+							),
+						),
+					)
+				),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return $response;
-        }
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
 
-        $status_code = wp_remote_retrieve_response_code( $response );
+		$status_code = wp_remote_retrieve_response_code( $response );
 
-        if ( 200 === $status_code ) {
-            return true;
-        }
+		if ( 200 === $status_code ) {
+			return true;
+		}
 
-        $body          = json_decode( wp_remote_retrieve_body( $response ), true );
-        $error_message = $body['error']['message'] ?? 'Invalid API key.';
+		$body          = json_decode( wp_remote_retrieve_body( $response ), true );
+		$error_message = $body['error']['message'] ?? 'Invalid API key.';
 
-        return new WP_Error( 'swps_invalid_key', $error_message );
-    }
+		return new WP_Error( 'swps_invalid_key', $error_message );
+	}
 }

--- a/includes/providers/images/class-gemini-provider.php
+++ b/includes/providers/images/class-gemini-provider.php
@@ -8,221 +8,228 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Gemini_Image_Provider extends SWPS_Image_Provider {
 
-    private const API_BASE = 'https://generativelanguage.googleapis.com/v1beta/models/';
-    private const MODEL    = 'gemini-3.1-flash-image-preview';
+	private const API_BASE = 'https://generativelanguage.googleapis.com/v1beta/models/';
+	private const MODEL    = 'gemini-3.1-flash-image-preview';
 
-    public function get_slug(): string {
-        return 'gemini';
-    }
+	public function get_slug(): string {
+		return 'gemini';
+	}
 
-    public function get_name(): string {
-        return 'Gemini (AI Generated)';
-    }
+	public function get_name(): string {
+		return 'Gemini (AI Generated)';
+	}
 
-    public function get_api_key_url(): string {
-        return 'https://aistudio.google.com/apikey';
-    }
+	public function get_api_key_url(): string {
+		return 'https://aistudio.google.com/apikey';
+	}
 
-    public function requires_api_key(): bool {
-        return false; // Reuses the Google AI API key.
-    }
+	public function requires_api_key(): bool {
+		return false; // Reuses the Google AI API key.
+	}
 
-    /**
-     * Get the API key — reuses the Google AI key.
-     */
-    public function get_api_key(): string {
-        return (string) get_option( 'swps_google_api_key', '' );
-    }
+	/**
+	 * Get the API key — reuses the Google AI key.
+	 */
+	public function get_api_key(): string {
+		return (string) get_option( 'swps_google_api_key', '' );
+	}
 
-    /**
-     * Gemini benefits from descriptive prompts, so we don't strip words.
-     */
-    protected function simplify_query( string $query ): string {
-        return $query;
-    }
+	/**
+	 * Gemini benefits from descriptive prompts, so we don't strip words.
+	 */
+	protected function simplify_query( string $query ): string {
+		return $query;
+	}
 
-    public function set_featured_image( int $post_id, string $query ): int|WP_Error {
-        $api_key = $this->get_api_key();
+	public function set_featured_image( int $post_id, string $query ): int|WP_Error {
+		$api_key = $this->get_api_key();
 
-        if ( empty( $api_key ) ) {
-            return new WP_Error( 'swps_no_google_key', __( 'Google API key not configured. Add your Google API key in settings.', 'stratawp-seo' ) );
-        }
+		if ( empty( $api_key ) ) {
+			return new WP_Error( 'swps_no_google_key', __( 'Google API key not configured. Add your Google API key in settings.', 'stratawp-seo' ) );
+		}
 
-        $prompt = sprintf(
-            'Generate a vivid, eye-catching featured image that directly illustrates the topic: "%s". '
-            . 'Show a specific, concrete scene or subject closely related to this topic — not abstract or generic. '
-            . 'Photorealistic style, rich colors, sharp detail, dramatic lighting. '
-            . 'No text, words, letters, watermarks, or logos anywhere in the image.',
-            $query
-        );
+		$prompt = sprintf(
+			'Generate a vivid, eye-catching featured image that directly illustrates the topic: "%s". '
+			. 'Show a specific, concrete scene or subject closely related to this topic — not abstract or generic. '
+			. 'Photorealistic style, rich colors, sharp detail, dramatic lighting. '
+			. 'No text, words, letters, watermarks, or logos anywhere in the image.',
+			$query
+		);
 
-        $tmp_file = $this->generate_image( $prompt, $api_key, '16:9' );
-        if ( is_wp_error( $tmp_file ) ) {
-            return $tmp_file;
-        }
+		$tmp_file = $this->generate_image( $prompt, $api_key, '16:9' );
+		if ( is_wp_error( $tmp_file ) ) {
+			return $tmp_file;
+		}
 
-        $filename = 'gemini-' . $post_id . '-' . time();
+		$filename = 'gemini-' . $post_id . '-' . time();
 
-        $attachment_id = $this->attach_temp_file( $tmp_file, $post_id, $filename, $query, 'AI-generated image by Gemini' );
+		$attachment_id = $this->attach_temp_file( $tmp_file, $post_id, $filename, $query, 'AI-generated image by Gemini' );
 
-        if ( is_wp_error( $attachment_id ) ) {
-            return $attachment_id;
-        }
+		if ( is_wp_error( $attachment_id ) ) {
+			return $attachment_id;
+		}
 
-        set_post_thumbnail( $post_id, $attachment_id );
+		set_post_thumbnail( $post_id, $attachment_id );
 
-        return $attachment_id;
-    }
+		return $attachment_id;
+	}
 
-    /**
-     * Generate an image via Gemini and return a temp file path.
-     *
-     * @param string $prompt  The image generation prompt.
-     * @param string $api_key Google API key.
-     * @param string $aspect  Aspect ratio (e.g., '16:9', '1:1').
-     * @return string|WP_Error Temp file path on success.
-     */
-    public function generate_image( string $prompt, string $api_key, string $aspect = '1:1' ): string|WP_Error {
-        $url = self::API_BASE . self::MODEL . ':generateContent?key=' . $api_key;
+	/**
+	 * Generate an image via Gemini and return a temp file path.
+	 *
+	 * @param string $prompt  The image generation prompt.
+	 * @param string $api_key Google API key.
+	 * @param string $aspect  Aspect ratio (e.g., '16:9', '1:1').
+	 * @return string|WP_Error Temp file path on success.
+	 */
+	public function generate_image( string $prompt, string $api_key, string $aspect = '1:1' ): string|WP_Error {
+		$url = self::API_BASE . self::MODEL . ':generateContent?key=' . $api_key;
 
-        $response = wp_remote_post( $url, [
-            'timeout' => 60,
-            'headers' => [
-                'Content-Type' => 'application/json',
-            ],
-            'body' => wp_json_encode( [
-                'contents' => [
-                    [
-                        'parts' => [
-                            [ 'text' => $prompt ],
-                        ],
-                    ],
-                ],
-                'generationConfig' => [
-                    'responseModalities' => [ 'TEXT', 'IMAGE' ],
-                    'imageConfig' => [
-                        'aspectRatio' => $aspect,
-                    ],
-                ],
-            ] ),
-        ] );
+		$response = wp_remote_post(
+			$url,
+			array(
+				'timeout' => 60,
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+				'body'    => wp_json_encode(
+					array(
+						'contents'         => array(
+							array(
+								'parts' => array(
+									array( 'text' => $prompt ),
+								),
+							),
+						),
+						'generationConfig' => array(
+							'responseModalities' => array( 'TEXT', 'IMAGE' ),
+							'imageConfig'        => array(
+								'aspectRatio' => $aspect,
+							),
+						),
+					)
+				),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error( 'swps_gemini_image_request_failed', $response->get_error_message() );
-        }
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'swps_gemini_image_request_failed', $response->get_error_message() );
+		}
 
-        $status = wp_remote_retrieve_response_code( $response );
-        $body   = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status = wp_remote_retrieve_response_code( $response );
+		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
 
-        if ( 200 !== $status ) {
-            $error = $body['error']['message'] ?? __( 'Gemini API error.', 'stratawp-seo' );
-            return new WP_Error( 'swps_gemini_image_error', $error );
-        }
+		if ( 200 !== $status ) {
+			$error = $body['error']['message'] ?? __( 'Gemini API error.', 'stratawp-seo' );
+			return new WP_Error( 'swps_gemini_image_error', $error );
+		}
 
-        // Find the image part in the response.
-        $candidates = $body['candidates'] ?? [];
+		// Find the image part in the response.
+		$candidates = $body['candidates'] ?? array();
 
-        if ( empty( $candidates ) ) {
-            // Log block reason if present (safety filter, etc.).
-            $block_reason = $body['promptFeedback']['blockReason'] ?? 'unknown';
-            error_log( '[StrataWP SEO] Gemini image: No candidates returned. Block reason: ' . $block_reason );
-            error_log( '[StrataWP SEO] Gemini image: Full response: ' . wp_json_encode( $body ) );
-            return new WP_Error( 'swps_gemini_no_image', __( 'Gemini did not return an image. The prompt may have been blocked.', 'stratawp-seo' ) );
-        }
+		if ( empty( $candidates ) ) {
+			// Log block reason if present (safety filter, etc.).
+			$block_reason = $body['promptFeedback']['blockReason'] ?? 'unknown';
+			error_log( '[StrataWP SEO] Gemini image: No candidates returned. Block reason: ' . $block_reason );
+			error_log( '[StrataWP SEO] Gemini image: Full response: ' . wp_json_encode( $body ) );
+			return new WP_Error( 'swps_gemini_no_image', __( 'Gemini did not return an image. The prompt may have been blocked.', 'stratawp-seo' ) );
+		}
 
-        $parts = $candidates[0]['content']['parts'] ?? [];
-        $image_data = null;
-        $mime_type  = 'image/png';
+		$parts      = $candidates[0]['content']['parts'] ?? array();
+		$image_data = null;
+		$mime_type  = 'image/png';
 
-        foreach ( $parts as $part ) {
-            // Check both camelCase and snake_case field names.
-            $inline = $part['inlineData'] ?? $part['inline_data'] ?? null;
-            if ( ! empty( $inline['data'] ) ) {
-                $image_data = $inline['data'];
-                $mime_type  = $inline['mimeType'] ?? $inline['mime_type'] ?? 'image/png';
-                break;
-            }
-        }
+		foreach ( $parts as $part ) {
+			// Check both camelCase and snake_case field names.
+			$inline = $part['inlineData'] ?? $part['inline_data'] ?? null;
+			if ( ! empty( $inline['data'] ) ) {
+				$image_data = $inline['data'];
+				$mime_type  = $inline['mimeType'] ?? $inline['mime_type'] ?? 'image/png';
+				break;
+			}
+		}
 
-        if ( empty( $image_data ) ) {
-            error_log( '[StrataWP SEO] Gemini image: Response has candidates but no image data. Parts: ' . wp_json_encode( $parts ) );
-            return new WP_Error( 'swps_gemini_no_image', __( 'Gemini did not return an image.', 'stratawp-seo' ) );
-        }
+		if ( empty( $image_data ) ) {
+			error_log( '[StrataWP SEO] Gemini image: Response has candidates but no image data. Parts: ' . wp_json_encode( $parts ) );
+			return new WP_Error( 'swps_gemini_no_image', __( 'Gemini did not return an image.', 'stratawp-seo' ) );
+		}
 
-        // Decode base64 and write to temp file.
-        $decoded = base64_decode( $image_data );
-        if ( false === $decoded ) {
-            return new WP_Error( 'swps_gemini_decode_failed', __( 'Failed to decode Gemini image data.', 'stratawp-seo' ) );
-        }
+		// Decode base64 and write to temp file.
+		$decoded = base64_decode( $image_data );
+		if ( false === $decoded ) {
+			return new WP_Error( 'swps_gemini_decode_failed', __( 'Failed to decode Gemini image data.', 'stratawp-seo' ) );
+		}
 
-        $ext = match ( $mime_type ) {
-            'image/png'  => '.png',
-            'image/jpeg' => '.jpg',
-            'image/webp' => '.webp',
-            default      => '.png',
-        };
+		$ext = match ( $mime_type ) {
+			'image/png'  => '.png',
+			'image/jpeg' => '.jpg',
+			'image/webp' => '.webp',
+			default      => '.png',
+		};
 
-        $tmp_file = wp_tempnam( 'gemini_img' ) . $ext;
-        if ( false === file_put_contents( $tmp_file, $decoded ) ) {
-            return new WP_Error( 'swps_gemini_write_failed', __( 'Failed to write Gemini image to temp file.', 'stratawp-seo' ) );
-        }
+		$tmp_file = wp_tempnam( 'gemini_img' ) . $ext;
+		if ( false === file_put_contents( $tmp_file, $decoded ) ) {
+			return new WP_Error( 'swps_gemini_write_failed', __( 'Failed to write Gemini image to temp file.', 'stratawp-seo' ) );
+		}
 
-        return $tmp_file;
-    }
+		return $tmp_file;
+	}
 
-    /**
-     * Attach a local temp file as a WordPress media attachment.
-     *
-     * @param string $tmp_file  Path to temp file.
-     * @param int    $post_id   Post to attach to.
-     * @param string $filename  Desired filename (without extension).
-     * @param string $alt_text  Alt text for the image.
-     * @param string $caption   Caption for the attachment.
-     * @return int|WP_Error Attachment ID or error.
-     */
-    private function attach_temp_file( string $tmp_file, int $post_id, string $filename, string $alt_text = '', string $caption = '' ): int|WP_Error {
-        require_once ABSPATH . 'wp-admin/includes/media.php';
-        require_once ABSPATH . 'wp-admin/includes/file.php';
-        require_once ABSPATH . 'wp-admin/includes/image.php';
+	/**
+	 * Attach a local temp file as a WordPress media attachment.
+	 *
+	 * @param string $tmp_file  Path to temp file.
+	 * @param int    $post_id   Post to attach to.
+	 * @param string $filename  Desired filename (without extension).
+	 * @param string $alt_text  Alt text for the image.
+	 * @param string $caption   Caption for the attachment.
+	 * @return int|WP_Error Attachment ID or error.
+	 */
+	private function attach_temp_file( string $tmp_file, int $post_id, string $filename, string $alt_text = '', string $caption = '' ): int|WP_Error {
+		require_once ABSPATH . 'wp-admin/includes/media.php';
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/image.php';
 
-        // Convert to WebP for optimized file size.
-        $webp_tmp = $this->convert_to_webp( $tmp_file );
-        if ( $webp_tmp !== $tmp_file ) {
-            @unlink( $tmp_file );
-            $tmp_file = $webp_tmp;
-            $ext = '.webp';
-        } else {
-            $ext = '.' . pathinfo( $tmp_file, PATHINFO_EXTENSION );
-        }
+		// Convert to WebP for optimized file size.
+		$webp_tmp = $this->convert_to_webp( $tmp_file );
+		if ( $webp_tmp !== $tmp_file ) {
+			@unlink( $tmp_file );
+			$tmp_file = $webp_tmp;
+			$ext      = '.webp';
+		} else {
+			$ext = '.' . pathinfo( $tmp_file, PATHINFO_EXTENSION );
+		}
 
-        $file_array = [
-            'name'     => sanitize_title( $filename ) . $ext,
-            'tmp_name' => $tmp_file,
-        ];
+		$file_array = array(
+			'name'     => sanitize_title( $filename ) . $ext,
+			'tmp_name' => $tmp_file,
+		);
 
-        $attachment_id = media_handle_sideload( $file_array, $post_id );
+		$attachment_id = media_handle_sideload( $file_array, $post_id );
 
-        if ( is_wp_error( $attachment_id ) ) {
-            @unlink( $tmp_file );
-            return $attachment_id;
-        }
+		if ( is_wp_error( $attachment_id ) ) {
+			@unlink( $tmp_file );
+			return $attachment_id;
+		}
 
-        if ( ! empty( $alt_text ) ) {
-            update_post_meta( $attachment_id, '_wp_attachment_image_alt', sanitize_text_field( $alt_text ) );
-        }
+		if ( ! empty( $alt_text ) ) {
+			update_post_meta( $attachment_id, '_wp_attachment_image_alt', sanitize_text_field( $alt_text ) );
+		}
 
-        if ( ! empty( $caption ) ) {
-            wp_update_post( [
-                'ID'           => $attachment_id,
-                'post_excerpt' => $caption,
-            ] );
-        }
+		if ( ! empty( $caption ) ) {
+			wp_update_post(
+				array(
+					'ID'           => $attachment_id,
+					'post_excerpt' => $caption,
+				)
+			);
+		}
 
-        return $attachment_id;
-    }
+		return $attachment_id;
+	}
 }

--- a/includes/providers/images/class-pexels-provider.php
+++ b/includes/providers/images/class-pexels-provider.php
@@ -6,103 +6,106 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Pexels_Provider extends SWPS_Image_Provider {
 
-    private const API_URL = 'https://api.pexels.com/v1/search';
+	private const API_URL = 'https://api.pexels.com/v1/search';
 
-    public function get_slug(): string {
-        return 'pexels';
-    }
+	public function get_slug(): string {
+		return 'pexels';
+	}
 
-    public function get_name(): string {
-        return 'Pexels';
-    }
+	public function get_name(): string {
+		return 'Pexels';
+	}
 
-    public function get_api_key_url(): string {
-        return 'https://www.pexels.com/api/';
-    }
+	public function get_api_key_url(): string {
+		return 'https://www.pexels.com/api/';
+	}
 
-    public function requires_api_key(): bool {
-        return true;
-    }
+	public function requires_api_key(): bool {
+		return true;
+	}
 
-    public function set_featured_image( int $post_id, string $query ): int|WP_Error {
-        $api_key = $this->get_api_key();
+	public function set_featured_image( int $post_id, string $query ): int|WP_Error {
+		$api_key = $this->get_api_key();
 
-        if ( empty( $api_key ) ) {
-            return new WP_Error( 'swps_no_pexels_key', __( 'Pexels API key not configured.', 'stratawp-seo' ) );
-        }
+		if ( empty( $api_key ) ) {
+			return new WP_Error( 'swps_no_pexels_key', __( 'Pexels API key not configured.', 'stratawp-seo' ) );
+		}
 
-        $photo = $this->search_photo( $query, $api_key );
+		$photo = $this->search_photo( $query, $api_key );
 
-        if ( is_wp_error( $photo ) ) {
-            return $photo;
-        }
+		if ( is_wp_error( $photo ) ) {
+			return $photo;
+		}
 
-        $image_url    = $photo['src']['large2x'] ?? $photo['src']['large'] ?? $photo['src']['original'];
-        $photographer = $photo['photographer'] ?? 'Unknown';
-        $photo_url    = $photo['url'] ?? '';
-        $alt_text     = $photo['alt'] ?? '';
+		$image_url    = $photo['src']['large2x'] ?? $photo['src']['large'] ?? $photo['src']['original'];
+		$photographer = $photo['photographer'] ?? 'Unknown';
+		$photo_url    = $photo['url'] ?? '';
+		$alt_text     = $photo['alt'] ?? '';
 
-        $caption = sprintf(
-            'Photo by <a href="%s">%s</a> on <a href="https://www.pexels.com">Pexels</a>',
-            esc_url( $photo_url ),
-            esc_html( $photographer )
-        );
+		$caption = sprintf(
+			'Photo by <a href="%s">%s</a> on <a href="https://www.pexels.com">Pexels</a>',
+			esc_url( $photo_url ),
+			esc_html( $photographer )
+		);
 
-        $filename = 'pexels-' . sanitize_title( $photographer ) . '-' . $photo['id'];
+		$filename = 'pexels-' . sanitize_title( $photographer ) . '-' . $photo['id'];
 
-        $attachment_id = $this->download_and_attach_image( $image_url, $post_id, $filename, $alt_text, $caption );
+		$attachment_id = $this->download_and_attach_image( $image_url, $post_id, $filename, $alt_text, $caption );
 
-        if ( is_wp_error( $attachment_id ) ) {
-            return $attachment_id;
-        }
+		if ( is_wp_error( $attachment_id ) ) {
+			return $attachment_id;
+		}
 
-        update_post_meta( $attachment_id, '_swps_pexels_photographer', $photographer );
-        update_post_meta( $attachment_id, '_swps_pexels_url', $photo_url );
+		update_post_meta( $attachment_id, '_swps_pexels_photographer', $photographer );
+		update_post_meta( $attachment_id, '_swps_pexels_url', $photo_url );
 
-        return $attachment_id;
-    }
+		return $attachment_id;
+	}
 
-    /**
-     * Search Pexels for a photo matching the query.
-     */
-    private function search_photo( string $query, string $api_key ): array|WP_Error {
-        $query = $this->simplify_query( $query );
+	/**
+	 * Search Pexels for a photo matching the query.
+	 */
+	private function search_photo( string $query, string $api_key ): array|WP_Error {
+		$query = $this->simplify_query( $query );
 
-        $response = wp_remote_get(
-            add_query_arg( [
-                'query'       => $query,
-                'per_page'    => 5,
-                'orientation' => 'landscape',
-            ], self::API_URL ),
-            [
-                'timeout' => 15,
-                'headers' => [
-                    'Authorization' => $api_key,
-                ],
-            ]
-        );
+		$response = wp_remote_get(
+			add_query_arg(
+				array(
+					'query'       => $query,
+					'per_page'    => 5,
+					'orientation' => 'landscape',
+				),
+				self::API_URL
+			),
+			array(
+				'timeout' => 15,
+				'headers' => array(
+					'Authorization' => $api_key,
+				),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error( 'swps_pexels_request_failed', $response->get_error_message() );
-        }
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'swps_pexels_request_failed', $response->get_error_message() );
+		}
 
-        $status = wp_remote_retrieve_response_code( $response );
-        $body   = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status = wp_remote_retrieve_response_code( $response );
+		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
 
-        if ( 200 !== $status ) {
-            $error = $body['error'] ?? 'Unknown Pexels API error.';
-            return new WP_Error( 'swps_pexels_error', $error );
-        }
+		if ( 200 !== $status ) {
+			$error = $body['error'] ?? 'Unknown Pexels API error.';
+			return new WP_Error( 'swps_pexels_error', $error );
+		}
 
-        if ( empty( $body['photos'] ) ) {
-            return new WP_Error( 'swps_no_photos', __( 'No photos found for this topic.', 'stratawp-seo' ) );
-        }
+		if ( empty( $body['photos'] ) ) {
+			return new WP_Error( 'swps_no_photos', __( 'No photos found for this topic.', 'stratawp-seo' ) );
+		}
 
-        return $body['photos'][ array_rand( $body['photos'] ) ];
-    }
+		return $body['photos'][ array_rand( $body['photos'] ) ];
+	}
 }

--- a/includes/providers/images/class-pixabay-provider.php
+++ b/includes/providers/images/class-pixabay-provider.php
@@ -6,99 +6,102 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Pixabay_Provider extends SWPS_Image_Provider {
 
-    private const API_URL = 'https://pixabay.com/api/';
+	private const API_URL = 'https://pixabay.com/api/';
 
-    public function get_slug(): string {
-        return 'pixabay';
-    }
+	public function get_slug(): string {
+		return 'pixabay';
+	}
 
-    public function get_name(): string {
-        return 'Pixabay';
-    }
+	public function get_name(): string {
+		return 'Pixabay';
+	}
 
-    public function get_api_key_url(): string {
-        return 'https://pixabay.com/api/docs/';
-    }
+	public function get_api_key_url(): string {
+		return 'https://pixabay.com/api/docs/';
+	}
 
-    public function requires_api_key(): bool {
-        return true;
-    }
+	public function requires_api_key(): bool {
+		return true;
+	}
 
-    public function set_featured_image( int $post_id, string $query ): int|WP_Error {
-        $api_key = $this->get_api_key();
+	public function set_featured_image( int $post_id, string $query ): int|WP_Error {
+		$api_key = $this->get_api_key();
 
-        if ( empty( $api_key ) ) {
-            return new WP_Error( 'swps_no_pixabay_key', __( 'Pixabay API key not configured.', 'stratawp-seo' ) );
-        }
+		if ( empty( $api_key ) ) {
+			return new WP_Error( 'swps_no_pixabay_key', __( 'Pixabay API key not configured.', 'stratawp-seo' ) );
+		}
 
-        $hit = $this->search_photo( $query, $api_key );
+		$hit = $this->search_photo( $query, $api_key );
 
-        if ( is_wp_error( $hit ) ) {
-            return $hit;
-        }
+		if ( is_wp_error( $hit ) ) {
+			return $hit;
+		}
 
-        $image_url = $hit['largeImageURL'] ?? $hit['webformatURL'];
-        $alt_text  = $hit['tags'] ?? '';
-        $filename  = 'pixabay-' . $hit['id'];
+		$image_url = $hit['largeImageURL'] ?? $hit['webformatURL'];
+		$alt_text  = $hit['tags'] ?? '';
+		$filename  = 'pixabay-' . $hit['id'];
 
-        $caption = sprintf(
-            'Image by <a href="%s">%s</a> on <a href="https://pixabay.com">Pixabay</a>',
-            esc_url( $hit['pageURL'] ?? 'https://pixabay.com' ),
-            esc_html( $hit['user'] ?? 'Unknown' )
-        );
+		$caption = sprintf(
+			'Image by <a href="%s">%s</a> on <a href="https://pixabay.com">Pixabay</a>',
+			esc_url( $hit['pageURL'] ?? 'https://pixabay.com' ),
+			esc_html( $hit['user'] ?? 'Unknown' )
+		);
 
-        $attachment_id = $this->download_and_attach_image( $image_url, $post_id, $filename, $alt_text, $caption );
+		$attachment_id = $this->download_and_attach_image( $image_url, $post_id, $filename, $alt_text, $caption );
 
-        if ( is_wp_error( $attachment_id ) ) {
-            return $attachment_id;
-        }
+		if ( is_wp_error( $attachment_id ) ) {
+			return $attachment_id;
+		}
 
-        update_post_meta( $attachment_id, '_swps_pixabay_user', $hit['user'] ?? '' );
-        update_post_meta( $attachment_id, '_swps_pixabay_url', $hit['pageURL'] ?? '' );
+		update_post_meta( $attachment_id, '_swps_pixabay_user', $hit['user'] ?? '' );
+		update_post_meta( $attachment_id, '_swps_pixabay_url', $hit['pageURL'] ?? '' );
 
-        return $attachment_id;
-    }
+		return $attachment_id;
+	}
 
-    /**
-     * Search Pixabay for a photo matching the query.
-     */
-    private function search_photo( string $query, string $api_key ): array|WP_Error {
-        $query = $this->simplify_query( $query );
+	/**
+	 * Search Pixabay for a photo matching the query.
+	 */
+	private function search_photo( string $query, string $api_key ): array|WP_Error {
+		$query = $this->simplify_query( $query );
 
-        $response = wp_remote_get(
-            add_query_arg( [
-                'key'         => $api_key,
-                'q'           => $query,
-                'per_page'    => 5,
-                'orientation' => 'horizontal',
-                'image_type'  => 'photo',
-                'safesearch'  => 'true',
-            ], self::API_URL ),
-            [
-                'timeout' => 15,
-            ]
-        );
+		$response = wp_remote_get(
+			add_query_arg(
+				array(
+					'key'         => $api_key,
+					'q'           => $query,
+					'per_page'    => 5,
+					'orientation' => 'horizontal',
+					'image_type'  => 'photo',
+					'safesearch'  => 'true',
+				),
+				self::API_URL
+			),
+			array(
+				'timeout' => 15,
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error( 'swps_pixabay_request_failed', $response->get_error_message() );
-        }
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'swps_pixabay_request_failed', $response->get_error_message() );
+		}
 
-        $status = wp_remote_retrieve_response_code( $response );
-        $body   = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status = wp_remote_retrieve_response_code( $response );
+		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
 
-        if ( 200 !== $status ) {
-            return new WP_Error( 'swps_pixabay_error', __( 'Pixabay API error.', 'stratawp-seo' ) );
-        }
+		if ( 200 !== $status ) {
+			return new WP_Error( 'swps_pixabay_error', __( 'Pixabay API error.', 'stratawp-seo' ) );
+		}
 
-        if ( empty( $body['hits'] ) ) {
-            return new WP_Error( 'swps_no_photos', __( 'No photos found for this topic.', 'stratawp-seo' ) );
-        }
+		if ( empty( $body['hits'] ) ) {
+			return new WP_Error( 'swps_no_photos', __( 'No photos found for this topic.', 'stratawp-seo' ) );
+		}
 
-        return $body['hits'][ array_rand( $body['hits'] ) ];
-    }
+		return $body['hits'][ array_rand( $body['hits'] ) ];
+	}
 }

--- a/includes/providers/images/class-unsplash-provider.php
+++ b/includes/providers/images/class-unsplash-provider.php
@@ -6,118 +6,124 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class SWPS_Unsplash_Provider extends SWPS_Image_Provider {
 
-    private const API_URL = 'https://api.unsplash.com';
+	private const API_URL = 'https://api.unsplash.com';
 
-    public function get_slug(): string {
-        return 'unsplash';
-    }
+	public function get_slug(): string {
+		return 'unsplash';
+	}
 
-    public function get_name(): string {
-        return 'Unsplash';
-    }
+	public function get_name(): string {
+		return 'Unsplash';
+	}
 
-    public function get_api_key_url(): string {
-        return 'https://unsplash.com/developers';
-    }
+	public function get_api_key_url(): string {
+		return 'https://unsplash.com/developers';
+	}
 
-    public function requires_api_key(): bool {
-        return true;
-    }
+	public function requires_api_key(): bool {
+		return true;
+	}
 
-    public function set_featured_image( int $post_id, string $query ): int|WP_Error {
-        $api_key = $this->get_api_key();
+	public function set_featured_image( int $post_id, string $query ): int|WP_Error {
+		$api_key = $this->get_api_key();
 
-        if ( empty( $api_key ) ) {
-            return new WP_Error( 'swps_no_unsplash_key', __( 'Unsplash API key not configured.', 'stratawp-seo' ) );
-        }
+		if ( empty( $api_key ) ) {
+			return new WP_Error( 'swps_no_unsplash_key', __( 'Unsplash API key not configured.', 'stratawp-seo' ) );
+		}
 
-        $photo = $this->search_photo( $query, $api_key );
+		$photo = $this->search_photo( $query, $api_key );
 
-        if ( is_wp_error( $photo ) ) {
-            return $photo;
-        }
+		if ( is_wp_error( $photo ) ) {
+			return $photo;
+		}
 
-        $image_url = $photo['urls']['regular'] ?? $photo['urls']['small'];
-        $slug      = $photo['slug'] ?? $photo['id'];
-        $alt_text  = $photo['alt_description'] ?? $photo['description'] ?? '';
+		$image_url = $photo['urls']['regular'] ?? $photo['urls']['small'];
+		$slug      = $photo['slug'] ?? $photo['id'];
+		$alt_text  = $photo['alt_description'] ?? $photo['description'] ?? '';
 
-        $photographer     = $photo['user']['name'] ?? 'Unknown';
-        $photographer_url = $photo['user']['links']['html'] ?? '';
+		$photographer     = $photo['user']['name'] ?? 'Unknown';
+		$photographer_url = $photo['user']['links']['html'] ?? '';
 
-        $caption = sprintf(
-            'Photo by <a href="%s?utm_source=stratawp_seo&utm_medium=referral">%s</a> on <a href="https://unsplash.com/?utm_source=stratawp_seo&utm_medium=referral">Unsplash</a>',
-            esc_url( $photographer_url ),
-            esc_html( $photographer )
-        );
+		$caption = sprintf(
+			'Photo by <a href="%s?utm_source=stratawp_seo&utm_medium=referral">%s</a> on <a href="https://unsplash.com/?utm_source=stratawp_seo&utm_medium=referral">Unsplash</a>',
+			esc_url( $photographer_url ),
+			esc_html( $photographer )
+		);
 
-        $attachment_id = $this->download_and_attach_image( $image_url, $post_id, $slug, $alt_text, $caption );
+		$attachment_id = $this->download_and_attach_image( $image_url, $post_id, $slug, $alt_text, $caption );
 
-        if ( is_wp_error( $attachment_id ) ) {
-            return $attachment_id;
-        }
+		if ( is_wp_error( $attachment_id ) ) {
+			return $attachment_id;
+		}
 
-        // Store Unsplash attribution as attachment meta.
-        update_post_meta( $attachment_id, '_swps_unsplash_photographer', $photographer );
-        update_post_meta( $attachment_id, '_swps_unsplash_photographer_url', $photographer_url );
-        update_post_meta( $attachment_id, '_swps_unsplash_url', $photo['links']['html'] ?? '' );
+		// Store Unsplash attribution as attachment meta.
+		update_post_meta( $attachment_id, '_swps_unsplash_photographer', $photographer );
+		update_post_meta( $attachment_id, '_swps_unsplash_photographer_url', $photographer_url );
+		update_post_meta( $attachment_id, '_swps_unsplash_url', $photo['links']['html'] ?? '' );
 
-        // Trigger Unsplash download endpoint (required by their API guidelines).
-        if ( ! empty( $photo['links']['download_location'] ) ) {
-            wp_remote_get( $photo['links']['download_location'], [
-                'timeout'  => 5,
-                'blocking' => false,
-                'headers'  => [
-                    'Authorization' => 'Client-ID ' . $api_key,
-                ],
-            ] );
-        }
+		// Trigger Unsplash download endpoint (required by their API guidelines).
+		if ( ! empty( $photo['links']['download_location'] ) ) {
+			wp_remote_get(
+				$photo['links']['download_location'],
+				array(
+					'timeout'  => 5,
+					'blocking' => false,
+					'headers'  => array(
+						'Authorization' => 'Client-ID ' . $api_key,
+					),
+				)
+			);
+		}
 
-        return $attachment_id;
-    }
+		return $attachment_id;
+	}
 
-    /**
-     * Search Unsplash for a photo matching the query.
-     */
-    private function search_photo( string $query, string $api_key ): array|WP_Error {
-        $query = $this->simplify_query( $query );
+	/**
+	 * Search Unsplash for a photo matching the query.
+	 */
+	private function search_photo( string $query, string $api_key ): array|WP_Error {
+		$query = $this->simplify_query( $query );
 
-        $response = wp_remote_get(
-            add_query_arg( [
-                'query'          => $query,
-                'per_page'       => 5,
-                'orientation'    => 'landscape',
-                'content_filter' => 'high',
-            ], self::API_URL . '/search/photos' ),
-            [
-                'timeout' => 15,
-                'headers' => [
-                    'Authorization'  => 'Client-ID ' . $api_key,
-                    'Accept-Version' => 'v1',
-                ],
-            ]
-        );
+		$response = wp_remote_get(
+			add_query_arg(
+				array(
+					'query'          => $query,
+					'per_page'       => 5,
+					'orientation'    => 'landscape',
+					'content_filter' => 'high',
+				),
+				self::API_URL . '/search/photos'
+			),
+			array(
+				'timeout' => 15,
+				'headers' => array(
+					'Authorization'  => 'Client-ID ' . $api_key,
+					'Accept-Version' => 'v1',
+				),
+			)
+		);
 
-        if ( is_wp_error( $response ) ) {
-            return new WP_Error( 'swps_unsplash_request_failed', $response->get_error_message() );
-        }
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'swps_unsplash_request_failed', $response->get_error_message() );
+		}
 
-        $status = wp_remote_retrieve_response_code( $response );
-        $body   = json_decode( wp_remote_retrieve_body( $response ), true );
+		$status = wp_remote_retrieve_response_code( $response );
+		$body   = json_decode( wp_remote_retrieve_body( $response ), true );
 
-        if ( 200 !== $status ) {
-            $error = $body['errors'][0] ?? 'Unknown Unsplash API error.';
-            return new WP_Error( 'swps_unsplash_error', $error );
-        }
+		if ( 200 !== $status ) {
+			$error = $body['errors'][0] ?? 'Unknown Unsplash API error.';
+			return new WP_Error( 'swps_unsplash_error', $error );
+		}
 
-        if ( empty( $body['results'] ) ) {
-            return new WP_Error( 'swps_no_photos', __( 'No photos found for this topic.', 'stratawp-seo' ) );
-        }
+		if ( empty( $body['results'] ) ) {
+			return new WP_Error( 'swps_no_photos', __( 'No photos found for this topic.', 'stratawp-seo' ) );
+		}
 
-        return $body['results'][ array_rand( $body['results'] ) ];
-    }
+		return $body['results'][ array_rand( $body['results'] ) ];
+	}
 }

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -14,7 +14,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 define( 'SWPS_VERSION', '4.5.0' );
@@ -151,7 +151,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-dashboard.php';
 
 // WP-CLI commands (only when CLI is available).
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
-    require_once SWPS_PLUGIN_DIR . 'includes/class-cli.php';
+	require_once SWPS_PLUGIN_DIR . 'includes/class-cli.php';
 }
 
 /**
@@ -159,1005 +159,1017 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
  */
 final class StrataWP_SEO {
 
-    private static ?StrataWP_SEO $instance = null;
-
-    public SWPS_Settings $settings;
-    public SWPS_Generator $generator;
-    public SWPS_Cron $cron;
-    public SWPS_Analyzer $analyzer;
-    public SWPS_AI_Provider $api;
-    public SWPS_Image_Provider $images;
-
-    // v2.0 subsystems.
-    public SWPS_Cache_Manager $cache_manager;
-    public SWPS_Duplicate_Checker $duplicate_checker;
-    public SWPS_Rate_Limiter $rate_limiter;
-    public SWPS_Cost_Tracker $cost_tracker;
-    public SWPS_Topic_Queue $topic_queue;
-    public SWPS_Calendar $calendar;
-    public SWPS_Background_Processor $background_processor;
-    public SWPS_REST_API $rest_api;
-    public SWPS_Content_Scorer $content_scorer;
-    public SWPS_Voice_Profile $voice_profile;
-    public SWPS_Image_Inserter $image_inserter;
-    public SWPS_SEO_Audit $seo_audit;
-    public SWPS_Schema $schema;
-    public SWPS_Analytics_Tracker $analytics_tracker;
-    public SWPS_Bot_Analytics_Tracker $bot_analytics_tracker;
-    public SWPS_Search_Console $search_console;
-    public SWPS_Analytics_Dashboard $analytics_dashboard;
-    public SWPS_Keyword_Tracker $keyword_tracker;
-    public SWPS_Keywords_Page $keywords_page;
-    public SWPS_Meta_Editor $meta_editor;
-    public SWPS_Head_Cleanup $head_cleanup;
-    public SWPS_RSS_Optimizer $rss_optimizer;
-    public SWPS_Taxonomy_Meta $taxonomy_meta;
-    public SWPS_Sitemap_Manager $sitemap_manager;
-    public SWPS_Search_Appearance $search_appearance;
-    public SWPS_Breadcrumbs $breadcrumbs;
-    public SWPS_Redirect_Manager $redirect_manager;
-    public SWPS_Post_List_SEO $post_list_seo;
-    public SWPS_Sitemap_Admin $sitemap_admin;
-    public SWPS_Internal_Links $internal_links;
-    public SWPS_Internal_Links_Admin $internal_links_admin;
-    public SWPS_AI_Bots $ai_bots;
-    public SWPS_Auto_Optimize $auto_optimize;
-    public SWPS_Competitors $competitors;
-    public SWPS_Local_SEO $local_seo;
-    public SWPS_Image_SEO $image_seo;
-    public SWPS_Crawl_Files $crawl_files;
-    public SWPS_Backlinks $backlinks;
-
-    // v4.0 admin shell.
-    public SWPS_User_Prefs $user_prefs;
-    public SWPS_Modules $modules;
-    public SWPS_Admin_Shell $admin_shell;
-    public SWPS_Dashboard $dashboard;
-    public SWPS_Migration $migration;
-
-    public static function instance(): self {
-        if ( null === self::$instance ) {
-            self::$instance = new self();
-        }
-        return self::$instance;
-    }
-
-    private function __construct() {
-        $this->maybe_migrate_legacy_options();
-
-        // Initialize foundation subsystems.
-        $this->cache_manager      = new SWPS_Cache_Manager();
-        $this->duplicate_checker  = new SWPS_Duplicate_Checker();
-        $this->rate_limiter       = new SWPS_Rate_Limiter();
-        $this->cost_tracker       = new SWPS_Cost_Tracker();
-        $this->topic_queue        = new SWPS_Topic_Queue();
-        $this->content_scorer     = new SWPS_Content_Scorer();
-        $this->voice_profile      = new SWPS_Voice_Profile();
-
-        // Initialize providers and core.
-        $this->api       = SWPS_Provider_Factory::create_ai_provider();
-        $this->images    = SWPS_Provider_Factory::create_image_provider();
-        $this->image_inserter = new SWPS_Image_Inserter( $this->images );
-        $this->seo_audit = new SWPS_SEO_Audit();
-        $this->schema    = new SWPS_Schema();
-        $this->analytics_tracker     = new SWPS_Analytics_Tracker();
-        $this->bot_analytics_tracker = new SWPS_Bot_Analytics_Tracker();
-        $this->search_console        = new SWPS_Search_Console();
-        $this->analytics_dashboard   = new SWPS_Analytics_Dashboard( $this->analytics_tracker, $this->search_console );
-        $this->keyword_tracker = new SWPS_Keyword_Tracker( $this->search_console );
-        $this->keywords_page   = new SWPS_Keywords_Page( $this->keyword_tracker );
-        $this->meta_editor     = new SWPS_Meta_Editor();
-        $this->head_cleanup    = new SWPS_Head_Cleanup();
-        $this->rss_optimizer   = new SWPS_RSS_Optimizer();
-        $this->taxonomy_meta      = new SWPS_Taxonomy_Meta();
-        $this->sitemap_manager    = new SWPS_Sitemap_Manager();
-        $this->search_appearance  = new SWPS_Search_Appearance();
-        $this->breadcrumbs        = new SWPS_Breadcrumbs();
-        $this->redirect_manager   = new SWPS_Redirect_Manager();
-        $this->sitemap_admin      = new SWPS_Sitemap_Admin();
-
-        if ( is_admin() ) {
-            $this->post_list_seo = new SWPS_Post_List_SEO( $this->content_scorer );
-        }
-        $link_keyword_engine = new SWPS_Link_Keyword_Engine();
-        $link_ai_engine      = new SWPS_Link_AI_Engine( $this->api, $this->cost_tracker );
-        $this->internal_links = new SWPS_Internal_Links( $link_keyword_engine, $link_ai_engine );
-        $this->internal_links_admin = new SWPS_Internal_Links_Admin( $this->internal_links );
-        $this->ai_bots             = new SWPS_AI_Bots();
-        $this->auto_optimize       = new SWPS_Auto_Optimize( $this->content_scorer );
-        $this->competitors         = new SWPS_Competitors();
-        $this->local_seo           = new SWPS_Local_SEO();
-        $this->image_seo           = new SWPS_Image_SEO();
-        $this->crawl_files         = new SWPS_Crawl_Files();
-        $this->backlinks           = new SWPS_Backlinks();
-        $this->settings  = new SWPS_Settings();
-        $this->analyzer  = new SWPS_Analyzer( $this->cache_manager );
-        $this->generator = new SWPS_Generator(
-            $this->api,
-            $this->analyzer,
-            $this->images,
-            $this->duplicate_checker,
-            $this->rate_limiter,
-            $this->cost_tracker
-        );
-        $this->cron      = new SWPS_Cron( $this->generator, $this->topic_queue );
-
-        // Initialize v2.0 subsystems.
-        $this->calendar             = new SWPS_Calendar( $this->topic_queue );
-        $this->background_processor = new SWPS_Background_Processor();
-        $this->rest_api             = new SWPS_REST_API();
-
-        // v4.0 admin shell — only relevant in admin, but instantiate always so REST routes register.
-        $this->user_prefs  = new SWPS_User_Prefs();
-        $this->modules     = new SWPS_Modules();
-        $this->admin_shell = new SWPS_Admin_Shell( $this->user_prefs );
-        $this->dashboard   = new SWPS_Dashboard();
-        $this->migration   = new SWPS_Migration();
-
-        // GitHub release-based updater (admin only).
-        if ( is_admin() ) {
-            new SWPS_GitHub_Updater( __FILE__, SWPS_VERSION );
-        }
-
-        // Register CPT.
-        add_action( 'init', [ SWPS_Topic_Queue::class, 'register_post_type' ] );
-
-        // Redirect 404 log pruning cron.
-        add_action( 'swps_prune_404_logs', [ SWPS_Redirect_Manager::class, 'prune_404_logs' ] );
-
-        // Admin assets.
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
-
-        // Frontend assets.
-        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_frontend_assets' ] );
-
-        // AJAX handlers — original.
-        add_action( 'wp_ajax_swps_generate_post', [ $this, 'ajax_generate_post' ] );
-        add_action( 'wp_ajax_swps_analyze_site', [ $this, 'ajax_analyze_site' ] );
-        add_action( 'wp_ajax_swps_get_models', [ $this, 'ajax_get_models' ] );
-
-        // AJAX handlers — v2.0.
-        add_action( 'wp_ajax_swps_bulk_generate', [ $this, 'ajax_bulk_generate' ] );
-        add_action( 'wp_ajax_swps_preview_post', [ $this, 'ajax_preview_post' ] );
-        add_action( 'wp_ajax_swps_clear_cache', [ $this, 'ajax_clear_cache' ] );
-
-        // Frontend.
-        add_action( 'wp_head', [ $this, 'output_faq_schema' ] );
-        add_action( 'wp_head', [ $this, 'output_takeaways_schema' ] );
-
-        // Content scoring on post creation.
-        add_action( 'swps_post_created', [ $this, 'score_generated_post' ], 10, 3 );
-
-        // Voice profile AJAX.
-        add_action( 'wp_ajax_swps_save_voice_profile', [ $this, 'ajax_save_voice_profile' ] );
-        add_action( 'wp_ajax_swps_delete_voice_profile', [ $this, 'ajax_delete_voice_profile' ] );
-
-        // In-content image insertion on post creation.
-        add_action( 'swps_post_created', [ $this, 'insert_content_images' ], 20, 3 );
-
-        // SEO Audit frontend hooks.
-        add_action( 'wp_head', [ SWPS_Canonical_Module::class, 'output_canonical' ], 1 );
-        add_action( 'wp_head', [ SWPS_OpenGraph_Module::class, 'output_meta_tags' ], 5 );
-        // Disable audit OG output when meta editor handles it.
-        if ( get_option( 'swps_meta_editor_enabled', 1 ) && ! defined( 'WPSEO_VERSION' ) && ! defined( 'RANK_MATH_VERSION' ) && ! defined( 'AIOSEO_VERSION' ) ) {
-            remove_action( 'wp_head', [ SWPS_OpenGraph_Module::class, 'output_meta_tags' ], 5 );
-        }
-        // Sitemap generation/serving/pinging now handled by SWPS_Sitemap_Manager.
-        // add_action( 'init', [ SWPS_Sitemap_Module::class, 'register_rewrite_rules' ] );
-        // add_action( 'template_redirect', [ SWPS_Sitemap_Module::class, 'serve_sitemap' ] );
-        // add_action( 'publish_post', [ SWPS_Sitemap_Module::class, 'ping_search_engines' ] );
-        add_filter( 'robots_txt', [ SWPS_Robots_Module::class, 'filter_robots_txt' ], 10, 2 );
-
-        // SEO Audit AJAX handlers.
-        add_action( 'wp_ajax_swps_run_audit', [ $this, 'ajax_run_audit' ] );
-        add_action( 'wp_ajax_swps_get_audit_results', [ $this, 'ajax_get_audit_results' ] );
-        add_action( 'wp_ajax_swps_fix_module', [ $this, 'ajax_fix_module' ] );
-        add_action( 'wp_ajax_swps_fix_all', [ $this, 'ajax_fix_all' ] );
-
-        // Dashboard widget.
-        add_action( 'wp_dashboard_setup', [ $this, 'register_dashboard_widget' ] );
-
-        // Plugins page link.
-        add_filter( 'plugin_action_links_' . SWPS_PLUGIN_BASENAME, [ $this, 'add_settings_link' ] );
-
-        // WP-CLI registration.
-        if ( defined( 'WP_CLI' ) && WP_CLI ) {
-            WP_CLI::add_command( 'swps', 'SWPS_CLI' );
-        }
-    }
-
-    /**
-     * Migrate legacy option names for existing installs.
-     */
-    private function maybe_migrate_legacy_options(): void {
-        if ( get_option( 'swps_provider_migrated' ) ) {
-            return;
-        }
-
-        $legacy_key = get_option( 'swps_api_key', '' );
-        if ( ! empty( $legacy_key ) && empty( get_option( 'swps_anthropic_api_key', '' ) ) ) {
-            update_option( 'swps_anthropic_api_key', $legacy_key );
-        }
-
-        if ( false === get_option( 'swps_ai_provider' ) ) {
-            update_option( 'swps_ai_provider', 'anthropic' );
-        }
-        if ( false === get_option( 'swps_image_provider' ) ) {
-            update_option( 'swps_image_provider', 'unsplash' );
-        }
-
-        update_option( 'swps_provider_migrated', 1 );
-    }
-
-    /**
-     * Enqueue admin CSS and JS on our pages only.
-     */
-    public function enqueue_admin_assets( string $hook ): void {
-        // Load only CSS on the Dashboard (for the audit widget).
-        if ( 'index.php' === $hook ) {
-            wp_enqueue_style( 'swps-admin', SWPS_PLUGIN_URL . 'admin/css/admin.css', [], SWPS_VERSION );
-            return;
-        }
-
-        if ( ! str_contains( $hook, 'stratawp-seo' ) && ! str_contains( $hook, 'swps-generate' ) && ! str_contains( $hook, 'swps-voice-profiles' ) && ! str_contains( $hook, 'swps-seo-audit' ) && ! str_contains( $hook, 'swps-analytics' ) && ! str_contains( $hook, 'swps-keywords' ) && ! in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
-            return;
-        }
-
-        wp_enqueue_style(
-            'swps-admin',
-            SWPS_PLUGIN_URL . 'admin/css/admin.css',
-            [],
-            SWPS_VERSION
-        );
-
-        wp_enqueue_script(
-            'swps-admin',
-            SWPS_PLUGIN_URL . 'admin/js/admin.js',
-            [ 'jquery' ],
-            SWPS_VERSION,
-            true
-        );
-
-        wp_localize_script( 'swps-admin', 'swpsAdmin', [
-            'ajax_url'            => admin_url( 'admin-ajax.php' ),
-            'nonce'               => wp_create_nonce( 'swps_nonce' ),
-            'current_ai_provider' => get_option( 'swps_ai_provider', 'anthropic' ),
-            'current_model'       => get_option( 'swps_model', '' ),
-            'templates'           => SWPS_Templates::get_options(),
-            'rate_limit_remaining' => $this->rate_limiter->get_remaining_seconds(),
-            'min_content_score'   => get_option( 'swps_min_content_score', 0 ),
-            'generate_url'        => admin_url( 'admin.php?page=swps-generate' ),
-        ] );
-
-        // Analytics dashboard JS.
-        if ( str_contains( $hook, 'swps-analytics' ) || in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
-            if ( str_contains( $hook, 'swps-analytics' ) ) {
-                wp_enqueue_script(
-                    'chartjs',
-                    'https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js',
-                    [],
-                    '4.4.7',
-                    true
-                );
-            }
-            wp_enqueue_script(
-                'swps-analytics',
-                SWPS_PLUGIN_URL . 'admin/js/analytics.js',
-                str_contains( $hook, 'swps-analytics' ) ? [ 'jquery', 'swps-admin', 'chartjs' ] : [ 'jquery', 'swps-admin' ],
-                SWPS_VERSION,
-                true
-            );
-        }
-
-        // Keywords page JS.
-        if ( str_contains( $hook, 'swps-keywords' ) ) {
-            wp_enqueue_script(
-                'swps-keywords',
-                SWPS_PLUGIN_URL . 'admin/js/keywords.js',
-                [ 'jquery', 'swps-admin' ],
-                SWPS_VERSION,
-                true
-            );
-        }
-
-        // Meta editor JS on post edit screens.
-        if ( in_array( $hook, [ 'post.php', 'post-new.php' ], true ) ) {
-            wp_enqueue_script(
-                'swps-meta-editor',
-                SWPS_PLUGIN_URL . 'admin/js/meta-editor.js',
-                [ 'jquery', 'swps-admin' ],
-                SWPS_VERSION,
-                true
-            );
-        }
-
-        // Search Appearance page JS.
-        if ( 'stratawp-seo_page_swps-search-appearance' === $hook ) {
-            wp_enqueue_script( 'swps-search-appearance', SWPS_PLUGIN_URL . 'admin/js/search-appearance.js', [], SWPS_VERSION, true );
-        }
-
-        // Redirects page JS.
-        if ( 'stratawp-seo_page_swps-redirects' === $hook ) {
-            wp_enqueue_script( 'swps-redirects', SWPS_PLUGIN_URL . 'admin/js/redirects.js', [], SWPS_VERSION, true );
-        }
-
-        if ( 'stratawp-seo_page_swps-sitemaps' === $hook ) {
-            wp_enqueue_script( 'swps-sitemaps', SWPS_PLUGIN_URL . 'admin/js/sitemaps.js', [ 'swps-admin' ], SWPS_VERSION, true );
-        }
-    }
-
-    /**
-     * Enqueue frontend CSS on single posts.
-     */
-    public function enqueue_frontend_assets(): void {
-        if ( ! is_singular( 'post' ) ) {
-            return;
-        }
-
-        wp_enqueue_style(
-            'swps-frontend',
-            SWPS_PLUGIN_URL . 'css/frontend.css',
-            [],
-            SWPS_VERSION
-        );
-    }
-
-    /**
-     * AJAX handler: Generate a single post.
-     */
-    public function ajax_generate_post(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $topic    = sanitize_text_field( $_POST['topic'] ?? '' );
-        $template = sanitize_text_field( $_POST['template'] ?? 'auto' );
-
-        $result = $this->generator->generate_post( $topic, $template );
-
-        if ( is_wp_error( $result ) ) {
-            wp_send_json_error( [ 'message' => $result->get_error_message() ] );
-        }
-
-        wp_send_json_success( $result );
-    }
-
-    /**
-     * AJAX handler: Bulk generate posts.
-     */
-    public function ajax_bulk_generate(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $count    = min( (int) ( $_POST['count'] ?? 1 ), 5 );
-        $template = sanitize_text_field( $_POST['template'] ?? 'auto' );
-        $results  = [];
-
-        for ( $i = 0; $i < $count; $i++ ) {
-            $result = $this->generator->generate_post( '', $template );
-
-            if ( is_wp_error( $result ) ) {
-                $results[] = [
-                    'success' => false,
-                    'message' => $result->get_error_message(),
-                ];
-                break;
-            }
-
-            $results[] = [
-                'success' => true,
-                'data'    => $result,
-            ];
-
-            if ( $i < $count - 1 ) {
-                sleep( 5 );
-            }
-        }
-
-        wp_send_json_success( [
-            'results'   => $results,
-            'completed' => count( array_filter( $results, fn( $r ) => $r['success'] ) ),
-            'total'     => $count,
-        ] );
-    }
-
-    /**
-     * AJAX handler: Preview post content without publishing.
-     */
-    public function ajax_preview_post(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $topic    = sanitize_text_field( $_POST['topic'] ?? '' );
-        $template = sanitize_text_field( $_POST['template'] ?? 'auto' );
-
-        $result = $this->generator->preview_content( $topic, $template );
-
-        if ( is_wp_error( $result ) ) {
-            wp_send_json_error( [ 'message' => $result->get_error_message() ] );
-        }
-
-        wp_send_json_success( $result );
-    }
-
-    /**
-     * AJAX handler: Clear analysis cache.
-     */
-    public function ajax_clear_cache(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $this->cache_manager->invalidate_all();
-
-        wp_send_json_success( [ 'message' => 'Cache cleared.' ] );
-    }
-
-    /**
-     * AJAX handler: Analyze site content.
-     */
-    public function ajax_analyze_site(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'edit_posts' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $analysis = $this->analyzer->get_site_summary();
-
-        wp_send_json_success( $analysis );
-    }
-
-    /**
-     * AJAX handler: Get models for a given AI provider slug.
-     */
-    public function ajax_get_models(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
-
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
-
-        $provider = sanitize_text_field( $_POST['provider'] ?? '' );
-        $models   = SWPS_Provider_Factory::get_models_for_provider( $provider );
-
-        wp_send_json_success( $models );
-    }
-
-    /**
-     * Output FAQ schema JSON-LD in <head> for generated posts.
-     */
-    public function output_faq_schema(): void {
-        if ( ! is_singular( 'post' ) ) {
-            return;
-        }
-
-        $schema = get_post_meta( get_the_ID(), '_swps_faq_schema', true );
-
-        $schema = $this->normalize_faq_schema_meta( $schema );
-
-        if ( empty( $schema ) ) {
-            return;
-        }
+	private static ?StrataWP_SEO $instance = null;
+
+	public SWPS_Settings $settings;
+	public SWPS_Generator $generator;
+	public SWPS_Cron $cron;
+	public SWPS_Analyzer $analyzer;
+	public SWPS_AI_Provider $api;
+	public SWPS_Image_Provider $images;
+
+	// v2.0 subsystems.
+	public SWPS_Cache_Manager $cache_manager;
+	public SWPS_Duplicate_Checker $duplicate_checker;
+	public SWPS_Rate_Limiter $rate_limiter;
+	public SWPS_Cost_Tracker $cost_tracker;
+	public SWPS_Topic_Queue $topic_queue;
+	public SWPS_Calendar $calendar;
+	public SWPS_Background_Processor $background_processor;
+	public SWPS_REST_API $rest_api;
+	public SWPS_Content_Scorer $content_scorer;
+	public SWPS_Voice_Profile $voice_profile;
+	public SWPS_Image_Inserter $image_inserter;
+	public SWPS_SEO_Audit $seo_audit;
+	public SWPS_Schema $schema;
+	public SWPS_Analytics_Tracker $analytics_tracker;
+	public SWPS_Bot_Analytics_Tracker $bot_analytics_tracker;
+	public SWPS_Search_Console $search_console;
+	public SWPS_Analytics_Dashboard $analytics_dashboard;
+	public SWPS_Keyword_Tracker $keyword_tracker;
+	public SWPS_Keywords_Page $keywords_page;
+	public SWPS_Meta_Editor $meta_editor;
+	public SWPS_Head_Cleanup $head_cleanup;
+	public SWPS_RSS_Optimizer $rss_optimizer;
+	public SWPS_Taxonomy_Meta $taxonomy_meta;
+	public SWPS_Sitemap_Manager $sitemap_manager;
+	public SWPS_Search_Appearance $search_appearance;
+	public SWPS_Breadcrumbs $breadcrumbs;
+	public SWPS_Redirect_Manager $redirect_manager;
+	public SWPS_Post_List_SEO $post_list_seo;
+	public SWPS_Sitemap_Admin $sitemap_admin;
+	public SWPS_Internal_Links $internal_links;
+	public SWPS_Internal_Links_Admin $internal_links_admin;
+	public SWPS_AI_Bots $ai_bots;
+	public SWPS_Auto_Optimize $auto_optimize;
+	public SWPS_Competitors $competitors;
+	public SWPS_Local_SEO $local_seo;
+	public SWPS_Image_SEO $image_seo;
+	public SWPS_Crawl_Files $crawl_files;
+	public SWPS_Backlinks $backlinks;
+
+	// v4.0 admin shell.
+	public SWPS_User_Prefs $user_prefs;
+	public SWPS_Modules $modules;
+	public SWPS_Admin_Shell $admin_shell;
+	public SWPS_Dashboard $dashboard;
+	public SWPS_Migration $migration;
+
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	private function __construct() {
+		$this->maybe_migrate_legacy_options();
+
+		// Initialize foundation subsystems.
+		$this->cache_manager     = new SWPS_Cache_Manager();
+		$this->duplicate_checker = new SWPS_Duplicate_Checker();
+		$this->rate_limiter      = new SWPS_Rate_Limiter();
+		$this->cost_tracker      = new SWPS_Cost_Tracker();
+		$this->topic_queue       = new SWPS_Topic_Queue();
+		$this->content_scorer    = new SWPS_Content_Scorer();
+		$this->voice_profile     = new SWPS_Voice_Profile();
+
+		// Initialize providers and core.
+		$this->api                   = SWPS_Provider_Factory::create_ai_provider();
+		$this->images                = SWPS_Provider_Factory::create_image_provider();
+		$this->image_inserter        = new SWPS_Image_Inserter( $this->images );
+		$this->seo_audit             = new SWPS_SEO_Audit();
+		$this->schema                = new SWPS_Schema();
+		$this->analytics_tracker     = new SWPS_Analytics_Tracker();
+		$this->bot_analytics_tracker = new SWPS_Bot_Analytics_Tracker();
+		$this->search_console        = new SWPS_Search_Console();
+		$this->analytics_dashboard   = new SWPS_Analytics_Dashboard( $this->analytics_tracker, $this->search_console );
+		$this->keyword_tracker       = new SWPS_Keyword_Tracker( $this->search_console );
+		$this->keywords_page         = new SWPS_Keywords_Page( $this->keyword_tracker );
+		$this->meta_editor           = new SWPS_Meta_Editor();
+		$this->head_cleanup          = new SWPS_Head_Cleanup();
+		$this->rss_optimizer         = new SWPS_RSS_Optimizer();
+		$this->taxonomy_meta         = new SWPS_Taxonomy_Meta();
+		$this->sitemap_manager       = new SWPS_Sitemap_Manager();
+		$this->search_appearance     = new SWPS_Search_Appearance();
+		$this->breadcrumbs           = new SWPS_Breadcrumbs();
+		$this->redirect_manager      = new SWPS_Redirect_Manager();
+		$this->sitemap_admin         = new SWPS_Sitemap_Admin();
+
+		if ( is_admin() ) {
+			$this->post_list_seo = new SWPS_Post_List_SEO( $this->content_scorer );
+		}
+		$link_keyword_engine        = new SWPS_Link_Keyword_Engine();
+		$link_ai_engine             = new SWPS_Link_AI_Engine( $this->api, $this->cost_tracker );
+		$this->internal_links       = new SWPS_Internal_Links( $link_keyword_engine, $link_ai_engine );
+		$this->internal_links_admin = new SWPS_Internal_Links_Admin( $this->internal_links );
+		$this->ai_bots              = new SWPS_AI_Bots();
+		$this->auto_optimize        = new SWPS_Auto_Optimize( $this->content_scorer );
+		$this->competitors          = new SWPS_Competitors();
+		$this->local_seo            = new SWPS_Local_SEO();
+		$this->image_seo            = new SWPS_Image_SEO();
+		$this->crawl_files          = new SWPS_Crawl_Files();
+		$this->backlinks            = new SWPS_Backlinks();
+		$this->settings             = new SWPS_Settings();
+		$this->analyzer             = new SWPS_Analyzer( $this->cache_manager );
+		$this->generator            = new SWPS_Generator(
+			$this->api,
+			$this->analyzer,
+			$this->images,
+			$this->duplicate_checker,
+			$this->rate_limiter,
+			$this->cost_tracker
+		);
+		$this->cron                 = new SWPS_Cron( $this->generator, $this->topic_queue );
+
+		// Initialize v2.0 subsystems.
+		$this->calendar             = new SWPS_Calendar( $this->topic_queue );
+		$this->background_processor = new SWPS_Background_Processor();
+		$this->rest_api             = new SWPS_REST_API();
+
+		// v4.0 admin shell — only relevant in admin, but instantiate always so REST routes register.
+		$this->user_prefs  = new SWPS_User_Prefs();
+		$this->modules     = new SWPS_Modules();
+		$this->admin_shell = new SWPS_Admin_Shell( $this->user_prefs );
+		$this->dashboard   = new SWPS_Dashboard();
+		$this->migration   = new SWPS_Migration();
+
+		// GitHub release-based updater (admin only).
+		if ( is_admin() ) {
+			new SWPS_GitHub_Updater( __FILE__, SWPS_VERSION );
+		}
+
+		// Register CPT.
+		add_action( 'init', array( SWPS_Topic_Queue::class, 'register_post_type' ) );
+
+		// Redirect 404 log pruning cron.
+		add_action( 'swps_prune_404_logs', array( SWPS_Redirect_Manager::class, 'prune_404_logs' ) );
+
+		// Admin assets.
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
+
+		// Frontend assets.
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ) );
+
+		// AJAX handlers — original.
+		add_action( 'wp_ajax_swps_generate_post', array( $this, 'ajax_generate_post' ) );
+		add_action( 'wp_ajax_swps_analyze_site', array( $this, 'ajax_analyze_site' ) );
+		add_action( 'wp_ajax_swps_get_models', array( $this, 'ajax_get_models' ) );
+
+		// AJAX handlers — v2.0.
+		add_action( 'wp_ajax_swps_bulk_generate', array( $this, 'ajax_bulk_generate' ) );
+		add_action( 'wp_ajax_swps_preview_post', array( $this, 'ajax_preview_post' ) );
+		add_action( 'wp_ajax_swps_clear_cache', array( $this, 'ajax_clear_cache' ) );
+
+		// Frontend.
+		add_action( 'wp_head', array( $this, 'output_faq_schema' ) );
+		add_action( 'wp_head', array( $this, 'output_takeaways_schema' ) );
+
+		// Content scoring on post creation.
+		add_action( 'swps_post_created', array( $this, 'score_generated_post' ), 10, 3 );
+
+		// Voice profile AJAX.
+		add_action( 'wp_ajax_swps_save_voice_profile', array( $this, 'ajax_save_voice_profile' ) );
+		add_action( 'wp_ajax_swps_delete_voice_profile', array( $this, 'ajax_delete_voice_profile' ) );
+
+		// In-content image insertion on post creation.
+		add_action( 'swps_post_created', array( $this, 'insert_content_images' ), 20, 3 );
+
+		// SEO Audit frontend hooks.
+		add_action( 'wp_head', array( SWPS_Canonical_Module::class, 'output_canonical' ), 1 );
+		add_action( 'wp_head', array( SWPS_OpenGraph_Module::class, 'output_meta_tags' ), 5 );
+		// Disable audit OG output when meta editor handles it.
+		if ( get_option( 'swps_meta_editor_enabled', 1 ) && ! defined( 'WPSEO_VERSION' ) && ! defined( 'RANK_MATH_VERSION' ) && ! defined( 'AIOSEO_VERSION' ) ) {
+			remove_action( 'wp_head', array( SWPS_OpenGraph_Module::class, 'output_meta_tags' ), 5 );
+		}
+		// Sitemap generation/serving/pinging now handled by SWPS_Sitemap_Manager.
+		// add_action( 'init', [ SWPS_Sitemap_Module::class, 'register_rewrite_rules' ] );
+		// add_action( 'template_redirect', [ SWPS_Sitemap_Module::class, 'serve_sitemap' ] );
+		// add_action( 'publish_post', [ SWPS_Sitemap_Module::class, 'ping_search_engines' ] );
+		add_filter( 'robots_txt', array( SWPS_Robots_Module::class, 'filter_robots_txt' ), 10, 2 );
+
+		// SEO Audit AJAX handlers.
+		add_action( 'wp_ajax_swps_run_audit', array( $this, 'ajax_run_audit' ) );
+		add_action( 'wp_ajax_swps_get_audit_results', array( $this, 'ajax_get_audit_results' ) );
+		add_action( 'wp_ajax_swps_fix_module', array( $this, 'ajax_fix_module' ) );
+		add_action( 'wp_ajax_swps_fix_all', array( $this, 'ajax_fix_all' ) );
+
+		// Dashboard widget.
+		add_action( 'wp_dashboard_setup', array( $this, 'register_dashboard_widget' ) );
+
+		// Plugins page link.
+		add_filter( 'plugin_action_links_' . SWPS_PLUGIN_BASENAME, array( $this, 'add_settings_link' ) );
+
+		// WP-CLI registration.
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			WP_CLI::add_command( 'swps', 'SWPS_CLI' );
+		}
+	}
+
+	/**
+	 * Migrate legacy option names for existing installs.
+	 */
+	private function maybe_migrate_legacy_options(): void {
+		if ( get_option( 'swps_provider_migrated' ) ) {
+			return;
+		}
+
+		$legacy_key = get_option( 'swps_api_key', '' );
+		if ( ! empty( $legacy_key ) && empty( get_option( 'swps_anthropic_api_key', '' ) ) ) {
+			update_option( 'swps_anthropic_api_key', $legacy_key );
+		}
+
+		if ( false === get_option( 'swps_ai_provider' ) ) {
+			update_option( 'swps_ai_provider', 'anthropic' );
+		}
+		if ( false === get_option( 'swps_image_provider' ) ) {
+			update_option( 'swps_image_provider', 'unsplash' );
+		}
+
+		update_option( 'swps_provider_migrated', 1 );
+	}
+
+	/**
+	 * Enqueue admin CSS and JS on our pages only.
+	 */
+	public function enqueue_admin_assets( string $hook ): void {
+		// Load only CSS on the Dashboard (for the audit widget).
+		if ( 'index.php' === $hook ) {
+			wp_enqueue_style( 'swps-admin', SWPS_PLUGIN_URL . 'admin/css/admin.css', array(), SWPS_VERSION );
+			return;
+		}
+
+		if ( ! str_contains( $hook, 'stratawp-seo' ) && ! str_contains( $hook, 'swps-generate' ) && ! str_contains( $hook, 'swps-voice-profiles' ) && ! str_contains( $hook, 'swps-seo-audit' ) && ! str_contains( $hook, 'swps-analytics' ) && ! str_contains( $hook, 'swps-keywords' ) && ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'swps-admin',
+			SWPS_PLUGIN_URL . 'admin/css/admin.css',
+			array(),
+			SWPS_VERSION
+		);
+
+		wp_enqueue_script(
+			'swps-admin',
+			SWPS_PLUGIN_URL . 'admin/js/admin.js',
+			array( 'jquery' ),
+			SWPS_VERSION,
+			true
+		);
+
+		wp_localize_script(
+			'swps-admin',
+			'swpsAdmin',
+			array(
+				'ajax_url'             => admin_url( 'admin-ajax.php' ),
+				'nonce'                => wp_create_nonce( 'swps_nonce' ),
+				'current_ai_provider'  => get_option( 'swps_ai_provider', 'anthropic' ),
+				'current_model'        => get_option( 'swps_model', '' ),
+				'templates'            => SWPS_Templates::get_options(),
+				'rate_limit_remaining' => $this->rate_limiter->get_remaining_seconds(),
+				'min_content_score'    => get_option( 'swps_min_content_score', 0 ),
+				'generate_url'         => admin_url( 'admin.php?page=swps-generate' ),
+			)
+		);
+
+		// Analytics dashboard JS.
+		if ( str_contains( $hook, 'swps-analytics' ) || in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
+			if ( str_contains( $hook, 'swps-analytics' ) ) {
+				wp_enqueue_script(
+					'chartjs',
+					'https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js',
+					array(),
+					'4.4.7',
+					true
+				);
+			}
+			wp_enqueue_script(
+				'swps-analytics',
+				SWPS_PLUGIN_URL . 'admin/js/analytics.js',
+				str_contains( $hook, 'swps-analytics' ) ? array( 'jquery', 'swps-admin', 'chartjs' ) : array( 'jquery', 'swps-admin' ),
+				SWPS_VERSION,
+				true
+			);
+		}
+
+		// Keywords page JS.
+		if ( str_contains( $hook, 'swps-keywords' ) ) {
+			wp_enqueue_script(
+				'swps-keywords',
+				SWPS_PLUGIN_URL . 'admin/js/keywords.js',
+				array( 'jquery', 'swps-admin' ),
+				SWPS_VERSION,
+				true
+			);
+		}
+
+		// Meta editor JS on post edit screens.
+		if ( in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
+			wp_enqueue_script(
+				'swps-meta-editor',
+				SWPS_PLUGIN_URL . 'admin/js/meta-editor.js',
+				array( 'jquery', 'swps-admin' ),
+				SWPS_VERSION,
+				true
+			);
+		}
+
+		// Search Appearance page JS.
+		if ( 'stratawp-seo_page_swps-search-appearance' === $hook ) {
+			wp_enqueue_script( 'swps-search-appearance', SWPS_PLUGIN_URL . 'admin/js/search-appearance.js', array(), SWPS_VERSION, true );
+		}
+
+		// Redirects page JS.
+		if ( 'stratawp-seo_page_swps-redirects' === $hook ) {
+			wp_enqueue_script( 'swps-redirects', SWPS_PLUGIN_URL . 'admin/js/redirects.js', array(), SWPS_VERSION, true );
+		}
+
+		if ( 'stratawp-seo_page_swps-sitemaps' === $hook ) {
+			wp_enqueue_script( 'swps-sitemaps', SWPS_PLUGIN_URL . 'admin/js/sitemaps.js', array( 'swps-admin' ), SWPS_VERSION, true );
+		}
+	}
+
+	/**
+	 * Enqueue frontend CSS on single posts.
+	 */
+	public function enqueue_frontend_assets(): void {
+		if ( ! is_singular( 'post' ) ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'swps-frontend',
+			SWPS_PLUGIN_URL . 'css/frontend.css',
+			array(),
+			SWPS_VERSION
+		);
+	}
+
+	/**
+	 * AJAX handler: Generate a single post.
+	 */
+	public function ajax_generate_post(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$topic    = sanitize_text_field( $_POST['topic'] ?? '' );
+		$template = sanitize_text_field( $_POST['template'] ?? 'auto' );
+
+		$result = $this->generator->generate_post( $topic, $template );
+
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+		}
+
+		wp_send_json_success( $result );
+	}
+
+	/**
+	 * AJAX handler: Bulk generate posts.
+	 */
+	public function ajax_bulk_generate(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$count    = min( (int) ( $_POST['count'] ?? 1 ), 5 );
+		$template = sanitize_text_field( $_POST['template'] ?? 'auto' );
+		$results  = array();
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$result = $this->generator->generate_post( '', $template );
+
+			if ( is_wp_error( $result ) ) {
+				$results[] = array(
+					'success' => false,
+					'message' => $result->get_error_message(),
+				);
+				break;
+			}
+
+			$results[] = array(
+				'success' => true,
+				'data'    => $result,
+			);
+
+			if ( $i < $count - 1 ) {
+				sleep( 5 );
+			}
+		}
+
+		wp_send_json_success(
+			array(
+				'results'   => $results,
+				'completed' => count( array_filter( $results, fn( $r ) => $r['success'] ) ),
+				'total'     => $count,
+			)
+		);
+	}
+
+	/**
+	 * AJAX handler: Preview post content without publishing.
+	 */
+	public function ajax_preview_post(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$topic    = sanitize_text_field( $_POST['topic'] ?? '' );
+		$template = sanitize_text_field( $_POST['template'] ?? 'auto' );
+
+		$result = $this->generator->preview_content( $topic, $template );
+
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+		}
+
+		wp_send_json_success( $result );
+	}
+
+	/**
+	 * AJAX handler: Clear analysis cache.
+	 */
+	public function ajax_clear_cache(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$this->cache_manager->invalidate_all();
+
+		wp_send_json_success( array( 'message' => 'Cache cleared.' ) );
+	}
+
+	/**
+	 * AJAX handler: Analyze site content.
+	 */
+	public function ajax_analyze_site(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$analysis = $this->analyzer->get_site_summary();
+
+		wp_send_json_success( $analysis );
+	}
+
+	/**
+	 * AJAX handler: Get models for a given AI provider slug.
+	 */
+	public function ajax_get_models(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$provider = sanitize_text_field( $_POST['provider'] ?? '' );
+		$models   = SWPS_Provider_Factory::get_models_for_provider( $provider );
+
+		wp_send_json_success( $models );
+	}
+
+	/**
+	 * Output FAQ schema JSON-LD in <head> for generated posts.
+	 */
+	public function output_faq_schema(): void {
+		if ( ! is_singular( 'post' ) ) {
+			return;
+		}
+
+		$schema = get_post_meta( get_the_ID(), '_swps_faq_schema', true );
+
+		$schema = $this->normalize_faq_schema_meta( $schema );
+
+		if ( empty( $schema ) ) {
+			return;
+		}
 
         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON-LD encoded from sanitized schema array.
-        echo '<script type="application/ld+json">'
-           . wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT )
-           . '</script>' . "\n";
-    }
+		echo '<script type="application/ld+json">'
+			. wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT )
+			. '</script>' . "\n";
+	}
 
-    /**
-     * Normalize legacy FAQ schema meta into a safe schema array.
-     *
-     * Older versions stored a full script tag. Newer generated posts store the
-     * schema array directly so output can always be encoded in one trusted path.
-     */
-    private function normalize_faq_schema_meta( mixed $schema ): array {
-        if ( empty( $schema ) ) {
-            return [];
-        }
+	/**
+	 * Normalize legacy FAQ schema meta into a safe schema array.
+	 *
+	 * Older versions stored a full script tag. Newer generated posts store the
+	 * schema array directly so output can always be encoded in one trusted path.
+	 */
+	private function normalize_faq_schema_meta( mixed $schema ): array {
+		if ( empty( $schema ) ) {
+			return array();
+		}
 
-        if ( is_string( $schema ) ) {
-            $json = trim( $schema );
+		if ( is_string( $schema ) ) {
+			$json = trim( $schema );
 
-            if ( false !== stripos( $json, '<script' ) ) {
-                if ( ! preg_match( '/<script[^>]*type=["\']application\/ld\+json["\'][^>]*>(.*?)<\/script>/is', $json, $matches ) ) {
-                    return [];
-                }
-                $json = html_entity_decode( trim( $matches[1] ), ENT_QUOTES, 'UTF-8' );
-            }
+			if ( false !== stripos( $json, '<script' ) ) {
+				if ( ! preg_match( '/<script[^>]*type=["\']application\/ld\+json["\'][^>]*>(.*?)<\/script>/is', $json, $matches ) ) {
+					return array();
+				}
+				$json = html_entity_decode( trim( $matches[1] ), ENT_QUOTES, 'UTF-8' );
+			}
 
-            $schema = json_decode( $json, true );
-        }
+			$schema = json_decode( $json, true );
+		}
 
-        if ( ! is_array( $schema ) || 'FAQPage' !== ( $schema['@type'] ?? '' ) ) {
-            return [];
-        }
+		if ( ! is_array( $schema ) || 'FAQPage' !== ( $schema['@type'] ?? '' ) ) {
+			return array();
+		}
 
-        $entities = $schema['mainEntity'] ?? [];
-        if ( ! is_array( $entities ) ) {
-            return [];
-        }
+		$entities = $schema['mainEntity'] ?? array();
+		if ( ! is_array( $entities ) ) {
+			return array();
+		}
 
-        $normalized = [
-            '@context'   => 'https://schema.org',
-            '@type'      => 'FAQPage',
-            'name'       => sanitize_text_field( wp_strip_all_tags( (string) ( $schema['name'] ?? get_the_title() ) ) ),
-            'mainEntity' => [],
-        ];
+		$normalized = array(
+			'@context'   => 'https://schema.org',
+			'@type'      => 'FAQPage',
+			'name'       => sanitize_text_field( wp_strip_all_tags( (string) ( $schema['name'] ?? get_the_title() ) ) ),
+			'mainEntity' => array(),
+		);
 
-        foreach ( $entities as $entity ) {
-            if ( ! is_array( $entity ) ) {
-                continue;
-            }
+		foreach ( $entities as $entity ) {
+			if ( ! is_array( $entity ) ) {
+				continue;
+			}
 
-            $answer = $entity['acceptedAnswer'] ?? [];
-            $text   = is_array( $answer ) ? ( $answer['text'] ?? '' ) : '';
+			$answer = $entity['acceptedAnswer'] ?? array();
+			$text   = is_array( $answer ) ? ( $answer['text'] ?? '' ) : '';
 
-            $question = sanitize_text_field( wp_strip_all_tags( (string) ( $entity['name'] ?? '' ) ) );
-            $text     = sanitize_textarea_field( wp_strip_all_tags( (string) $text ) );
+			$question = sanitize_text_field( wp_strip_all_tags( (string) ( $entity['name'] ?? '' ) ) );
+			$text     = sanitize_textarea_field( wp_strip_all_tags( (string) $text ) );
 
-            if ( '' === $question || '' === $text ) {
-                continue;
-            }
+			if ( '' === $question || '' === $text ) {
+				continue;
+			}
 
-            $normalized['mainEntity'][] = [
-                '@type'          => 'Question',
-                'name'           => $question,
-                'acceptedAnswer' => [
-                    '@type' => 'Answer',
-                    'text'  => $text,
-                ],
-            ];
-        }
+			$normalized['mainEntity'][] = array(
+				'@type'          => 'Question',
+				'name'           => $question,
+				'acceptedAnswer' => array(
+					'@type' => 'Answer',
+					'text'  => $text,
+				),
+			);
+		}
 
-        return empty( $normalized['mainEntity'] ) ? [] : $normalized;
-    }
+		return empty( $normalized['mainEntity'] ) ? array() : $normalized;
+	}
 
-    /**
-     * Output Key Takeaways ItemList schema JSON-LD in <head>.
-     */
-    public function output_takeaways_schema(): void {
-        if ( ! is_singular( 'post' ) ) {
-            return;
-        }
+	/**
+	 * Output Key Takeaways ItemList schema JSON-LD in <head>.
+	 */
+	public function output_takeaways_schema(): void {
+		if ( ! is_singular( 'post' ) ) {
+			return;
+		}
 
-        if ( ! get_option( 'swps_takeaways_schema', 1 ) ) {
-            return;
-        }
+		if ( ! get_option( 'swps_takeaways_schema', 1 ) ) {
+			return;
+		}
 
-        $takeaways = get_post_meta( get_the_ID(), '_swps_key_takeaways', true );
-        if ( empty( $takeaways ) || ! is_array( $takeaways ) ) {
-            return;
-        }
+		$takeaways = get_post_meta( get_the_ID(), '_swps_key_takeaways', true );
+		if ( empty( $takeaways ) || ! is_array( $takeaways ) ) {
+			return;
+		}
 
-        $schema = [
-            '@context'        => 'https://schema.org',
-            '@type'           => 'ItemList',
-            'name'            => __( 'Key Takeaways', 'stratawp-seo' ),
-            'numberOfItems'   => count( $takeaways ),
-            'itemListElement' => [],
-        ];
+		$schema = array(
+			'@context'        => 'https://schema.org',
+			'@type'           => 'ItemList',
+			'name'            => __( 'Key Takeaways', 'stratawp-seo' ),
+			'numberOfItems'   => count( $takeaways ),
+			'itemListElement' => array(),
+		);
 
-        foreach ( $takeaways as $index => $takeaway ) {
-            $schema['itemListElement'][] = [
-                '@type'    => 'ListItem',
-                'position' => $index + 1,
-                'name'     => $takeaway,
-            ];
-        }
+		foreach ( $takeaways as $index => $takeaway ) {
+			$schema['itemListElement'][] = array(
+				'@type'    => 'ListItem',
+				'position' => $index + 1,
+				'name'     => $takeaway,
+			);
+		}
 
-        $schema = SWPS_Hooks::filter_takeaways_schema( $schema, $takeaways );
+		$schema = SWPS_Hooks::filter_takeaways_schema( $schema, $takeaways );
 
         // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- pre-built JSON-LD script tag.
-        echo '<script type="application/ld+json">'
-           . wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT )
-           . '</script>' . "\n";
-    }
+		echo '<script type="application/ld+json">'
+			. wp_json_encode( $schema, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT )
+			. '</script>' . "\n";
+	}
 
-    /**
-     * Add settings link on plugins list page.
-     */
-    public function add_settings_link( array $links ): array {
-        $settings_link = '<a href="' . admin_url( 'admin.php?page=stratawp-seo' ) . '">' . __( 'Settings', 'stratawp-seo' ) . '</a>';
-        array_unshift( $links, $settings_link );
-        return $links;
-    }
+	/**
+	 * Add settings link on plugins list page.
+	 */
+	public function add_settings_link( array $links ): array {
+		$settings_link = '<a href="' . admin_url( 'admin.php?page=stratawp-seo' ) . '">' . __( 'Settings', 'stratawp-seo' ) . '</a>';
+		array_unshift( $links, $settings_link );
+		return $links;
+	}
 
-    /**
-     * Score a generated post and store results.
-     *
-     * @param int   $post_id   The new post ID.
-     * @param array $ai_result The AI response data.
-     * @param array $post_data The WordPress post data.
-     */
-    public function score_generated_post( int $post_id, array $ai_result, array $post_data ): void {
-        $results = $this->content_scorer->score( $post_id, $ai_result );
+	/**
+	 * Score a generated post and store results.
+	 *
+	 * @param int   $post_id   The new post ID.
+	 * @param array $ai_result The AI response data.
+	 * @param array $post_data The WordPress post data.
+	 */
+	public function score_generated_post( int $post_id, array $ai_result, array $post_data ): void {
+		$results = $this->content_scorer->score( $post_id, $ai_result );
 
-        update_post_meta( $post_id, '_swps_content_score', $results['overall_score'] );
-        update_post_meta( $post_id, '_swps_score_details', $results['details'] );
-        update_post_meta( $post_id, '_swps_score_recommendations', $results['recommendations'] );
+		update_post_meta( $post_id, '_swps_content_score', $results['overall_score'] );
+		update_post_meta( $post_id, '_swps_score_details', $results['details'] );
+		update_post_meta( $post_id, '_swps_score_recommendations', $results['recommendations'] );
 
-        // Optional score gate: force draft if below threshold.
-        $min_score = (int) get_option( 'swps_min_content_score', 0 );
-        if ( $min_score > 0 && $results['overall_score'] < $min_score ) {
-            wp_update_post( [
-                'ID'          => $post_id,
-                'post_status' => 'draft',
-            ] );
-            update_post_meta( $post_id, '_swps_score_blocked', true );
-        }
+		// Optional score gate: force draft if below threshold.
+		$min_score = (int) get_option( 'swps_min_content_score', 0 );
+		if ( $min_score > 0 && $results['overall_score'] < $min_score ) {
+			wp_update_post(
+				array(
+					'ID'          => $post_id,
+					'post_status' => 'draft',
+				)
+			);
+			update_post_meta( $post_id, '_swps_score_blocked', true );
+		}
 
-        SWPS_Hooks::do_score_complete( $results, $post_id );
-    }
+		SWPS_Hooks::do_score_complete( $results, $post_id );
+	}
 
-    /**
-     * Insert contextual images into generated post content.
-     *
-     * @param int   $post_id   The new post ID.
-     * @param array $ai_result The AI response data.
-     * @param array $post_data The WordPress post data.
-     */
-    public function insert_content_images( int $post_id, array $ai_result, array $post_data ): void {
-        $this->image_inserter->insert_images( $post_id, $ai_result );
-    }
+	/**
+	 * Insert contextual images into generated post content.
+	 *
+	 * @param int   $post_id   The new post ID.
+	 * @param array $ai_result The AI response data.
+	 * @param array $post_data The WordPress post data.
+	 */
+	public function insert_content_images( int $post_id, array $ai_result, array $post_data ): void {
+		$this->image_inserter->insert_images( $post_id, $ai_result );
+	}
 
-    /**
-     * AJAX: Save (create or update) a voice profile.
-     */
-    public function ajax_save_voice_profile(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
+	/**
+	 * AJAX: Save (create or update) a voice profile.
+	 */
+	public function ajax_save_voice_profile(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $profile_id = absint( $_POST['profile_id'] ?? 0 );
-        $name       = sanitize_text_field( $_POST['name'] ?? '' );
+		$profile_id = absint( $_POST['profile_id'] ?? 0 );
+		$name       = sanitize_text_field( $_POST['name'] ?? '' );
 
-        if ( empty( $name ) ) {
-            wp_send_json_error( [ 'message' => 'Profile name is required.' ] );
-        }
+		if ( empty( $name ) ) {
+			wp_send_json_error( array( 'message' => 'Profile name is required.' ) );
+		}
 
-        $meta = [
-            'tone'             => sanitize_text_field( $_POST['tone'] ?? 'professional' ),
-            'formality'        => absint( $_POST['formality'] ?? 5 ),
-            'sentence_length'  => sanitize_text_field( $_POST['sentence_length'] ?? 'varied' ),
-            'vocabulary_level' => sanitize_text_field( $_POST['vocabulary_level'] ?? 'moderate' ),
-            'person'           => sanitize_text_field( $_POST['person'] ?? 'second' ),
-            'example_content'  => sanitize_textarea_field( $_POST['example_content'] ?? '' ),
-            'avoid_phrases'    => sanitize_textarea_field( $_POST['avoid_phrases'] ?? '' ),
-            'preferred_phrases' => sanitize_textarea_field( $_POST['preferred_phrases'] ?? '' ),
-        ];
+		$meta = array(
+			'tone'              => sanitize_text_field( $_POST['tone'] ?? 'professional' ),
+			'formality'         => absint( $_POST['formality'] ?? 5 ),
+			'sentence_length'   => sanitize_text_field( $_POST['sentence_length'] ?? 'varied' ),
+			'vocabulary_level'  => sanitize_text_field( $_POST['vocabulary_level'] ?? 'moderate' ),
+			'person'            => sanitize_text_field( $_POST['person'] ?? 'second' ),
+			'example_content'   => sanitize_textarea_field( $_POST['example_content'] ?? '' ),
+			'avoid_phrases'     => sanitize_textarea_field( $_POST['avoid_phrases'] ?? '' ),
+			'preferred_phrases' => sanitize_textarea_field( $_POST['preferred_phrases'] ?? '' ),
+		);
 
-        if ( $profile_id > 0 ) {
-            $result = $this->voice_profile->update( $profile_id, $name, $meta );
-        } else {
-            $result = $this->voice_profile->create( $name, $meta );
-        }
+		if ( $profile_id > 0 ) {
+			$result = $this->voice_profile->update( $profile_id, $name, $meta );
+		} else {
+			$result = $this->voice_profile->create( $name, $meta );
+		}
 
-        if ( is_wp_error( $result ) ) {
-            wp_send_json_error( [ 'message' => $result->get_error_message() ] );
-        }
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+		}
 
-        wp_send_json_success( [ 'profile_id' => $result ] );
-    }
+		wp_send_json_success( array( 'profile_id' => $result ) );
+	}
 
-    /**
-     * AJAX: Delete a voice profile.
-     */
-    public function ajax_delete_voice_profile(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
+	/**
+	 * AJAX: Delete a voice profile.
+	 */
+	public function ajax_delete_voice_profile(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $profile_id = absint( $_POST['profile_id'] ?? 0 );
-        $this->voice_profile->delete( $profile_id );
+		$profile_id = absint( $_POST['profile_id'] ?? 0 );
+		$this->voice_profile->delete( $profile_id );
 
-        wp_send_json_success();
-    }
+		wp_send_json_success();
+	}
 
-    /**
-     * Register the SEO Audit dashboard widget.
-     */
-    public function register_dashboard_widget(): void {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            return;
-        }
+	/**
+	 * Register the SEO Audit dashboard widget.
+	 */
+	public function register_dashboard_widget(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
 
-        wp_add_dashboard_widget(
-            'swps_audit_widget',
-            __( 'StrataWP SEO — Site Health', 'stratawp-seo' ),
-            [ $this, 'render_dashboard_widget' ]
-        );
-    }
+		wp_add_dashboard_widget(
+			'swps_audit_widget',
+			__( 'StrataWP SEO — Site Health', 'stratawp-seo' ),
+			array( $this, 'render_dashboard_widget' )
+		);
+	}
 
-    /**
-     * Render the SEO Audit dashboard widget.
-     */
-    public function render_dashboard_widget(): void {
-        $results  = $this->seo_audit->get_cached_results();
-        $last_run = $this->seo_audit->get_last_run();
-        $modules  = $this->seo_audit->get_modules();
-        $overall  = $results['overall_score'] ?? 0;
+	/**
+	 * Render the SEO Audit dashboard widget.
+	 */
+	public function render_dashboard_widget(): void {
+		$results  = $this->seo_audit->get_cached_results();
+		$last_run = $this->seo_audit->get_last_run();
+		$modules  = $this->seo_audit->get_modules();
+		$overall  = $results['overall_score'] ?? 0;
 
-        $score_class = $overall >= 80 ? 'excellent' : ( $overall >= 50 ? 'good' : 'poor' );
+		$score_class = $overall >= 80 ? 'excellent' : ( $overall >= 50 ? 'good' : 'poor' );
 
-        if ( empty( $results['modules'] ) ) {
-            echo '<p>' . esc_html__( 'No audit results yet. Run your first audit.', 'stratawp-seo' ) . '</p>';
-            echo '<p><a href="' . esc_url( admin_url( 'admin.php?page=swps-seo-audit' ) ) . '" class="button button-primary">' . esc_html__( 'Run Audit', 'stratawp-seo' ) . '</a></p>';
-            return;
-        }
+		if ( empty( $results['modules'] ) ) {
+			echo '<p>' . esc_html__( 'No audit results yet. Run your first audit.', 'stratawp-seo' ) . '</p>';
+			echo '<p><a href="' . esc_url( admin_url( 'admin.php?page=swps-seo-audit' ) ) . '" class="button button-primary">' . esc_html__( 'Run Audit', 'stratawp-seo' ) . '</a></p>';
+			return;
+		}
 
-        printf(
-            '<div class="swps-widget-score swps-score-badge swps-score-badge--%s" style="font-size:16px;padding:8px 16px;margin-bottom:12px;">%s: %d/100</div>',
-            esc_attr( $score_class ),
-            esc_html__( 'Site Health', 'stratawp-seo' ),
-            (int) $overall
-        );
+		printf(
+			'<div class="swps-widget-score swps-score-badge swps-score-badge--%s" style="font-size:16px;padding:8px 16px;margin-bottom:12px;">%s: %d/100</div>',
+			esc_attr( $score_class ),
+			esc_html__( 'Site Health', 'stratawp-seo' ),
+			(int) $overall
+		);
 
-        echo '<table class="widefat striped" style="margin-bottom:12px;">';
-        echo '<tbody>';
+		echo '<table class="widefat striped" style="margin-bottom:12px;">';
+		echo '<tbody>';
 
-        foreach ( $modules as $id => $module ) {
-            $mod_result = $results['modules'][ $id ] ?? null;
-            $mod_status = $mod_result['status'] ?? 'fail';
-            $mod_score  = $mod_result['score'] ?? 0;
-            $issue_count = count( $mod_result['issues'] ?? [] );
+		foreach ( $modules as $id => $module ) {
+			$mod_result  = $results['modules'][ $id ] ?? null;
+			$mod_status  = $mod_result['status'] ?? 'fail';
+			$mod_score   = $mod_result['score'] ?? 0;
+			$issue_count = count( $mod_result['issues'] ?? array() );
 
-            $icon = match ( $mod_status ) {
-                'pass'    => '<span style="color:#00a32a;">&#10003;</span>',
-                'warning' => '<span style="color:#dba617;">&#9888;</span>',
-                default   => '<span style="color:#d63638;">&#10007;</span>',
-            };
+			$icon = match ( $mod_status ) {
+				'pass'    => '<span style="color:#00a32a;">&#10003;</span>',
+				'warning' => '<span style="color:#dba617;">&#9888;</span>',
+				default   => '<span style="color:#d63638;">&#10007;</span>',
+			};
 
-            printf(
-                '<tr><td>%s %s</td><td style="text-align:right;">%d/100</td><td style="text-align:right;color:#646970;">%d issues</td></tr>',
-                $icon, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                esc_html( $module->get_label() ),
-                (int) $mod_score,
-                $issue_count
-            );
-        }
+			printf(
+				'<tr><td>%s %s</td><td style="text-align:right;">%d/100</td><td style="text-align:right;color:#646970;">%d issues</td></tr>',
+				$icon, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				esc_html( $module->get_label() ),
+				(int) $mod_score,
+				$issue_count
+			);
+		}
 
-        echo '</tbody></table>';
+		echo '</tbody></table>';
 
-        printf(
-            '<p><a href="%s" class="button">%s</a></p>',
-            esc_url( admin_url( 'admin.php?page=swps-seo-audit' ) ),
-            esc_html__( 'View Details', 'stratawp-seo' )
-        );
+		printf(
+			'<p><a href="%s" class="button">%s</a></p>',
+			esc_url( admin_url( 'admin.php?page=swps-seo-audit' ) ),
+			esc_html__( 'View Details', 'stratawp-seo' )
+		);
 
-        if ( $last_run ) {
-            printf(
-                '<p class="description">%s %s</p>',
-                esc_html__( 'Last audited:', 'stratawp-seo' ),
-                esc_html( human_time_diff( strtotime( $last_run ), time() ) . ' ago' )
-            );
-        }
-    }
+		if ( $last_run ) {
+			printf(
+				'<p class="description">%s %s</p>',
+				esc_html__( 'Last audited:', 'stratawp-seo' ),
+				esc_html( human_time_diff( strtotime( $last_run ), time() ) . ' ago' )
+			);
+		}
+	}
 
-    /**
-     * AJAX: Run full SEO audit.
-     */
-    public function ajax_run_audit(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
+	/**
+	 * AJAX: Run full SEO audit.
+	 */
+	public function ajax_run_audit(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $results = $this->seo_audit->run_all();
+		$results = $this->seo_audit->run_all();
 
-        wp_send_json_success( $results );
-    }
+		wp_send_json_success( $results );
+	}
 
-    /**
-     * AJAX: Get cached audit results without re-running.
-     */
-    public function ajax_get_audit_results(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
+	/**
+	 * AJAX: Get cached audit results without re-running.
+	 */
+	public function ajax_get_audit_results(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        wp_send_json_success( $this->seo_audit->get_cached_results() );
-    }
+		wp_send_json_success( $this->seo_audit->get_cached_results() );
+	}
 
-    /**
-     * AJAX: Fix a single audit module.
-     */
-    public function ajax_fix_module(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
+	/**
+	 * AJAX: Fix a single audit module.
+	 */
+	public function ajax_fix_module(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $module_id  = sanitize_text_field( $_POST['module_id'] ?? '' );
-        $fix_result = $this->seo_audit->fix_module( $module_id );
+		$module_id  = sanitize_text_field( $_POST['module_id'] ?? '' );
+		$fix_result = $this->seo_audit->fix_module( $module_id );
 
-        if ( null === $fix_result ) {
-            wp_send_json_error( [ 'message' => 'Module not found or does not support auto-fix.' ] );
-        }
+		if ( null === $fix_result ) {
+			wp_send_json_error( array( 'message' => 'Module not found or does not support auto-fix.' ) );
+		}
 
-        wp_send_json_success( [
-            'fix'     => $fix_result,
-            'results' => $this->seo_audit->get_cached_results(),
-        ] );
-    }
+		wp_send_json_success(
+			array(
+				'fix'     => $fix_result,
+				'results' => $this->seo_audit->get_cached_results(),
+			)
+		);
+	}
 
-    /**
-     * AJAX: Fix all fixable audit modules.
-     */
-    public function ajax_fix_all(): void {
-        check_ajax_referer( 'swps_nonce', 'nonce' );
+	/**
+	 * AJAX: Fix all fixable audit modules.
+	 */
+	public function ajax_fix_all(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( [ 'message' => 'Insufficient permissions.' ] );
-        }
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
 
-        $all_fixes = [];
+		$all_fixes = array();
 
-        foreach ( $this->seo_audit->get_modules() as $id => $module ) {
-            if ( $module->can_auto_fix() ) {
-                $cached = $this->seo_audit->get_cached_results();
-                $issues = $cached['modules'][ $id ]['issues'] ?? [];
+		foreach ( $this->seo_audit->get_modules() as $id => $module ) {
+			if ( $module->can_auto_fix() ) {
+				$cached = $this->seo_audit->get_cached_results();
+				$issues = $cached['modules'][ $id ]['issues'] ?? array();
 
-                if ( ! empty( $issues ) ) {
-                    $all_fixes[ $id ] = $this->seo_audit->fix_module( $id );
-                }
-            }
-        }
+				if ( ! empty( $issues ) ) {
+					$all_fixes[ $id ] = $this->seo_audit->fix_module( $id );
+				}
+			}
+		}
 
-        wp_send_json_success( [
-            'fixes'   => $all_fixes,
-            'results' => $this->seo_audit->get_cached_results(),
-        ] );
-    }
+		wp_send_json_success(
+			array(
+				'fixes'   => $all_fixes,
+				'results' => $this->seo_audit->get_cached_results(),
+			)
+		);
+	}
 }
 
 /**
  * Activation hook.
  */
 function swps_activate(): void {
-    $defaults = [
-        'ai_provider'        => 'anthropic',
-        'image_provider'     => 'unsplash',
-        'anthropic_api_key'  => '',
-        'openai_api_key'     => '',
-        'google_api_key'     => '',
-        'xai_api_key'        => '',
-        'unsplash_api_key'   => '',
-        'pexels_api_key'     => '',
-        'pixabay_api_key'    => '',
-        // Gemini image provider reuses google_api_key — no separate key needed.
-        'model'              => 'claude-sonnet-4-6',
-        'featured_images'    => 1,
-        'site_niche'         => '',
-        'site_description'   => '',
-        'tone'               => 'professional',
-        'writing_style'      => '',
-        'target_keywords'    => '',
-        'post_category'      => 0,
-        'post_author'        => get_current_user_id(),
-        'post_status'        => 'draft',
-        'word_count_min'     => 1200,
-        'word_count_max'     => 2000,
-        'include_faq_schema' => 1,
-        'include_toc'        => 1,
-        'internal_links_min' => 3,
-        'internal_links_max' => 6,
-        'include_takeaways'  => 0,
-        'takeaways_count'    => 5,
-        'takeaways_schema'   => 1,
-        'cron_enabled'       => 0,
-        'cron_frequency'     => 'weekly',
-        'cron_day'           => 'monday',
-        'cron_time'          => '09:00',
-        'cron_posts_per_run' => 1,
-        // v2.0 defaults.
-        'rate_limit'         => 60,
-        'duplicate_check'    => 0,
-        'default_template'   => 'auto',
-        'cost_tracking'      => 0,
-        'min_content_score'  => 0,
-        'voice_profile'      => 0,
-        'insert_content_images' => 0,
-        'content_images_count'  => 2,
-        'image_max_width'       => 1200,
-        'jon_ai_endpoint'    => '',
-        'jon_ai_secret'      => '',
-        // SEO Audit defaults.
-        'audit_auto_canonical'  => 1,
-        'audit_auto_og'         => 1,
-        'audit_auto_sitemap'    => 1,
-        'audit_cron_schedule'   => 'weekly',
-        // Schema defaults.
-        'schema_enabled'         => 1,
-        'schema_article_type'    => 'Article',
-        'schema_searchbox'       => 1,
-        'schema_entity_type'     => 'Organization',
-        'schema_name'            => '',
-        'schema_logo'            => '',
-        'schema_social_profiles' => '',
-        // Analytics defaults.
-        'analytics_enabled'        => 1,
-        'analytics_retention'      => 90,
-        'analytics_exclude_admins' => 1,
-        // Bot Analytics defaults.
-        'bot_analytics_enabled'       => 1,
-        'bot_analytics_retention'     => 90,
-        'bot_analytics_sample_rate'   => 100,
-        'bot_analytics_exclude_paths' => "/wp-admin\n/wp-json\n/wp-login\n/feed\n/xmlrpc.php",
-        'gsc_client_id'            => '',
-        'gsc_client_secret'        => '',
-        // Keywords & Meta defaults.
-        'meta_editor_enabled'          => 1,
-        'meta_editor_post_types'       => 'post,page',
-        'meta_auto_generate'           => 0,
-        'keyword_tracking_frequency'   => 'weekly',
-        // RSS Feed defaults.
-        'rss_before' => '',
-        'rss_after'  => 'The post %%post_link%% appeared first on %%blog_link%%.',
-        // Search Appearance defaults.
-        'title_separator' => '-',
-        // Breadcrumb defaults.
-        'breadcrumbs_enabled'    => 1,
-        'breadcrumbs_separator'  => '&raquo;',
-        'breadcrumbs_home_label' => 'Home',
-        // Redirect defaults.
-        'auto_redirect_slug_change' => 1,
-    ];
+	$defaults = array(
+		'ai_provider'                 => 'anthropic',
+		'image_provider'              => 'unsplash',
+		'anthropic_api_key'           => '',
+		'openai_api_key'              => '',
+		'google_api_key'              => '',
+		'xai_api_key'                 => '',
+		'unsplash_api_key'            => '',
+		'pexels_api_key'              => '',
+		'pixabay_api_key'             => '',
+		// Gemini image provider reuses google_api_key — no separate key needed.
+		'model'                       => 'claude-sonnet-4-6',
+		'featured_images'             => 1,
+		'site_niche'                  => '',
+		'site_description'            => '',
+		'tone'                        => 'professional',
+		'writing_style'               => '',
+		'target_keywords'             => '',
+		'post_category'               => 0,
+		'post_author'                 => get_current_user_id(),
+		'post_status'                 => 'draft',
+		'word_count_min'              => 1200,
+		'word_count_max'              => 2000,
+		'include_faq_schema'          => 1,
+		'include_toc'                 => 1,
+		'internal_links_min'          => 3,
+		'internal_links_max'          => 6,
+		'include_takeaways'           => 0,
+		'takeaways_count'             => 5,
+		'takeaways_schema'            => 1,
+		'cron_enabled'                => 0,
+		'cron_frequency'              => 'weekly',
+		'cron_day'                    => 'monday',
+		'cron_time'                   => '09:00',
+		'cron_posts_per_run'          => 1,
+		// v2.0 defaults.
+		'rate_limit'                  => 60,
+		'duplicate_check'             => 0,
+		'default_template'            => 'auto',
+		'cost_tracking'               => 0,
+		'min_content_score'           => 0,
+		'voice_profile'               => 0,
+		'insert_content_images'       => 0,
+		'content_images_count'        => 2,
+		'image_max_width'             => 1200,
+		'jon_ai_endpoint'             => '',
+		'jon_ai_secret'               => '',
+		// SEO Audit defaults.
+		'audit_auto_canonical'        => 1,
+		'audit_auto_og'               => 1,
+		'audit_auto_sitemap'          => 1,
+		'audit_cron_schedule'         => 'weekly',
+		// Schema defaults.
+		'schema_enabled'              => 1,
+		'schema_article_type'         => 'Article',
+		'schema_searchbox'            => 1,
+		'schema_entity_type'          => 'Organization',
+		'schema_name'                 => '',
+		'schema_logo'                 => '',
+		'schema_social_profiles'      => '',
+		// Analytics defaults.
+		'analytics_enabled'           => 1,
+		'analytics_retention'         => 90,
+		'analytics_exclude_admins'    => 1,
+		// Bot Analytics defaults.
+		'bot_analytics_enabled'       => 1,
+		'bot_analytics_retention'     => 90,
+		'bot_analytics_sample_rate'   => 100,
+		'bot_analytics_exclude_paths' => "/wp-admin\n/wp-json\n/wp-login\n/feed\n/xmlrpc.php",
+		'gsc_client_id'               => '',
+		'gsc_client_secret'           => '',
+		// Keywords & Meta defaults.
+		'meta_editor_enabled'         => 1,
+		'meta_editor_post_types'      => 'post,page',
+		'meta_auto_generate'          => 0,
+		'keyword_tracking_frequency'  => 'weekly',
+		// RSS Feed defaults.
+		'rss_before'                  => '',
+		'rss_after'                   => 'The post %%post_link%% appeared first on %%blog_link%%.',
+		// Search Appearance defaults.
+		'title_separator'             => '-',
+		// Breadcrumb defaults.
+		'breadcrumbs_enabled'         => 1,
+		'breadcrumbs_separator'       => '&raquo;',
+		'breadcrumbs_home_label'      => 'Home',
+		// Redirect defaults.
+		'auto_redirect_slug_change'   => 1,
+	);
 
-    foreach ( $defaults as $key => $value ) {
-        if ( false === get_option( "swps_{$key}" ) ) {
-            update_option( "swps_{$key}", $value );
-        }
-    }
+	foreach ( $defaults as $key => $value ) {
+		if ( false === get_option( "swps_{$key}" ) ) {
+			update_option( "swps_{$key}", $value );
+		}
+	}
 
-    // Register CPTs for flush_rewrite_rules.
-    SWPS_Topic_Queue::register_post_type();
-    SWPS_Voice_Profile::register_post_type();
-    SWPS_SEO_Audit::schedule_cron();
-    flush_rewrite_rules();
+	// Register CPTs for flush_rewrite_rules.
+	SWPS_Topic_Queue::register_post_type();
+	SWPS_Voice_Profile::register_post_type();
+	SWPS_SEO_Audit::schedule_cron();
+	flush_rewrite_rules();
 
-    SWPS_Analytics_Tracker::create_tables();
-    SWPS_Analytics_Tracker::schedule_cron();
-    SWPS_Bot_Analytics_Tracker::create_tables();
-    SWPS_Bot_Analytics_Tracker::schedule_cron();
-    SWPS_Search_Console::schedule_cron();
-    SWPS_Keyword_Tracker::create_tables();
-    SWPS_Keyword_Tracker::schedule_cron();
+	SWPS_Analytics_Tracker::create_tables();
+	SWPS_Analytics_Tracker::schedule_cron();
+	SWPS_Bot_Analytics_Tracker::create_tables();
+	SWPS_Bot_Analytics_Tracker::schedule_cron();
+	SWPS_Search_Console::schedule_cron();
+	SWPS_Keyword_Tracker::create_tables();
+	SWPS_Keyword_Tracker::schedule_cron();
 
-    SWPS_Redirect_Manager::create_tables();
-    SWPS_Link_Keyword_Engine::create_tables();
-    SWPS_Internal_Links::create_tables();
-    SWPS_Internal_Links::schedule_cron();
+	SWPS_Redirect_Manager::create_tables();
+	SWPS_Link_Keyword_Engine::create_tables();
+	SWPS_Internal_Links::create_tables();
+	SWPS_Internal_Links::schedule_cron();
 
-    SWPS_Backlinks::create_tables();
-    SWPS_Backlinks::schedule_cron();
+	SWPS_Backlinks::create_tables();
+	SWPS_Backlinks::schedule_cron();
 
-    if ( ! wp_next_scheduled( 'swps_prune_404_logs' ) ) {
-        wp_schedule_event( time(), 'daily', 'swps_prune_404_logs' );
-    }
+	if ( ! wp_next_scheduled( 'swps_prune_404_logs' ) ) {
+		wp_schedule_event( time(), 'daily', 'swps_prune_404_logs' );
+	}
 
-    if ( get_option( 'swps_cron_enabled' ) ) {
-        SWPS_Cron::schedule();
-    }
+	if ( get_option( 'swps_cron_enabled' ) ) {
+		SWPS_Cron::schedule();
+	}
 }
 register_activation_hook( __FILE__, 'swps_activate' );
 
@@ -1165,15 +1177,15 @@ register_activation_hook( __FILE__, 'swps_activate' );
  * Deactivation hook.
  */
 function swps_deactivate(): void {
-    SWPS_Cron::unschedule();
-    SWPS_SEO_Audit::unschedule_cron();
-    SWPS_Analytics_Tracker::unschedule_cron();
-    SWPS_Bot_Analytics_Tracker::unschedule_cron();
-    SWPS_Search_Console::unschedule_cron();
-    SWPS_Keyword_Tracker::unschedule_cron();
-    SWPS_Competitors::unschedule_cron();
-    SWPS_Backlinks::unschedule_cron();
-    flush_rewrite_rules();
+	SWPS_Cron::unschedule();
+	SWPS_SEO_Audit::unschedule_cron();
+	SWPS_Analytics_Tracker::unschedule_cron();
+	SWPS_Bot_Analytics_Tracker::unschedule_cron();
+	SWPS_Search_Console::unschedule_cron();
+	SWPS_Keyword_Tracker::unschedule_cron();
+	SWPS_Competitors::unschedule_cron();
+	SWPS_Backlinks::unschedule_cron();
+	flush_rewrite_rules();
 }
 register_deactivation_hook( __FILE__, 'swps_deactivate' );
 
@@ -1181,6 +1193,6 @@ register_deactivation_hook( __FILE__, 'swps_deactivate' );
  * Initialize plugin.
  */
 function stratawp_seo(): StrataWP_SEO {
-    return StrataWP_SEO::instance();
+	return StrataWP_SEO::instance();
 }
 add_action( 'plugins_loaded', 'stratawp_seo' );

--- a/templates/analytics-page.php
+++ b/templates/analytics-page.php
@@ -12,287 +12,302 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 ?>
 <div class="wrap swps-analytics-wrap">
 
-    <?php
-    $title    = __( 'Analytics', 'stratawp-seo' );
-    $subtitle = __( "Track your site's performance and search visibility. Cookie-free and GDPR-friendly.", 'stratawp-seo' );
-    $actions  = [];
-    if ( $gsc_connected ) {
-        $actions[] = [ 'label' => __( 'Refresh GSC', 'stratawp-seo' ), 'class' => 'swps-btn-secondary', 'attrs' => 'id="swps-gsc-refresh" title="Refresh GSC data"' ];
-        $actions[] = [ 'label' => __( 'Disconnect', 'stratawp-seo' ), 'class' => 'swps-btn-secondary', 'attrs' => 'id="swps-gsc-disconnect"' ];
-    } elseif ( ! empty( $gsc_auth_url ) ) {
-        $actions[] = [ 'label' => __( 'Connect Search Console', 'stratawp-seo' ), 'url' => $gsc_auth_url, 'class' => 'swps-btn-grad' ];
-    }
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'Analytics', 'stratawp-seo' );
+	$subtitle = __( "Track your site's performance and search visibility. Cookie-free and GDPR-friendly.", 'stratawp-seo' );
+	$actions  = array();
+	if ( $gsc_connected ) {
+		$actions[] = array(
+			'label' => __( 'Refresh GSC', 'stratawp-seo' ),
+			'class' => 'swps-btn-secondary',
+			'attrs' => 'id="swps-gsc-refresh" title="Refresh GSC data"',
+		);
+		$actions[] = array(
+			'label' => __( 'Disconnect', 'stratawp-seo' ),
+			'class' => 'swps-btn-secondary',
+			'attrs' => 'id="swps-gsc-disconnect"',
+		);
+	} elseif ( ! empty( $gsc_auth_url ) ) {
+		$actions[] = array(
+			'label' => __( 'Connect Search Console', 'stratawp-seo' ),
+			'url'   => $gsc_auth_url,
+			'class' => 'swps-btn-grad',
+		);
+	}
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <?php if ( $gsc_connected && empty( $gsc_property ) && ! empty( $properties ) ) : ?>
-        <div class="notice notice-info">
-            <p>
-                <strong><?php esc_html_e( 'Select your Search Console property:', 'stratawp-seo' ); ?></strong>
-                <select id="swps-gsc-property-select">
-                    <option value=""><?php esc_html_e( '— Select —', 'stratawp-seo' ); ?></option>
-                    <?php foreach ( $properties as $prop ) : ?>
-                        <option value="<?php echo esc_attr( $prop ); ?>"><?php echo esc_html( $prop ); ?></option>
-                    <?php endforeach; ?>
-                </select>
-                <button class="swps-btn swps-btn-secondary" id="swps-gsc-save-property"><?php esc_html_e( 'Save', 'stratawp-seo' ); ?></button>
-            </p>
-        </div>
-    <?php elseif ( ! $gsc_connected && empty( $gsc_auth_url ) ) : ?>
-        <div class="notice notice-info">
-            <p><?php esc_html_e( 'Enter Google OAuth credentials in Settings to connect Search Console.', 'stratawp-seo' ); ?></p>
-        </div>
-    <?php endif; ?>
+	<?php if ( $gsc_connected && empty( $gsc_property ) && ! empty( $properties ) ) : ?>
+		<div class="notice notice-info">
+			<p>
+				<strong><?php esc_html_e( 'Select your Search Console property:', 'stratawp-seo' ); ?></strong>
+				<select id="swps-gsc-property-select">
+					<option value=""><?php esc_html_e( '— Select —', 'stratawp-seo' ); ?></option>
+					<?php foreach ( $properties as $prop ) : ?>
+						<option value="<?php echo esc_attr( $prop ); ?>"><?php echo esc_html( $prop ); ?></option>
+					<?php endforeach; ?>
+				</select>
+				<button class="swps-btn swps-btn-secondary" id="swps-gsc-save-property"><?php esc_html_e( 'Save', 'stratawp-seo' ); ?></button>
+			</p>
+		</div>
+	<?php elseif ( ! $gsc_connected && empty( $gsc_auth_url ) ) : ?>
+		<div class="notice notice-info">
+			<p><?php esc_html_e( 'Enter Google OAuth credentials in Settings to connect Search Console.', 'stratawp-seo' ); ?></p>
+		</div>
+	<?php endif; ?>
 
-    <div class="swps-analytics-toolbar" style="display:flex;justify-content:space-between;align-items:center;gap:12px;margin-bottom:16px">
-        <div class="swps-date-range" style="display:inline-flex;gap:4px;background:var(--swps-bg-surface);border:1px solid var(--swps-border);border-radius:var(--swps-radius-sm);padding:2px">
-            <button class="swps-btn swps-range-btn" data-days="7" style="padding:6px 12px;font-size:11px"><?php esc_html_e( '7 days', 'stratawp-seo' ); ?></button>
-            <button class="swps-btn swps-btn-grad swps-range-btn active" data-days="30" style="padding:6px 12px;font-size:11px"><?php esc_html_e( '30 days', 'stratawp-seo' ); ?></button>
-            <button class="swps-btn swps-range-btn" data-days="90" style="padding:6px 12px;font-size:11px"><?php esc_html_e( '90 days', 'stratawp-seo' ); ?></button>
-        </div>
-        <?php if ( $gsc_connected ) : ?>
-            <span class="swps-gsc-status swps-gsc-connected" style="color:var(--swps-success);font-size:12px">
-                <span class="dashicons dashicons-yes-alt"></span>
-                <?php echo esc_html( $gsc_property ); ?>
-            </span>
-        <?php endif; ?>
-    </div>
+	<div class="swps-analytics-toolbar" style="display:flex;justify-content:space-between;align-items:center;gap:12px;margin-bottom:16px">
+		<div class="swps-date-range" style="display:inline-flex;gap:4px;background:var(--swps-bg-surface);border:1px solid var(--swps-border);border-radius:var(--swps-radius-sm);padding:2px">
+			<button class="swps-btn swps-range-btn" data-days="7" style="padding:6px 12px;font-size:11px"><?php esc_html_e( '7 days', 'stratawp-seo' ); ?></button>
+			<button class="swps-btn swps-btn-grad swps-range-btn active" data-days="30" style="padding:6px 12px;font-size:11px"><?php esc_html_e( '30 days', 'stratawp-seo' ); ?></button>
+			<button class="swps-btn swps-range-btn" data-days="90" style="padding:6px 12px;font-size:11px"><?php esc_html_e( '90 days', 'stratawp-seo' ); ?></button>
+		</div>
+		<?php if ( $gsc_connected ) : ?>
+			<span class="swps-gsc-status swps-gsc-connected" style="color:var(--swps-success);font-size:12px">
+				<span class="dashicons dashicons-yes-alt"></span>
+				<?php echo esc_html( $gsc_property ); ?>
+			</span>
+		<?php endif; ?>
+	</div>
 
-    <div class="swps-summary-tiles">
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Page Views', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-grad" id="swps-total-views">—</div>
-            <div class="swps-summary-tile-foot" id="swps-views-change"></div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Avg Time on Page', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-grad" id="swps-avg-time">—</div>
-        </div>
-        <?php if ( $gsc_connected ) : ?>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Search Clicks', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-grad" id="swps-gsc-clicks">—</div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-grad" id="swps-gsc-impressions">—</div>
-        </div>
-        <?php endif; ?>
-    </div>
+	<div class="swps-summary-tiles">
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Page Views', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad" id="swps-total-views">—</div>
+			<div class="swps-summary-tile-foot" id="swps-views-change"></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Avg Time on Page', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad" id="swps-avg-time">—</div>
+		</div>
+		<?php if ( $gsc_connected ) : ?>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Search Clicks', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad" id="swps-gsc-clicks">—</div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad" id="swps-gsc-impressions">—</div>
+		</div>
+		<?php endif; ?>
+	</div>
 
-    <div class="swps-tile" style="margin-bottom:16px">
-        <div class="swps-tile-h"><?php esc_html_e( 'Traffic Overview', 'stratawp-seo' ); ?></div>
-        <p style="color:var(--swps-text-muted);font-size:12px;margin:0 0 12px"><?php esc_html_e( 'Page views and search clicks over time', 'stratawp-seo' ); ?></p>
-        <canvas id="swps-analytics-chart" class="swps-chart" style="max-height:320px"></canvas>
-    </div>
+	<div class="swps-tile" style="margin-bottom:16px">
+		<div class="swps-tile-h"><?php esc_html_e( 'Traffic Overview', 'stratawp-seo' ); ?></div>
+		<p style="color:var(--swps-text-muted);font-size:12px;margin:0 0 12px"><?php esc_html_e( 'Page views and search clicks over time', 'stratawp-seo' ); ?></p>
+		<canvas id="swps-analytics-chart" class="swps-chart" style="max-height:320px"></canvas>
+	</div>
 
-    <div class="swps-section-h">
-        <h3><?php esc_html_e( 'Top Pages', 'stratawp-seo' ); ?></h3>
-    </div>
-    <table class="widefat striped" id="swps-top-pages-table">
-        <thead>
-            <tr>
-                <th><?php esc_html_e( 'Page', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Views', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Avg Time', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Scroll', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Bounce', 'stratawp-seo' ); ?></th>
-                <?php if ( $gsc_connected ) : ?>
-                <th><?php esc_html_e( 'Clicks', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Position', 'stratawp-seo' ); ?></th>
-                <?php endif; ?>
-            </tr>
-        </thead>
-        <tbody>
-            <tr><td colspan="8" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
-        </tbody>
-    </table>
+	<div class="swps-section-h">
+		<h3><?php esc_html_e( 'Top Pages', 'stratawp-seo' ); ?></h3>
+	</div>
+	<table class="widefat striped" id="swps-top-pages-table">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Page', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Views', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Avg Time', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Scroll', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Bounce', 'stratawp-seo' ); ?></th>
+				<?php if ( $gsc_connected ) : ?>
+				<th><?php esc_html_e( 'Clicks', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Position', 'stratawp-seo' ); ?></th>
+				<?php endif; ?>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td colspan="8" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+		</tbody>
+	</table>
 
-    <?php if ( $gsc_connected ) : ?>
-    <div class="swps-section-h" style="margin-top:32px">
-        <h3><?php esc_html_e( 'Top Search Queries', 'stratawp-seo' ); ?></h3>
-    </div>
-    <table class="widefat striped" id="swps-top-queries-table">
-        <thead>
-            <tr>
-                <th><?php esc_html_e( 'Query', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Clicks', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'CTR', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Position', 'stratawp-seo' ); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr><td colspan="5" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
-        </tbody>
-    </table>
-    <?php endif; ?>
+	<?php if ( $gsc_connected ) : ?>
+	<div class="swps-section-h" style="margin-top:32px">
+		<h3><?php esc_html_e( 'Top Search Queries', 'stratawp-seo' ); ?></h3>
+	</div>
+	<table class="widefat striped" id="swps-top-queries-table">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Query', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Clicks', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'CTR', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Position', 'stratawp-seo' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td colspan="5" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+		</tbody>
+	</table>
+	<?php endif; ?>
 
-    <?php if ( ! empty( $bot_data ) ) :
-        $totals    = $bot_data['totals'];
-        $bots      = $bot_data['bots'];
-        $top_pages = $bot_data['top_pages'];
-        $gaps      = $bot_data['gaps'];
-        $top_404s  = $bot_data['top_404s'];
+	<?php
+	if ( ! empty( $bot_data ) ) :
+		$totals    = $bot_data['totals'];
+		$bots      = $bot_data['bots'];
+		$top_pages = $bot_data['top_pages'];
+		$gaps      = $bot_data['gaps'];
+		$top_404s  = $bot_data['top_404s'];
 
-        $delta = 0;
-        if ( $totals['prev_hits'] > 0 ) {
-            $delta = (int) round( ( ( $totals['total_hits'] - $totals['prev_hits'] ) / $totals['prev_hits'] ) * 100 );
-        }
-        ?>
-    <div class="swps-section-h" style="margin-top:40px">
-        <h3><?php esc_html_e( 'AI Crawlers', 'stratawp-seo' ); ?></h3>
-        <p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
-            <?php esc_html_e( 'Server-side hits from known AI bots (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, etc.) in the last 30 days.', 'stratawp-seo' ); ?>
-        </p>
-    </div>
+		$delta = 0;
+		if ( $totals['prev_hits'] > 0 ) {
+			$delta = (int) round( ( ( $totals['total_hits'] - $totals['prev_hits'] ) / $totals['prev_hits'] ) * 100 );
+		}
+		?>
+	<div class="swps-section-h" style="margin-top:40px">
+		<h3><?php esc_html_e( 'AI Crawlers', 'stratawp-seo' ); ?></h3>
+		<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+			<?php esc_html_e( 'Server-side hits from known AI bots (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, etc.) in the last 30 days.', 'stratawp-seo' ); ?>
+		</p>
+	</div>
 
-    <div class="swps-summary-tiles" style="margin-bottom:16px">
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Bot Hits (30d)', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-grad"><?php echo esc_html( number_format_i18n( $totals['total_hits'] ) ); ?></div>
-            <?php if ( $totals['prev_hits'] > 0 ) : ?>
-                <div class="swps-summary-tile-foot" style="color:<?php echo $delta >= 0 ? 'var(--swps-success)' : 'var(--swps-danger)'; ?>">
-                    <?php echo esc_html( ( $delta >= 0 ? '+' : '' ) . $delta . '%' ); ?>
-                    <?php esc_html_e( 'vs prior 30d', 'stratawp-seo' ); ?>
-                </div>
-            <?php endif; ?>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Active Bots', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-grad"><?php echo esc_html( number_format_i18n( $totals['active_bots'] ) ); ?></div>
-            <div class="swps-summary-tile-foot"><?php esc_html_e( 'distinct crawlers', 'stratawp-seo' ); ?></div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( '404s to Bots', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-grad"><?php echo esc_html( number_format_i18n( $totals['total_404'] ) ); ?></div>
-            <div class="swps-summary-tile-foot"><?php esc_html_e( 'broken URLs hit', 'stratawp-seo' ); ?></div>
-        </div>
-    </div>
+	<div class="swps-summary-tiles" style="margin-bottom:16px">
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Bot Hits (30d)', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad"><?php echo esc_html( number_format_i18n( $totals['total_hits'] ) ); ?></div>
+			<?php if ( $totals['prev_hits'] > 0 ) : ?>
+				<div class="swps-summary-tile-foot" style="color:<?php echo $delta >= 0 ? 'var(--swps-success)' : 'var(--swps-danger)'; ?>">
+					<?php echo esc_html( ( $delta >= 0 ? '+' : '' ) . $delta . '%' ); ?>
+					<?php esc_html_e( 'vs prior 30d', 'stratawp-seo' ); ?>
+				</div>
+			<?php endif; ?>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Active Bots', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad"><?php echo esc_html( number_format_i18n( $totals['active_bots'] ) ); ?></div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'distinct crawlers', 'stratawp-seo' ); ?></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( '404s to Bots', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad"><?php echo esc_html( number_format_i18n( $totals['total_404'] ) ); ?></div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'broken URLs hit', 'stratawp-seo' ); ?></div>
+		</div>
+	</div>
 
-    <?php if ( empty( $bots ) ) : ?>
-        <div class="swps-tile" style="margin-bottom:16px">
-            <p style="margin:0;color:var(--swps-text-muted)">
-                <?php esc_html_e( 'No AI bot traffic detected yet. AI crawler activity will appear here once bots start visiting your site.', 'stratawp-seo' ); ?>
-            </p>
-        </div>
-    <?php else : ?>
-        <div class="swps-tile" style="margin-bottom:16px">
-            <div class="swps-tile-h"><?php esc_html_e( 'By Crawler', 'stratawp-seo' ); ?></div>
-            <table class="widefat striped" style="margin-top:8px">
-                <thead>
-                    <tr>
-                        <th><?php esc_html_e( 'Bot', 'stratawp-seo' ); ?></th>
-                        <th style="text-align:right"><?php esc_html_e( 'Hits (30d)', 'stratawp-seo' ); ?></th>
-                        <th><?php esc_html_e( 'Last Seen', 'stratawp-seo' ); ?></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php foreach ( $bots as $bot ) :
-                        $last = $bot['last_seen'] ? human_time_diff( strtotime( $bot['last_seen'] ), time() ) . ' ago' : '—';
-                        ?>
-                        <tr>
-                            <td><code><?php echo esc_html( $bot['label'] ); ?></code></td>
-                            <td style="text-align:right"><?php echo esc_html( number_format_i18n( $bot['hits'] ) ); ?></td>
-                            <td style="color:var(--swps-text-muted)"><?php echo esc_html( $last ); ?></td>
-                        </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
-        </div>
-    <?php endif; ?>
+		<?php if ( empty( $bots ) ) : ?>
+		<div class="swps-tile" style="margin-bottom:16px">
+			<p style="margin:0;color:var(--swps-text-muted)">
+				<?php esc_html_e( 'No AI bot traffic detected yet. AI crawler activity will appear here once bots start visiting your site.', 'stratawp-seo' ); ?>
+			</p>
+		</div>
+	<?php else : ?>
+		<div class="swps-tile" style="margin-bottom:16px">
+			<div class="swps-tile-h"><?php esc_html_e( 'By Crawler', 'stratawp-seo' ); ?></div>
+			<table class="widefat striped" style="margin-top:8px">
+				<thead>
+					<tr>
+						<th><?php esc_html_e( 'Bot', 'stratawp-seo' ); ?></th>
+						<th style="text-align:right"><?php esc_html_e( 'Hits (30d)', 'stratawp-seo' ); ?></th>
+						<th><?php esc_html_e( 'Last Seen', 'stratawp-seo' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php
+					foreach ( $bots as $bot ) :
+						$last = $bot['last_seen'] ? human_time_diff( strtotime( $bot['last_seen'] ), time() ) . ' ago' : '—';
+						?>
+						<tr>
+							<td><code><?php echo esc_html( $bot['label'] ); ?></code></td>
+							<td style="text-align:right"><?php echo esc_html( number_format_i18n( $bot['hits'] ) ); ?></td>
+							<td style="color:var(--swps-text-muted)"><?php echo esc_html( $last ); ?></td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+		</div>
+	<?php endif; ?>
 
-    <?php if ( ! empty( $top_pages ) ) : ?>
-        <div class="swps-section-h" style="margin-top:24px">
-            <h3><?php esc_html_e( 'Top Crawled Pages (30d)', 'stratawp-seo' ); ?></h3>
-        </div>
-        <table class="widefat striped">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e( 'Page', 'stratawp-seo' ); ?></th>
-                    <th style="text-align:right"><?php esc_html_e( 'Bot Hits', 'stratawp-seo' ); ?></th>
-                    <th style="text-align:right"><?php esc_html_e( '404s', 'stratawp-seo' ); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ( $top_pages as $page ) :
-                    $label = '' !== $page['title'] ? $page['title'] : ( '' !== $page['request_uri'] ? $page['request_uri'] : __( '(Unknown)', 'stratawp-seo' ) );
-                    ?>
-                    <tr>
-                        <td>
-                            <?php if ( ! empty( $page['url'] ) ) : ?>
-                                <a href="<?php echo esc_url( $page['url'] ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $label ); ?></a>
-                            <?php else : ?>
-                                <?php echo esc_html( $label ); ?>
-                            <?php endif; ?>
-                        </td>
-                        <td style="text-align:right"><?php echo esc_html( number_format_i18n( $page['hits'] ) ); ?></td>
-                        <td style="text-align:right;color:<?php echo $page['errors_404'] > 0 ? 'var(--swps-danger)' : 'var(--swps-text-muted)'; ?>">
-                            <?php echo esc_html( number_format_i18n( $page['errors_404'] ) ); ?>
-                        </td>
-                    </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
-    <?php endif; ?>
+		<?php if ( ! empty( $top_pages ) ) : ?>
+		<div class="swps-section-h" style="margin-top:24px">
+			<h3><?php esc_html_e( 'Top Crawled Pages (30d)', 'stratawp-seo' ); ?></h3>
+		</div>
+		<table class="widefat striped">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Page', 'stratawp-seo' ); ?></th>
+					<th style="text-align:right"><?php esc_html_e( 'Bot Hits', 'stratawp-seo' ); ?></th>
+					<th style="text-align:right"><?php esc_html_e( '404s', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php
+				foreach ( $top_pages as $page ) :
+					$label = '' !== $page['title'] ? $page['title'] : ( '' !== $page['request_uri'] ? $page['request_uri'] : __( '(Unknown)', 'stratawp-seo' ) );
+					?>
+					<tr>
+						<td>
+							<?php if ( ! empty( $page['url'] ) ) : ?>
+								<a href="<?php echo esc_url( $page['url'] ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $label ); ?></a>
+							<?php else : ?>
+								<?php echo esc_html( $label ); ?>
+							<?php endif; ?>
+						</td>
+						<td style="text-align:right"><?php echo esc_html( number_format_i18n( $page['hits'] ) ); ?></td>
+						<td style="text-align:right;color:<?php echo $page['errors_404'] > 0 ? 'var(--swps-danger)' : 'var(--swps-text-muted)'; ?>">
+							<?php echo esc_html( number_format_i18n( $page['errors_404'] ) ); ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+	<?php endif; ?>
 
-    <?php if ( ! empty( $gaps ) ) : ?>
-        <div class="swps-section-h" style="margin-top:24px">
-            <h3><?php esc_html_e( 'AEO Gap — Posts Never Crawled (30d)', 'stratawp-seo' ); ?></h3>
-            <p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
-                <?php esc_html_e( 'Published content that no AI crawler has fetched. Candidates for sitemap re-submission, internal linking, or refresh.', 'stratawp-seo' ); ?>
-            </p>
-        </div>
-        <table class="widefat striped">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e( 'Post', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Published', 'stratawp-seo' ); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ( $gaps as $gap ) : ?>
-                    <tr>
-                        <td>
-                            <a href="<?php echo esc_url( get_edit_post_link( $gap['post_id'] ) ); ?>"><?php echo esc_html( $gap['title'] ); ?></a>
-                            &nbsp;<a href="<?php echo esc_url( $gap['url'] ); ?>" target="_blank" rel="noopener" style="color:var(--swps-text-muted);font-size:11px">↗</a>
-                        </td>
-                        <td style="color:var(--swps-text-muted)"><?php echo esc_html( mysql2date( get_option( 'date_format' ), $gap['post_date'] ) ); ?></td>
-                    </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
-    <?php endif; ?>
+		<?php if ( ! empty( $gaps ) ) : ?>
+		<div class="swps-section-h" style="margin-top:24px">
+			<h3><?php esc_html_e( 'AEO Gap — Posts Never Crawled (30d)', 'stratawp-seo' ); ?></h3>
+			<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+				<?php esc_html_e( 'Published content that no AI crawler has fetched. Candidates for sitemap re-submission, internal linking, or refresh.', 'stratawp-seo' ); ?>
+			</p>
+		</div>
+		<table class="widefat striped">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Post', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Published', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( $gaps as $gap ) : ?>
+					<tr>
+						<td>
+							<a href="<?php echo esc_url( get_edit_post_link( $gap['post_id'] ) ); ?>"><?php echo esc_html( $gap['title'] ); ?></a>
+							&nbsp;<a href="<?php echo esc_url( $gap['url'] ); ?>" target="_blank" rel="noopener" style="color:var(--swps-text-muted);font-size:11px">↗</a>
+						</td>
+						<td style="color:var(--swps-text-muted)"><?php echo esc_html( mysql2date( get_option( 'date_format' ), $gap['post_date'] ) ); ?></td>
+					</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+	<?php endif; ?>
 
-    <?php if ( ! empty( $top_404s ) ) : ?>
-        <div class="swps-section-h" style="margin-top:24px">
-            <h3><?php esc_html_e( 'Bot 404s (last 7d)', 'stratawp-seo' ); ?></h3>
-            <p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
-                <?php esc_html_e( 'URLs that AI bots are requesting but returning 404. Consider adding redirects.', 'stratawp-seo' ); ?>
-            </p>
-        </div>
-        <table class="widefat striped">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e( 'URL', 'stratawp-seo' ); ?></th>
-                    <th style="text-align:right"><?php esc_html_e( 'Hits', 'stratawp-seo' ); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ( $top_404s as $row ) : ?>
-                    <tr>
-                        <td><code style="font-size:12px"><?php echo esc_html( $row['request_uri'] ); ?></code></td>
-                        <td style="text-align:right"><?php echo esc_html( number_format_i18n( $row['hits'] ) ); ?></td>
-                    </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
-    <?php endif; ?>
-    <?php endif; // bot_data ?>
+		<?php if ( ! empty( $top_404s ) ) : ?>
+		<div class="swps-section-h" style="margin-top:24px">
+			<h3><?php esc_html_e( 'Bot 404s (last 7d)', 'stratawp-seo' ); ?></h3>
+			<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+				<?php esc_html_e( 'URLs that AI bots are requesting but returning 404. Consider adding redirects.', 'stratawp-seo' ); ?>
+			</p>
+		</div>
+		<table class="widefat striped">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'URL', 'stratawp-seo' ); ?></th>
+					<th style="text-align:right"><?php esc_html_e( 'Hits', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( $top_404s as $row ) : ?>
+					<tr>
+						<td><code style="font-size:12px"><?php echo esc_html( $row['request_uri'] ); ?></code></td>
+						<td style="text-align:right"><?php echo esc_html( number_format_i18n( $row['hits'] ) ); ?></td>
+					</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+	<?php endif; ?>
+	<?php endif; // bot_data ?>
 </div>

--- a/templates/audit-page.php
+++ b/templates/audit-page.php
@@ -9,7 +9,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 $audit    = stratawp_seo()->seo_audit;
@@ -22,208 +22,221 @@ $crit_count = 0;
 $warn_count = 0;
 $pass_count = 0;
 foreach ( $modules as $id => $mod ) {
-    $status = $results['modules'][ $id ]['status'] ?? 'fail';
-    if ( 'pass' === $status ) {
-        $pass_count++;
-    } elseif ( 'warning' === $status ) {
-        $warn_count++;
-    } else {
-        $crit_count++;
-    }
+	$status = $results['modules'][ $id ]['status'] ?? 'fail';
+	if ( 'pass' === $status ) {
+		++$pass_count;
+	} elseif ( 'warning' === $status ) {
+		++$warn_count;
+	} else {
+		++$crit_count;
+	}
 }
 ?>
 <div class="wrap swps-audit-wrap">
 
-    <?php
-    $title    = __( 'SEO Audit', 'stratawp-seo' );
-    $subtitle = $last_run
-        ? sprintf(
-            /* translators: %s: human time diff */
-            esc_html__( 'Last run %s. Click "Run Audit" to refresh.', 'stratawp-seo' ),
-            esc_html( human_time_diff( strtotime( $last_run ), time() ) . ' ago' )
-        )
-        : esc_html__( 'No audit run yet — click "Run Audit" to start.', 'stratawp-seo' );
-    $actions  = [
-        [ 'label' => __( 'Export CSV', 'stratawp-seo' ), 'class' => 'swps-btn-secondary', 'attrs' => 'id="swps-export-csv"' ],
-        [ 'label' => __( 'Fix All', 'stratawp-seo' ),    'class' => 'swps-btn-secondary', 'attrs' => 'id="swps-fix-all"' ],
-        [ 'label' => __( 'Run Audit', 'stratawp-seo' ),  'class' => 'swps-btn-grad',      'attrs' => 'id="swps-run-audit"' ],
-    ];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'SEO Audit', 'stratawp-seo' );
+	$subtitle = $last_run
+		? sprintf(
+			/* translators: %s: human time diff */
+			esc_html__( 'Last run %s. Click "Run Audit" to refresh.', 'stratawp-seo' ),
+			esc_html( human_time_diff( strtotime( $last_run ), time() ) . ' ago' )
+		)
+		: esc_html__( 'No audit run yet — click "Run Audit" to start.', 'stratawp-seo' );
+	$actions = array(
+		array(
+			'label' => __( 'Export CSV', 'stratawp-seo' ),
+			'class' => 'swps-btn-secondary',
+			'attrs' => 'id="swps-export-csv"',
+		),
+		array(
+			'label' => __( 'Fix All', 'stratawp-seo' ),
+			'class' => 'swps-btn-secondary',
+			'attrs' => 'id="swps-fix-all"',
+		),
+		array(
+			'label' => __( 'Run Audit', 'stratawp-seo' ),
+			'class' => 'swps-btn-grad',
+			'attrs' => 'id="swps-run-audit"',
+		),
+	);
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <div class="swps-summary-tiles">
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Overall score', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-grad"><?php echo (int) $overall; ?></div>
-            <div class="swps-summary-tile-foot"><?php esc_html_e( 'out of 100', 'stratawp-seo' ); ?></div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Critical', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-crit"><?php echo (int) $crit_count; ?></div>
-            <div class="swps-summary-tile-foot"><?php esc_html_e( 'modules failing', 'stratawp-seo' ); ?></div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Warnings', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-warn"><?php echo (int) $warn_count; ?></div>
-            <div class="swps-summary-tile-foot"><?php esc_html_e( 'minor issues', 'stratawp-seo' ); ?></div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Passing', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-ok"><?php echo (int) $pass_count; ?></div>
-            <div class="swps-summary-tile-foot">
-                <?php
-                printf(
-                    /* translators: %d: total modules */
-                    esc_html__( 'of %d modules', 'stratawp-seo' ),
-                    count( $modules )
-                );
-                ?>
-            </div>
-        </div>
-    </div>
+	<div class="swps-summary-tiles">
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Overall score', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad"><?php echo (int) $overall; ?></div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'out of 100', 'stratawp-seo' ); ?></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Critical', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-crit"><?php echo (int) $crit_count; ?></div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'modules failing', 'stratawp-seo' ); ?></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Warnings', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-warn"><?php echo (int) $warn_count; ?></div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'minor issues', 'stratawp-seo' ); ?></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Passing', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-ok"><?php echo (int) $pass_count; ?></div>
+			<div class="swps-summary-tile-foot">
+				<?php
+				printf(
+					/* translators: %d: total modules */
+					esc_html__( 'of %d modules', 'stratawp-seo' ),
+					count( $modules )
+				);
+				?>
+			</div>
+		</div>
+	</div>
 
-    <div id="swps-audit-progress" class="swps-progress" style="display: none;">
-        <div class="swps-spinner"></div>
-        <div class="swps-progress-text">
-            <strong id="swps-audit-progress-title"><?php esc_html_e( 'Running audit...', 'stratawp-seo' ); ?></strong>
-        </div>
-    </div>
+	<div id="swps-audit-progress" class="swps-progress" style="display: none;">
+		<div class="swps-spinner"></div>
+		<div class="swps-progress-text">
+			<strong id="swps-audit-progress-title"><?php esc_html_e( 'Running audit...', 'stratawp-seo' ); ?></strong>
+		</div>
+	</div>
 
-    <div class="swps-section-h">
-        <h3><?php esc_html_e( 'Module results', 'stratawp-seo' ); ?></h3>
-        <div class="swps-filter-chips">
-            <button type="button" class="swps-filter-chip is-on" data-swps-audit-filter="all"><?php esc_html_e( 'All', 'stratawp-seo' ); ?></button>
-            <button type="button" class="swps-filter-chip" data-swps-audit-filter="issues"><?php esc_html_e( 'Issues only', 'stratawp-seo' ); ?></button>
-            <button type="button" class="swps-filter-chip" data-swps-audit-filter="fixable"><?php esc_html_e( 'Auto-fixable', 'stratawp-seo' ); ?></button>
-        </div>
-    </div>
+	<div class="swps-section-h">
+		<h3><?php esc_html_e( 'Module results', 'stratawp-seo' ); ?></h3>
+		<div class="swps-filter-chips">
+			<button type="button" class="swps-filter-chip is-on" data-swps-audit-filter="all"><?php esc_html_e( 'All', 'stratawp-seo' ); ?></button>
+			<button type="button" class="swps-filter-chip" data-swps-audit-filter="issues"><?php esc_html_e( 'Issues only', 'stratawp-seo' ); ?></button>
+			<button type="button" class="swps-filter-chip" data-swps-audit-filter="fixable"><?php esc_html_e( 'Auto-fixable', 'stratawp-seo' ); ?></button>
+		</div>
+	</div>
 
-    <div class="swps-audit-modules">
-        <?php foreach ( $modules as $id => $module ) :
-            $mod_result = $results['modules'][ $id ] ?? null;
-            $mod_score  = (int) ( $mod_result['score'] ?? 0 );
-            $mod_status = $mod_result['status'] ?? 'fail';
-            $issues     = $mod_result['issues'] ?? [];
-            $summary    = $mod_result['summary'] ?? __( 'Not yet audited.', 'stratawp-seo' );
-            $can_fix    = $module->can_auto_fix();
+	<div class="swps-audit-modules">
+		<?php
+		foreach ( $modules as $id => $module ) :
+			$mod_result = $results['modules'][ $id ] ?? null;
+			$mod_score  = (int) ( $mod_result['score'] ?? 0 );
+			$mod_status = $mod_result['status'] ?? 'fail';
+			$issues     = $mod_result['issues'] ?? array();
+			$summary    = $mod_result['summary'] ?? __( 'Not yet audited.', 'stratawp-seo' );
+			$can_fix    = $module->can_auto_fix();
 
-            $status_dot_class = match ( $mod_status ) {
-                'pass'    => 'swps-status-dot-ok',
-                'warning' => 'swps-status-dot-warn',
-                default   => 'swps-status-dot-crit',
-            };
-            $status_dot_glyph = match ( $mod_status ) {
-                'pass'    => '✓',
-                default   => '!',
-            };
-        ?>
-        <div class="swps-row-card swps-audit-module-card"
-             data-module-id="<?php echo esc_attr( $id ); ?>"
-             data-status="<?php echo esc_attr( $mod_status ); ?>"
-             data-fixable="<?php echo $can_fix ? '1' : '0'; ?>">
-            <div class="swps-row-head">
-                <div class="swps-status-dot <?php echo esc_attr( $status_dot_class ); ?>">
-                    <?php echo esc_html( $status_dot_glyph ); ?>
-                </div>
-                <div>
-                    <div class="swps-row-head-name"><?php echo esc_html( $module->get_label() ); ?></div>
-                    <div class="swps-row-head-msg"><?php echo esc_html( $summary ); ?></div>
-                </div>
-                <div class="swps-row-head-meta">
-                    <div class="swps-row-head-score"><?php echo (int) $mod_score; ?> / 100</div>
-                    <?php if ( $can_fix && ! empty( $issues ) ) : ?>
-                        <button class="swps-btn swps-btn-grad swps-fix-module" data-module="<?php echo esc_attr( $id ); ?>" style="padding:6px 12px;font-size:11px">
-                            <?php esc_html_e( 'Auto-fix all', 'stratawp-seo' ); ?>
-                        </button>
-                    <?php endif; ?>
-                    <?php if ( ! empty( $issues ) ) : ?>
-                        <button type="button" class="swps-btn swps-btn-secondary swps-toggle-issues"
-                            data-module="<?php echo esc_attr( $id ); ?>"
-                            style="padding:6px 12px;font-size:11px">
-                            <?php
-                            printf(
-                                /* translators: %d: number of issues */
-                                esc_html( _n( '%d issue', '%d issues', count( $issues ), 'stratawp-seo' ) ),
-                                count( $issues )
-                            );
-                            ?>
-                        </button>
-                    <?php endif; ?>
-                </div>
-            </div>
+			$status_dot_class = match ( $mod_status ) {
+				'pass'    => 'swps-status-dot-ok',
+				'warning' => 'swps-status-dot-warn',
+				default   => 'swps-status-dot-crit',
+			};
+			$status_dot_glyph = match ( $mod_status ) {
+				'pass'    => '✓',
+				default   => '!',
+			};
+			?>
+		<div class="swps-row-card swps-audit-module-card"
+			data-module-id="<?php echo esc_attr( $id ); ?>"
+			data-status="<?php echo esc_attr( $mod_status ); ?>"
+			data-fixable="<?php echo $can_fix ? '1' : '0'; ?>">
+			<div class="swps-row-head">
+				<div class="swps-status-dot <?php echo esc_attr( $status_dot_class ); ?>">
+					<?php echo esc_html( $status_dot_glyph ); ?>
+				</div>
+				<div>
+					<div class="swps-row-head-name"><?php echo esc_html( $module->get_label() ); ?></div>
+					<div class="swps-row-head-msg"><?php echo esc_html( $summary ); ?></div>
+				</div>
+				<div class="swps-row-head-meta">
+					<div class="swps-row-head-score"><?php echo (int) $mod_score; ?> / 100</div>
+					<?php if ( $can_fix && ! empty( $issues ) ) : ?>
+						<button class="swps-btn swps-btn-grad swps-fix-module" data-module="<?php echo esc_attr( $id ); ?>" style="padding:6px 12px;font-size:11px">
+							<?php esc_html_e( 'Auto-fix all', 'stratawp-seo' ); ?>
+						</button>
+					<?php endif; ?>
+					<?php if ( ! empty( $issues ) ) : ?>
+						<button type="button" class="swps-btn swps-btn-secondary swps-toggle-issues"
+							data-module="<?php echo esc_attr( $id ); ?>"
+							style="padding:6px 12px;font-size:11px">
+							<?php
+							printf(
+								/* translators: %d: number of issues */
+								esc_html( _n( '%d issue', '%d issues', count( $issues ), 'stratawp-seo' ) ),
+								count( $issues )
+							);
+							?>
+						</button>
+					<?php endif; ?>
+				</div>
+			</div>
 
-            <?php if ( ! empty( $issues ) ) : ?>
-            <div class="swps-row-detail" id="swps-issues-<?php echo esc_attr( $id ); ?>">
-                <table class="widefat">
-                    <tbody>
-                    <?php foreach ( $issues as $issue ) : ?>
-                        <tr>
-                            <td>
-                                <?php echo esc_html( $issue['message'] ); ?>
-                                <?php if ( $issue['post_id'] ) : ?>
-                                    <a href="<?php echo esc_url( get_edit_post_link( $issue['post_id'] ) ); ?>" target="_blank" class="swps-issue-link">
-                                        <?php esc_html_e( 'Edit', 'stratawp-seo' ); ?> &rarr;
-                                    </a>
-                                <?php endif; ?>
-                            </td>
-                            <td class="swps-issue-fixable" style="width:60px;text-align:right">
-                                <?php if ( $issue['fixable'] ) : ?>
-                                    <span class="swps-pill swps-pill-info" title="<?php esc_attr_e( 'Auto-fixable', 'stratawp-seo' ); ?>">FIX</span>
-                                <?php endif; ?>
-                            </td>
-                        </tr>
-                    <?php endforeach; ?>
-                    </tbody>
-                </table>
-            </div>
-            <?php endif; ?>
-        </div>
-        <?php endforeach; ?>
-    </div>
+			<?php if ( ! empty( $issues ) ) : ?>
+			<div class="swps-row-detail" id="swps-issues-<?php echo esc_attr( $id ); ?>">
+				<table class="widefat">
+					<tbody>
+					<?php foreach ( $issues as $issue ) : ?>
+						<tr>
+							<td>
+								<?php echo esc_html( $issue['message'] ); ?>
+								<?php if ( $issue['post_id'] ) : ?>
+									<a href="<?php echo esc_url( get_edit_post_link( $issue['post_id'] ) ); ?>" target="_blank" class="swps-issue-link">
+										<?php esc_html_e( 'Edit', 'stratawp-seo' ); ?> &rarr;
+									</a>
+								<?php endif; ?>
+							</td>
+							<td class="swps-issue-fixable" style="width:60px;text-align:right">
+								<?php if ( $issue['fixable'] ) : ?>
+									<span class="swps-pill swps-pill-info" title="<?php esc_attr_e( 'Auto-fixable', 'stratawp-seo' ); ?>">FIX</span>
+								<?php endif; ?>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+					</tbody>
+				</table>
+			</div>
+			<?php endif; ?>
+		</div>
+		<?php endforeach; ?>
+	</div>
 </div>
 
 <script>
 (function () {
-    'use strict';
-    document.addEventListener('DOMContentLoaded', function () {
-        var wrap = document.querySelector('.swps-audit-wrap');
-        if (!wrap) return;
+	'use strict';
+	document.addEventListener('DOMContentLoaded', function () {
+		var wrap = document.querySelector('.swps-audit-wrap');
+		if (!wrap) return;
 
-        // Filter chips
-        var chips = wrap.querySelectorAll('[data-swps-audit-filter]');
-        var cards = wrap.querySelectorAll('.swps-audit-module-card');
-        chips.forEach(function (chip) {
-            chip.addEventListener('click', function () {
-                chips.forEach(function (c) { c.classList.remove('is-on'); });
-                chip.classList.add('is-on');
-                var filter = chip.dataset.swpsAuditFilter;
-                cards.forEach(function (card) {
-                    var status = card.dataset.status || 'fail';
-                    var fixable = card.dataset.fixable === '1';
-                    var show = true;
-                    if (filter === 'issues') show = (status !== 'pass');
-                    else if (filter === 'fixable') show = fixable;
-                    card.style.display = show ? '' : 'none';
-                });
-            });
-        });
+		// Filter chips
+		var chips = wrap.querySelectorAll('[data-swps-audit-filter]');
+		var cards = wrap.querySelectorAll('.swps-audit-module-card');
+		chips.forEach(function (chip) {
+			chip.addEventListener('click', function () {
+				chips.forEach(function (c) { c.classList.remove('is-on'); });
+				chip.classList.add('is-on');
+				var filter = chip.dataset.swpsAuditFilter;
+				cards.forEach(function (card) {
+					var status = card.dataset.status || 'fail';
+					var fixable = card.dataset.fixable === '1';
+					var show = true;
+					if (filter === 'issues') show = (status !== 'pass');
+					else if (filter === 'fixable') show = fixable;
+					card.style.display = show ? '' : 'none';
+				});
+			});
+		});
 
-        // Toggle expand/collapse on click of toggle-issues OR row head
-        wrap.querySelectorAll('.swps-toggle-issues').forEach(function (btn) {
-            btn.addEventListener('click', function (e) {
-                e.preventDefault();
-                e.stopPropagation();
-                var card = btn.closest('.swps-row-card');
-                if (card) card.classList.toggle('is-open');
-            });
-        });
-        wrap.querySelectorAll('.swps-row-head').forEach(function (head) {
-            head.addEventListener('click', function (e) {
-                if (e.target.closest('button') || e.target.closest('a')) return;
-                var card = head.closest('.swps-row-card');
-                if (card) card.classList.toggle('is-open');
-            });
-        });
-    });
+		// Toggle expand/collapse on click of toggle-issues OR row head
+		wrap.querySelectorAll('.swps-toggle-issues').forEach(function (btn) {
+			btn.addEventListener('click', function (e) {
+				e.preventDefault();
+				e.stopPropagation();
+				var card = btn.closest('.swps-row-card');
+				if (card) card.classList.toggle('is-open');
+			});
+		});
+		wrap.querySelectorAll('.swps-row-head').forEach(function (head) {
+			head.addEventListener('click', function (e) {
+				if (e.target.closest('button') || e.target.closest('a')) return;
+				var card = head.closest('.swps-row-card');
+				if (card) card.classList.toggle('is-open');
+			});
+		});
+	});
 })();
 </script>

--- a/templates/auto-optimize-page.php
+++ b/templates/auto-optimize-page.php
@@ -11,7 +11,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /** @var SWPS_Auto_Optimize $auto */
@@ -30,148 +30,156 @@ $stats     = $auto->get_stats( $queue );
  * @param array $row Queue row from SWPS_Auto_Optimize::get_queue().
  */
 if ( ! function_exists( 'swps_render_optimize_row' ) ) {
-    function swps_render_optimize_row( array $row ): void {
-        $score        = (int) $row['current_score'];
-        $score_class  = $score >= 80 ? 'swps-status-dot-ok' : ( $score >= 50 ? 'swps-status-dot-warn' : 'swps-status-dot-crit' );
-        $score_glyph  = $score >= 80 ? '✓' : '!';
-        $has_proposal = ! empty( $row['has_proposal'] );
-        $projected    = $has_proposal ? (int) ( $row['proposal']['projected_score'] ?? 0 ) : null;
-        $top_recs     = (array) ( $row['top_recs'] ?? [] );
-        $reason       = ! empty( $top_recs ) ? (string) $top_recs[0] : '';
-        ?>
-        <div class="swps-row-card swps-optimize-row"
-             data-post-id="<?php echo (int) $row['post_id']; ?>"
-             data-current-score="<?php echo (int) $score; ?>"
-             data-status="<?php echo $has_proposal ? 'proposed' : 'needs'; ?>">
-            <div class="swps-row-head">
-                <div class="swps-status-dot <?php echo esc_attr( $score_class ); ?>"><?php echo esc_html( $score_glyph ); ?></div>
-                <div>
-                    <div class="swps-row-head-name">
-                        <a href="<?php echo esc_url( $row['edit_url'] ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $row['title'] ); ?></a>
-                    </div>
-                    <div class="swps-row-head-msg">
-                        <?php echo esc_html( '' !== $reason ? $reason : __( 'Click "Generate proposal" for AI suggestions.', 'stratawp-seo' ) ); ?>
-                        &middot; <?php echo (int) $row['word_count']; ?> <?php esc_html_e( 'words', 'stratawp-seo' ); ?>
-                        &middot; <a href="<?php echo esc_url( $row['permalink'] ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'View', 'stratawp-seo' ); ?></a>
-                    </div>
-                </div>
-                <div class="swps-row-head-meta">
-                    <div class="swps-row-head-score">
-                        <?php echo (int) $score; ?>
-                        <?php if ( null !== $projected ) : ?>
-                            <span class="swps-optimize-arrow">&rarr;</span>
-                            <span class="swps-optimize-projected"><?php echo (int) $projected; ?></span>
-                        <?php endif; ?>
-                    </div>
-                    <?php if ( $has_proposal ) : ?>
-                        <button class="swps-btn swps-btn-grad swps-optimize-review" style="padding:6px 12px;font-size:11px"><?php esc_html_e( 'Review', 'stratawp-seo' ); ?></button>
-                        <button class="swps-btn swps-btn-secondary swps-optimize-propose" title="<?php esc_attr_e( 'Re-generate proposal', 'stratawp-seo' ); ?>" style="padding:6px 10px;font-size:11px">
-                            <span class="dashicons dashicons-update"></span>
-                        </button>
-                    <?php else : ?>
-                        <button class="swps-btn swps-btn-grad swps-optimize-propose" style="padding:6px 12px;font-size:11px"><?php esc_html_e( 'Generate proposal', 'stratawp-seo' ); ?></button>
-                    <?php endif; ?>
-                    <button class="swps-btn swps-btn-secondary swps-optimize-dismiss" title="<?php esc_attr_e( 'Dismiss', 'stratawp-seo' ); ?>" style="padding:6px 10px;font-size:11px">
-                        <span class="dashicons dashicons-no-alt"></span>
-                    </button>
-                </div>
-            </div>
-        </div>
-        <?php
-    }
+	function swps_render_optimize_row( array $row ): void {
+		$score        = (int) $row['current_score'];
+		$score_class  = $score >= 80 ? 'swps-status-dot-ok' : ( $score >= 50 ? 'swps-status-dot-warn' : 'swps-status-dot-crit' );
+		$score_glyph  = $score >= 80 ? '✓' : '!';
+		$has_proposal = ! empty( $row['has_proposal'] );
+		$projected    = $has_proposal ? (int) ( $row['proposal']['projected_score'] ?? 0 ) : null;
+		$top_recs     = (array) ( $row['top_recs'] ?? array() );
+		$reason       = ! empty( $top_recs ) ? (string) $top_recs[0] : '';
+		?>
+		<div class="swps-row-card swps-optimize-row"
+			data-post-id="<?php echo (int) $row['post_id']; ?>"
+			data-current-score="<?php echo (int) $score; ?>"
+			data-status="<?php echo $has_proposal ? 'proposed' : 'needs'; ?>">
+			<div class="swps-row-head">
+				<div class="swps-status-dot <?php echo esc_attr( $score_class ); ?>"><?php echo esc_html( $score_glyph ); ?></div>
+				<div>
+					<div class="swps-row-head-name">
+						<a href="<?php echo esc_url( $row['edit_url'] ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $row['title'] ); ?></a>
+					</div>
+					<div class="swps-row-head-msg">
+						<?php echo esc_html( '' !== $reason ? $reason : __( 'Click "Generate proposal" for AI suggestions.', 'stratawp-seo' ) ); ?>
+						&middot; <?php echo (int) $row['word_count']; ?> <?php esc_html_e( 'words', 'stratawp-seo' ); ?>
+						&middot; <a href="<?php echo esc_url( $row['permalink'] ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'View', 'stratawp-seo' ); ?></a>
+					</div>
+				</div>
+				<div class="swps-row-head-meta">
+					<div class="swps-row-head-score">
+						<?php echo (int) $score; ?>
+						<?php if ( null !== $projected ) : ?>
+							<span class="swps-optimize-arrow">&rarr;</span>
+							<span class="swps-optimize-projected"><?php echo (int) $projected; ?></span>
+						<?php endif; ?>
+					</div>
+					<?php if ( $has_proposal ) : ?>
+						<button class="swps-btn swps-btn-grad swps-optimize-review" style="padding:6px 12px;font-size:11px"><?php esc_html_e( 'Review', 'stratawp-seo' ); ?></button>
+						<button class="swps-btn swps-btn-secondary swps-optimize-propose" title="<?php esc_attr_e( 'Re-generate proposal', 'stratawp-seo' ); ?>" style="padding:6px 10px;font-size:11px">
+							<span class="dashicons dashicons-update"></span>
+						</button>
+					<?php else : ?>
+						<button class="swps-btn swps-btn-grad swps-optimize-propose" style="padding:6px 12px;font-size:11px"><?php esc_html_e( 'Generate proposal', 'stratawp-seo' ); ?></button>
+					<?php endif; ?>
+					<button class="swps-btn swps-btn-secondary swps-optimize-dismiss" title="<?php esc_attr_e( 'Dismiss', 'stratawp-seo' ); ?>" style="padding:6px 10px;font-size:11px">
+						<span class="dashicons dashicons-no-alt"></span>
+					</button>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
 }
 ?>
 <div class="wrap swps-auto-optimize-wrap">
 
-    <?php
-    $title    = __( 'AI Auto-Optimize', 'stratawp-seo' );
-    $subtitle = __( 'Find low-scoring posts, generate AI edit proposals, review the diff, then apply with one click. Every edit is reviewed before it touches your content.', 'stratawp-seo' );
-    $actions  = [
-        [ 'label' => __( 'Refresh queue', 'stratawp-seo' ),     'class' => 'swps-btn-secondary', 'attrs' => 'id="swps-optimize-refresh"' ],
-        [ 'label' => __( 'Re-scan all posts', 'stratawp-seo' ), 'class' => 'swps-btn-grad',      'attrs' => 'id="swps-optimize-rescan"' ],
-    ];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'AI Auto-Optimize', 'stratawp-seo' );
+	$subtitle = __( 'Find low-scoring posts, generate AI edit proposals, review the diff, then apply with one click. Every edit is reviewed before it touches your content.', 'stratawp-seo' );
+	$actions  = array(
+		array(
+			'label' => __( 'Refresh queue', 'stratawp-seo' ),
+			'class' => 'swps-btn-secondary',
+			'attrs' => 'id="swps-optimize-refresh"',
+		),
+		array(
+			'label' => __( 'Re-scan all posts', 'stratawp-seo' ),
+			'class' => 'swps-btn-grad',
+			'attrs' => 'id="swps-optimize-rescan"',
+		),
+	);
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <div class="swps-summary-tiles">
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Below threshold', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-grad" id="swps-optimize-tile-count"><?php echo (int) $stats['count']; ?></div>
-            <div class="swps-summary-tile-foot">
-                <?php
-                printf(
-                    /* translators: %d: threshold */
-                    esc_html__( 'posts under %d', 'stratawp-seo' ),
-                    (int) $threshold
-                );
-                ?>
-            </div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Proposals ready', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-ok" id="swps-optimize-tile-proposed"><?php echo (int) $stats['with_proposal']; ?></div>
-            <div class="swps-summary-tile-foot"><?php esc_html_e( 'awaiting review', 'stratawp-seo' ); ?></div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Avg projected lift', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-warn" id="swps-optimize-tile-lift">+<?php echo (int) $stats['avg_lift']; ?></div>
-            <div class="swps-summary-tile-foot"><?php esc_html_e( 'points per post', 'stratawp-seo' ); ?></div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Est. cost', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num" id="swps-optimize-tile-cost">$<?php echo esc_html( number_format( (float) $stats['est_cost'], 4 ) ); ?></div>
-            <div class="swps-summary-tile-foot"><?php esc_html_e( 'all queued proposals', 'stratawp-seo' ); ?></div>
-        </div>
-    </div>
+	<div class="swps-summary-tiles">
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Below threshold', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad" id="swps-optimize-tile-count"><?php echo (int) $stats['count']; ?></div>
+			<div class="swps-summary-tile-foot">
+				<?php
+				printf(
+					/* translators: %d: threshold */
+					esc_html__( 'posts under %d', 'stratawp-seo' ),
+					(int) $threshold
+				);
+				?>
+			</div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Proposals ready', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-ok" id="swps-optimize-tile-proposed"><?php echo (int) $stats['with_proposal']; ?></div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'awaiting review', 'stratawp-seo' ); ?></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Avg projected lift', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-warn" id="swps-optimize-tile-lift">+<?php echo (int) $stats['avg_lift']; ?></div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'points per post', 'stratawp-seo' ); ?></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Est. cost', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num" id="swps-optimize-tile-cost">$<?php echo esc_html( number_format( (float) $stats['est_cost'], 4 ) ); ?></div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'all queued proposals', 'stratawp-seo' ); ?></div>
+		</div>
+	</div>
 
-    <div class="swps-row-card swps-optimize-controls">
-        <div class="swps-optimize-controls-row">
-            <div class="swps-optimize-control-field">
-                <label for="swps-optimize-threshold"><strong><?php esc_html_e( 'Score threshold', 'stratawp-seo' ); ?></strong></label>
-                <p class="swps-optimize-control-help"><?php esc_html_e( 'Posts below this score appear in the queue.', 'stratawp-seo' ); ?></p>
-            </div>
-            <input type="number" id="swps-optimize-threshold" min="0" max="100" step="1" value="<?php echo (int) $threshold; ?>" />
-            <div class="swps-optimize-progress" id="swps-optimize-progress" style="display:none;">
-                <span class="spinner is-active" style="float:none;margin:0 8px 0 0;"></span>
-                <span id="swps-optimize-progress-text"><?php esc_html_e( 'Working...', 'stratawp-seo' ); ?></span>
-            </div>
-        </div>
-    </div>
+	<div class="swps-row-card swps-optimize-controls">
+		<div class="swps-optimize-controls-row">
+			<div class="swps-optimize-control-field">
+				<label for="swps-optimize-threshold"><strong><?php esc_html_e( 'Score threshold', 'stratawp-seo' ); ?></strong></label>
+				<p class="swps-optimize-control-help"><?php esc_html_e( 'Posts below this score appear in the queue.', 'stratawp-seo' ); ?></p>
+			</div>
+			<input type="number" id="swps-optimize-threshold" min="0" max="100" step="1" value="<?php echo (int) $threshold; ?>" />
+			<div class="swps-optimize-progress" id="swps-optimize-progress" style="display:none;">
+				<span class="spinner is-active" style="float:none;margin:0 8px 0 0;"></span>
+				<span id="swps-optimize-progress-text"><?php esc_html_e( 'Working...', 'stratawp-seo' ); ?></span>
+			</div>
+		</div>
+	</div>
 
-    <div class="swps-section-h">
-        <h3><?php esc_html_e( 'Optimization queue', 'stratawp-seo' ); ?></h3>
-        <div class="swps-filter-chips">
-            <button type="button" class="swps-filter-chip is-on" data-swps-filter="all"><?php esc_html_e( 'All', 'stratawp-seo' ); ?></button>
-            <button type="button" class="swps-filter-chip" data-swps-filter="proposed"><?php esc_html_e( 'Has proposal', 'stratawp-seo' ); ?></button>
-            <button type="button" class="swps-filter-chip" data-swps-filter="needs"><?php esc_html_e( 'Needs proposal', 'stratawp-seo' ); ?></button>
-        </div>
-    </div>
+	<div class="swps-section-h">
+		<h3><?php esc_html_e( 'Optimization queue', 'stratawp-seo' ); ?></h3>
+		<div class="swps-filter-chips">
+			<button type="button" class="swps-filter-chip is-on" data-swps-filter="all"><?php esc_html_e( 'All', 'stratawp-seo' ); ?></button>
+			<button type="button" class="swps-filter-chip" data-swps-filter="proposed"><?php esc_html_e( 'Has proposal', 'stratawp-seo' ); ?></button>
+			<button type="button" class="swps-filter-chip" data-swps-filter="needs"><?php esc_html_e( 'Needs proposal', 'stratawp-seo' ); ?></button>
+		</div>
+	</div>
 
-    <div class="swps-optimize-queue" id="swps-optimize-queue">
-        <?php if ( empty( $queue ) ) : ?>
-            <div class="swps-row-card swps-optimize-empty">
-                <p><?php esc_html_e( 'Nothing to optimize. No published posts are below the threshold. Lower the threshold or run a re-scan to refresh scores.', 'stratawp-seo' ); ?></p>
-            </div>
-        <?php else : ?>
-            <?php foreach ( $queue as $row ) : ?>
-                <?php swps_render_optimize_row( $row ); ?>
-            <?php endforeach; ?>
-        <?php endif; ?>
-    </div>
+	<div class="swps-optimize-queue" id="swps-optimize-queue">
+		<?php if ( empty( $queue ) ) : ?>
+			<div class="swps-row-card swps-optimize-empty">
+				<p><?php esc_html_e( 'Nothing to optimize. No published posts are below the threshold. Lower the threshold or run a re-scan to refresh scores.', 'stratawp-seo' ); ?></p>
+			</div>
+		<?php else : ?>
+			<?php foreach ( $queue as $row ) : ?>
+				<?php swps_render_optimize_row( $row ); ?>
+			<?php endforeach; ?>
+		<?php endif; ?>
+	</div>
 </div>
 
 <!-- Review modal -->
 <div class="swps-optimize-modal" id="swps-optimize-modal" style="display:none;" aria-hidden="true">
-    <div class="swps-optimize-modal-backdrop" data-close></div>
-    <div class="swps-optimize-modal-panel" role="dialog" aria-modal="true" aria-labelledby="swps-optimize-modal-title">
-        <div class="swps-optimize-modal-head">
-            <h2 id="swps-optimize-modal-title"><?php esc_html_e( 'Review proposal', 'stratawp-seo' ); ?></h2>
-            <button class="swps-optimize-modal-close" data-close aria-label="<?php esc_attr_e( 'Close', 'stratawp-seo' ); ?>">&times;</button>
-        </div>
-        <div class="swps-optimize-modal-body" id="swps-optimize-modal-body"></div>
-        <div class="swps-optimize-modal-foot">
-            <button class="swps-btn swps-btn-secondary" data-close><?php esc_html_e( 'Cancel', 'stratawp-seo' ); ?></button>
-            <button class="swps-btn swps-btn-grad" id="swps-optimize-apply"><?php esc_html_e( 'Apply selected edits', 'stratawp-seo' ); ?></button>
-        </div>
-    </div>
+	<div class="swps-optimize-modal-backdrop" data-close></div>
+	<div class="swps-optimize-modal-panel" role="dialog" aria-modal="true" aria-labelledby="swps-optimize-modal-title">
+		<div class="swps-optimize-modal-head">
+			<h2 id="swps-optimize-modal-title"><?php esc_html_e( 'Review proposal', 'stratawp-seo' ); ?></h2>
+			<button class="swps-optimize-modal-close" data-close aria-label="<?php esc_attr_e( 'Close', 'stratawp-seo' ); ?>">&times;</button>
+		</div>
+		<div class="swps-optimize-modal-body" id="swps-optimize-modal-body"></div>
+		<div class="swps-optimize-modal-foot">
+			<button class="swps-btn swps-btn-secondary" data-close><?php esc_html_e( 'Cancel', 'stratawp-seo' ); ?></button>
+			<button class="swps-btn swps-btn-grad" id="swps-optimize-apply"><?php esc_html_e( 'Apply selected edits', 'stratawp-seo' ); ?></button>
+		</div>
+	</div>
 </div>

--- a/templates/backlinks-page.php
+++ b/templates/backlinks-page.php
@@ -6,7 +6,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 $bl    = stratawp_seo()->backlinks;
@@ -16,200 +16,203 @@ $rows  = $bl->get_all();
 $home_host = wp_parse_url( home_url(), PHP_URL_HOST );
 ?>
 <div class="wrap">
-    <?php
-    $title    = __( 'Backlinks', 'stratawp-seo' );
-    $subtitle = sprintf(
-        /* translators: %s: site host */
-        esc_html__( 'Track pages that link to %s. Add backlinks one at a time, or paste a CSV (e.g. the "Top linking sites" export from Google Search Console). StrataWP re-checks each link daily and tells you when one disappears.', 'stratawp-seo' ),
-        '<code>' . esc_html( $home_host ) . '</code>'
-    );
-    $actions  = [
-        [
-            'label' => __( 'Verify all', 'stratawp-seo' ),
-            'url'   => '',
-            'class' => 'swps-btn-grad',
-            'attrs' => 'id="swps-bl-verify-all"',
-        ],
-        [
-            'label' => __( 'Export CSV', 'stratawp-seo' ),
-            'url'   => add_query_arg( [
-                'action' => 'swps_backlink_export',
-                'nonce'  => wp_create_nonce( 'swps_nonce' ),
-            ], admin_url( 'admin-ajax.php' ) ),
-            'class' => 'swps-btn-secondary',
-        ],
-    ];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'Backlinks', 'stratawp-seo' );
+	$subtitle = sprintf(
+		/* translators: %s: site host */
+		esc_html__( 'Track pages that link to %s. Add backlinks one at a time, or paste a CSV (e.g. the "Top linking sites" export from Google Search Console). StrataWP re-checks each link daily and tells you when one disappears.', 'stratawp-seo' ),
+		'<code>' . esc_html( $home_host ) . '</code>'
+	);
+	$actions = array(
+		array(
+			'label' => __( 'Verify all', 'stratawp-seo' ),
+			'url'   => '',
+			'class' => 'swps-btn-grad',
+			'attrs' => 'id="swps-bl-verify-all"',
+		),
+		array(
+			'label' => __( 'Export CSV', 'stratawp-seo' ),
+			'url'   => add_query_arg(
+				array(
+					'action' => 'swps_backlink_export',
+					'nonce'  => wp_create_nonce( 'swps_nonce' ),
+				),
+				admin_url( 'admin-ajax.php' )
+			),
+			'class' => 'swps-btn-secondary',
+		),
+	);
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <!-- Stats tiles -->
-    <div class="swps-bl-stats">
-        <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'Total tracked', 'stratawp-seo' ); ?></div>
-            <div class="swps-tile-stat" id="swps-bl-stat-total"><?php echo number_format( (int) $stats['total'] ); ?></div>
-            <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
-                <?php
-                printf(
-                    /* translators: %d: unique referring domains */
-                    esc_html__( '%d unique referring domains', 'stratawp-seo' ),
-                    (int) $stats['unique_domains']
-                );
-                ?>
-            </div>
-        </div>
-        <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'Live', 'stratawp-seo' ); ?></div>
-            <div class="swps-tile-stat" id="swps-bl-stat-live" style="color:#10b981"><?php echo number_format( (int) $stats['live'] ); ?></div>
-            <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
-                <?php
-                printf(
-                    /* translators: %d: count gained in last 30 days */
-                    esc_html__( '+%d in last 30 days', 'stratawp-seo' ),
-                    (int) $stats['new_30d']
-                );
-                ?>
-            </div>
-        </div>
-        <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'Lost', 'stratawp-seo' ); ?></div>
-            <div class="swps-tile-stat" id="swps-bl-stat-lost" style="color:#f59e0b"><?php echo number_format( (int) $stats['lost'] ); ?></div>
-            <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
-                <?php
-                printf(
-                    /* translators: %d: count lost in last 30 days */
-                    esc_html__( '%d lost in last 30 days', 'stratawp-seo' ),
-                    (int) $stats['lost_30d']
-                );
-                ?>
-            </div>
-        </div>
-        <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'Broken', 'stratawp-seo' ); ?></div>
-            <div class="swps-tile-stat" id="swps-bl-stat-broken" style="color:#ef4444"><?php echo number_format( (int) $stats['broken'] ); ?></div>
-            <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
-                <?php esc_html_e( 'Source page returns an error', 'stratawp-seo' ); ?>
-            </div>
-        </div>
-    </div>
+	<!-- Stats tiles -->
+	<div class="swps-bl-stats">
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'Total tracked', 'stratawp-seo' ); ?></div>
+			<div class="swps-tile-stat" id="swps-bl-stat-total"><?php echo number_format( (int) $stats['total'] ); ?></div>
+			<div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+				<?php
+				printf(
+					/* translators: %d: unique referring domains */
+					esc_html__( '%d unique referring domains', 'stratawp-seo' ),
+					(int) $stats['unique_domains']
+				);
+				?>
+			</div>
+		</div>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'Live', 'stratawp-seo' ); ?></div>
+			<div class="swps-tile-stat" id="swps-bl-stat-live" style="color:#10b981"><?php echo number_format( (int) $stats['live'] ); ?></div>
+			<div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+				<?php
+				printf(
+					/* translators: %d: count gained in last 30 days */
+					esc_html__( '+%d in last 30 days', 'stratawp-seo' ),
+					(int) $stats['new_30d']
+				);
+				?>
+			</div>
+		</div>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'Lost', 'stratawp-seo' ); ?></div>
+			<div class="swps-tile-stat" id="swps-bl-stat-lost" style="color:#f59e0b"><?php echo number_format( (int) $stats['lost'] ); ?></div>
+			<div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+				<?php
+				printf(
+					/* translators: %d: count lost in last 30 days */
+					esc_html__( '%d lost in last 30 days', 'stratawp-seo' ),
+					(int) $stats['lost_30d']
+				);
+				?>
+			</div>
+		</div>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'Broken', 'stratawp-seo' ); ?></div>
+			<div class="swps-tile-stat" id="swps-bl-stat-broken" style="color:#ef4444"><?php echo number_format( (int) $stats['broken'] ); ?></div>
+			<div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+				<?php esc_html_e( 'Source page returns an error', 'stratawp-seo' ); ?>
+			</div>
+		</div>
+	</div>
 
-    <!-- Add + import row -->
-    <div class="swps-bl-tools">
-        <div class="swps-card">
-            <h2 style="margin-top:0"><?php esc_html_e( 'Add backlink', 'stratawp-seo' ); ?></h2>
-            <form id="swps-bl-add" class="swps-bl-add-form" autocomplete="off">
-                <label class="swps-bl-field">
-                    <span><?php esc_html_e( 'Source URL', 'stratawp-seo' ); ?></span>
-                    <input type="url" name="source_url" required placeholder="https://example.com/article-linking-to-you" />
-                </label>
-                <label class="swps-bl-field">
-                    <span><?php esc_html_e( 'Target URL on your site', 'stratawp-seo' ); ?> <em><?php esc_html_e( '(optional)', 'stratawp-seo' ); ?></em></span>
-                    <input type="url" name="target_url" placeholder="<?php echo esc_attr( home_url( '/' ) ); ?>" />
-                </label>
-                <label class="swps-bl-field">
-                    <span><?php esc_html_e( 'Anchor text', 'stratawp-seo' ); ?> <em><?php esc_html_e( '(optional)', 'stratawp-seo' ); ?></em></span>
-                    <input type="text" name="anchor_text" />
-                </label>
-                <button type="submit" class="swps-btn swps-btn-grad"><?php esc_html_e( 'Add & verify', 'stratawp-seo' ); ?></button>
-                <span class="swps-bl-add-status" style="margin-left:8px;color:var(--swps-text-muted);font-size:12px"></span>
-            </form>
-        </div>
+	<!-- Add + import row -->
+	<div class="swps-bl-tools">
+		<div class="swps-card">
+			<h2 style="margin-top:0"><?php esc_html_e( 'Add backlink', 'stratawp-seo' ); ?></h2>
+			<form id="swps-bl-add" class="swps-bl-add-form" autocomplete="off">
+				<label class="swps-bl-field">
+					<span><?php esc_html_e( 'Source URL', 'stratawp-seo' ); ?></span>
+					<input type="url" name="source_url" required placeholder="https://example.com/article-linking-to-you" />
+				</label>
+				<label class="swps-bl-field">
+					<span><?php esc_html_e( 'Target URL on your site', 'stratawp-seo' ); ?> <em><?php esc_html_e( '(optional)', 'stratawp-seo' ); ?></em></span>
+					<input type="url" name="target_url" placeholder="<?php echo esc_attr( home_url( '/' ) ); ?>" />
+				</label>
+				<label class="swps-bl-field">
+					<span><?php esc_html_e( 'Anchor text', 'stratawp-seo' ); ?> <em><?php esc_html_e( '(optional)', 'stratawp-seo' ); ?></em></span>
+					<input type="text" name="anchor_text" />
+				</label>
+				<button type="submit" class="swps-btn swps-btn-grad"><?php esc_html_e( 'Add & verify', 'stratawp-seo' ); ?></button>
+				<span class="swps-bl-add-status" style="margin-left:8px;color:var(--swps-text-muted);font-size:12px"></span>
+			</form>
+		</div>
 
-        <div class="swps-card">
-            <h2 style="margin-top:0"><?php esc_html_e( 'Bulk import', 'stratawp-seo' ); ?></h2>
-            <p class="description" style="margin-top:0">
-                <?php esc_html_e( 'Paste rows below: one source URL per line, or a CSV in the format source_url,target_url,anchor_text. The "Top linking sites" CSV export from Google Search Console works directly.', 'stratawp-seo' ); ?>
-            </p>
-            <form id="swps-bl-import">
-                <textarea name="csv" rows="6" class="swps-bl-import-area"
-                          placeholder="https://blog.example.com/post-1&#10;https://news.example.org/page-2"></textarea>
-                <div style="display:flex;align-items:center;gap:10px;margin-top:8px">
-                    <button type="submit" class="swps-btn swps-btn-grad"><?php esc_html_e( 'Import', 'stratawp-seo' ); ?></button>
-                    <span class="swps-bl-import-status" style="color:var(--swps-text-muted);font-size:12px"></span>
-                </div>
-            </form>
-        </div>
-    </div>
+		<div class="swps-card">
+			<h2 style="margin-top:0"><?php esc_html_e( 'Bulk import', 'stratawp-seo' ); ?></h2>
+			<p class="description" style="margin-top:0">
+				<?php esc_html_e( 'Paste rows below: one source URL per line, or a CSV in the format source_url,target_url,anchor_text. The "Top linking sites" CSV export from Google Search Console works directly.', 'stratawp-seo' ); ?>
+			</p>
+			<form id="swps-bl-import">
+				<textarea name="csv" rows="6" class="swps-bl-import-area"
+							placeholder="https://blog.example.com/post-1&#10;https://news.example.org/page-2"></textarea>
+				<div style="display:flex;align-items:center;gap:10px;margin-top:8px">
+					<button type="submit" class="swps-btn swps-btn-grad"><?php esc_html_e( 'Import', 'stratawp-seo' ); ?></button>
+					<span class="swps-bl-import-status" style="color:var(--swps-text-muted);font-size:12px"></span>
+				</div>
+			</form>
+		</div>
+	</div>
 
-    <!-- Table -->
-    <div class="swps-card swps-bl-table-card">
-        <div class="swps-bl-table-head">
-            <h2 style="margin:0;font-size:14px;text-transform:uppercase;letter-spacing:.04em;color:var(--swps-text-muted)">
-                <?php esc_html_e( 'Tracked backlinks', 'stratawp-seo' ); ?>
-            </h2>
-            <div class="swps-bl-progress" id="swps-bl-progress" hidden>
-                <span></span>
-            </div>
-        </div>
+	<!-- Table -->
+	<div class="swps-card swps-bl-table-card">
+		<div class="swps-bl-table-head">
+			<h2 style="margin:0;font-size:14px;text-transform:uppercase;letter-spacing:.04em;color:var(--swps-text-muted)">
+				<?php esc_html_e( 'Tracked backlinks', 'stratawp-seo' ); ?>
+			</h2>
+			<div class="swps-bl-progress" id="swps-bl-progress" hidden>
+				<span></span>
+			</div>
+		</div>
 
-        <?php if ( empty( $rows ) ) : ?>
-            <p style="color:var(--swps-text-muted);font-size:13px;margin:8px 0 0">
-                <?php esc_html_e( 'No backlinks yet. Add one above, or paste a CSV from GSC.', 'stratawp-seo' ); ?>
-            </p>
-        <?php else : ?>
-            <table class="widefat striped swps-bl-table">
-                <thead>
-                    <tr>
-                        <th><?php esc_html_e( 'Status', 'stratawp-seo' ); ?></th>
-                        <th><?php esc_html_e( 'Source', 'stratawp-seo' ); ?></th>
-                        <th><?php esc_html_e( 'Anchor', 'stratawp-seo' ); ?></th>
-                        <th><?php esc_html_e( 'Target', 'stratawp-seo' ); ?></th>
-                        <th><?php esc_html_e( 'First seen', 'stratawp-seo' ); ?></th>
-                        <th><?php esc_html_e( 'Last checked', 'stratawp-seo' ); ?></th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody id="swps-bl-tbody">
-                    <?php foreach ( $rows as $row ) : ?>
-                        <?php $status = (string) $row['status']; ?>
-                        <tr data-id="<?php echo (int) $row['id']; ?>">
-                            <td>
-                                <span class="swps-bl-status is-<?php echo esc_attr( $status ); ?>">
-                                    <?php echo esc_html( ucfirst( $status ) ); ?>
-                                    <?php if ( (int) $row['http_status'] > 0 && in_array( $status, [ 'broken' ], true ) ) : ?>
-                                        <small>(<?php echo (int) $row['http_status']; ?>)</small>
-                                    <?php endif; ?>
-                                </span>
-                            </td>
-                            <td>
-                                <a href="<?php echo esc_url( $row['source_url'] ); ?>" target="_blank" rel="noopener noreferrer">
-                                    <?php echo esc_html( $row['source_host'] ?: $row['source_url'] ); ?>
-                                </a>
-                                <?php if ( ! empty( $row['notes'] ) ) : ?>
-                                    <div style="font-size:11px;color:var(--swps-text-muted);margin-top:2px">
-                                        <?php echo esc_html( $row['notes'] ); ?>
-                                    </div>
-                                <?php endif; ?>
-                            </td>
-                            <td>
-                                <?php if ( ! empty( $row['anchor_text'] ) ) : ?>
-                                    <span style="font-size:12px"><?php echo esc_html( $row['anchor_text'] ); ?></span>
-                                <?php else : ?>
-                                    <span style="color:var(--swps-text-faint);font-size:12px">—</span>
-                                <?php endif; ?>
-                            </td>
-                            <td>
-                                <?php if ( ! empty( $row['target_url'] ) ) : ?>
-                                    <a href="<?php echo esc_url( $row['target_url'] ); ?>" target="_blank" rel="noopener" style="font-size:12px">
-                                        <?php echo esc_html( wp_parse_url( $row['target_url'], PHP_URL_PATH ) ?: $row['target_url'] ); ?>
-                                    </a>
-                                <?php else : ?>
-                                    <span style="color:var(--swps-text-faint);font-size:12px">—</span>
-                                <?php endif; ?>
-                            </td>
-                            <td style="font-size:12px;color:var(--swps-text-muted)">
-                                <?php echo $row['first_seen'] ? esc_html( mysql2date( 'Y-m-d', $row['first_seen'] ) ) : '—'; ?>
-                            </td>
-                            <td style="font-size:12px;color:var(--swps-text-muted)">
-                                <?php echo $row['last_checked'] ? esc_html( human_time_diff( strtotime( $row['last_checked'] ) ) . ' ago' ) : esc_html__( 'never', 'stratawp-seo' ); ?>
-                            </td>
-                            <td style="text-align:right;white-space:nowrap">
-                                <button type="button" class="button-link swps-bl-verify" title="<?php esc_attr_e( 'Re-verify now', 'stratawp-seo' ); ?>">⟳</button>
-                                <button type="button" class="button-link swps-bl-delete" title="<?php esc_attr_e( 'Delete', 'stratawp-seo' ); ?>" style="color:#ef4444">✕</button>
-                            </td>
-                        </tr>
-                    <?php endforeach; ?>
-                </tbody>
-            </table>
-        <?php endif; ?>
-    </div>
+		<?php if ( empty( $rows ) ) : ?>
+			<p style="color:var(--swps-text-muted);font-size:13px;margin:8px 0 0">
+				<?php esc_html_e( 'No backlinks yet. Add one above, or paste a CSV from GSC.', 'stratawp-seo' ); ?>
+			</p>
+		<?php else : ?>
+			<table class="widefat striped swps-bl-table">
+				<thead>
+					<tr>
+						<th><?php esc_html_e( 'Status', 'stratawp-seo' ); ?></th>
+						<th><?php esc_html_e( 'Source', 'stratawp-seo' ); ?></th>
+						<th><?php esc_html_e( 'Anchor', 'stratawp-seo' ); ?></th>
+						<th><?php esc_html_e( 'Target', 'stratawp-seo' ); ?></th>
+						<th><?php esc_html_e( 'First seen', 'stratawp-seo' ); ?></th>
+						<th><?php esc_html_e( 'Last checked', 'stratawp-seo' ); ?></th>
+						<th></th>
+					</tr>
+				</thead>
+				<tbody id="swps-bl-tbody">
+					<?php foreach ( $rows as $row ) : ?>
+						<?php $status = (string) $row['status']; ?>
+						<tr data-id="<?php echo (int) $row['id']; ?>">
+							<td>
+								<span class="swps-bl-status is-<?php echo esc_attr( $status ); ?>">
+									<?php echo esc_html( ucfirst( $status ) ); ?>
+									<?php if ( (int) $row['http_status'] > 0 && in_array( $status, array( 'broken' ), true ) ) : ?>
+										<small>(<?php echo (int) $row['http_status']; ?>)</small>
+									<?php endif; ?>
+								</span>
+							</td>
+							<td>
+								<a href="<?php echo esc_url( $row['source_url'] ); ?>" target="_blank" rel="noopener noreferrer">
+									<?php echo esc_html( $row['source_host'] ?: $row['source_url'] ); ?>
+								</a>
+								<?php if ( ! empty( $row['notes'] ) ) : ?>
+									<div style="font-size:11px;color:var(--swps-text-muted);margin-top:2px">
+										<?php echo esc_html( $row['notes'] ); ?>
+									</div>
+								<?php endif; ?>
+							</td>
+							<td>
+								<?php if ( ! empty( $row['anchor_text'] ) ) : ?>
+									<span style="font-size:12px"><?php echo esc_html( $row['anchor_text'] ); ?></span>
+								<?php else : ?>
+									<span style="color:var(--swps-text-faint);font-size:12px">—</span>
+								<?php endif; ?>
+							</td>
+							<td>
+								<?php if ( ! empty( $row['target_url'] ) ) : ?>
+									<a href="<?php echo esc_url( $row['target_url'] ); ?>" target="_blank" rel="noopener" style="font-size:12px">
+										<?php echo esc_html( wp_parse_url( $row['target_url'], PHP_URL_PATH ) ?: $row['target_url'] ); ?>
+									</a>
+								<?php else : ?>
+									<span style="color:var(--swps-text-faint);font-size:12px">—</span>
+								<?php endif; ?>
+							</td>
+							<td style="font-size:12px;color:var(--swps-text-muted)">
+								<?php echo $row['first_seen'] ? esc_html( mysql2date( 'Y-m-d', $row['first_seen'] ) ) : '—'; ?>
+							</td>
+							<td style="font-size:12px;color:var(--swps-text-muted)">
+								<?php echo $row['last_checked'] ? esc_html( human_time_diff( strtotime( $row['last_checked'] ) ) . ' ago' ) : esc_html__( 'never', 'stratawp-seo' ); ?>
+							</td>
+							<td style="text-align:right;white-space:nowrap">
+								<button type="button" class="button-link swps-bl-verify" title="<?php esc_attr_e( 'Re-verify now', 'stratawp-seo' ); ?>">⟳</button>
+								<button type="button" class="button-link swps-bl-delete" title="<?php esc_attr_e( 'Delete', 'stratawp-seo' ); ?>" style="color:#ef4444">✕</button>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+		<?php endif; ?>
+	</div>
 </div>

--- a/templates/calendar-page.php
+++ b/templates/calendar-page.php
@@ -6,111 +6,111 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 ?>
 <div class="wrap swps-calendar-wrap">
 
-    <?php
-    $title    = __( 'Content Calendar', 'stratawp-seo' );
-    $subtitle = __( 'Plan your content schedule — click any date to add a topic.', 'stratawp-seo' );
-    $actions  = [];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'Content Calendar', 'stratawp-seo' );
+	$subtitle = __( 'Plan your content schedule — click any date to add a topic.', 'stratawp-seo' );
+	$actions  = array();
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <div id="swps-calendar"></div>
+	<div id="swps-calendar"></div>
 
-    <div class="swps-calendar-legend">
-        <div class="swps-legend-item">
-            <span class="swps-legend-dot swps-legend-queued"></span>
-            <?php esc_html_e( 'Queued', 'stratawp-seo' ); ?>
-        </div>
-        <div class="swps-legend-item">
-            <span class="swps-legend-dot swps-legend-generating"></span>
-            <?php esc_html_e( 'Generating', 'stratawp-seo' ); ?>
-        </div>
-        <div class="swps-legend-item">
-            <span class="swps-legend-dot swps-legend-published"></span>
-            <?php esc_html_e( 'AI Published', 'stratawp-seo' ); ?>
-        </div>
-        <div class="swps-legend-item">
-            <span class="swps-legend-dot swps-legend-failed"></span>
-            <?php esc_html_e( 'Failed', 'stratawp-seo' ); ?>
-        </div>
-        <div class="swps-legend-item">
-            <span class="swps-legend-dot swps-legend-existing"></span>
-            <?php esc_html_e( 'Existing Post', 'stratawp-seo' ); ?>
-        </div>
-    </div>
+	<div class="swps-calendar-legend">
+		<div class="swps-legend-item">
+			<span class="swps-legend-dot swps-legend-queued"></span>
+			<?php esc_html_e( 'Queued', 'stratawp-seo' ); ?>
+		</div>
+		<div class="swps-legend-item">
+			<span class="swps-legend-dot swps-legend-generating"></span>
+			<?php esc_html_e( 'Generating', 'stratawp-seo' ); ?>
+		</div>
+		<div class="swps-legend-item">
+			<span class="swps-legend-dot swps-legend-published"></span>
+			<?php esc_html_e( 'AI Published', 'stratawp-seo' ); ?>
+		</div>
+		<div class="swps-legend-item">
+			<span class="swps-legend-dot swps-legend-failed"></span>
+			<?php esc_html_e( 'Failed', 'stratawp-seo' ); ?>
+		</div>
+		<div class="swps-legend-item">
+			<span class="swps-legend-dot swps-legend-existing"></span>
+			<?php esc_html_e( 'Existing Post', 'stratawp-seo' ); ?>
+		</div>
+	</div>
 </div>
 
 <!-- Create Topic Modal -->
 <div id="swps-create-modal" class="swps-modal">
-    <div class="swps-modal-overlay"></div>
-    <div class="swps-modal-content">
-        <button class="swps-modal-close" type="button">&times;</button>
-        <h2><?php esc_html_e( 'Add Topic to Queue', 'stratawp-seo' ); ?></h2>
+	<div class="swps-modal-overlay"></div>
+	<div class="swps-modal-content">
+		<button class="swps-modal-close" type="button">&times;</button>
+		<h2><?php esc_html_e( 'Add Topic to Queue', 'stratawp-seo' ); ?></h2>
 
-        <form id="swps-topic-create-form">
-            <div class="swps-form-group">
-                <label for="swps-topic-title"><?php esc_html_e( 'Topic / Headline', 'stratawp-seo' ); ?></label>
-                <input type="text" id="swps-topic-title" placeholder="<?php esc_attr_e( 'e.g., 10 Best WordPress Security Plugins', 'stratawp-seo' ); ?>" required />
-            </div>
+		<form id="swps-topic-create-form">
+			<div class="swps-form-group">
+				<label for="swps-topic-title"><?php esc_html_e( 'Topic / Headline', 'stratawp-seo' ); ?></label>
+				<input type="text" id="swps-topic-title" placeholder="<?php esc_attr_e( 'e.g., 10 Best WordPress Security Plugins', 'stratawp-seo' ); ?>" required />
+			</div>
 
-            <div class="swps-form-group">
-                <label for="swps-topic-date"><?php esc_html_e( 'Scheduled Date', 'stratawp-seo' ); ?></label>
-                <input type="date" id="swps-topic-date" />
-            </div>
+			<div class="swps-form-group">
+				<label for="swps-topic-date"><?php esc_html_e( 'Scheduled Date', 'stratawp-seo' ); ?></label>
+				<input type="date" id="swps-topic-date" />
+			</div>
 
-            <div class="swps-form-group">
-                <label for="swps-topic-template"><?php esc_html_e( 'Content Template', 'stratawp-seo' ); ?></label>
-                <select id="swps-topic-template">
-                    <?php foreach ( SWPS_Templates::get_options() as $slug => $name ) : ?>
-                        <option value="<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $name ); ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </div>
+			<div class="swps-form-group">
+				<label for="swps-topic-template"><?php esc_html_e( 'Content Template', 'stratawp-seo' ); ?></label>
+				<select id="swps-topic-template">
+					<?php foreach ( SWPS_Templates::get_options() as $slug => $name ) : ?>
+						<option value="<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $name ); ?></option>
+					<?php endforeach; ?>
+				</select>
+			</div>
 
-            <div class="swps-form-group">
-                <label for="swps-topic-notes"><?php esc_html_e( 'Notes (optional)', 'stratawp-seo' ); ?></label>
-                <textarea id="swps-topic-notes" rows="3" placeholder="<?php esc_attr_e( 'Any specific instructions for this topic...', 'stratawp-seo' ); ?>"></textarea>
-            </div>
+			<div class="swps-form-group">
+				<label for="swps-topic-notes"><?php esc_html_e( 'Notes (optional)', 'stratawp-seo' ); ?></label>
+				<textarea id="swps-topic-notes" rows="3" placeholder="<?php esc_attr_e( 'Any specific instructions for this topic...', 'stratawp-seo' ); ?>"></textarea>
+			</div>
 
-            <button type="submit" class="swps-btn swps-btn-grad"><?php esc_html_e( 'Add to Queue', 'stratawp-seo' ); ?></button>
-        </form>
-    </div>
+			<button type="submit" class="swps-btn swps-btn-grad"><?php esc_html_e( 'Add to Queue', 'stratawp-seo' ); ?></button>
+		</form>
+	</div>
 </div>
 
 <!-- Topic Detail Modal -->
 <div id="swps-detail-modal" class="swps-modal">
-    <div class="swps-modal-overlay"></div>
-    <div class="swps-modal-content">
-        <button class="swps-modal-close" type="button">&times;</button>
-        <h2 id="swps-detail-title"></h2>
+	<div class="swps-modal-overlay"></div>
+	<div class="swps-modal-content">
+		<button class="swps-modal-close" type="button">&times;</button>
+		<h2 id="swps-detail-title"></h2>
 
-        <table class="swps-detail-table">
-            <tr>
-                <td><?php esc_html_e( 'Date:', 'stratawp-seo' ); ?></td>
-                <td id="swps-detail-date"></td>
-            </tr>
-            <tr>
-                <td><?php esc_html_e( 'Status:', 'stratawp-seo' ); ?></td>
-                <td id="swps-detail-status"></td>
-            </tr>
-            <tr>
-                <td><?php esc_html_e( 'Template:', 'stratawp-seo' ); ?></td>
-                <td id="swps-detail-template"></td>
-            </tr>
-            <tr>
-                <td><?php esc_html_e( 'Notes:', 'stratawp-seo' ); ?></td>
-                <td id="swps-detail-notes"></td>
-            </tr>
-        </table>
+		<table class="swps-detail-table">
+			<tr>
+				<td><?php esc_html_e( 'Date:', 'stratawp-seo' ); ?></td>
+				<td id="swps-detail-date"></td>
+			</tr>
+			<tr>
+				<td><?php esc_html_e( 'Status:', 'stratawp-seo' ); ?></td>
+				<td id="swps-detail-status"></td>
+			</tr>
+			<tr>
+				<td><?php esc_html_e( 'Template:', 'stratawp-seo' ); ?></td>
+				<td id="swps-detail-template"></td>
+			</tr>
+			<tr>
+				<td><?php esc_html_e( 'Notes:', 'stratawp-seo' ); ?></td>
+				<td id="swps-detail-notes"></td>
+			</tr>
+		</table>
 
-        <div class="swps-modal-actions">
-            <button type="button" id="swps-topic-delete" class="swps-btn swps-btn-secondary" data-topic-id="" style="color:var(--swps-crit);border-color:var(--swps-crit)">
-                <?php esc_html_e( 'Delete Topic', 'stratawp-seo' ); ?>
-            </button>
-        </div>
-    </div>
+		<div class="swps-modal-actions">
+			<button type="button" id="swps-topic-delete" class="swps-btn swps-btn-secondary" data-topic-id="" style="color:var(--swps-crit);border-color:var(--swps-crit)">
+				<?php esc_html_e( 'Delete Topic', 'stratawp-seo' ); ?>
+			</button>
+		</div>
+	</div>
 </div>

--- a/templates/competitors-page.php
+++ b/templates/competitors-page.php
@@ -11,7 +11,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /** @var SWPS_Competitors $competitors */
@@ -27,228 +27,237 @@ $summary     = $competitors->get_summary( $list );
  * `if (! function_exists(...))` block before that block executes is a fatal.
  */
 if ( ! function_exists( 'swps_render_competitor_row' ) ) {
-    function swps_render_competitor_row( array $c, array $diff ): void {
-        $has_data    = ! empty( $diff['has_data'] );
-        $err         = (string) ( $c['last_error'] ?? '' );
-        $has_error   = '' !== $err;
-        $is_warning  = $has_error && $has_data; // partial scan (homepage worked, no feed/sitemap)
-        $is_critical = $has_error && ! $has_data;
+	function swps_render_competitor_row( array $c, array $diff ): void {
+		$has_data    = ! empty( $diff['has_data'] );
+		$err         = (string) ( $c['last_error'] ?? '' );
+		$has_error   = '' !== $err;
+		$is_warning  = $has_error && $has_data; // partial scan (homepage worked, no feed/sitemap)
+		$is_critical = $has_error && ! $has_data;
 
-        if ( $is_critical ) {
-            $dot_class = 'swps-status-dot-crit';
-            $dot_glyph = '!';
-        } elseif ( $is_warning ) {
-            $dot_class = 'swps-status-dot-warn';
-            $dot_glyph = '!';
-        } else {
-            $dot_class = 'swps-status-dot-ok';
-            $dot_glyph = '✓';
-        }
+		if ( $is_critical ) {
+			$dot_class = 'swps-status-dot-crit';
+			$dot_glyph = '!';
+		} elseif ( $is_warning ) {
+			$dot_class = 'swps-status-dot-warn';
+			$dot_glyph = '!';
+		} else {
+			$dot_class = 'swps-status-dot-ok';
+			$dot_glyph = '✓';
+		}
 
-        $velocity     = (float)  ( $diff['velocity_per_week']  ?? 0 );
-        $new_posts    = (int)    ( $diff['new_post_count']     ?? 0 );
-        $new_schemas  = (array)  ( $diff['new_schema_types']   ?? [] );
-        $title_chg    = ! empty( $diff['homepage_title_changed'] );
-        $h1_chg       = ! empty( $diff['homepage_h1_changed']    );
-        $latest_snap  = ! empty( $c['snapshots'] ) ? end( $c['snapshots'] ) : null;
-        $schemas_now  = is_array( $latest_snap ) ? (array) ( $latest_snap['schema_types'] ?? [] ) : [];
-        $last_scanned = (string) ( $c['last_scanned'] ?? '' );
-        $source       = (string) ( $c['data_source']  ?? '' );
-        ?>
-        <div class="swps-row-card swps-comp-row"
-             data-id="<?php echo esc_attr( $c['id'] ); ?>"
-             data-url="<?php echo esc_attr( $c['url'] ); ?>"
-             data-label="<?php echo esc_attr( $c['label'] ); ?>">
-            <div class="swps-row-head">
-                <div class="swps-status-dot <?php echo esc_attr( $dot_class ); ?>"><?php echo esc_html( $dot_glyph ); ?></div>
-                <div>
-                    <div class="swps-row-head-name">
-                        <a href="<?php echo esc_url( $c['url'] ); ?>" target="_blank" rel="noopener">
-                            <?php echo esc_html( $c['label'] ); ?>
-                        </a>
-                        <?php if ( '' !== $source && 'none' !== $source ) : ?>
-                            <span class="swps-comp-source-pill"><?php echo esc_html( strtoupper( $source ) ); ?></span>
-                        <?php endif; ?>
-                    </div>
-                    <div class="swps-row-head-msg">
-                        <?php echo esc_html( wp_parse_url( $c['url'], PHP_URL_HOST ) ?: $c['url'] ); ?>
-                        <?php if ( '' !== $last_scanned ) : ?>
-                            &middot; <?php
-                            printf(
-                                /* translators: %s: time-ago */
-                                esc_html__( 'scanned %s ago', 'stratawp-seo' ),
-                                esc_html( human_time_diff( strtotime( $last_scanned ), current_time( 'timestamp' ) ) )
-                            );
-                            ?>
-                        <?php else : ?>
-                            &middot; <?php esc_html_e( 'never scanned', 'stratawp-seo' ); ?>
-                        <?php endif; ?>
-                        <?php if ( $has_error ) : ?>
-                            &middot; <span class="swps-comp-err"><?php echo esc_html( $err ); ?></span>
-                        <?php endif; ?>
-                    </div>
-                </div>
-                <div class="swps-row-head-meta">
-                    <div class="swps-comp-stats">
-                        <?php if ( $has_data ) : ?>
-                            <?php if ( $new_posts > 0 ) : ?>
-                                <button type="button" class="swps-comp-newposts swps-comp-newposts--has" data-toggle-newposts>
-                                    +<?php echo (int) $new_posts; ?> <?php esc_html_e( 'new', 'stratawp-seo' ); ?>
-                                </button>
-                            <?php else : ?>
-                                <span class="swps-comp-newposts">0 <?php esc_html_e( 'new', 'stratawp-seo' ); ?></span>
-                            <?php endif; ?>
-                            <span class="swps-comp-velocity">
-                                <?php echo esc_html( number_format_i18n( $velocity, 1 ) ); ?>
-                                <span class="swps-comp-velocity-unit"><?php esc_html_e( '/wk', 'stratawp-seo' ); ?></span>
-                            </span>
-                        <?php endif; ?>
-                    </div>
-                    <button class="swps-btn swps-btn-grad swps-comp-scan" style="padding:6px 12px;font-size:11px"><?php esc_html_e( 'Scan now', 'stratawp-seo' ); ?></button>
-                    <button class="swps-btn swps-btn-secondary swps-comp-edit" title="<?php esc_attr_e( 'Edit', 'stratawp-seo' ); ?>" style="padding:6px 10px;font-size:11px">
-                        <span class="dashicons dashicons-edit"></span>
-                    </button>
-                    <button class="swps-btn swps-btn-secondary swps-comp-delete" title="<?php esc_attr_e( 'Delete', 'stratawp-seo' ); ?>" style="padding:6px 10px;font-size:11px">
-                        <span class="dashicons dashicons-trash"></span>
-                    </button>
-                </div>
-            </div>
+		$velocity     = (float) ( $diff['velocity_per_week'] ?? 0 );
+		$new_posts    = (int) ( $diff['new_post_count'] ?? 0 );
+		$new_schemas  = (array) ( $diff['new_schema_types'] ?? array() );
+		$title_chg    = ! empty( $diff['homepage_title_changed'] );
+		$h1_chg       = ! empty( $diff['homepage_h1_changed'] );
+		$latest_snap  = ! empty( $c['snapshots'] ) ? end( $c['snapshots'] ) : null;
+		$schemas_now  = is_array( $latest_snap ) ? (array) ( $latest_snap['schema_types'] ?? array() ) : array();
+		$last_scanned = (string) ( $c['last_scanned'] ?? '' );
+		$source       = (string) ( $c['data_source'] ?? '' );
+		?>
+		<div class="swps-row-card swps-comp-row"
+			data-id="<?php echo esc_attr( $c['id'] ); ?>"
+			data-url="<?php echo esc_attr( $c['url'] ); ?>"
+			data-label="<?php echo esc_attr( $c['label'] ); ?>">
+			<div class="swps-row-head">
+				<div class="swps-status-dot <?php echo esc_attr( $dot_class ); ?>"><?php echo esc_html( $dot_glyph ); ?></div>
+				<div>
+					<div class="swps-row-head-name">
+						<a href="<?php echo esc_url( $c['url'] ); ?>" target="_blank" rel="noopener">
+							<?php echo esc_html( $c['label'] ); ?>
+						</a>
+						<?php if ( '' !== $source && 'none' !== $source ) : ?>
+							<span class="swps-comp-source-pill"><?php echo esc_html( strtoupper( $source ) ); ?></span>
+						<?php endif; ?>
+					</div>
+					<div class="swps-row-head-msg">
+						<?php echo esc_html( wp_parse_url( $c['url'], PHP_URL_HOST ) ?: $c['url'] ); ?>
+						<?php if ( '' !== $last_scanned ) : ?>
+							&middot; 
+							<?php
+							printf(
+								/* translators: %s: time-ago */
+								esc_html__( 'scanned %s ago', 'stratawp-seo' ),
+								esc_html( human_time_diff( strtotime( $last_scanned ), current_time( 'timestamp' ) ) )
+							);
+							?>
+						<?php else : ?>
+							&middot; <?php esc_html_e( 'never scanned', 'stratawp-seo' ); ?>
+						<?php endif; ?>
+						<?php if ( $has_error ) : ?>
+							&middot; <span class="swps-comp-err"><?php echo esc_html( $err ); ?></span>
+						<?php endif; ?>
+					</div>
+				</div>
+				<div class="swps-row-head-meta">
+					<div class="swps-comp-stats">
+						<?php if ( $has_data ) : ?>
+							<?php if ( $new_posts > 0 ) : ?>
+								<button type="button" class="swps-comp-newposts swps-comp-newposts--has" data-toggle-newposts>
+									+<?php echo (int) $new_posts; ?> <?php esc_html_e( 'new', 'stratawp-seo' ); ?>
+								</button>
+							<?php else : ?>
+								<span class="swps-comp-newposts">0 <?php esc_html_e( 'new', 'stratawp-seo' ); ?></span>
+							<?php endif; ?>
+							<span class="swps-comp-velocity">
+								<?php echo esc_html( number_format_i18n( $velocity, 1 ) ); ?>
+								<span class="swps-comp-velocity-unit"><?php esc_html_e( '/wk', 'stratawp-seo' ); ?></span>
+							</span>
+						<?php endif; ?>
+					</div>
+					<button class="swps-btn swps-btn-grad swps-comp-scan" style="padding:6px 12px;font-size:11px"><?php esc_html_e( 'Scan now', 'stratawp-seo' ); ?></button>
+					<button class="swps-btn swps-btn-secondary swps-comp-edit" title="<?php esc_attr_e( 'Edit', 'stratawp-seo' ); ?>" style="padding:6px 10px;font-size:11px">
+						<span class="dashicons dashicons-edit"></span>
+					</button>
+					<button class="swps-btn swps-btn-secondary swps-comp-delete" title="<?php esc_attr_e( 'Delete', 'stratawp-seo' ); ?>" style="padding:6px 10px;font-size:11px">
+						<span class="dashicons dashicons-trash"></span>
+					</button>
+				</div>
+			</div>
 
-            <?php if ( $has_data && ( ! empty( $schemas_now ) || ! empty( $new_schemas ) || $title_chg || $h1_chg ) ) : ?>
-                <div class="swps-comp-row-body">
-                    <?php if ( ! empty( $schemas_now ) || ! empty( $new_schemas ) ) : ?>
-                        <div class="swps-comp-schema-row">
-                            <span class="swps-comp-schema-label"><?php esc_html_e( 'Schema:', 'stratawp-seo' ); ?></span>
-                            <?php foreach ( $schemas_now as $type ) : ?>
-                                <?php $is_new = in_array( $type, $new_schemas, true ); ?>
-                                <span class="swps-comp-schema-chip<?php echo $is_new ? ' is-new' : ''; ?>">
-                                    <?php echo esc_html( $type ); ?>
-                                </span>
-                            <?php endforeach; ?>
-                        </div>
-                    <?php endif; ?>
-                    <?php if ( $title_chg || $h1_chg ) : ?>
-                        <div class="swps-comp-changes">
-                            <?php if ( $title_chg ) : ?>
-                                <span class="swps-comp-change-pill">
-                                    <span class="dashicons dashicons-edit-page"></span>
-                                    <?php esc_html_e( 'Title changed', 'stratawp-seo' ); ?>
-                                </span>
-                            <?php endif; ?>
-                            <?php if ( $h1_chg ) : ?>
-                                <span class="swps-comp-change-pill">
-                                    <span class="dashicons dashicons-heading"></span>
-                                    <?php esc_html_e( 'H1 changed', 'stratawp-seo' ); ?>
-                                </span>
-                            <?php endif; ?>
-                        </div>
-                    <?php endif; ?>
-                </div>
-            <?php endif; ?>
+			<?php if ( $has_data && ( ! empty( $schemas_now ) || ! empty( $new_schemas ) || $title_chg || $h1_chg ) ) : ?>
+				<div class="swps-comp-row-body">
+					<?php if ( ! empty( $schemas_now ) || ! empty( $new_schemas ) ) : ?>
+						<div class="swps-comp-schema-row">
+							<span class="swps-comp-schema-label"><?php esc_html_e( 'Schema:', 'stratawp-seo' ); ?></span>
+							<?php foreach ( $schemas_now as $type ) : ?>
+								<?php $is_new = in_array( $type, $new_schemas, true ); ?>
+								<span class="swps-comp-schema-chip<?php echo $is_new ? ' is-new' : ''; ?>">
+									<?php echo esc_html( $type ); ?>
+								</span>
+							<?php endforeach; ?>
+						</div>
+					<?php endif; ?>
+					<?php if ( $title_chg || $h1_chg ) : ?>
+						<div class="swps-comp-changes">
+							<?php if ( $title_chg ) : ?>
+								<span class="swps-comp-change-pill">
+									<span class="dashicons dashicons-edit-page"></span>
+									<?php esc_html_e( 'Title changed', 'stratawp-seo' ); ?>
+								</span>
+							<?php endif; ?>
+							<?php if ( $h1_chg ) : ?>
+								<span class="swps-comp-change-pill">
+									<span class="dashicons dashicons-heading"></span>
+									<?php esc_html_e( 'H1 changed', 'stratawp-seo' ); ?>
+								</span>
+							<?php endif; ?>
+						</div>
+					<?php endif; ?>
+				</div>
+			<?php endif; ?>
 
-            <?php if ( $has_data && $new_posts > 0 ) : ?>
-                <div class="swps-comp-newposts-list" style="display:none;">
-                    <div class="swps-comp-newposts-h"><?php esc_html_e( 'New posts since last scan', 'stratawp-seo' ); ?></div>
-                    <ul>
-                        <?php foreach ( $diff['new_posts'] as $post ) : ?>
-                            <li>
-                                <a href="<?php echo esc_url( $post['url'] ); ?>" target="_blank" rel="noopener">
-                                    <?php echo esc_html( $post['title'] !== '' ? $post['title'] : $post['url'] ); ?>
-                                </a>
-                                <?php if ( ! empty( $post['date'] ) ) : ?>
-                                    <span class="swps-comp-newposts-date"><?php echo esc_html( $post['date'] ); ?></span>
-                                <?php endif; ?>
-                            </li>
-                        <?php endforeach; ?>
-                    </ul>
-                </div>
-            <?php endif; ?>
-        </div>
-        <?php
-    }
+			<?php if ( $has_data && $new_posts > 0 ) : ?>
+				<div class="swps-comp-newposts-list" style="display:none;">
+					<div class="swps-comp-newposts-h"><?php esc_html_e( 'New posts since last scan', 'stratawp-seo' ); ?></div>
+					<ul>
+						<?php foreach ( $diff['new_posts'] as $post ) : ?>
+							<li>
+								<a href="<?php echo esc_url( $post['url'] ); ?>" target="_blank" rel="noopener">
+									<?php echo esc_html( $post['title'] !== '' ? $post['title'] : $post['url'] ); ?>
+								</a>
+								<?php if ( ! empty( $post['date'] ) ) : ?>
+									<span class="swps-comp-newposts-date"><?php echo esc_html( $post['date'] ); ?></span>
+								<?php endif; ?>
+							</li>
+						<?php endforeach; ?>
+					</ul>
+				</div>
+			<?php endif; ?>
+		</div>
+		<?php
+	}
 }
 ?>
 <div class="wrap swps-competitors-wrap">
 
-    <?php
-    $title    = __( 'Competitors', 'stratawp-seo' );
-    $subtitle = __( 'Track competitor sites — content velocity, schema diff, and homepage changes. Daily auto-scan, with manual refresh per row.', 'stratawp-seo' );
-    $actions  = [
-        [ 'label' => __( 'Scan all', 'stratawp-seo' ),       'class' => 'swps-btn-secondary', 'attrs' => 'id="swps-comp-scan-all"' ],
-        [ 'label' => __( 'Add competitor', 'stratawp-seo' ), 'class' => 'swps-btn-grad',      'attrs' => 'id="swps-comp-add-toggle"' ],
-    ];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'Competitors', 'stratawp-seo' );
+	$subtitle = __( 'Track competitor sites — content velocity, schema diff, and homepage changes. Daily auto-scan, with manual refresh per row.', 'stratawp-seo' );
+	$actions  = array(
+		array(
+			'label' => __( 'Scan all', 'stratawp-seo' ),
+			'class' => 'swps-btn-secondary',
+			'attrs' => 'id="swps-comp-scan-all"',
+		),
+		array(
+			'label' => __( 'Add competitor', 'stratawp-seo' ),
+			'class' => 'swps-btn-grad',
+			'attrs' => 'id="swps-comp-add-toggle"',
+		),
+	);
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <div class="swps-summary-tiles">
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Tracking', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-grad" id="swps-comp-tile-count"><?php echo (int) $summary['count']; ?></div>
-            <div class="swps-summary-tile-foot">
-                <?php
-                printf(
-                    /* translators: %d: max */
-                    esc_html__( 'of %d max', 'stratawp-seo' ),
-                    (int) SWPS_Competitors::MAX_COMPETITORS
-                );
-                ?>
-            </div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'New posts', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-ok" id="swps-comp-tile-newposts"><?php echo (int) $summary['new_posts_week']; ?></div>
-            <div class="swps-summary-tile-foot"><?php esc_html_e( 'since previous scan', 'stratawp-seo' ); ?></div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Changes detected', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-warn" id="swps-comp-tile-changes"><?php echo (int) $summary['changes']; ?></div>
-            <div class="swps-summary-tile-foot"><?php esc_html_e( 'schema, title, H1', 'stratawp-seo' ); ?></div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Last scan', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num" id="swps-comp-tile-lastscan" style="font-size:18px;font-weight:600">
-                <?php echo $summary['latest_scan'] !== '' ? esc_html( human_time_diff( strtotime( $summary['latest_scan'] ), current_time( 'timestamp' ) ) . ' ago' ) : esc_html__( 'never', 'stratawp-seo' ); ?>
-            </div>
-            <div class="swps-summary-tile-foot"><?php esc_html_e( 'auto-runs daily', 'stratawp-seo' ); ?></div>
-        </div>
-    </div>
+	<div class="swps-summary-tiles">
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Tracking', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad" id="swps-comp-tile-count"><?php echo (int) $summary['count']; ?></div>
+			<div class="swps-summary-tile-foot">
+				<?php
+				printf(
+					/* translators: %d: max */
+					esc_html__( 'of %d max', 'stratawp-seo' ),
+					(int) SWPS_Competitors::MAX_COMPETITORS
+				);
+				?>
+			</div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'New posts', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-ok" id="swps-comp-tile-newposts"><?php echo (int) $summary['new_posts_week']; ?></div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'since previous scan', 'stratawp-seo' ); ?></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Changes detected', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-warn" id="swps-comp-tile-changes"><?php echo (int) $summary['changes']; ?></div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'schema, title, H1', 'stratawp-seo' ); ?></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Last scan', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num" id="swps-comp-tile-lastscan" style="font-size:18px;font-weight:600">
+				<?php echo $summary['latest_scan'] !== '' ? esc_html( human_time_diff( strtotime( $summary['latest_scan'] ), current_time( 'timestamp' ) ) . ' ago' ) : esc_html__( 'never', 'stratawp-seo' ); ?>
+			</div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'auto-runs daily', 'stratawp-seo' ); ?></div>
+		</div>
+	</div>
 
-    <!-- Add / edit form (toggle) -->
-    <div class="swps-row-card swps-comp-form" id="swps-comp-form" style="display:none;">
-        <div class="swps-comp-form-row">
-            <input type="hidden" id="swps-comp-form-id" value="" />
-            <div class="swps-comp-form-field">
-                <label for="swps-comp-form-url"><strong><?php esc_html_e( 'Competitor URL', 'stratawp-seo' ); ?></strong></label>
-                <input type="url" id="swps-comp-form-url" placeholder="https://competitor.com" />
-            </div>
-            <div class="swps-comp-form-field">
-                <label for="swps-comp-form-label"><strong><?php esc_html_e( 'Label', 'stratawp-seo' ); ?></strong></label>
-                <input type="text" id="swps-comp-form-label" placeholder="<?php esc_attr_e( 'Optional — defaults to domain', 'stratawp-seo' ); ?>" />
-            </div>
-            <div class="swps-comp-form-actions">
-                <button type="button" class="swps-btn swps-btn-secondary" id="swps-comp-form-cancel"><?php esc_html_e( 'Cancel', 'stratawp-seo' ); ?></button>
-                <button type="button" class="swps-btn swps-btn-grad"     id="swps-comp-form-save"><?php esc_html_e( 'Save', 'stratawp-seo' ); ?></button>
-            </div>
-        </div>
-        <div class="swps-comp-progress" id="swps-comp-progress" style="display:none;">
-            <span class="spinner is-active" style="float:none;margin:0 8px 0 0;"></span>
-            <span id="swps-comp-progress-text"><?php esc_html_e( 'Working...', 'stratawp-seo' ); ?></span>
-        </div>
-    </div>
+	<!-- Add / edit form (toggle) -->
+	<div class="swps-row-card swps-comp-form" id="swps-comp-form" style="display:none;">
+		<div class="swps-comp-form-row">
+			<input type="hidden" id="swps-comp-form-id" value="" />
+			<div class="swps-comp-form-field">
+				<label for="swps-comp-form-url"><strong><?php esc_html_e( 'Competitor URL', 'stratawp-seo' ); ?></strong></label>
+				<input type="url" id="swps-comp-form-url" placeholder="https://competitor.com" />
+			</div>
+			<div class="swps-comp-form-field">
+				<label for="swps-comp-form-label"><strong><?php esc_html_e( 'Label', 'stratawp-seo' ); ?></strong></label>
+				<input type="text" id="swps-comp-form-label" placeholder="<?php esc_attr_e( 'Optional — defaults to domain', 'stratawp-seo' ); ?>" />
+			</div>
+			<div class="swps-comp-form-actions">
+				<button type="button" class="swps-btn swps-btn-secondary" id="swps-comp-form-cancel"><?php esc_html_e( 'Cancel', 'stratawp-seo' ); ?></button>
+				<button type="button" class="swps-btn swps-btn-grad"     id="swps-comp-form-save"><?php esc_html_e( 'Save', 'stratawp-seo' ); ?></button>
+			</div>
+		</div>
+		<div class="swps-comp-progress" id="swps-comp-progress" style="display:none;">
+			<span class="spinner is-active" style="float:none;margin:0 8px 0 0;"></span>
+			<span id="swps-comp-progress-text"><?php esc_html_e( 'Working...', 'stratawp-seo' ); ?></span>
+		</div>
+	</div>
 
-    <div class="swps-section-h">
-        <h3><?php esc_html_e( 'Tracked competitors', 'stratawp-seo' ); ?></h3>
-    </div>
+	<div class="swps-section-h">
+		<h3><?php esc_html_e( 'Tracked competitors', 'stratawp-seo' ); ?></h3>
+	</div>
 
-    <div class="swps-comp-list" id="swps-comp-list">
-        <?php if ( empty( $list ) ) : ?>
-            <div class="swps-row-card swps-comp-empty">
-                <p><?php esc_html_e( 'No competitors tracked yet. Click "Add competitor" to start.', 'stratawp-seo' ); ?></p>
-            </div>
-        <?php else : ?>
-            <?php foreach ( $list as $c ) : ?>
-                <?php swps_render_competitor_row( $c, $competitors->latest_diff( $c ) ); ?>
-            <?php endforeach; ?>
-        <?php endif; ?>
-    </div>
+	<div class="swps-comp-list" id="swps-comp-list">
+		<?php if ( empty( $list ) ) : ?>
+			<div class="swps-row-card swps-comp-empty">
+				<p><?php esc_html_e( 'No competitors tracked yet. Click "Add competitor" to start.', 'stratawp-seo' ); ?></p>
+			</div>
+		<?php else : ?>
+			<?php foreach ( $list as $c ) : ?>
+				<?php swps_render_competitor_row( $c, $competitors->latest_diff( $c ) ); ?>
+			<?php endforeach; ?>
+		<?php endif; ?>
+	</div>
 </div>

--- a/templates/crawl-files-page.php
+++ b/templates/crawl-files-page.php
@@ -8,16 +8,16 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 $plugin = stratawp_seo();
 $cf     = $plugin->crawl_files;
 $bots   = $plugin->ai_bots;
 
-$llms_mode    = $cf->get_llms_mode();
-$llms_custom  = $cf->get_llms_custom();
-$robots_mode  = $cf->get_robots_mode();
+$llms_mode     = $cf->get_llms_mode();
+$llms_custom   = $cf->get_llms_custom();
+$robots_mode   = $cf->get_robots_mode();
 $robots_custom = $cf->get_robots_custom();
 
 $auto_llms   = $cf->render_auto_llms( $bots );
@@ -27,162 +27,162 @@ $llms_url   = home_url( '/llms.txt' );
 $robots_url = home_url( '/robots.txt' );
 ?>
 <div class="wrap">
-    <?php
-    $title    = __( 'Crawlers & Files', 'stratawp-seo' );
-    $subtitle = __( 'Edit the dynamic /llms.txt and /robots.txt files served by your site. Use auto for the StrataWP-generated defaults, or paste your own content to override.', 'stratawp-seo' );
-    $actions  = [
-        [
-            'label' => __( 'View /llms.txt', 'stratawp-seo' ),
-            'url'   => $llms_url,
-            'class' => 'swps-btn-secondary',
-            'attrs' => 'target="_blank" rel="noopener"',
-        ],
-        [
-            'label' => __( 'View /robots.txt', 'stratawp-seo' ),
-            'url'   => $robots_url,
-            'class' => 'swps-btn-secondary',
-            'attrs' => 'target="_blank" rel="noopener"',
-        ],
-    ];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'Crawlers & Files', 'stratawp-seo' );
+	$subtitle = __( 'Edit the dynamic /llms.txt and /robots.txt files served by your site. Use auto for the StrataWP-generated defaults, or paste your own content to override.', 'stratawp-seo' );
+	$actions  = array(
+		array(
+			'label' => __( 'View /llms.txt', 'stratawp-seo' ),
+			'url'   => $llms_url,
+			'class' => 'swps-btn-secondary',
+			'attrs' => 'target="_blank" rel="noopener"',
+		),
+		array(
+			'label' => __( 'View /robots.txt', 'stratawp-seo' ),
+			'url'   => $robots_url,
+			'class' => 'swps-btn-secondary',
+			'attrs' => 'target="_blank" rel="noopener"',
+		),
+	);
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <form method="post" action="options.php" class="swps-crawl-files-form">
-        <?php settings_fields( 'swps_crawl_files_group' ); ?>
+	<form method="post" action="options.php" class="swps-crawl-files-form">
+		<?php settings_fields( 'swps_crawl_files_group' ); ?>
 
-        <!-- llms.txt -->
-        <div class="swps-card swps-crawl-card">
-            <div class="swps-crawl-card-head">
-                <div>
-                    <h2 style="margin:0">/llms.txt</h2>
-                    <p class="description" style="margin:4px 0 0">
-                        <?php esc_html_e( 'A markdown index that helps AI crawlers (ChatGPT, Claude, Perplexity) understand the structure of your site. By default StrataWP builds it from your most recent posts, top-level pages, and busiest categories.', 'stratawp-seo' ); ?>
-                    </p>
-                </div>
-            </div>
+		<!-- llms.txt -->
+		<div class="swps-card swps-crawl-card">
+			<div class="swps-crawl-card-head">
+				<div>
+					<h2 style="margin:0">/llms.txt</h2>
+					<p class="description" style="margin:4px 0 0">
+						<?php esc_html_e( 'A markdown index that helps AI crawlers (ChatGPT, Claude, Perplexity) understand the structure of your site. By default StrataWP builds it from your most recent posts, top-level pages, and busiest categories.', 'stratawp-seo' ); ?>
+					</p>
+				</div>
+			</div>
 
-            <fieldset style="margin-top:14px">
-                <legend class="screen-reader-text"><?php esc_html_e( 'llms.txt mode', 'stratawp-seo' ); ?></legend>
-                <label style="display:inline-flex;gap:8px;align-items:center;margin-right:24px">
-                    <input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_LLMS_MODE ); ?>"
-                           value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_AUTO ); ?>"
-                           <?php checked( $llms_mode, SWPS_Crawl_Files::MODE_AUTO ); ?>
-                           data-swps-mode-target="llms" />
-                    <strong><?php esc_html_e( 'Auto', 'stratawp-seo' ); ?></strong>
-                    <span style="color:var(--swps-text-muted);font-size:12px"><?php esc_html_e( 'Use the generated default', 'stratawp-seo' ); ?></span>
-                </label>
-                <label style="display:inline-flex;gap:8px;align-items:center">
-                    <input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_LLMS_MODE ); ?>"
-                           value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_CUSTOM ); ?>"
-                           <?php checked( $llms_mode, SWPS_Crawl_Files::MODE_CUSTOM ); ?>
-                           data-swps-mode-target="llms" />
-                    <strong><?php esc_html_e( 'Custom', 'stratawp-seo' ); ?></strong>
-                    <span style="color:var(--swps-text-muted);font-size:12px"><?php esc_html_e( 'Serve the markdown below verbatim', 'stratawp-seo' ); ?></span>
-                </label>
-            </fieldset>
+			<fieldset style="margin-top:14px">
+				<legend class="screen-reader-text"><?php esc_html_e( 'llms.txt mode', 'stratawp-seo' ); ?></legend>
+				<label style="display:inline-flex;gap:8px;align-items:center;margin-right:24px">
+					<input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_LLMS_MODE ); ?>"
+							value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_AUTO ); ?>"
+							<?php checked( $llms_mode, SWPS_Crawl_Files::MODE_AUTO ); ?>
+							data-swps-mode-target="llms" />
+					<strong><?php esc_html_e( 'Auto', 'stratawp-seo' ); ?></strong>
+					<span style="color:var(--swps-text-muted);font-size:12px"><?php esc_html_e( 'Use the generated default', 'stratawp-seo' ); ?></span>
+				</label>
+				<label style="display:inline-flex;gap:8px;align-items:center">
+					<input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_LLMS_MODE ); ?>"
+							value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_CUSTOM ); ?>"
+							<?php checked( $llms_mode, SWPS_Crawl_Files::MODE_CUSTOM ); ?>
+							data-swps-mode-target="llms" />
+					<strong><?php esc_html_e( 'Custom', 'stratawp-seo' ); ?></strong>
+					<span style="color:var(--swps-text-muted);font-size:12px"><?php esc_html_e( 'Serve the markdown below verbatim', 'stratawp-seo' ); ?></span>
+				</label>
+			</fieldset>
 
-            <div class="swps-crawl-grid" style="margin-top:14px">
-                <div class="swps-crawl-col">
-                    <label for="swps-llms-custom" class="swps-crawl-col-label">
-                        <?php esc_html_e( 'Your llms.txt', 'stratawp-seo' ); ?>
-                    </label>
-                    <textarea id="swps-llms-custom" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_LLMS_CUSTOM ); ?>"
-                              class="swps-crawl-textarea"
-                              rows="22"
-                              spellcheck="false"
-                              placeholder="<?php esc_attr_e( 'Paste markdown here. Used only when Custom is selected above.', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $llms_custom ); ?></textarea>
-                    <button type="button" class="button-link swps-crawl-copy-default"
-                            data-swps-copy-target="swps-llms-custom"
-                            data-swps-copy-source="swps-llms-default">
-                        <?php esc_html_e( '↑ Copy auto-generated content into the editor', 'stratawp-seo' ); ?>
-                    </button>
-                </div>
-                <div class="swps-crawl-col">
-                    <label class="swps-crawl-col-label"><?php esc_html_e( 'Auto preview', 'stratawp-seo' ); ?></label>
-                    <textarea id="swps-llms-default" class="swps-crawl-textarea is-readonly" rows="22" readonly><?php echo esc_textarea( $auto_llms ); ?></textarea>
-                </div>
-            </div>
-        </div>
+			<div class="swps-crawl-grid" style="margin-top:14px">
+				<div class="swps-crawl-col">
+					<label for="swps-llms-custom" class="swps-crawl-col-label">
+						<?php esc_html_e( 'Your llms.txt', 'stratawp-seo' ); ?>
+					</label>
+					<textarea id="swps-llms-custom" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_LLMS_CUSTOM ); ?>"
+								class="swps-crawl-textarea"
+								rows="22"
+								spellcheck="false"
+								placeholder="<?php esc_attr_e( 'Paste markdown here. Used only when Custom is selected above.', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $llms_custom ); ?></textarea>
+					<button type="button" class="button-link swps-crawl-copy-default"
+							data-swps-copy-target="swps-llms-custom"
+							data-swps-copy-source="swps-llms-default">
+						<?php esc_html_e( '↑ Copy auto-generated content into the editor', 'stratawp-seo' ); ?>
+					</button>
+				</div>
+				<div class="swps-crawl-col">
+					<label class="swps-crawl-col-label"><?php esc_html_e( 'Auto preview', 'stratawp-seo' ); ?></label>
+					<textarea id="swps-llms-default" class="swps-crawl-textarea is-readonly" rows="22" readonly><?php echo esc_textarea( $auto_llms ); ?></textarea>
+				</div>
+			</div>
+		</div>
 
-        <!-- robots.txt -->
-        <div class="swps-card swps-crawl-card" style="margin-top:16px">
-            <div class="swps-crawl-card-head">
-                <div>
-                    <h2 style="margin:0">/robots.txt</h2>
-                    <p class="description" style="margin:4px 0 0">
-                        <?php esc_html_e( 'Tells search engines and crawlers which paths are off-limits. The auto baseline is what WordPress would normally serve, plus the AI-bot allow/disallow rules StrataWP adds. Append to extend it; replace to take full control.', 'stratawp-seo' ); ?>
-                    </p>
-                </div>
-            </div>
+		<!-- robots.txt -->
+		<div class="swps-card swps-crawl-card" style="margin-top:16px">
+			<div class="swps-crawl-card-head">
+				<div>
+					<h2 style="margin:0">/robots.txt</h2>
+					<p class="description" style="margin:4px 0 0">
+						<?php esc_html_e( 'Tells search engines and crawlers which paths are off-limits. The auto baseline is what WordPress would normally serve, plus the AI-bot allow/disallow rules StrataWP adds. Append to extend it; replace to take full control.', 'stratawp-seo' ); ?>
+					</p>
+				</div>
+			</div>
 
-            <?php if ( file_exists( ABSPATH . 'robots.txt' ) ) : ?>
-                <p class="notice notice-warning" style="margin:12px 0 0;padding:8px 12px">
-                    <?php esc_html_e( 'A physical robots.txt exists in your site root. WordPress (and this plugin) will be ignored — that file is served instead. Delete it to use the dynamic version.', 'stratawp-seo' ); ?>
-                </p>
-            <?php endif; ?>
+			<?php if ( file_exists( ABSPATH . 'robots.txt' ) ) : ?>
+				<p class="notice notice-warning" style="margin:12px 0 0;padding:8px 12px">
+					<?php esc_html_e( 'A physical robots.txt exists in your site root. WordPress (and this plugin) will be ignored — that file is served instead. Delete it to use the dynamic version.', 'stratawp-seo' ); ?>
+				</p>
+			<?php endif; ?>
 
-            <fieldset style="margin-top:14px">
-                <legend class="screen-reader-text"><?php esc_html_e( 'robots.txt mode', 'stratawp-seo' ); ?></legend>
-                <label style="display:inline-flex;gap:8px;align-items:center;margin-right:24px">
-                    <input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_ROBOTS_MODE ); ?>"
-                           value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_AUTO ); ?>"
-                           <?php checked( $robots_mode, SWPS_Crawl_Files::MODE_AUTO ); ?> />
-                    <strong><?php esc_html_e( 'Auto', 'stratawp-seo' ); ?></strong>
-                </label>
-                <label style="display:inline-flex;gap:8px;align-items:center;margin-right:24px">
-                    <input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_ROBOTS_MODE ); ?>"
-                           value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_APPEND ); ?>"
-                           <?php checked( $robots_mode, SWPS_Crawl_Files::MODE_APPEND ); ?> />
-                    <strong><?php esc_html_e( 'Append', 'stratawp-seo' ); ?></strong>
-                    <span style="color:var(--swps-text-muted);font-size:12px"><?php esc_html_e( 'Auto + your extra rules', 'stratawp-seo' ); ?></span>
-                </label>
-                <label style="display:inline-flex;gap:8px;align-items:center">
-                    <input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_ROBOTS_MODE ); ?>"
-                           value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_REPLACE ); ?>"
-                           <?php checked( $robots_mode, SWPS_Crawl_Files::MODE_REPLACE ); ?> />
-                    <strong><?php esc_html_e( 'Replace', 'stratawp-seo' ); ?></strong>
-                    <span style="color:var(--swps-text-muted);font-size:12px"><?php esc_html_e( 'Serve only your content', 'stratawp-seo' ); ?></span>
-                </label>
-            </fieldset>
+			<fieldset style="margin-top:14px">
+				<legend class="screen-reader-text"><?php esc_html_e( 'robots.txt mode', 'stratawp-seo' ); ?></legend>
+				<label style="display:inline-flex;gap:8px;align-items:center;margin-right:24px">
+					<input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_ROBOTS_MODE ); ?>"
+							value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_AUTO ); ?>"
+							<?php checked( $robots_mode, SWPS_Crawl_Files::MODE_AUTO ); ?> />
+					<strong><?php esc_html_e( 'Auto', 'stratawp-seo' ); ?></strong>
+				</label>
+				<label style="display:inline-flex;gap:8px;align-items:center;margin-right:24px">
+					<input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_ROBOTS_MODE ); ?>"
+							value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_APPEND ); ?>"
+							<?php checked( $robots_mode, SWPS_Crawl_Files::MODE_APPEND ); ?> />
+					<strong><?php esc_html_e( 'Append', 'stratawp-seo' ); ?></strong>
+					<span style="color:var(--swps-text-muted);font-size:12px"><?php esc_html_e( 'Auto + your extra rules', 'stratawp-seo' ); ?></span>
+				</label>
+				<label style="display:inline-flex;gap:8px;align-items:center">
+					<input type="radio" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_ROBOTS_MODE ); ?>"
+							value="<?php echo esc_attr( SWPS_Crawl_Files::MODE_REPLACE ); ?>"
+							<?php checked( $robots_mode, SWPS_Crawl_Files::MODE_REPLACE ); ?> />
+					<strong><?php esc_html_e( 'Replace', 'stratawp-seo' ); ?></strong>
+					<span style="color:var(--swps-text-muted);font-size:12px"><?php esc_html_e( 'Serve only your content', 'stratawp-seo' ); ?></span>
+				</label>
+			</fieldset>
 
-            <div class="swps-crawl-grid" style="margin-top:14px">
-                <div class="swps-crawl-col">
-                    <label for="swps-robots-custom" class="swps-crawl-col-label">
-                        <?php esc_html_e( 'Your robots.txt', 'stratawp-seo' ); ?>
-                    </label>
-                    <textarea id="swps-robots-custom" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_ROBOTS_CUSTOM ); ?>"
-                              class="swps-crawl-textarea"
-                              rows="16"
-                              spellcheck="false"
-                              placeholder="<?php esc_attr_e( "User-agent: *\nDisallow: /private/\n\nSitemap: https://example.com/sitemap.xml", 'stratawp-seo' ); ?>"><?php echo esc_textarea( $robots_custom ); ?></textarea>
-                    <button type="button" class="button-link swps-crawl-copy-default"
-                            data-swps-copy-target="swps-robots-custom"
-                            data-swps-copy-source="swps-robots-default">
-                        <?php esc_html_e( '↑ Copy auto-generated content into the editor', 'stratawp-seo' ); ?>
-                    </button>
-                </div>
-                <div class="swps-crawl-col">
-                    <label class="swps-crawl-col-label"><?php esc_html_e( 'Auto preview', 'stratawp-seo' ); ?></label>
-                    <textarea id="swps-robots-default" class="swps-crawl-textarea is-readonly" rows="16" readonly><?php echo esc_textarea( $auto_robots ); ?></textarea>
-                </div>
-            </div>
-        </div>
+			<div class="swps-crawl-grid" style="margin-top:14px">
+				<div class="swps-crawl-col">
+					<label for="swps-robots-custom" class="swps-crawl-col-label">
+						<?php esc_html_e( 'Your robots.txt', 'stratawp-seo' ); ?>
+					</label>
+					<textarea id="swps-robots-custom" name="<?php echo esc_attr( SWPS_Crawl_Files::OPT_ROBOTS_CUSTOM ); ?>"
+								class="swps-crawl-textarea"
+								rows="16"
+								spellcheck="false"
+								placeholder="<?php esc_attr_e( "User-agent: *\nDisallow: /private/\n\nSitemap: https://example.com/sitemap.xml", 'stratawp-seo' ); ?>"><?php echo esc_textarea( $robots_custom ); ?></textarea>
+					<button type="button" class="button-link swps-crawl-copy-default"
+							data-swps-copy-target="swps-robots-custom"
+							data-swps-copy-source="swps-robots-default">
+						<?php esc_html_e( '↑ Copy auto-generated content into the editor', 'stratawp-seo' ); ?>
+					</button>
+				</div>
+				<div class="swps-crawl-col">
+					<label class="swps-crawl-col-label"><?php esc_html_e( 'Auto preview', 'stratawp-seo' ); ?></label>
+					<textarea id="swps-robots-default" class="swps-crawl-textarea is-readonly" rows="16" readonly><?php echo esc_textarea( $auto_robots ); ?></textarea>
+				</div>
+			</div>
+		</div>
 
-        <?php submit_button( __( 'Save changes', 'stratawp-seo' ) ); ?>
-    </form>
+		<?php submit_button( __( 'Save changes', 'stratawp-seo' ) ); ?>
+	</form>
 </div>
 
 <script>
 (function () {
-    document.querySelectorAll('.swps-crawl-copy-default').forEach(function (btn) {
-        btn.addEventListener('click', function () {
-            var target = document.getElementById(btn.dataset.swpsCopyTarget);
-            var source = document.getElementById(btn.dataset.swpsCopySource);
-            if (target && source) {
-                target.value = source.value;
-                target.focus();
-            }
-        });
-    });
+	document.querySelectorAll('.swps-crawl-copy-default').forEach(function (btn) {
+		btn.addEventListener('click', function () {
+			var target = document.getElementById(btn.dataset.swpsCopyTarget);
+			var source = document.getElementById(btn.dataset.swpsCopySource);
+			if (target && source) {
+				target.value = source.value;
+				target.focus();
+			}
+		});
+	});
 }());
 </script>

--- a/templates/dashboard-page.php
+++ b/templates/dashboard-page.php
@@ -8,416 +8,430 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /** @var array $data */
-$first_name      = $data['first_name'] ?? '';
-$health          = $data['site_health'] ?? [];
-$recent          = $data['recent_generations'] ?? [];
-$ai_cost         = $data['ai_cost_30d'] ?? [ 'usd' => 0, 'gens' => 0 ];
-$posts_30d       = $data['posts_30d'] ?? [ 'views' => 0, 'delta_pct' => null ];
-$issues          = $data['top_issues'] ?? [];
-$top_queries     = $data['top_queries'] ?? [];
-$auto_q          = $data['auto_optimize_queue'] ?? [];
-$competitors     = $data['competitors'] ?? [];
-$backlinks_data  = $data['backlinks'] ?? [ 'stats' => [], 'recent' => [] ];
-$bl_stats        = (array) ( $backlinks_data['stats']  ?? [] );
-$bl_recent       = (array) ( $backlinks_data['recent'] ?? [] );
-$modules         = $data['modules'] ?? [];
+$first_name     = $data['first_name'] ?? '';
+$health         = $data['site_health'] ?? array();
+$recent         = $data['recent_generations'] ?? array();
+$ai_cost        = $data['ai_cost_30d'] ?? array(
+	'usd'  => 0,
+	'gens' => 0,
+);
+$posts_30d      = $data['posts_30d'] ?? array(
+	'views'     => 0,
+	'delta_pct' => null,
+);
+$issues         = $data['top_issues'] ?? array();
+$top_queries    = $data['top_queries'] ?? array();
+$auto_q         = $data['auto_optimize_queue'] ?? array();
+$competitors    = $data['competitors'] ?? array();
+$backlinks_data = $data['backlinks'] ?? array(
+	'stats'  => array(),
+	'recent' => array(),
+);
+$bl_stats       = (array) ( $backlinks_data['stats'] ?? array() );
+$bl_recent      = (array) ( $backlinks_data['recent'] ?? array() );
+$modules        = $data['modules'] ?? array();
 
-$score           = (int) ( $health['score'] ?? 0 );
-$health_label    = $health['label'] ?? '—';
-$score_deg       = (int) round( ( $score / 100 ) * 360 );
-$last_audit_ago  = ! empty( $health['last_run'] )
-    ? human_time_diff( (int) $health['last_run'], time() ) . ' ago'
-    : esc_html__( 'never', 'stratawp-seo' );
+$score          = (int) ( $health['score'] ?? 0 );
+$health_label   = $health['label'] ?? '—';
+$score_deg      = (int) round( ( $score / 100 ) * 360 );
+$last_audit_ago = ! empty( $health['last_run'] )
+	? human_time_diff( (int) $health['last_run'], time() ) . ' ago'
+	: esc_html__( 'never', 'stratawp-seo' );
 
 // Welcome line — tailored to top action.
 $welcome_msg = sprintf(
-    /* translators: 1: site health score, 2: number of issues */
-    esc_html__( 'Site Health %1$d. %2$d fixable issues. AI cost this month $%3$s.', 'stratawp-seo' ),
-    $score,
-    (int) ( $health['crit_count'] ?? 0 ) + (int) ( $health['warn_count'] ?? 0 ),
-    number_format( (float) $ai_cost['usd'], 2 )
+	/* translators: 1: site health score, 2: number of issues */
+	esc_html__( 'Site Health %1$d. %2$d fixable issues. AI cost this month $%3$s.', 'stratawp-seo' ),
+	$score,
+	(int) ( $health['crit_count'] ?? 0 ) + (int) ( $health['warn_count'] ?? 0 ),
+	number_format( (float) $ai_cost['usd'], 2 )
 );
 ?>
 <div class="wrap swps-dashboard-wrap">
 
-    <?php
-    $title    = sprintf(
-        /* translators: %s: user first name */
-        esc_html__( 'Welcome back, %s', 'stratawp-seo' ),
-        esc_html( $first_name )
-    );
-    $subtitle = $welcome_msg;
-    $actions  = [
-        [
-            'label' => __( 'Generate post', 'stratawp-seo' ),
-            'url'   => admin_url( 'admin.php?page=swps-generate' ),
-            'class' => 'swps-btn-secondary',
-        ],
-        [
-            'label' => __( 'Run audit', 'stratawp-seo' ),
-            'class' => 'swps-btn-grad',
-            'attrs' => 'data-swps-action="run-audit"',
-        ],
-    ];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title = sprintf(
+		/* translators: %s: user first name */
+		esc_html__( 'Welcome back, %s', 'stratawp-seo' ),
+		esc_html( $first_name )
+	);
+	$subtitle = $welcome_msg;
+	$actions  = array(
+		array(
+			'label' => __( 'Generate post', 'stratawp-seo' ),
+			'url'   => admin_url( 'admin.php?page=swps-generate' ),
+			'class' => 'swps-btn-secondary',
+		),
+		array(
+			'label' => __( 'Run audit', 'stratawp-seo' ),
+			'class' => 'swps-btn-grad',
+			'attrs' => 'data-swps-action="run-audit"',
+		),
+	);
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <!-- Row 1 — KPI tiles -->
-    <div class="swps-dash-row swps-dash-row-1">
+	<!-- Row 1 — KPI tiles -->
+	<div class="swps-dash-row swps-dash-row-1">
 
-        <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'Site Health', 'stratawp-seo' ); ?></div>
-            <div class="swps-dash-health">
-                <div class="swps-dash-gauge" style="--swps-dash-gauge-deg:<?php echo (int) $score_deg; ?>deg">
-                    <span class="swps-dash-gauge-num"><?php echo (int) $score; ?></span>
-                </div>
-                <div class="swps-dash-health-meta">
-                    <div class="swps-dash-health-label"><?php echo esc_html( $health_label ); ?></div>
-                    <div class="swps-dash-health-sub">
-                        <?php
-                        printf(
-                            /* translators: 1: critical count, 2: warning count */
-                            esc_html__( '%1$d critical, %2$d warning', 'stratawp-seo' ),
-                            (int) ( $health['crit_count'] ?? 0 ),
-                            (int) ( $health['warn_count'] ?? 0 )
-                        );
-                        ?>
-                        <br><?php echo esc_html( $last_audit_ago ); ?>
-                    </div>
-                </div>
-            </div>
-        </div>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'Site Health', 'stratawp-seo' ); ?></div>
+			<div class="swps-dash-health">
+				<div class="swps-dash-gauge" style="--swps-dash-gauge-deg:<?php echo (int) $score_deg; ?>deg">
+					<span class="swps-dash-gauge-num"><?php echo (int) $score; ?></span>
+				</div>
+				<div class="swps-dash-health-meta">
+					<div class="swps-dash-health-label"><?php echo esc_html( $health_label ); ?></div>
+					<div class="swps-dash-health-sub">
+						<?php
+						printf(
+							/* translators: 1: critical count, 2: warning count */
+							esc_html__( '%1$d critical, %2$d warning', 'stratawp-seo' ),
+							(int) ( $health['crit_count'] ?? 0 ),
+							(int) ( $health['warn_count'] ?? 0 )
+						);
+						?>
+						<br><?php echo esc_html( $last_audit_ago ); ?>
+					</div>
+				</div>
+			</div>
+		</div>
 
-        <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'Post views (30d)', 'stratawp-seo' ); ?></div>
-            <div class="swps-tile-stat"><?php echo number_format( (int) ( $posts_30d['views'] ?? 0 ) ); ?></div>
-            <?php if ( null !== ( $posts_30d['delta_pct'] ?? null ) ) :
-                $delta = (float) $posts_30d['delta_pct'];
-                $cls   = $delta >= 0 ? '' : ' is-down';
-                $arrow = $delta >= 0 ? '↑' : '↓';
-            ?>
-                <div class="swps-tile-trend<?php echo esc_attr( $cls ); ?>">
-                    <?php echo esc_html( $arrow ); ?>
-                    <?php echo esc_html( number_format( abs( $delta ), 1 ) ); ?>%
-                    <?php esc_html_e( 'vs prev 30d', 'stratawp-seo' ); ?>
-                </div>
-            <?php else : ?>
-                <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
-                    <?php esc_html_e( 'On-site analytics — no data yet', 'stratawp-seo' ); ?>
-                </div>
-            <?php endif; ?>
-        </div>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'Post views (30d)', 'stratawp-seo' ); ?></div>
+			<div class="swps-tile-stat"><?php echo number_format( (int) ( $posts_30d['views'] ?? 0 ) ); ?></div>
+			<?php
+			if ( null !== ( $posts_30d['delta_pct'] ?? null ) ) :
+				$delta = (float) $posts_30d['delta_pct'];
+				$cls   = $delta >= 0 ? '' : ' is-down';
+				$arrow = $delta >= 0 ? '↑' : '↓';
+				?>
+				<div class="swps-tile-trend<?php echo esc_attr( $cls ); ?>">
+					<?php echo esc_html( $arrow ); ?>
+					<?php echo esc_html( number_format( abs( $delta ), 1 ) ); ?>%
+					<?php esc_html_e( 'vs prev 30d', 'stratawp-seo' ); ?>
+				</div>
+			<?php else : ?>
+				<div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+					<?php esc_html_e( 'On-site analytics — no data yet', 'stratawp-seo' ); ?>
+				</div>
+			<?php endif; ?>
+		</div>
 
-        <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'Backlinks', 'stratawp-seo' ); ?></div>
-            <?php if ( (int) ( $bl_stats['total'] ?? 0 ) > 0 ) : ?>
-                <div class="swps-tile-stat"><?php echo number_format( (int) $bl_stats['total'] ); ?></div>
-                <div class="swps-tile-trend" style="color:var(--swps-text-muted)">
-                    <?php
-                    printf(
-                        /* translators: 1: live count, 2: lost count, 3: unique domains */
-                        esc_html__( '%1$d live · %2$d lost · %3$d domains', 'stratawp-seo' ),
-                        (int) ( $bl_stats['live'] ?? 0 ),
-                        (int) ( $bl_stats['lost'] ?? 0 ),
-                        (int) ( $bl_stats['unique_domains'] ?? 0 )
-                    );
-                    ?>
-                </div>
-            <?php else : ?>
-                <div class="swps-tile-stat" style="font-size:18px;-webkit-text-fill-color:var(--swps-text-muted);background:none;color:var(--swps-text-muted)">
-                    <?php esc_html_e( '— Add some', 'stratawp-seo' ); ?>
-                </div>
-                <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
-                    <a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-backlinks' ) ); ?>" style="color:inherit;text-decoration:underline">
-                        <?php esc_html_e( 'Track inbound links →', 'stratawp-seo' ); ?>
-                    </a>
-                </div>
-            <?php endif; ?>
-        </div>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'Backlinks', 'stratawp-seo' ); ?></div>
+			<?php if ( (int) ( $bl_stats['total'] ?? 0 ) > 0 ) : ?>
+				<div class="swps-tile-stat"><?php echo number_format( (int) $bl_stats['total'] ); ?></div>
+				<div class="swps-tile-trend" style="color:var(--swps-text-muted)">
+					<?php
+					printf(
+						/* translators: 1: live count, 2: lost count, 3: unique domains */
+						esc_html__( '%1$d live · %2$d lost · %3$d domains', 'stratawp-seo' ),
+						(int) ( $bl_stats['live'] ?? 0 ),
+						(int) ( $bl_stats['lost'] ?? 0 ),
+						(int) ( $bl_stats['unique_domains'] ?? 0 )
+					);
+					?>
+				</div>
+			<?php else : ?>
+				<div class="swps-tile-stat" style="font-size:18px;-webkit-text-fill-color:var(--swps-text-muted);background:none;color:var(--swps-text-muted)">
+					<?php esc_html_e( '— Add some', 'stratawp-seo' ); ?>
+				</div>
+				<div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+					<a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-backlinks' ) ); ?>" style="color:inherit;text-decoration:underline">
+						<?php esc_html_e( 'Track inbound links →', 'stratawp-seo' ); ?>
+					</a>
+				</div>
+			<?php endif; ?>
+		</div>
 
-        <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'AI cost (30d)', 'stratawp-seo' ); ?></div>
-            <div class="swps-tile-stat">$<?php echo esc_html( number_format( (float) $ai_cost['usd'], 2 ) ); ?></div>
-            <div class="swps-tile-trend" style="color:var(--swps-text-muted)">
-                <?php
-                printf(
-                    /* translators: %d: number of generations */
-                    esc_html__( '%d generations', 'stratawp-seo' ),
-                    (int) $ai_cost['gens']
-                );
-                ?>
-            </div>
-        </div>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'AI cost (30d)', 'stratawp-seo' ); ?></div>
+			<div class="swps-tile-stat">$<?php echo esc_html( number_format( (float) $ai_cost['usd'], 2 ) ); ?></div>
+			<div class="swps-tile-trend" style="color:var(--swps-text-muted)">
+				<?php
+				printf(
+					/* translators: %d: number of generations */
+					esc_html__( '%d generations', 'stratawp-seo' ),
+					(int) $ai_cost['gens']
+				);
+				?>
+			</div>
+		</div>
 
-    </div>
+	</div>
 
-    <!-- Row 2 — Recent generations + Quick actions -->
-    <div class="swps-dash-row swps-dash-row-2">
+	<!-- Row 2 — Recent generations + Quick actions -->
+	<div class="swps-dash-row swps-dash-row-2">
 
-        <div class="swps-tile">
-            <div class="swps-tile-h">
-                <span><?php esc_html_e( 'Recent AI generations', 'stratawp-seo' ); ?></span>
-            </div>
-            <?php if ( empty( $recent ) ) : ?>
-                <div class="swps-dash-empty">
-                    <p><?php esc_html_e( 'No posts generated yet.', 'stratawp-seo' ); ?></p>
-                    <a class="swps-btn swps-btn-grad" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-generate' ) ); ?>">
-                        <?php esc_html_e( 'Generate your first post', 'stratawp-seo' ); ?>
-                    </a>
-                </div>
-            <?php else : ?>
-                <div class="swps-dash-list">
-                    <?php foreach ( $recent as $r ) :
-                        $score_class = $r['score'] >= 85 ? 'good' : ( $r['score'] >= 60 ? 'mid' : 'low' );
-                    ?>
-                        <a class="swps-dash-list-row" href="<?php echo esc_url( $r['edit_link'] ); ?>">
-                            <div class="swps-dash-list-icon">✦</div>
-                            <div class="swps-dash-list-main">
-                                <div class="swps-dash-list-title"><?php echo esc_html( $r['title'] ); ?></div>
-                                <div class="swps-dash-list-sub">
-                                    <?php
-                                    echo esc_html( ucfirst( $r['template'] ) ) . ' · ';
-                                    printf(
-                                        /* translators: %s: word count formatted */
-                                        esc_html__( '%s words', 'stratawp-seo' ),
-                                        number_format( (int) $r['word_count'] )
-                                    );
-                                    if ( ! empty( $r['model'] ) ) {
-                                        echo ' · ' . esc_html( $r['model'] );
-                                    }
-                                    echo ' · ' . esc_html( $r['status'] ) . ' · ' . esc_html( $r['time_ago'] );
-                                    ?>
-                                </div>
-                            </div>
-                            <?php if ( $r['score'] > 0 ) : ?>
-                                <span class="swps-dash-list-score is-<?php echo esc_attr( $score_class ); ?>">
-                                    <?php echo (int) $r['score']; ?>
-                                </span>
-                            <?php endif; ?>
-                        </a>
-                    <?php endforeach; ?>
-                </div>
-            <?php endif; ?>
-        </div>
+		<div class="swps-tile">
+			<div class="swps-tile-h">
+				<span><?php esc_html_e( 'Recent AI generations', 'stratawp-seo' ); ?></span>
+			</div>
+			<?php if ( empty( $recent ) ) : ?>
+				<div class="swps-dash-empty">
+					<p><?php esc_html_e( 'No posts generated yet.', 'stratawp-seo' ); ?></p>
+					<a class="swps-btn swps-btn-grad" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-generate' ) ); ?>">
+						<?php esc_html_e( 'Generate your first post', 'stratawp-seo' ); ?>
+					</a>
+				</div>
+			<?php else : ?>
+				<div class="swps-dash-list">
+					<?php
+					foreach ( $recent as $r ) :
+						$score_class = $r['score'] >= 85 ? 'good' : ( $r['score'] >= 60 ? 'mid' : 'low' );
+						?>
+						<a class="swps-dash-list-row" href="<?php echo esc_url( $r['edit_link'] ); ?>">
+							<div class="swps-dash-list-icon">✦</div>
+							<div class="swps-dash-list-main">
+								<div class="swps-dash-list-title"><?php echo esc_html( $r['title'] ); ?></div>
+								<div class="swps-dash-list-sub">
+									<?php
+									echo esc_html( ucfirst( $r['template'] ) ) . ' · ';
+									printf(
+										/* translators: %s: word count formatted */
+										esc_html__( '%s words', 'stratawp-seo' ),
+										number_format( (int) $r['word_count'] )
+									);
+									if ( ! empty( $r['model'] ) ) {
+										echo ' · ' . esc_html( $r['model'] );
+									}
+									echo ' · ' . esc_html( $r['status'] ) . ' · ' . esc_html( $r['time_ago'] );
+									?>
+								</div>
+							</div>
+							<?php if ( $r['score'] > 0 ) : ?>
+								<span class="swps-dash-list-score is-<?php echo esc_attr( $score_class ); ?>">
+									<?php echo (int) $r['score']; ?>
+								</span>
+							<?php endif; ?>
+						</a>
+					<?php endforeach; ?>
+				</div>
+			<?php endif; ?>
+		</div>
 
-        <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'Quick actions', 'stratawp-seo' ); ?></div>
-            <div class="swps-dash-actions">
-                <a class="swps-dash-action" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-generate' ) ); ?>">
-                    <div class="swps-dash-action-icon">✦</div>
-                    <div class="swps-dash-action-label"><?php esc_html_e( 'Generate post', 'stratawp-seo' ); ?></div>
-                    <div class="swps-dash-action-sub"><?php esc_html_e( 'AI · 60-90s', 'stratawp-seo' ); ?></div>
-                </a>
-                <a class="swps-dash-action" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-seo-audit' ) ); ?>" data-swps-action="run-audit">
-                    <div class="swps-dash-action-icon">⚡</div>
-                    <div class="swps-dash-action-label"><?php esc_html_e( 'Run audit', 'stratawp-seo' ); ?></div>
-                    <div class="swps-dash-action-sub"><?php esc_html_e( '8 modules', 'stratawp-seo' ); ?></div>
-                </a>
-                <a class="swps-dash-action" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-auto-optimize' ) ); ?>">
-                    <div class="swps-dash-action-icon">↻</div>
-                    <div class="swps-dash-action-label"><?php esc_html_e( 'Auto-Optimize', 'stratawp-seo' ); ?></div>
-                    <div class="swps-dash-action-sub"><?php esc_html_e( 'Coming soon', 'stratawp-seo' ); ?></div>
-                </a>
-                <a class="swps-dash-action" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-keywords' ) ); ?>">
-                    <div class="swps-dash-action-icon">↗</div>
-                    <div class="swps-dash-action-label"><?php esc_html_e( 'Striking kw', 'stratawp-seo' ); ?></div>
-                    <div class="swps-dash-action-sub"><?php esc_html_e( 'Pos 8-20', 'stratawp-seo' ); ?></div>
-                </a>
-            </div>
-        </div>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'Quick actions', 'stratawp-seo' ); ?></div>
+			<div class="swps-dash-actions">
+				<a class="swps-dash-action" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-generate' ) ); ?>">
+					<div class="swps-dash-action-icon">✦</div>
+					<div class="swps-dash-action-label"><?php esc_html_e( 'Generate post', 'stratawp-seo' ); ?></div>
+					<div class="swps-dash-action-sub"><?php esc_html_e( 'AI · 60-90s', 'stratawp-seo' ); ?></div>
+				</a>
+				<a class="swps-dash-action" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-seo-audit' ) ); ?>" data-swps-action="run-audit">
+					<div class="swps-dash-action-icon">⚡</div>
+					<div class="swps-dash-action-label"><?php esc_html_e( 'Run audit', 'stratawp-seo' ); ?></div>
+					<div class="swps-dash-action-sub"><?php esc_html_e( '8 modules', 'stratawp-seo' ); ?></div>
+				</a>
+				<a class="swps-dash-action" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-auto-optimize' ) ); ?>">
+					<div class="swps-dash-action-icon">↻</div>
+					<div class="swps-dash-action-label"><?php esc_html_e( 'Auto-Optimize', 'stratawp-seo' ); ?></div>
+					<div class="swps-dash-action-sub"><?php esc_html_e( 'Coming soon', 'stratawp-seo' ); ?></div>
+				</a>
+				<a class="swps-dash-action" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-keywords' ) ); ?>">
+					<div class="swps-dash-action-icon">↗</div>
+					<div class="swps-dash-action-label"><?php esc_html_e( 'Striking kw', 'stratawp-seo' ); ?></div>
+					<div class="swps-dash-action-sub"><?php esc_html_e( 'Pos 8-20', 'stratawp-seo' ); ?></div>
+				</a>
+			</div>
+		</div>
 
-    </div>
+	</div>
 
-    <!-- Row 3 — Issues + Top GSC queries -->
-    <div class="swps-dash-row swps-dash-row-2">
+	<!-- Row 3 — Issues + Top GSC queries -->
+	<div class="swps-dash-row swps-dash-row-2">
 
-        <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'Issues to fix', 'stratawp-seo' ); ?></div>
-            <?php if ( empty( $issues ) ) : ?>
-                <p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
-                    <?php esc_html_e( 'No issues found. Run an audit to refresh.', 'stratawp-seo' ); ?>
-                </p>
-            <?php else : ?>
-                <div>
-                    <?php foreach ( $issues as $iss ) : ?>
-                        <div class="swps-dash-issue">
-                            <span class="swps-pill swps-pill-<?php echo esc_attr( $iss['level'] ); ?>">
-                                <?php echo $iss['level'] === 'crit' ? esc_html__( 'Critical', 'stratawp-seo' ) : esc_html__( 'Warning', 'stratawp-seo' ); ?>
-                            </span>
-                            <div>
-                                <div class="swps-dash-issue-text"><?php echo esc_html( $iss['name'] ); ?> — <?php echo esc_html( $iss['message'] ); ?></div>
-                                <a class="swps-dash-issue-cta" href="<?php echo esc_url( $iss['page_url'] ); ?>">
-                                    <?php
-                                    echo $iss['fixable']
-                                        ? esc_html__( 'Auto-fix →', 'stratawp-seo' )
-                                        : esc_html__( 'View →', 'stratawp-seo' );
-                                    ?>
-                                </a>
-                            </div>
-                        </div>
-                    <?php endforeach; ?>
-                </div>
-            <?php endif; ?>
-        </div>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'Issues to fix', 'stratawp-seo' ); ?></div>
+			<?php if ( empty( $issues ) ) : ?>
+				<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+					<?php esc_html_e( 'No issues found. Run an audit to refresh.', 'stratawp-seo' ); ?>
+				</p>
+			<?php else : ?>
+				<div>
+					<?php foreach ( $issues as $iss ) : ?>
+						<div class="swps-dash-issue">
+							<span class="swps-pill swps-pill-<?php echo esc_attr( $iss['level'] ); ?>">
+								<?php echo $iss['level'] === 'crit' ? esc_html__( 'Critical', 'stratawp-seo' ) : esc_html__( 'Warning', 'stratawp-seo' ); ?>
+							</span>
+							<div>
+								<div class="swps-dash-issue-text"><?php echo esc_html( $iss['name'] ); ?> — <?php echo esc_html( $iss['message'] ); ?></div>
+								<a class="swps-dash-issue-cta" href="<?php echo esc_url( $iss['page_url'] ); ?>">
+									<?php
+									echo $iss['fixable']
+										? esc_html__( 'Auto-fix →', 'stratawp-seo' )
+										: esc_html__( 'View →', 'stratawp-seo' );
+									?>
+								</a>
+							</div>
+						</div>
+					<?php endforeach; ?>
+				</div>
+			<?php endif; ?>
+		</div>
 
-        <div class="swps-tile">
-            <div class="swps-tile-h">
-                <span><?php esc_html_e( 'Top GSC queries (7d)', 'stratawp-seo' ); ?></span>
-            </div>
-            <?php if ( empty( $top_queries ) ) : ?>
-                <p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
-                    <?php esc_html_e( 'Connect Google Search Console to see top queries.', 'stratawp-seo' ); ?>
-                </p>
-            <?php else : ?>
-                <div class="swps-dash-list">
-                    <?php foreach ( $top_queries as $q ) : ?>
-                        <div class="swps-dash-list-row">
-                            <div class="swps-dash-list-main">
-                                <div class="swps-dash-list-title"><?php echo esc_html( $q['query'] ?? '' ); ?></div>
-                                <div class="swps-dash-list-sub">
-                                    <?php echo (int) ( $q['clicks'] ?? 0 ); ?> clicks ·
-                                    <?php echo number_format( (int) ( $q['impressions'] ?? 0 ) ); ?> imp ·
-                                    pos <?php echo number_format( (float) ( $q['position'] ?? 0 ), 1 ); ?>
-                                </div>
-                            </div>
-                        </div>
-                    <?php endforeach; ?>
-                </div>
-            <?php endif; ?>
-        </div>
+		<div class="swps-tile">
+			<div class="swps-tile-h">
+				<span><?php esc_html_e( 'Top GSC queries (7d)', 'stratawp-seo' ); ?></span>
+			</div>
+			<?php if ( empty( $top_queries ) ) : ?>
+				<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+					<?php esc_html_e( 'Connect Google Search Console to see top queries.', 'stratawp-seo' ); ?>
+				</p>
+			<?php else : ?>
+				<div class="swps-dash-list">
+					<?php foreach ( $top_queries as $q ) : ?>
+						<div class="swps-dash-list-row">
+							<div class="swps-dash-list-main">
+								<div class="swps-dash-list-title"><?php echo esc_html( $q['query'] ?? '' ); ?></div>
+								<div class="swps-dash-list-sub">
+									<?php echo (int) ( $q['clicks'] ?? 0 ); ?> clicks ·
+									<?php echo number_format( (int) ( $q['impressions'] ?? 0 ) ); ?> imp ·
+									pos <?php echo number_format( (float) ( $q['position'] ?? 0 ), 1 ); ?>
+								</div>
+							</div>
+						</div>
+					<?php endforeach; ?>
+				</div>
+			<?php endif; ?>
+		</div>
 
-    </div>
+	</div>
 
-    <!-- Row 4 — Competitor watch -->
-    <div class="swps-dash-row swps-dash-row-2">
-        <div class="swps-tile">
-            <div class="swps-tile-h" style="display:flex;justify-content:space-between;align-items:baseline;gap:8px">
-                <span><?php esc_html_e( 'Competitor watch', 'stratawp-seo' ); ?></span>
-                <a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-competitors' ) ); ?>"
-                   style="color:var(--swps-accent-1);font-size:11px;font-weight:600;text-decoration:none">
-                    <?php esc_html_e( 'Manage →', 'stratawp-seo' ); ?>
-                </a>
-            </div>
-            <?php if ( empty( $competitors ) ) : ?>
-                <p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
-                    <?php esc_html_e( 'No competitors tracked yet. Add up to 10 sites to monitor for content velocity, schema diff, and homepage changes.', 'stratawp-seo' ); ?>
-                </p>
-            <?php else : ?>
-                <div class="swps-dash-list">
-                    <?php foreach ( $competitors as $c ) : ?>
-                        <div class="swps-dash-list-row">
-                            <div class="swps-dash-list-main">
-                                <div class="swps-dash-list-title"><?php echo esc_html( $c['label'] ); ?></div>
-                                <div class="swps-dash-list-sub"><?php echo esc_html( $c['summary'] ); ?></div>
-                            </div>
-                            <?php if ( ! empty( $c['has_changes'] ) ) : ?>
-                                <span class="swps-pill swps-pill-warn"><?php esc_html_e( 'Δ', 'stratawp-seo' ); ?></span>
-                            <?php endif; ?>
-                        </div>
-                    <?php endforeach; ?>
-                </div>
-            <?php endif; ?>
-        </div>
+	<!-- Row 4 — Competitor watch -->
+	<div class="swps-dash-row swps-dash-row-2">
+		<div class="swps-tile">
+			<div class="swps-tile-h" style="display:flex;justify-content:space-between;align-items:baseline;gap:8px">
+				<span><?php esc_html_e( 'Competitor watch', 'stratawp-seo' ); ?></span>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-competitors' ) ); ?>"
+					style="color:var(--swps-accent-1);font-size:11px;font-weight:600;text-decoration:none">
+					<?php esc_html_e( 'Manage →', 'stratawp-seo' ); ?>
+				</a>
+			</div>
+			<?php if ( empty( $competitors ) ) : ?>
+				<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+					<?php esc_html_e( 'No competitors tracked yet. Add up to 10 sites to monitor for content velocity, schema diff, and homepage changes.', 'stratawp-seo' ); ?>
+				</p>
+			<?php else : ?>
+				<div class="swps-dash-list">
+					<?php foreach ( $competitors as $c ) : ?>
+						<div class="swps-dash-list-row">
+							<div class="swps-dash-list-main">
+								<div class="swps-dash-list-title"><?php echo esc_html( $c['label'] ); ?></div>
+								<div class="swps-dash-list-sub"><?php echo esc_html( $c['summary'] ); ?></div>
+							</div>
+							<?php if ( ! empty( $c['has_changes'] ) ) : ?>
+								<span class="swps-pill swps-pill-warn"><?php esc_html_e( 'Δ', 'stratawp-seo' ); ?></span>
+							<?php endif; ?>
+						</div>
+					<?php endforeach; ?>
+				</div>
+			<?php endif; ?>
+		</div>
 
-        <div class="swps-tile">
-            <div class="swps-tile-h" style="display:flex;justify-content:space-between;align-items:baseline;gap:8px">
-                <span><?php esc_html_e( 'Backlinks', 'stratawp-seo' ); ?></span>
-                <a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-backlinks' ) ); ?>"
-                   style="color:var(--swps-accent-1);font-size:11px;font-weight:600;text-decoration:none">
-                    <?php esc_html_e( 'Manage →', 'stratawp-seo' ); ?>
-                </a>
-            </div>
-            <?php if ( empty( $bl_recent ) ) : ?>
-                <p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
-                    <?php esc_html_e( 'No backlinks tracked yet. Add manually or paste a CSV from Google Search Console (Top linking sites).', 'stratawp-seo' ); ?>
-                </p>
-            <?php else : ?>
-                <div class="swps-dash-list">
-                    <?php foreach ( $bl_recent as $bl ) :
-                        $status_color = 'live' === $bl['status'] ? '#10b981' : ( 'lost' === $bl['status'] ? '#f59e0b' : ( 'broken' === $bl['status'] ? '#ef4444' : '#6b7280' ) );
-                    ?>
-                        <div class="swps-dash-list-row">
-                            <div class="swps-dash-list-main">
-                                <div class="swps-dash-list-title"><?php echo esc_html( $bl['label'] ); ?></div>
-                                <div class="swps-dash-list-sub">
-                                    <span style="color:<?php echo esc_attr( $status_color ); ?>;font-weight:600;text-transform:uppercase;font-size:10px;letter-spacing:.05em">
-                                        <?php echo esc_html( $bl['status'] ); ?>
-                                    </span>
-                                    <?php if ( ! empty( $bl['when'] ) ) : ?>
-                                        · <?php echo esc_html( human_time_diff( strtotime( $bl['when'] ) ) . ' ago' ); ?>
-                                    <?php endif; ?>
-                                </div>
-                            </div>
-                        </div>
-                    <?php endforeach; ?>
-                </div>
-            <?php endif; ?>
-        </div>
-    </div>
+		<div class="swps-tile">
+			<div class="swps-tile-h" style="display:flex;justify-content:space-between;align-items:baseline;gap:8px">
+				<span><?php esc_html_e( 'Backlinks', 'stratawp-seo' ); ?></span>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-backlinks' ) ); ?>"
+					style="color:var(--swps-accent-1);font-size:11px;font-weight:600;text-decoration:none">
+					<?php esc_html_e( 'Manage →', 'stratawp-seo' ); ?>
+				</a>
+			</div>
+			<?php if ( empty( $bl_recent ) ) : ?>
+				<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+					<?php esc_html_e( 'No backlinks tracked yet. Add manually or paste a CSV from Google Search Console (Top linking sites).', 'stratawp-seo' ); ?>
+				</p>
+			<?php else : ?>
+				<div class="swps-dash-list">
+					<?php
+					foreach ( $bl_recent as $bl ) :
+						$status_color = 'live' === $bl['status'] ? '#10b981' : ( 'lost' === $bl['status'] ? '#f59e0b' : ( 'broken' === $bl['status'] ? '#ef4444' : '#6b7280' ) );
+						?>
+						<div class="swps-dash-list-row">
+							<div class="swps-dash-list-main">
+								<div class="swps-dash-list-title"><?php echo esc_html( $bl['label'] ); ?></div>
+								<div class="swps-dash-list-sub">
+									<span style="color:<?php echo esc_attr( $status_color ); ?>;font-weight:600;text-transform:uppercase;font-size:10px;letter-spacing:.05em">
+										<?php echo esc_html( $bl['status'] ); ?>
+									</span>
+									<?php if ( ! empty( $bl['when'] ) ) : ?>
+										· <?php echo esc_html( human_time_diff( strtotime( $bl['when'] ) ) . ' ago' ); ?>
+									<?php endif; ?>
+								</div>
+							</div>
+						</div>
+					<?php endforeach; ?>
+				</div>
+			<?php endif; ?>
+		</div>
+	</div>
 
-    <!-- Modules grid -->
-    <div class="swps-dash-section-h">
-        <h3><?php esc_html_e( 'Modules', 'stratawp-seo' ); ?></h3>
-        <span class="swps-dash-section-h-sub">
-            <?php
-            $enabled_count = count( array_filter( $modules, fn( $m ) => ! empty( $m['enabled'] ) ) );
-            $available     = count( $modules );
-            printf(
-                /* translators: 1: enabled count, 2: total count */
-                esc_html__( 'Toggle features on or off · %1$d enabled, %2$d total', 'stratawp-seo' ),
-                $enabled_count,
-                $available
-            );
-            ?>
-        </span>
-    </div>
+	<!-- Modules grid -->
+	<div class="swps-dash-section-h">
+		<h3><?php esc_html_e( 'Modules', 'stratawp-seo' ); ?></h3>
+		<span class="swps-dash-section-h-sub">
+			<?php
+			$enabled_count = count( array_filter( $modules, fn( $m ) => ! empty( $m['enabled'] ) ) );
+			$available     = count( $modules );
+			printf(
+				/* translators: 1: enabled count, 2: total count */
+				esc_html__( 'Toggle features on or off · %1$d enabled, %2$d total', 'stratawp-seo' ),
+				$enabled_count,
+				$available
+			);
+			?>
+		</span>
+	</div>
 
-    <div class="swps-dash-modules">
-        <?php foreach ( $modules as $mod ) :
-            $is_coming   = ( ( $mod['badge'] ?? '' ) === 'soon' );
-        ?>
-            <div class="swps-dash-module<?php echo $is_coming ? ' is-coming' : ''; ?>">
-                <?php if ( ! empty( $mod['badge'] ) ) :
-                    $bclass = 'swps-badge-' . ( $mod['badge'] === 'soon' ? 'beta' : ( $mod['badge'] === 'ai' ? 'ai' : 'new' ) );
-                    $blabel = match ( $mod['badge'] ) {
-                        'soon'  => __( 'Soon', 'stratawp-seo' ),
-                        'ai'    => __( 'AI New', 'stratawp-seo' ),
-                        default => __( 'New', 'stratawp-seo' ),
-                    };
-                ?>
-                    <span class="swps-badge <?php echo esc_attr( $bclass ); ?> swps-dash-module-badge">
-                        <?php echo esc_html( $blabel ); ?>
-                    </span>
-                <?php endif; ?>
+	<div class="swps-dash-modules">
+		<?php
+		foreach ( $modules as $mod ) :
+			$is_coming = ( ( $mod['badge'] ?? '' ) === 'soon' );
+			?>
+			<div class="swps-dash-module<?php echo $is_coming ? ' is-coming' : ''; ?>">
+				<?php
+				if ( ! empty( $mod['badge'] ) ) :
+					$bclass = 'swps-badge-' . ( $mod['badge'] === 'soon' ? 'beta' : ( $mod['badge'] === 'ai' ? 'ai' : 'new' ) );
+					$blabel = match ( $mod['badge'] ) {
+						'soon'  => __( 'Soon', 'stratawp-seo' ),
+						'ai'    => __( 'AI New', 'stratawp-seo' ),
+						default => __( 'New', 'stratawp-seo' ),
+					};
+					?>
+					<span class="swps-badge <?php echo esc_attr( $bclass ); ?> swps-dash-module-badge">
+						<?php echo esc_html( $blabel ); ?>
+					</span>
+				<?php endif; ?>
 
-                <div class="swps-dash-module-icon"><?php echo esc_html( $mod['icon'] ); ?></div>
-                <div class="swps-dash-module-title"><?php echo esc_html( $mod['title'] ); ?></div>
-                <div class="swps-dash-module-desc"><?php echo esc_html( $mod['desc'] ); ?></div>
-                <div class="swps-dash-module-toggle">
-                    <?php if ( ! empty( $mod['settings_url'] ) ) : ?>
-                        <a class="swps-dash-module-link" href="<?php echo esc_url( $mod['settings_url'] ); ?>">
-                            <?php esc_html_e( 'Settings →', 'stratawp-seo' ); ?>
-                        </a>
-                    <?php else : ?>
-                        <span class="swps-dash-module-link" style="opacity:.5">
-                            <?php esc_html_e( '— ', 'stratawp-seo' ); ?>
-                        </span>
-                    <?php endif; ?>
-                    <button type="button"
-                        class="swps-toggle swps-toggle-sm <?php echo ! empty( $mod['enabled'] ) ? 'is-on' : ''; ?>"
-                        data-swps-module-toggle="<?php echo esc_attr( $mod['slug'] ); ?>"
-                        data-swps-locked="<?php echo ! empty( $mod['locked'] ) ? '1' : '0'; ?>"
-                        aria-checked="<?php echo ! empty( $mod['enabled'] ) ? 'true' : 'false'; ?>"
-                        aria-label="<?php echo esc_attr( sprintf( __( 'Toggle %s', 'stratawp-seo' ), $mod['title'] ) ); ?>"
-                        <?php disabled( ! empty( $mod['locked'] ) ); ?>
-                    ></button>
-                </div>
-            </div>
-        <?php endforeach; ?>
-    </div>
+				<div class="swps-dash-module-icon"><?php echo esc_html( $mod['icon'] ); ?></div>
+				<div class="swps-dash-module-title"><?php echo esc_html( $mod['title'] ); ?></div>
+				<div class="swps-dash-module-desc"><?php echo esc_html( $mod['desc'] ); ?></div>
+				<div class="swps-dash-module-toggle">
+					<?php if ( ! empty( $mod['settings_url'] ) ) : ?>
+						<a class="swps-dash-module-link" href="<?php echo esc_url( $mod['settings_url'] ); ?>">
+							<?php esc_html_e( 'Settings →', 'stratawp-seo' ); ?>
+						</a>
+					<?php else : ?>
+						<span class="swps-dash-module-link" style="opacity:.5">
+							<?php esc_html_e( '— ', 'stratawp-seo' ); ?>
+						</span>
+					<?php endif; ?>
+					<button type="button"
+						class="swps-toggle swps-toggle-sm <?php echo ! empty( $mod['enabled'] ) ? 'is-on' : ''; ?>"
+						data-swps-module-toggle="<?php echo esc_attr( $mod['slug'] ); ?>"
+						data-swps-locked="<?php echo ! empty( $mod['locked'] ) ? '1' : '0'; ?>"
+						aria-checked="<?php echo ! empty( $mod['enabled'] ) ? 'true' : 'false'; ?>"
+						aria-label="<?php echo esc_attr( sprintf( __( 'Toggle %s', 'stratawp-seo' ), $mod['title'] ) ); ?>"
+						<?php disabled( ! empty( $mod['locked'] ) ); ?>
+					></button>
+				</div>
+			</div>
+		<?php endforeach; ?>
+	</div>
 
 </div>

--- a/templates/generate-page.php
+++ b/templates/generate-page.php
@@ -6,293 +6,303 @@ $cost_stats  = stratawp_seo()->cost_tracker->get_monthly_stats();
 $templates   = SWPS_Templates::get_options();
 ?>
 <div class="wrap swps-generate-wrap">
-    <?php
-    $title    = __( 'Generate Content', 'stratawp-seo' );
-    $subtitle = __( 'Create AI-powered, SEO-optimized blog posts. Enter a topic or let the AI pick one based on your site\'s gaps.', 'stratawp-seo' );
-    $actions  = [];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'Generate Content', 'stratawp-seo' );
+	$subtitle = __( 'Create AI-powered, SEO-optimized blog posts. Enter a topic or let the AI pick one based on your site\'s gaps.', 'stratawp-seo' );
+	$actions  = array();
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <?php if ( ! $has_api_key ) : ?>
-        <div class="notice notice-error">
-            <p><?php printf(
-                __( 'You need to <a href="%s">add your AI provider API key</a> before generating content.', 'stratawp-seo' ),
-                esc_url( admin_url( 'admin.php?page=swps-settings' ) )
-            ); ?></p>
-        </div>
-    <?php endif; ?>
+	<?php if ( ! $has_api_key ) : ?>
+		<div class="notice notice-error">
+			<p>
+			<?php
+			printf(
+				__( 'You need to <a href="%s">add your AI provider API key</a> before generating content.', 'stratawp-seo' ),
+				esc_url( admin_url( 'admin.php?page=swps-settings' ) )
+			);
+			?>
+			</p>
+		</div>
+	<?php endif; ?>
 
-    <div class="swps-generate-grid">
+	<div class="swps-generate-grid">
 
-        <!-- Generate Card -->
-        <div class="swps-card swps-card-generate">
-            <h2><?php esc_html_e( 'Generate a New Post', 'stratawp-seo' ); ?></h2>
-            <p class="swps-card-desc"><?php esc_html_e( 'Create an SEO-optimized blog post. Enter a specific topic or let the AI choose one based on your site\'s content gaps.', 'stratawp-seo' ); ?></p>
+		<!-- Generate Card -->
+		<div class="swps-card swps-card-generate">
+			<h2><?php esc_html_e( 'Generate a New Post', 'stratawp-seo' ); ?></h2>
+			<p class="swps-card-desc"><?php esc_html_e( 'Create an SEO-optimized blog post. Enter a specific topic or let the AI choose one based on your site\'s content gaps.', 'stratawp-seo' ); ?></p>
 
-            <div class="swps-form-group">
-                <label for="swps-topic"><?php esc_html_e( 'Topic (optional)', 'stratawp-seo' ); ?></label>
-                <input
-                    type="text"
-                    id="swps-topic"
-                    class="regular-text"
-                    placeholder="<?php esc_attr_e( 'e.g., How to Choose the Right Kitchen Countertop — or leave blank for AI suggestion', 'stratawp-seo' ); ?>"
-                    <?php echo ! $has_api_key ? 'disabled' : ''; ?>
-                />
-            </div>
+			<div class="swps-form-group">
+				<label for="swps-topic"><?php esc_html_e( 'Topic (optional)', 'stratawp-seo' ); ?></label>
+				<input
+					type="text"
+					id="swps-topic"
+					class="regular-text"
+					placeholder="<?php esc_attr_e( 'e.g., How to Choose the Right Kitchen Countertop — or leave blank for AI suggestion', 'stratawp-seo' ); ?>"
+					<?php echo ! $has_api_key ? 'disabled' : ''; ?>
+				/>
+			</div>
 
-            <div class="swps-form-row">
-                <div class="swps-form-group swps-form-group-inline">
-                    <label for="swps-template"><?php esc_html_e( 'Template', 'stratawp-seo' ); ?></label>
-                    <select id="swps-template" <?php echo ! $has_api_key ? 'disabled' : ''; ?>>
-                        <?php foreach ( $templates as $value => $label ) : ?>
-                            <option value="<?php echo esc_attr( $value ); ?>"><?php echo esc_html( $label ); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </div>
+			<div class="swps-form-row">
+				<div class="swps-form-group swps-form-group-inline">
+					<label for="swps-template"><?php esc_html_e( 'Template', 'stratawp-seo' ); ?></label>
+					<select id="swps-template" <?php echo ! $has_api_key ? 'disabled' : ''; ?>>
+						<?php foreach ( $templates as $value => $label ) : ?>
+							<option value="<?php echo esc_attr( $value ); ?>"><?php echo esc_html( $label ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</div>
 
-                <div class="swps-form-group swps-form-group-inline">
-                    <label for="swps-bulk-count"><?php esc_html_e( 'Bulk Count', 'stratawp-seo' ); ?></label>
-                    <input type="number" id="swps-bulk-count" value="1" min="1" max="5" class="small-text" <?php echo ! $has_api_key ? 'disabled' : ''; ?> />
-                </div>
-            </div>
+				<div class="swps-form-group swps-form-group-inline">
+					<label for="swps-bulk-count"><?php esc_html_e( 'Bulk Count', 'stratawp-seo' ); ?></label>
+					<input type="number" id="swps-bulk-count" value="1" min="1" max="5" class="small-text" <?php echo ! $has_api_key ? 'disabled' : ''; ?> />
+				</div>
+			</div>
 
-            <!-- Rate limit indicator -->
-            <div id="swps-rate-limit" class="swps-rate-limit" style="display: none;"></div>
+			<!-- Rate limit indicator -->
+			<div id="swps-rate-limit" class="swps-rate-limit" style="display: none;"></div>
 
-            <div class="swps-generate-actions">
-                <button
-                    type="button"
-                    id="swps-generate-btn"
-                    class="button button-primary button-hero"
-                    <?php echo ! $has_api_key ? 'disabled' : ''; ?>
-                >
-                    <span class="dashicons dashicons-edit-large" style="margin-top: 4px;"></span>
-                    <?php esc_html_e( 'Generate Post', 'stratawp-seo' ); ?>
-                </button>
+			<div class="swps-generate-actions">
+				<button
+					type="button"
+					id="swps-generate-btn"
+					class="button button-primary button-hero"
+					<?php echo ! $has_api_key ? 'disabled' : ''; ?>
+				>
+					<span class="dashicons dashicons-edit-large" style="margin-top: 4px;"></span>
+					<?php esc_html_e( 'Generate Post', 'stratawp-seo' ); ?>
+				</button>
 
-                <button
-                    type="button"
-                    id="swps-preview-btn"
-                    class="button button-secondary button-hero"
-                    <?php echo ! $has_api_key ? 'disabled' : ''; ?>
-                >
-                    <span class="dashicons dashicons-visibility" style="margin-top: 4px;"></span>
-                    <?php esc_html_e( 'Preview', 'stratawp-seo' ); ?>
-                </button>
+				<button
+					type="button"
+					id="swps-preview-btn"
+					class="button button-secondary button-hero"
+					<?php echo ! $has_api_key ? 'disabled' : ''; ?>
+				>
+					<span class="dashicons dashicons-visibility" style="margin-top: 4px;"></span>
+					<?php esc_html_e( 'Preview', 'stratawp-seo' ); ?>
+				</button>
 
-                <button
-                    type="button"
-                    id="swps-bulk-btn"
-                    class="button button-secondary"
-                    <?php echo ! $has_api_key ? 'disabled' : ''; ?>
-                >
-                    <span class="dashicons dashicons-controls-repeat" style="margin-top: 4px;"></span>
-                    <?php esc_html_e( 'Bulk Generate', 'stratawp-seo' ); ?>
-                </button>
+				<button
+					type="button"
+					id="swps-bulk-btn"
+					class="button button-secondary"
+					<?php echo ! $has_api_key ? 'disabled' : ''; ?>
+				>
+					<span class="dashicons dashicons-controls-repeat" style="margin-top: 4px;"></span>
+					<?php esc_html_e( 'Bulk Generate', 'stratawp-seo' ); ?>
+				</button>
 
-                <button
-                    type="button"
-                    id="swps-analyze-btn"
-                    class="button button-secondary"
-                    <?php echo ! $has_api_key ? 'disabled' : ''; ?>
-                >
-                    <span class="dashicons dashicons-chart-bar" style="margin-top: 4px;"></span>
-                    <?php esc_html_e( 'Analyze My Site', 'stratawp-seo' ); ?>
-                </button>
-            </div>
+				<button
+					type="button"
+					id="swps-analyze-btn"
+					class="button button-secondary"
+					<?php echo ! $has_api_key ? 'disabled' : ''; ?>
+				>
+					<span class="dashicons dashicons-chart-bar" style="margin-top: 4px;"></span>
+					<?php esc_html_e( 'Analyze My Site', 'stratawp-seo' ); ?>
+				</button>
+			</div>
 
-            <!-- Progress indicator -->
-            <div id="swps-progress" class="swps-progress" style="display: none;">
-                <div class="swps-spinner"></div>
-                <div class="swps-progress-text">
-                    <strong id="swps-progress-title"><?php esc_html_e( 'Generating your post...', 'stratawp-seo' ); ?></strong>
-                    <p id="swps-progress-desc"><?php esc_html_e( 'The AI is analyzing your site content and crafting an optimized post. This usually takes 30-60 seconds.', 'stratawp-seo' ); ?></p>
-                </div>
-            </div>
+			<!-- Progress indicator -->
+			<div id="swps-progress" class="swps-progress" style="display: none;">
+				<div class="swps-spinner"></div>
+				<div class="swps-progress-text">
+					<strong id="swps-progress-title"><?php esc_html_e( 'Generating your post...', 'stratawp-seo' ); ?></strong>
+					<p id="swps-progress-desc"><?php esc_html_e( 'The AI is analyzing your site content and crafting an optimized post. This usually takes 30-60 seconds.', 'stratawp-seo' ); ?></p>
+				</div>
+			</div>
 
-            <!-- Error display -->
-            <div id="swps-error" class="notice notice-error" style="display: none;">
-                <p id="swps-error-message"></p>
-            </div>
-        </div>
+			<!-- Error display -->
+			<div id="swps-error" class="notice notice-error" style="display: none;">
+				<p id="swps-error-message"></p>
+			</div>
+		</div>
 
-        <!-- Schedule Info Card -->
-        <div class="swps-card swps-card-schedule">
-            <h2><?php esc_html_e( 'Auto-Publishing', 'stratawp-seo' ); ?></h2>
-            <?php if ( $schedule['enabled'] ) : ?>
-                <div class="swps-schedule-active">
-                    <span class="swps-status-dot swps-status-active"></span>
-                    <strong><?php esc_html_e( 'Active', 'stratawp-seo' ); ?></strong>
-                </div>
-                <table class="swps-info-table">
-                    <tr>
-                        <td><?php esc_html_e( 'Frequency:', 'stratawp-seo' ); ?></td>
-                        <td><?php echo esc_html( ucfirst( str_replace( '_', ' ', $schedule['frequency'] ) ) ); ?></td>
-                    </tr>
-                    <tr>
-                        <td><?php esc_html_e( 'Next run:', 'stratawp-seo' ); ?></td>
-                        <td><?php echo esc_html( $schedule['next_run'] ); ?></td>
-                    </tr>
-                    <tr>
-                        <td><?php esc_html_e( 'Last run:', 'stratawp-seo' ); ?></td>
-                        <td><?php echo esc_html( $schedule['last_run'] ); ?></td>
-                    </tr>
-                    <tr>
-                        <td><?php esc_html_e( 'Posts per run:', 'stratawp-seo' ); ?></td>
-                        <td><?php echo esc_html( $schedule['posts_per'] ); ?></td>
-                    </tr>
-                </table>
-            <?php else : ?>
-                <div class="swps-schedule-inactive">
-                    <span class="swps-status-dot swps-status-inactive"></span>
-                    <strong><?php esc_html_e( 'Inactive', 'stratawp-seo' ); ?></strong>
-                    <p><?php printf(
-                        __( 'Enable automated posting in <a href="%s">Settings</a>.', 'stratawp-seo' ),
-                        esc_url( admin_url( 'admin.php?page=swps-settings' ) )
-                    ); ?></p>
-                </div>
-            <?php endif; ?>
-        </div>
+		<!-- Schedule Info Card -->
+		<div class="swps-card swps-card-schedule">
+			<h2><?php esc_html_e( 'Auto-Publishing', 'stratawp-seo' ); ?></h2>
+			<?php if ( $schedule['enabled'] ) : ?>
+				<div class="swps-schedule-active">
+					<span class="swps-status-dot swps-status-active"></span>
+					<strong><?php esc_html_e( 'Active', 'stratawp-seo' ); ?></strong>
+				</div>
+				<table class="swps-info-table">
+					<tr>
+						<td><?php esc_html_e( 'Frequency:', 'stratawp-seo' ); ?></td>
+						<td><?php echo esc_html( ucfirst( str_replace( '_', ' ', $schedule['frequency'] ) ) ); ?></td>
+					</tr>
+					<tr>
+						<td><?php esc_html_e( 'Next run:', 'stratawp-seo' ); ?></td>
+						<td><?php echo esc_html( $schedule['next_run'] ); ?></td>
+					</tr>
+					<tr>
+						<td><?php esc_html_e( 'Last run:', 'stratawp-seo' ); ?></td>
+						<td><?php echo esc_html( $schedule['last_run'] ); ?></td>
+					</tr>
+					<tr>
+						<td><?php esc_html_e( 'Posts per run:', 'stratawp-seo' ); ?></td>
+						<td><?php echo esc_html( $schedule['posts_per'] ); ?></td>
+					</tr>
+				</table>
+			<?php else : ?>
+				<div class="swps-schedule-inactive">
+					<span class="swps-status-dot swps-status-inactive"></span>
+					<strong><?php esc_html_e( 'Inactive', 'stratawp-seo' ); ?></strong>
+					<p>
+					<?php
+					printf(
+						__( 'Enable automated posting in <a href="%s">Settings</a>.', 'stratawp-seo' ),
+						esc_url( admin_url( 'admin.php?page=swps-settings' ) )
+					);
+					?>
+					</p>
+				</div>
+			<?php endif; ?>
+		</div>
 
-        <!-- Site Stats Card -->
-        <div class="swps-card swps-card-stats">
-            <h2><?php esc_html_e( 'Site Overview', 'stratawp-seo' ); ?></h2>
-            <?php
-            $post_count = wp_count_posts( 'post' );
-            $generated  = new WP_Query( [
-                'post_type'      => 'post',
-                'post_status'    => 'any',
-                'meta_key'       => '_swps_generated',
-                'meta_value'     => '1',
-                'posts_per_page' => -1,
-                'fields'         => 'ids',
-            ] );
-            ?>
-            <div class="swps-stats-grid">
-                <div class="swps-stat">
-                    <span class="swps-stat-number"><?php echo esc_html( $post_count->publish ); ?></span>
-                    <span class="swps-stat-label"><?php esc_html_e( 'Published Posts', 'stratawp-seo' ); ?></span>
-                </div>
-                <div class="swps-stat">
-                    <span class="swps-stat-number"><?php echo esc_html( $post_count->draft ); ?></span>
-                    <span class="swps-stat-label"><?php esc_html_e( 'Drafts', 'stratawp-seo' ); ?></span>
-                </div>
-                <div class="swps-stat">
-                    <span class="swps-stat-number"><?php echo esc_html( $generated->found_posts ); ?></span>
-                    <span class="swps-stat-label"><?php esc_html_e( 'AI Generated', 'stratawp-seo' ); ?></span>
-                </div>
-            </div>
-        </div>
+		<!-- Site Stats Card -->
+		<div class="swps-card swps-card-stats">
+			<h2><?php esc_html_e( 'Site Overview', 'stratawp-seo' ); ?></h2>
+			<?php
+			$post_count = wp_count_posts( 'post' );
+			$generated  = new WP_Query(
+				array(
+					'post_type'      => 'post',
+					'post_status'    => 'any',
+					'meta_key'       => '_swps_generated',
+					'meta_value'     => '1',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+				)
+			);
+			?>
+			<div class="swps-stats-grid">
+				<div class="swps-stat">
+					<span class="swps-stat-number"><?php echo esc_html( $post_count->publish ); ?></span>
+					<span class="swps-stat-label"><?php esc_html_e( 'Published Posts', 'stratawp-seo' ); ?></span>
+				</div>
+				<div class="swps-stat">
+					<span class="swps-stat-number"><?php echo esc_html( $post_count->draft ); ?></span>
+					<span class="swps-stat-label"><?php esc_html_e( 'Drafts', 'stratawp-seo' ); ?></span>
+				</div>
+				<div class="swps-stat">
+					<span class="swps-stat-number"><?php echo esc_html( $generated->found_posts ); ?></span>
+					<span class="swps-stat-label"><?php esc_html_e( 'AI Generated', 'stratawp-seo' ); ?></span>
+				</div>
+			</div>
+		</div>
 
-        <?php if ( get_option( 'swps_cost_tracking', false ) ) : ?>
-        <!-- Cost Stats Card -->
-        <div class="swps-card swps-card-cost">
-            <h2><?php esc_html_e( 'Cost This Month', 'stratawp-seo' ); ?></h2>
-            <div class="swps-stats-grid">
-                <div class="swps-stat">
-                    <span class="swps-stat-number">$<?php echo esc_html( number_format( $cost_stats['total_cost'], 2 ) ); ?></span>
-                    <span class="swps-stat-label"><?php esc_html_e( 'Spent', 'stratawp-seo' ); ?></span>
-                </div>
-                <div class="swps-stat">
-                    <span class="swps-stat-number"><?php echo esc_html( $cost_stats['generation_count'] ); ?></span>
-                    <span class="swps-stat-label"><?php esc_html_e( 'Generations', 'stratawp-seo' ); ?></span>
-                </div>
-                <div class="swps-stat">
-                    <span class="swps-stat-number"><?php echo esc_html( number_format( $cost_stats['total_input_tokens'] + $cost_stats['total_output_tokens'] ) ); ?></span>
-                    <span class="swps-stat-label"><?php esc_html_e( 'Tokens', 'stratawp-seo' ); ?></span>
-                </div>
-            </div>
-        </div>
-        <?php endif; ?>
+		<?php if ( get_option( 'swps_cost_tracking', false ) ) : ?>
+		<!-- Cost Stats Card -->
+		<div class="swps-card swps-card-cost">
+			<h2><?php esc_html_e( 'Cost This Month', 'stratawp-seo' ); ?></h2>
+			<div class="swps-stats-grid">
+				<div class="swps-stat">
+					<span class="swps-stat-number">$<?php echo esc_html( number_format( $cost_stats['total_cost'], 2 ) ); ?></span>
+					<span class="swps-stat-label"><?php esc_html_e( 'Spent', 'stratawp-seo' ); ?></span>
+				</div>
+				<div class="swps-stat">
+					<span class="swps-stat-number"><?php echo esc_html( $cost_stats['generation_count'] ); ?></span>
+					<span class="swps-stat-label"><?php esc_html_e( 'Generations', 'stratawp-seo' ); ?></span>
+				</div>
+				<div class="swps-stat">
+					<span class="swps-stat-number"><?php echo esc_html( number_format( $cost_stats['total_input_tokens'] + $cost_stats['total_output_tokens'] ) ); ?></span>
+					<span class="swps-stat-label"><?php esc_html_e( 'Tokens', 'stratawp-seo' ); ?></span>
+				</div>
+			</div>
+		</div>
+		<?php endif; ?>
 
-    </div>
+	</div>
 
-    <!-- Results section -->
-    <div id="swps-result" class="swps-card swps-card-result" style="display: none;">
-        <h2>
-            <span class="dashicons dashicons-yes-alt" style="color: #00a32a;"></span>
-            <?php esc_html_e( 'Post Generated Successfully!', 'stratawp-seo' ); ?>
-        </h2>
+	<!-- Results section -->
+	<div id="swps-result" class="swps-card swps-card-result" style="display: none;">
+		<h2>
+			<span class="dashicons dashicons-yes-alt" style="color: #00a32a;"></span>
+			<?php esc_html_e( 'Post Generated Successfully!', 'stratawp-seo' ); ?>
+		</h2>
 
-        <table class="swps-result-table">
-            <tr>
-                <td><strong><?php esc_html_e( 'Title:', 'stratawp-seo' ); ?></strong></td>
-                <td id="swps-result-title"></td>
-            </tr>
-            <tr>
-                <td><strong><?php esc_html_e( 'Status:', 'stratawp-seo' ); ?></strong></td>
-                <td id="swps-result-status"></td>
-            </tr>
-            <tr>
-                <td><strong><?php esc_html_e( 'Focus Keyword:', 'stratawp-seo' ); ?></strong></td>
-                <td id="swps-result-keyword"></td>
-            </tr>
-            <tr>
-                <td><strong><?php esc_html_e( 'Meta Description:', 'stratawp-seo' ); ?></strong></td>
-                <td id="swps-result-meta"></td>
-            </tr>
-            <tr>
-                <td><strong><?php esc_html_e( 'Word Count:', 'stratawp-seo' ); ?></strong></td>
-                <td id="swps-result-words"></td>
-            </tr>
-            <tr>
-                <td><strong><?php esc_html_e( 'Internal Links:', 'stratawp-seo' ); ?></strong></td>
-                <td id="swps-result-links"></td>
-            </tr>
-            <tr id="swps-result-cost-row" style="display: none;">
-                <td><strong><?php esc_html_e( 'Cost:', 'stratawp-seo' ); ?></strong></td>
-                <td id="swps-result-cost"></td>
-            </tr>
-            <tr id="swps-result-score-row" style="display: none;">
-                <td><strong><?php esc_html_e( 'Content Score:', 'stratawp-seo' ); ?></strong></td>
-                <td id="swps-result-score"></td>
-            </tr>
-        </table>
+		<table class="swps-result-table">
+			<tr>
+				<td><strong><?php esc_html_e( 'Title:', 'stratawp-seo' ); ?></strong></td>
+				<td id="swps-result-title"></td>
+			</tr>
+			<tr>
+				<td><strong><?php esc_html_e( 'Status:', 'stratawp-seo' ); ?></strong></td>
+				<td id="swps-result-status"></td>
+			</tr>
+			<tr>
+				<td><strong><?php esc_html_e( 'Focus Keyword:', 'stratawp-seo' ); ?></strong></td>
+				<td id="swps-result-keyword"></td>
+			</tr>
+			<tr>
+				<td><strong><?php esc_html_e( 'Meta Description:', 'stratawp-seo' ); ?></strong></td>
+				<td id="swps-result-meta"></td>
+			</tr>
+			<tr>
+				<td><strong><?php esc_html_e( 'Word Count:', 'stratawp-seo' ); ?></strong></td>
+				<td id="swps-result-words"></td>
+			</tr>
+			<tr>
+				<td><strong><?php esc_html_e( 'Internal Links:', 'stratawp-seo' ); ?></strong></td>
+				<td id="swps-result-links"></td>
+			</tr>
+			<tr id="swps-result-cost-row" style="display: none;">
+				<td><strong><?php esc_html_e( 'Cost:', 'stratawp-seo' ); ?></strong></td>
+				<td id="swps-result-cost"></td>
+			</tr>
+			<tr id="swps-result-score-row" style="display: none;">
+				<td><strong><?php esc_html_e( 'Content Score:', 'stratawp-seo' ); ?></strong></td>
+				<td id="swps-result-score"></td>
+			</tr>
+		</table>
 
-        <div class="swps-result-actions">
-            <a id="swps-result-edit" href="#" class="button button-primary" target="_blank">
-                <?php esc_html_e( 'Edit Post', 'stratawp-seo' ); ?>
-            </a>
-            <a id="swps-result-preview" href="#" class="button" target="_blank">
-                <?php esc_html_e( 'Preview Post', 'stratawp-seo' ); ?>
-            </a>
-            <button type="button" id="swps-generate-another" class="button">
-                <?php esc_html_e( 'Generate Another', 'stratawp-seo' ); ?>
-            </button>
-        </div>
-    </div>
+		<div class="swps-result-actions">
+			<a id="swps-result-edit" href="#" class="button button-primary" target="_blank">
+				<?php esc_html_e( 'Edit Post', 'stratawp-seo' ); ?>
+			</a>
+			<a id="swps-result-preview" href="#" class="button" target="_blank">
+				<?php esc_html_e( 'Preview Post', 'stratawp-seo' ); ?>
+			</a>
+			<button type="button" id="swps-generate-another" class="button">
+				<?php esc_html_e( 'Generate Another', 'stratawp-seo' ); ?>
+			</button>
+		</div>
+	</div>
 
-    <!-- Site Analysis Results -->
-    <div id="swps-analysis" class="swps-card" style="display: none;">
-        <h2><?php esc_html_e( 'Site Content Analysis', 'stratawp-seo' ); ?></h2>
-        <pre id="swps-analysis-data" class="swps-code-block"></pre>
-    </div>
+	<!-- Site Analysis Results -->
+	<div id="swps-analysis" class="swps-card" style="display: none;">
+		<h2><?php esc_html_e( 'Site Content Analysis', 'stratawp-seo' ); ?></h2>
+		<pre id="swps-analysis-data" class="swps-code-block"></pre>
+	</div>
 
-    <!-- Preview Modal -->
-    <div id="swps-preview-modal" class="swps-modal" style="display: none;">
-        <div class="swps-modal-overlay"></div>
-        <div class="swps-modal-dialog swps-modal-large">
-            <div class="swps-modal-header">
-                <h2 id="swps-preview-title"><?php esc_html_e( 'Post Preview', 'stratawp-seo' ); ?></h2>
-                <button type="button" class="swps-modal-close" aria-label="Close">&times;</button>
-            </div>
-            <div class="swps-modal-body">
-                <div class="swps-preview-meta">
-                    <p><strong><?php esc_html_e( 'Focus Keyword:', 'stratawp-seo' ); ?></strong> <span id="swps-preview-keyword"></span></p>
-                    <p><strong><?php esc_html_e( 'Meta Description:', 'stratawp-seo' ); ?></strong> <span id="swps-preview-meta"></span></p>
-                </div>
-                <div id="swps-preview-content" class="swps-preview-content"></div>
-            </div>
-            <div class="swps-modal-footer">
-                <button type="button" id="swps-preview-publish" class="button button-primary">
-                    <span class="dashicons dashicons-yes" style="margin-top: 4px;"></span>
-                    <?php esc_html_e( 'Publish This', 'stratawp-seo' ); ?>
-                </button>
-                <button type="button" class="button swps-modal-close">
-                    <?php esc_html_e( 'Close', 'stratawp-seo' ); ?>
-                </button>
-            </div>
-        </div>
-    </div>
+	<!-- Preview Modal -->
+	<div id="swps-preview-modal" class="swps-modal" style="display: none;">
+		<div class="swps-modal-overlay"></div>
+		<div class="swps-modal-dialog swps-modal-large">
+			<div class="swps-modal-header">
+				<h2 id="swps-preview-title"><?php esc_html_e( 'Post Preview', 'stratawp-seo' ); ?></h2>
+				<button type="button" class="swps-modal-close" aria-label="Close">&times;</button>
+			</div>
+			<div class="swps-modal-body">
+				<div class="swps-preview-meta">
+					<p><strong><?php esc_html_e( 'Focus Keyword:', 'stratawp-seo' ); ?></strong> <span id="swps-preview-keyword"></span></p>
+					<p><strong><?php esc_html_e( 'Meta Description:', 'stratawp-seo' ); ?></strong> <span id="swps-preview-meta"></span></p>
+				</div>
+				<div id="swps-preview-content" class="swps-preview-content"></div>
+			</div>
+			<div class="swps-modal-footer">
+				<button type="button" id="swps-preview-publish" class="button button-primary">
+					<span class="dashicons dashicons-yes" style="margin-top: 4px;"></span>
+					<?php esc_html_e( 'Publish This', 'stratawp-seo' ); ?>
+				</button>
+				<button type="button" class="button swps-modal-close">
+					<?php esc_html_e( 'Close', 'stratawp-seo' ); ?>
+				</button>
+			</div>
+		</div>
+	</div>
 
 </div>

--- a/templates/image-seo-page.php
+++ b/templates/image-seo-page.php
@@ -6,7 +6,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 $image_seo = stratawp_seo()->image_seo;
@@ -15,141 +15,143 @@ $missing   = $image_seo->get_missing_alt_count();
 
 global $wpdb;
 // phpcs:ignore WordPress.DB.DirectDatabaseQuery
-$total = (int) $wpdb->get_var( "
+$total = (int) $wpdb->get_var(
+	"
     SELECT COUNT(*) FROM {$wpdb->posts}
     WHERE post_type = 'attachment' AND post_mime_type LIKE 'image/%'
-" );
+"
+);
 $ok    = max( 0, $total - $missing );
 $pct   = $total > 0 ? round( ( $ok / $total ) * 100 ) : 100;
 ?>
 <div class="wrap">
-    <?php
-    $title    = __( 'Image SEO', 'stratawp-seo' );
-    $subtitle = __( 'Auto-fill missing alt text, sanitize uploaded filenames, and keep images lazy-loaded. Helps both search ranking and accessibility.', 'stratawp-seo' );
-    $actions  = [];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'Image SEO', 'stratawp-seo' );
+	$subtitle = __( 'Auto-fill missing alt text, sanitize uploaded filenames, and keep images lazy-loaded. Helps both search ranking and accessibility.', 'stratawp-seo' );
+	$actions  = array();
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <!-- Stats tiles -->
-    <div class="swps-image-seo-stats">
-        <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'Images in library', 'stratawp-seo' ); ?></div>
-            <div class="swps-tile-stat"><?php echo number_format( $total ); ?></div>
-        </div>
-        <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'Missing alt text', 'stratawp-seo' ); ?></div>
-            <div class="swps-tile-stat" id="swps-img-missing"><?php echo number_format( $missing ); ?></div>
-            <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
-                <?php
-                printf(
-                    /* translators: %d: percent with alt */
-                    esc_html__( '%d%% have alt text', 'stratawp-seo' ),
-                    (int) $pct
-                );
-                ?>
-            </div>
-        </div>
-        <div class="swps-tile">
-            <div class="swps-tile-h"><?php esc_html_e( 'Auto-alt mode', 'stratawp-seo' ); ?></div>
-            <div class="swps-tile-stat" style="font-size:18px">
-                <?php echo 'ai' === ( $opts['alt_mode'] ?? 'heuristic' ) ? esc_html__( 'AI', 'stratawp-seo' ) : esc_html__( 'Heuristic', 'stratawp-seo' ); ?>
-            </div>
-            <div class="swps-tile-trend" style="color:var(--swps-text-faint)">
-                <?php echo empty( $opts['auto_alt'] ) ? esc_html__( 'Disabled', 'stratawp-seo' ) : esc_html__( 'Active on upload', 'stratawp-seo' ); ?>
-            </div>
-        </div>
-    </div>
+	<!-- Stats tiles -->
+	<div class="swps-image-seo-stats">
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'Images in library', 'stratawp-seo' ); ?></div>
+			<div class="swps-tile-stat"><?php echo number_format( $total ); ?></div>
+		</div>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'Missing alt text', 'stratawp-seo' ); ?></div>
+			<div class="swps-tile-stat" id="swps-img-missing"><?php echo number_format( $missing ); ?></div>
+			<div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+				<?php
+				printf(
+					/* translators: %d: percent with alt */
+					esc_html__( '%d%% have alt text', 'stratawp-seo' ),
+					(int) $pct
+				);
+				?>
+			</div>
+		</div>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'Auto-alt mode', 'stratawp-seo' ); ?></div>
+			<div class="swps-tile-stat" style="font-size:18px">
+				<?php echo 'ai' === ( $opts['alt_mode'] ?? 'heuristic' ) ? esc_html__( 'AI', 'stratawp-seo' ) : esc_html__( 'Heuristic', 'stratawp-seo' ); ?>
+			</div>
+			<div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+				<?php echo empty( $opts['auto_alt'] ) ? esc_html__( 'Disabled', 'stratawp-seo' ) : esc_html__( 'Active on upload', 'stratawp-seo' ); ?>
+			</div>
+		</div>
+	</div>
 
-    <!-- Bulk fix -->
-    <div class="swps-card" style="margin-bottom:16px">
-        <h2 style="margin-top:0"><?php esc_html_e( 'Bulk fix missing alt text', 'stratawp-seo' ); ?></h2>
-        <p class="description" style="margin-top:0">
-            <?php esc_html_e( 'Process the existing library and write alt text for every image that does not have any. Uses the auto-alt mode you have selected below. Runs in batches of 20 — safe to leave open while it works.', 'stratawp-seo' ); ?>
-        </p>
-        <div class="swps-image-seo-bulk-actions" style="display:flex;align-items:center;gap:12px;margin-top:12px">
-            <button type="button" class="swps-btn swps-btn-grad" id="swps-img-bulk-fix"
-                    <?php disabled( 0 === $missing ); ?>>
-                <?php esc_html_e( 'Fix missing alt text', 'stratawp-seo' ); ?>
-            </button>
-            <span class="swps-image-seo-status" id="swps-img-status" style="color:var(--swps-text-muted);font-size:13px">
-                <?php
-                if ( 0 === $missing ) {
-                    esc_html_e( 'All images have alt text. Nothing to do here.', 'stratawp-seo' );
-                } else {
-                    printf(
-                        /* translators: %d: count missing */
-                        esc_html__( '%d images need alt text.', 'stratawp-seo' ),
-                        (int) $missing
-                    );
-                }
-                ?>
-            </span>
-        </div>
-    </div>
+	<!-- Bulk fix -->
+	<div class="swps-card" style="margin-bottom:16px">
+		<h2 style="margin-top:0"><?php esc_html_e( 'Bulk fix missing alt text', 'stratawp-seo' ); ?></h2>
+		<p class="description" style="margin-top:0">
+			<?php esc_html_e( 'Process the existing library and write alt text for every image that does not have any. Uses the auto-alt mode you have selected below. Runs in batches of 20 — safe to leave open while it works.', 'stratawp-seo' ); ?>
+		</p>
+		<div class="swps-image-seo-bulk-actions" style="display:flex;align-items:center;gap:12px;margin-top:12px">
+			<button type="button" class="swps-btn swps-btn-grad" id="swps-img-bulk-fix"
+					<?php disabled( 0 === $missing ); ?>>
+				<?php esc_html_e( 'Fix missing alt text', 'stratawp-seo' ); ?>
+			</button>
+			<span class="swps-image-seo-status" id="swps-img-status" style="color:var(--swps-text-muted);font-size:13px">
+				<?php
+				if ( 0 === $missing ) {
+					esc_html_e( 'All images have alt text. Nothing to do here.', 'stratawp-seo' );
+				} else {
+					printf(
+						/* translators: %d: count missing */
+						esc_html__( '%d images need alt text.', 'stratawp-seo' ),
+						(int) $missing
+					);
+				}
+				?>
+			</span>
+		</div>
+	</div>
 
-    <!-- Settings form -->
-    <form method="post" action="options.php" class="swps-image-seo-form">
-        <?php settings_fields( 'swps_image_seo_group' ); ?>
+	<!-- Settings form -->
+	<form method="post" action="options.php" class="swps-image-seo-form">
+		<?php settings_fields( 'swps_image_seo_group' ); ?>
 
-        <div class="swps-card" style="margin-bottom:16px">
-            <h2 style="margin-top:0"><?php esc_html_e( 'Auto-alt on upload', 'stratawp-seo' ); ?></h2>
+		<div class="swps-card" style="margin-bottom:16px">
+			<h2 style="margin-top:0"><?php esc_html_e( 'Auto-alt on upload', 'stratawp-seo' ); ?></h2>
 
-            <label style="display:flex;align-items:center;gap:10px;margin-bottom:10px">
-                <input type="checkbox"
-                       name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[auto_alt]"
-                       value="1" <?php checked( ! empty( $opts['auto_alt'] ) ); ?> />
-                <span style="font-weight:600"><?php esc_html_e( 'Generate alt text automatically when an image is uploaded', 'stratawp-seo' ); ?></span>
-            </label>
+			<label style="display:flex;align-items:center;gap:10px;margin-bottom:10px">
+				<input type="checkbox"
+						name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[auto_alt]"
+						value="1" <?php checked( ! empty( $opts['auto_alt'] ) ); ?> />
+				<span style="font-weight:600"><?php esc_html_e( 'Generate alt text automatically when an image is uploaded', 'stratawp-seo' ); ?></span>
+			</label>
 
-            <fieldset style="margin-left:28px;margin-top:8px">
-                <legend class="screen-reader-text"><?php esc_html_e( 'Alt text generation mode', 'stratawp-seo' ); ?></legend>
-                <label style="display:block;margin-bottom:6px">
-                    <input type="radio"
-                           name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[alt_mode]"
-                           value="heuristic" <?php checked( ( $opts['alt_mode'] ?? 'heuristic' ), 'heuristic' ); ?> />
-                    <strong><?php esc_html_e( 'Heuristic (free, instant)', 'stratawp-seo' ); ?></strong>
-                    <span style="color:var(--swps-text-muted);font-size:12px">
-                        — <?php esc_html_e( 'Derives alt from filename + parent post title. No API calls.', 'stratawp-seo' ); ?>
-                    </span>
-                </label>
-                <label style="display:block">
-                    <input type="radio"
-                           name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[alt_mode]"
-                           value="ai" <?php checked( ( $opts['alt_mode'] ?? 'heuristic' ), 'ai' ); ?> />
-                    <strong><?php esc_html_e( 'AI (uses your configured provider)', 'stratawp-seo' ); ?></strong>
-                    <span style="color:var(--swps-text-muted);font-size:12px">
-                        — <?php esc_html_e( 'Sends filename + post context to your AI provider. Falls back to heuristic on error. Each call costs a fraction of a cent.', 'stratawp-seo' ); ?>
-                    </span>
-                </label>
-            </fieldset>
-        </div>
+			<fieldset style="margin-left:28px;margin-top:8px">
+				<legend class="screen-reader-text"><?php esc_html_e( 'Alt text generation mode', 'stratawp-seo' ); ?></legend>
+				<label style="display:block;margin-bottom:6px">
+					<input type="radio"
+							name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[alt_mode]"
+							value="heuristic" <?php checked( ( $opts['alt_mode'] ?? 'heuristic' ), 'heuristic' ); ?> />
+					<strong><?php esc_html_e( 'Heuristic (free, instant)', 'stratawp-seo' ); ?></strong>
+					<span style="color:var(--swps-text-muted);font-size:12px">
+						— <?php esc_html_e( 'Derives alt from filename + parent post title. No API calls.', 'stratawp-seo' ); ?>
+					</span>
+				</label>
+				<label style="display:block">
+					<input type="radio"
+							name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[alt_mode]"
+							value="ai" <?php checked( ( $opts['alt_mode'] ?? 'heuristic' ), 'ai' ); ?> />
+					<strong><?php esc_html_e( 'AI (uses your configured provider)', 'stratawp-seo' ); ?></strong>
+					<span style="color:var(--swps-text-muted);font-size:12px">
+						— <?php esc_html_e( 'Sends filename + post context to your AI provider. Falls back to heuristic on error. Each call costs a fraction of a cent.', 'stratawp-seo' ); ?>
+					</span>
+				</label>
+			</fieldset>
+		</div>
 
-        <div class="swps-card" style="margin-bottom:16px">
-            <h2 style="margin-top:0"><?php esc_html_e( 'Filename sanitization', 'stratawp-seo' ); ?></h2>
-            <label style="display:flex;align-items:center;gap:10px">
-                <input type="checkbox"
-                       name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[filename_sanitize]"
-                       value="1" <?php checked( ! empty( $opts['filename_sanitize'] ) ); ?> />
-                <span style="font-weight:600"><?php esc_html_e( 'Clean up filenames on upload', 'stratawp-seo' ); ?></span>
-            </label>
-            <p class="description" style="margin:6px 0 0 28px">
-                <?php esc_html_e( 'Strips device prefixes (IMG_, DSC_), lowercases, and converts spaces/underscores to dashes. Example: "IMG_4523 Vacation.JPG" → "vacation.jpg".', 'stratawp-seo' ); ?>
-            </p>
-        </div>
+		<div class="swps-card" style="margin-bottom:16px">
+			<h2 style="margin-top:0"><?php esc_html_e( 'Filename sanitization', 'stratawp-seo' ); ?></h2>
+			<label style="display:flex;align-items:center;gap:10px">
+				<input type="checkbox"
+						name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[filename_sanitize]"
+						value="1" <?php checked( ! empty( $opts['filename_sanitize'] ) ); ?> />
+				<span style="font-weight:600"><?php esc_html_e( 'Clean up filenames on upload', 'stratawp-seo' ); ?></span>
+			</label>
+			<p class="description" style="margin:6px 0 0 28px">
+				<?php esc_html_e( 'Strips device prefixes (IMG_, DSC_), lowercases, and converts spaces/underscores to dashes. Example: "IMG_4523 Vacation.JPG" → "vacation.jpg".', 'stratawp-seo' ); ?>
+			</p>
+		</div>
 
-        <div class="swps-card" style="margin-bottom:16px">
-            <h2 style="margin-top:0"><?php esc_html_e( 'Lazy loading', 'stratawp-seo' ); ?></h2>
-            <label style="display:flex;align-items:center;gap:10px">
-                <input type="checkbox"
-                       name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[lazy_load]"
-                       value="1" <?php checked( ! empty( $opts['lazy_load'] ) ); ?> />
-                <span style="font-weight:600"><?php esc_html_e( 'Force loading="lazy" + decoding="async" on all post-content images', 'stratawp-seo' ); ?></span>
-            </label>
-            <p class="description" style="margin:6px 0 0 28px">
-                <?php esc_html_e( 'WordPress already lazy-loads images that have width/height attributes. This adds the attributes to any image still missing them, which improves Core Web Vitals.', 'stratawp-seo' ); ?>
-            </p>
-        </div>
+		<div class="swps-card" style="margin-bottom:16px">
+			<h2 style="margin-top:0"><?php esc_html_e( 'Lazy loading', 'stratawp-seo' ); ?></h2>
+			<label style="display:flex;align-items:center;gap:10px">
+				<input type="checkbox"
+						name="<?php echo esc_attr( SWPS_Image_SEO::OPTION_KEY ); ?>[lazy_load]"
+						value="1" <?php checked( ! empty( $opts['lazy_load'] ) ); ?> />
+				<span style="font-weight:600"><?php esc_html_e( 'Force loading="lazy" + decoding="async" on all post-content images', 'stratawp-seo' ); ?></span>
+			</label>
+			<p class="description" style="margin:6px 0 0 28px">
+				<?php esc_html_e( 'WordPress already lazy-loads images that have width/height attributes. This adds the attributes to any image still missing them, which improves Core Web Vitals.', 'stratawp-seo' ); ?>
+			</p>
+		</div>
 
-        <?php submit_button( __( 'Save Image SEO settings', 'stratawp-seo' ) ); ?>
-    </form>
+		<?php submit_button( __( 'Save Image SEO settings', 'stratawp-seo' ) ); ?>
+	</form>
 </div>

--- a/templates/internal-links-page.php
+++ b/templates/internal-links-page.php
@@ -7,146 +7,150 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 ?>
 <div class="wrap swps-internal-links-wrap">
 
-    <?php
-    $title    = __( 'Internal Links', 'stratawp-seo' );
-    $subtitle = __( 'AI + keyword-based internal linking. Rebuild the index, then accept link suggestions per post.', 'stratawp-seo' );
-    $actions  = [
-        [
-            'label' => __( 'Rebuild Index', 'stratawp-seo' ),
-            'class' => 'swps-btn-grad',
-            'attrs' => 'id="swps-rebuild-index"',
-        ],
-    ];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'Internal Links', 'stratawp-seo' );
+	$subtitle = __( 'AI + keyword-based internal linking. Rebuild the index, then accept link suggestions per post.', 'stratawp-seo' );
+	$actions  = array(
+		array(
+			'label' => __( 'Rebuild Index', 'stratawp-seo' ),
+			'class' => 'swps-btn-grad',
+			'attrs' => 'id="swps-rebuild-index"',
+		),
+	);
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <div id="swps-rebuild-progress" style="display:none; margin-bottom:16px;">
-        <progress id="swps-rebuild-bar" value="0" max="100" style="width:300px;"></progress>
-        <span id="swps-rebuild-text" style="margin-left:10px;color:var(--swps-text-muted);font-size:12px"></span>
-    </div>
-    <span id="swps-rebuild-status"></span>
+	<div id="swps-rebuild-progress" style="display:none; margin-bottom:16px;">
+		<progress id="swps-rebuild-bar" value="0" max="100" style="width:300px;"></progress>
+		<span id="swps-rebuild-text" style="margin-left:10px;color:var(--swps-text-muted);font-size:12px"></span>
+	</div>
+	<span id="swps-rebuild-status"></span>
 
-    <div class="swps-summary-tiles">
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Total Internal Links', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-grad"><?php echo esc_html( number_format( (int) $stats['total_links'] ) ); ?></div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Avg Links/Post', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-grad"><?php echo esc_html( $stats['avg_links'] ); ?></div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Orphan Pages', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num <?php echo $stats['orphan_count'] > 0 ? 'is-crit' : 'is-ok'; ?>">
-                <?php echo (int) $stats['orphan_count']; ?>
-            </div>
-            <div class="swps-summary-tile-foot"><?php esc_html_e( 'no inbound links', 'stratawp-seo' ); ?></div>
-        </div>
-        <div class="swps-summary-tile">
-            <div class="swps-summary-tile-h"><?php esc_html_e( 'Pending Suggestions', 'stratawp-seo' ); ?></div>
-            <div class="swps-summary-tile-num is-grad"><?php echo (int) $stats['pending_suggestions']; ?></div>
-        </div>
-    </div>
+	<div class="swps-summary-tiles">
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Total Internal Links', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad"><?php echo esc_html( number_format( (int) $stats['total_links'] ) ); ?></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Avg Links/Post', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad"><?php echo esc_html( $stats['avg_links'] ); ?></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Orphan Pages', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num <?php echo $stats['orphan_count'] > 0 ? 'is-crit' : 'is-ok'; ?>">
+				<?php echo (int) $stats['orphan_count']; ?>
+			</div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'no inbound links', 'stratawp-seo' ); ?></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Pending Suggestions', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad"><?php echo (int) $stats['pending_suggestions']; ?></div>
+		</div>
+	</div>
 
-    <?php if ( ! empty( $stats['most_linked'] ) ) : ?>
-    <div class="swps-section-h">
-        <h3><?php esc_html_e( 'Most Linked Posts', 'stratawp-seo' ); ?></h3>
-    </div>
-    <table class="widefat striped" style="max-width:600px; margin-bottom:24px;">
-        <thead><tr><th><?php esc_html_e( 'Post', 'stratawp-seo' ); ?></th><th><?php esc_html_e( 'Inbound Links', 'stratawp-seo' ); ?></th></tr></thead>
-        <tbody>
-        <?php foreach ( $stats['most_linked'] as $row ) :
-            $post = get_post( (int) $row['target_post_id'] );
-            if ( ! $post ) { continue; }
-        ?>
-            <tr>
-                <td><a href="<?php echo esc_url( get_edit_post_link( $post->ID ) ); ?>"><?php echo esc_html( $post->post_title ); ?></a></td>
-                <td><?php echo esc_html( $row['link_count'] ); ?></td>
-            </tr>
-        <?php endforeach; ?>
-        </tbody>
-    </table>
-    <?php endif; ?>
+	<?php if ( ! empty( $stats['most_linked'] ) ) : ?>
+	<div class="swps-section-h">
+		<h3><?php esc_html_e( 'Most Linked Posts', 'stratawp-seo' ); ?></h3>
+	</div>
+	<table class="widefat striped" style="max-width:600px; margin-bottom:24px;">
+		<thead><tr><th><?php esc_html_e( 'Post', 'stratawp-seo' ); ?></th><th><?php esc_html_e( 'Inbound Links', 'stratawp-seo' ); ?></th></tr></thead>
+		<tbody>
+		<?php
+		foreach ( $stats['most_linked'] as $row ) :
+			$post = get_post( (int) $row['target_post_id'] );
+			if ( ! $post ) {
+				continue; }
+			?>
+			<tr>
+				<td><a href="<?php echo esc_url( get_edit_post_link( $post->ID ) ); ?>"><?php echo esc_html( $post->post_title ); ?></a></td>
+				<td><?php echo esc_html( $row['link_count'] ); ?></td>
+			</tr>
+		<?php endforeach; ?>
+		</tbody>
+	</table>
+	<?php endif; ?>
 
-    <div class="swps-section-h">
-        <h3><?php esc_html_e( 'Link Opportunities', 'stratawp-seo' ); ?></h3>
-    </div>
-    <?php if ( ! empty( $stats['opportunities'] ) ) : ?>
-    <table class="widefat striped">
-        <thead>
-            <tr>
-                <th><input type="checkbox" id="swps-check-all" /></th>
-                <th><?php esc_html_e( 'Source Post', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Target Post', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Relevance', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Type', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Anchor Text', 'stratawp-seo' ); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-        <?php foreach ( $stats['opportunities'] as $opp ) :
-            $source = get_post( (int) $opp['source_post_id'] );
-            $target = get_post( (int) $opp['target_post_id'] );
-            if ( ! $source || ! $target ) { continue; }
-            $score = (float) $opp['relevance_score'];
-            $color = $score >= 0.7 ? 'var(--swps-success)' : ( $score >= 0.4 ? 'var(--swps-warn)' : 'var(--swps-crit)' );
-        ?>
-            <tr>
-                <td><input type="checkbox" class="swps-opp-check" value="<?php echo esc_attr( $opp['id'] ); ?>" /></td>
-                <td><a href="<?php echo esc_url( get_edit_post_link( $source->ID ) ); ?>"><?php echo esc_html( $source->post_title ); ?></a></td>
-                <td><a href="<?php echo esc_url( get_edit_post_link( $target->ID ) ); ?>"><?php echo esc_html( $target->post_title ); ?></a></td>
-                <td><span style="color:<?php echo esc_attr( $color ); ?>;">&#9679;</span> <?php echo esc_html( round( $score * 100 ) ); ?>%</td>
-                <td><?php echo esc_html( $opp['match_type'] ); ?></td>
-                <td><?php echo esc_html( $opp['anchor_text'] ?: '—' ); ?></td>
-            </tr>
-        <?php endforeach; ?>
-        </tbody>
-    </table>
+	<div class="swps-section-h">
+		<h3><?php esc_html_e( 'Link Opportunities', 'stratawp-seo' ); ?></h3>
+	</div>
+	<?php if ( ! empty( $stats['opportunities'] ) ) : ?>
+	<table class="widefat striped">
+		<thead>
+			<tr>
+				<th><input type="checkbox" id="swps-check-all" /></th>
+				<th><?php esc_html_e( 'Source Post', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Target Post', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Relevance', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Type', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Anchor Text', 'stratawp-seo' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+		<?php
+		foreach ( $stats['opportunities'] as $opp ) :
+			$source = get_post( (int) $opp['source_post_id'] );
+			$target = get_post( (int) $opp['target_post_id'] );
+			if ( ! $source || ! $target ) {
+				continue; }
+			$score = (float) $opp['relevance_score'];
+			$color = $score >= 0.7 ? 'var(--swps-success)' : ( $score >= 0.4 ? 'var(--swps-warn)' : 'var(--swps-crit)' );
+			?>
+			<tr>
+				<td><input type="checkbox" class="swps-opp-check" value="<?php echo esc_attr( $opp['id'] ); ?>" /></td>
+				<td><a href="<?php echo esc_url( get_edit_post_link( $source->ID ) ); ?>"><?php echo esc_html( $source->post_title ); ?></a></td>
+				<td><a href="<?php echo esc_url( get_edit_post_link( $target->ID ) ); ?>"><?php echo esc_html( $target->post_title ); ?></a></td>
+				<td><span style="color:<?php echo esc_attr( $color ); ?>;">&#9679;</span> <?php echo esc_html( round( $score * 100 ) ); ?>%</td>
+				<td><?php echo esc_html( $opp['match_type'] ); ?></td>
+				<td><?php echo esc_html( $opp['anchor_text'] ?: '—' ); ?></td>
+			</tr>
+		<?php endforeach; ?>
+		</tbody>
+	</table>
 
-    <div style="margin:16px 0;">
-        <button type="button" class="swps-btn swps-btn-secondary" id="swps-bulk-dismiss"><?php esc_html_e( 'Dismiss Selected', 'stratawp-seo' ); ?></button>
-    </div>
+	<div style="margin:16px 0;">
+		<button type="button" class="swps-btn swps-btn-secondary" id="swps-bulk-dismiss"><?php esc_html_e( 'Dismiss Selected', 'stratawp-seo' ); ?></button>
+	</div>
 
-    <?php if ( $stats['total_pages'] > 1 ) : ?>
-    <div class="tablenav">
-        <div class="tablenav-pages">
-            <?php for ( $i = 1; $i <= $stats['total_pages']; $i++ ) : ?>
-                <?php if ( $i === $stats['current_page'] ) : ?>
-                    <span class="tablenav-pages-navspan button disabled"><?php echo esc_html( $i ); ?></span>
-                <?php else : ?>
-                    <a class="button" href="<?php echo esc_url( add_query_arg( 'link_page', $i ) ); ?>"><?php echo esc_html( $i ); ?></a>
-                <?php endif; ?>
-            <?php endfor; ?>
-        </div>
-    </div>
-    <?php endif; ?>
+		<?php if ( $stats['total_pages'] > 1 ) : ?>
+	<div class="tablenav">
+		<div class="tablenav-pages">
+			<?php for ( $i = 1; $i <= $stats['total_pages']; $i++ ) : ?>
+				<?php if ( $i === $stats['current_page'] ) : ?>
+					<span class="tablenav-pages-navspan button disabled"><?php echo esc_html( $i ); ?></span>
+				<?php else : ?>
+					<a class="button" href="<?php echo esc_url( add_query_arg( 'link_page', $i ) ); ?>"><?php echo esc_html( $i ); ?></a>
+				<?php endif; ?>
+			<?php endfor; ?>
+		</div>
+	</div>
+	<?php endif; ?>
 
-    <?php else : ?>
-        <p style="color:var(--swps-text-muted)"><?php esc_html_e( 'No link opportunities found. Try rebuilding the index.', 'stratawp-seo' ); ?></p>
-    <?php endif; ?>
+	<?php else : ?>
+		<p style="color:var(--swps-text-muted)"><?php esc_html_e( 'No link opportunities found. Try rebuilding the index.', 'stratawp-seo' ); ?></p>
+	<?php endif; ?>
 
-    <div class="swps-section-h" style="margin-top:32px">
-        <h3><?php esc_html_e( 'Orphan Pages', 'stratawp-seo' ); ?></h3>
-    </div>
-    <?php if ( ! empty( $stats['orphan_posts'] ) ) : ?>
-    <p style="color:var(--swps-text-muted)"><?php esc_html_e( 'These posts have no inbound internal links — consider linking to them from related content.', 'stratawp-seo' ); ?></p>
-    <table class="widefat striped" style="max-width:600px;">
-        <thead><tr><th><?php esc_html_e( 'Post', 'stratawp-seo' ); ?></th><th><?php esc_html_e( 'Published', 'stratawp-seo' ); ?></th></tr></thead>
-        <tbody>
-        <?php foreach ( $stats['orphan_posts'] as $orphan ) : ?>
-            <tr>
-                <td><a href="<?php echo esc_url( get_edit_post_link( (int) $orphan['ID'] ) ); ?>"><?php echo esc_html( $orphan['post_title'] ); ?></a></td>
-                <td><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $orphan['post_date'] ) ) ); ?></td>
-            </tr>
-        <?php endforeach; ?>
-        </tbody>
-    </table>
-    <?php else : ?>
-        <p style="color:var(--swps-success)"><?php esc_html_e( 'No orphan pages found. All posts have at least one inbound link.', 'stratawp-seo' ); ?></p>
-    <?php endif; ?>
+	<div class="swps-section-h" style="margin-top:32px">
+		<h3><?php esc_html_e( 'Orphan Pages', 'stratawp-seo' ); ?></h3>
+	</div>
+	<?php if ( ! empty( $stats['orphan_posts'] ) ) : ?>
+	<p style="color:var(--swps-text-muted)"><?php esc_html_e( 'These posts have no inbound internal links — consider linking to them from related content.', 'stratawp-seo' ); ?></p>
+	<table class="widefat striped" style="max-width:600px;">
+		<thead><tr><th><?php esc_html_e( 'Post', 'stratawp-seo' ); ?></th><th><?php esc_html_e( 'Published', 'stratawp-seo' ); ?></th></tr></thead>
+		<tbody>
+		<?php foreach ( $stats['orphan_posts'] as $orphan ) : ?>
+			<tr>
+				<td><a href="<?php echo esc_url( get_edit_post_link( (int) $orphan['ID'] ) ); ?>"><?php echo esc_html( $orphan['post_title'] ); ?></a></td>
+				<td><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $orphan['post_date'] ) ) ); ?></td>
+			</tr>
+		<?php endforeach; ?>
+		</tbody>
+	</table>
+	<?php else : ?>
+		<p style="color:var(--swps-success)"><?php esc_html_e( 'No orphan pages found. All posts have at least one inbound link.', 'stratawp-seo' ); ?></p>
+	<?php endif; ?>
 </div>

--- a/templates/keywords-page.php
+++ b/templates/keywords-page.php
@@ -7,88 +7,88 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 ?>
 <div class="wrap swps-keywords-wrap">
 
-    <?php
-    $title    = __( 'Keyword Research & Tracking', 'stratawp-seo' );
-    $subtitle = __( 'Discover opportunities and track your keyword rankings. Striking-distance keywords (positions 8-20) are your fastest wins.', 'stratawp-seo' );
-    $actions  = [];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'Keyword Research & Tracking', 'stratawp-seo' );
+	$subtitle = __( 'Discover opportunities and track your keyword rankings. Striking-distance keywords (positions 8-20) are your fastest wins.', 'stratawp-seo' );
+	$actions  = array();
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <div class="swps-settings-panel">
-        <h2 style="margin-top:0"><?php esc_html_e( 'Discover Keywords', 'stratawp-seo' ); ?></h2>
-        <div class="swps-suggest-form" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:16px">
-            <input type="text" id="swps-seed-topic" class="regular-text" style="flex:1;min-width:240px"
-                   placeholder="<?php esc_attr_e( 'Enter a seed topic (e.g., home renovation tips)', 'stratawp-seo' ); ?>" />
-            <button class="swps-btn swps-btn-grad" id="swps-suggest-btn">
-                <?php esc_html_e( 'Get AI Suggestions', 'stratawp-seo' ); ?>
-            </button>
-            <span class="spinner" id="swps-suggest-spinner"></span>
-        </div>
-        <table class="widefat striped" id="swps-suggestions-table" style="display:none;">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e( 'Keyword', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Intent', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Difficulty', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Suggested Title', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
-    </div>
+	<div class="swps-settings-panel">
+		<h2 style="margin-top:0"><?php esc_html_e( 'Discover Keywords', 'stratawp-seo' ); ?></h2>
+		<div class="swps-suggest-form" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:16px">
+			<input type="text" id="swps-seed-topic" class="regular-text" style="flex:1;min-width:240px"
+					placeholder="<?php esc_attr_e( 'Enter a seed topic (e.g., home renovation tips)', 'stratawp-seo' ); ?>" />
+			<button class="swps-btn swps-btn-grad" id="swps-suggest-btn">
+				<?php esc_html_e( 'Get AI Suggestions', 'stratawp-seo' ); ?>
+			</button>
+			<span class="spinner" id="swps-suggest-spinner"></span>
+		</div>
+		<table class="widefat striped" id="swps-suggestions-table" style="display:none;">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Keyword', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Intent', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Difficulty', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Suggested Title', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody></tbody>
+		</table>
+	</div>
 
-    <div class="swps-settings-panel">
-        <h2 style="margin-top:0"><?php esc_html_e( 'Tracked Keywords', 'stratawp-seo' ); ?></h2>
-        <table class="widefat striped" id="swps-tracked-table">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e( 'Keyword', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Position', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Clicks', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'CTR', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Linked Post', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr><td colspan="7" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
-            </tbody>
-        </table>
-    </div>
+	<div class="swps-settings-panel">
+		<h2 style="margin-top:0"><?php esc_html_e( 'Tracked Keywords', 'stratawp-seo' ); ?></h2>
+		<table class="widefat striped" id="swps-tracked-table">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Keyword', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Position', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Clicks', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'CTR', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Linked Post', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr><td colspan="7" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+			</tbody>
+		</table>
+	</div>
 
-    <?php if ( $gsc_connected ) : ?>
-    <div class="swps-settings-panel">
-        <h2 style="margin-top:0"><?php esc_html_e( 'Opportunities (Striking Distance)', 'stratawp-seo' ); ?></h2>
-        <p style="color:var(--swps-text-muted);font-size:12px;margin:0 0 12px"><?php esc_html_e( 'Keywords ranking position 8-20 with high impressions — optimize these for quick wins.', 'stratawp-seo' ); ?></p>
-        <table class="widefat striped" id="swps-opportunities-table">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e( 'Keyword', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Position', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'CTR', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr><td colspan="5" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
-            </tbody>
-        </table>
-    </div>
-    <?php endif; ?>
+	<?php if ( $gsc_connected ) : ?>
+	<div class="swps-settings-panel">
+		<h2 style="margin-top:0"><?php esc_html_e( 'Opportunities (Striking Distance)', 'stratawp-seo' ); ?></h2>
+		<p style="color:var(--swps-text-muted);font-size:12px;margin:0 0 12px"><?php esc_html_e( 'Keywords ranking position 8-20 with high impressions — optimize these for quick wins.', 'stratawp-seo' ); ?></p>
+		<table class="widefat striped" id="swps-opportunities-table">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Keyword', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Position', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Impressions', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'CTR', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr><td colspan="5" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+			</tbody>
+		</table>
+	</div>
+	<?php endif; ?>
 
-    <div id="swps-keyword-history-modal" class="swps-modal" style="display:none;">
-        <div class="swps-modal-content">
-            <span class="swps-modal-close">&times;</span>
-            <h3 id="swps-history-title"></h3>
-            <div id="swps-history-chart" class="swps-chart"></div>
-        </div>
-    </div>
+	<div id="swps-keyword-history-modal" class="swps-modal" style="display:none;">
+		<div class="swps-modal-content">
+			<span class="swps-modal-close">&times;</span>
+			<h3 id="swps-history-title"></h3>
+			<div id="swps-history-chart" class="swps-chart"></div>
+		</div>
+	</div>
 </div>

--- a/templates/local-seo-page.php
+++ b/templates/local-seo-page.php
@@ -9,7 +9,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 $local = stratawp_seo()->local_seo;
@@ -20,247 +20,252 @@ $days  = SWPS_Local_SEO::DAYS;
 $preview = $local->build_schema();
 ?>
 <div class="wrap">
-    <?php
-    $title    = __( 'Local SEO', 'stratawp-seo' );
-    $subtitle = __( 'Add your business name, address, phone, and hours. StrataWP outputs LocalBusiness JSON-LD on your homepage so Google can show your hours, location, and contact info in search.', 'stratawp-seo' );
-    $actions  = [];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'Local SEO', 'stratawp-seo' );
+	$subtitle = __( 'Add your business name, address, phone, and hours. StrataWP outputs LocalBusiness JSON-LD on your homepage so Google can show your hours, location, and contact info in search.', 'stratawp-seo' );
+	$actions  = array();
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <form method="post" action="options.php" class="swps-local-seo-form">
-        <?php settings_fields( 'swps_local_seo_group' ); ?>
+	<form method="post" action="options.php" class="swps-local-seo-form">
+		<?php settings_fields( 'swps_local_seo_group' ); ?>
 
-        <div class="swps-card" style="margin-bottom:16px">
-            <label class="swps-toggle-row" style="display:flex;align-items:center;gap:10px">
-                <input type="checkbox"
-                       name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[enabled]"
-                       value="1"
-                       <?php checked( ! empty( $d['enabled'] ) ); ?> />
-                <span style="font-weight:600"><?php esc_html_e( 'Enable Local SEO schema output', 'stratawp-seo' ); ?></span>
-            </label>
-            <p class="description" style="margin:6px 0 0 28px">
-                <?php esc_html_e( 'When enabled (and a business name + city are set), LocalBusiness JSON-LD is added to your homepage. If Yoast/RankMath/AIOSEO are active, StrataWP defers to them.', 'stratawp-seo' ); ?>
-            </p>
-        </div>
+		<div class="swps-card" style="margin-bottom:16px">
+			<label class="swps-toggle-row" style="display:flex;align-items:center;gap:10px">
+				<input type="checkbox"
+						name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[enabled]"
+						value="1"
+						<?php checked( ! empty( $d['enabled'] ) ); ?> />
+				<span style="font-weight:600"><?php esc_html_e( 'Enable Local SEO schema output', 'stratawp-seo' ); ?></span>
+			</label>
+			<p class="description" style="margin:6px 0 0 28px">
+				<?php esc_html_e( 'When enabled (and a business name + city are set), LocalBusiness JSON-LD is added to your homepage. If Yoast/RankMath/AIOSEO are active, StrataWP defers to them.', 'stratawp-seo' ); ?>
+			</p>
+		</div>
 
-        <!-- Business identity -->
-        <div class="swps-card" style="margin-bottom:16px">
-            <h2 style="margin-top:0"><?php esc_html_e( 'Business identity', 'stratawp-seo' ); ?></h2>
-            <table class="form-table" role="presentation">
-                <tbody>
-                <tr>
-                    <th scope="row"><label for="swps-bt"><?php esc_html_e( 'Business type', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <select id="swps-bt" name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[business_type]">
-                            <?php foreach ( $types as $val => $label ) : ?>
-                                <option value="<?php echo esc_attr( $val ); ?>" <?php selected( $d['business_type'], $val ); ?>>
-                                    <?php echo esc_html( $label ); ?>
-                                </option>
-                            <?php endforeach; ?>
-                        </select>
-                        <p class="description"><?php esc_html_e( 'Picks the most specific schema.org type Google understands for your business.', 'stratawp-seo' ); ?></p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="swps-name"><?php esc_html_e( 'Business name', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input id="swps-name" type="text" class="regular-text"
-                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[name]"
-                               value="<?php echo esc_attr( $d['name'] ); ?>" />
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="swps-phone"><?php esc_html_e( 'Phone', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input id="swps-phone" type="text" class="regular-text"
-                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[phone]"
-                               value="<?php echo esc_attr( $d['phone'] ); ?>"
-                               placeholder="+1-555-555-1234" />
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="swps-email"><?php esc_html_e( 'Email', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input id="swps-email" type="email" class="regular-text"
-                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[email]"
-                               value="<?php echo esc_attr( $d['email'] ); ?>" />
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="swps-price"><?php esc_html_e( 'Price range', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input id="swps-price" type="text" class="regular-text"
-                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[price_range]"
-                               value="<?php echo esc_attr( $d['price_range'] ); ?>"
-                               placeholder="$$ or $10-30" />
-                        <p class="description"><?php esc_html_e( 'Use $, $$, $$$, $$$$ — or a range like $10-30.', 'stratawp-seo' ); ?></p>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
+		<!-- Business identity -->
+		<div class="swps-card" style="margin-bottom:16px">
+			<h2 style="margin-top:0"><?php esc_html_e( 'Business identity', 'stratawp-seo' ); ?></h2>
+			<table class="form-table" role="presentation">
+				<tbody>
+				<tr>
+					<th scope="row"><label for="swps-bt"><?php esc_html_e( 'Business type', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<select id="swps-bt" name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[business_type]">
+							<?php foreach ( $types as $val => $label ) : ?>
+								<option value="<?php echo esc_attr( $val ); ?>" <?php selected( $d['business_type'], $val ); ?>>
+									<?php echo esc_html( $label ); ?>
+								</option>
+							<?php endforeach; ?>
+						</select>
+						<p class="description"><?php esc_html_e( 'Picks the most specific schema.org type Google understands for your business.', 'stratawp-seo' ); ?></p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="swps-name"><?php esc_html_e( 'Business name', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input id="swps-name" type="text" class="regular-text"
+								name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[name]"
+								value="<?php echo esc_attr( $d['name'] ); ?>" />
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="swps-phone"><?php esc_html_e( 'Phone', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input id="swps-phone" type="text" class="regular-text"
+								name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[phone]"
+								value="<?php echo esc_attr( $d['phone'] ); ?>"
+								placeholder="+1-555-555-1234" />
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="swps-email"><?php esc_html_e( 'Email', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input id="swps-email" type="email" class="regular-text"
+								name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[email]"
+								value="<?php echo esc_attr( $d['email'] ); ?>" />
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="swps-price"><?php esc_html_e( 'Price range', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input id="swps-price" type="text" class="regular-text"
+								name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[price_range]"
+								value="<?php echo esc_attr( $d['price_range'] ); ?>"
+								placeholder="$$ or $10-30" />
+						<p class="description"><?php esc_html_e( 'Use $, $$, $$$, $$$$ — or a range like $10-30.', 'stratawp-seo' ); ?></p>
+					</td>
+				</tr>
+				</tbody>
+			</table>
+		</div>
 
-        <!-- Address -->
-        <div class="swps-card" style="margin-bottom:16px">
-            <h2 style="margin-top:0"><?php esc_html_e( 'Address', 'stratawp-seo' ); ?></h2>
-            <table class="form-table" role="presentation">
-                <tbody>
-                <tr>
-                    <th scope="row"><label for="swps-street"><?php esc_html_e( 'Street', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input id="swps-street" type="text" class="regular-text"
-                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[street]"
-                               value="<?php echo esc_attr( $d['street'] ); ?>" />
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="swps-loc"><?php esc_html_e( 'City', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input id="swps-loc" type="text" class="regular-text"
-                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[locality]"
-                               value="<?php echo esc_attr( $d['locality'] ); ?>" />
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="swps-region"><?php esc_html_e( 'State / region', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input id="swps-region" type="text" class="regular-text"
-                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[region]"
-                               value="<?php echo esc_attr( $d['region'] ); ?>" />
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="swps-zip"><?php esc_html_e( 'Postal code', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input id="swps-zip" type="text" class="regular-text"
-                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[postal_code]"
-                               value="<?php echo esc_attr( $d['postal_code'] ); ?>" />
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="swps-country"><?php esc_html_e( 'Country', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input id="swps-country" type="text" class="regular-text"
-                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[country]"
-                               value="<?php echo esc_attr( $d['country'] ); ?>"
-                               placeholder="US, GB, DE..." />
-                        <p class="description"><?php esc_html_e( 'Two-letter ISO code preferred (US, GB, DE, AU…). Full names also work.', 'stratawp-seo' ); ?></p>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
+		<!-- Address -->
+		<div class="swps-card" style="margin-bottom:16px">
+			<h2 style="margin-top:0"><?php esc_html_e( 'Address', 'stratawp-seo' ); ?></h2>
+			<table class="form-table" role="presentation">
+				<tbody>
+				<tr>
+					<th scope="row"><label for="swps-street"><?php esc_html_e( 'Street', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input id="swps-street" type="text" class="regular-text"
+								name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[street]"
+								value="<?php echo esc_attr( $d['street'] ); ?>" />
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="swps-loc"><?php esc_html_e( 'City', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input id="swps-loc" type="text" class="regular-text"
+								name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[locality]"
+								value="<?php echo esc_attr( $d['locality'] ); ?>" />
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="swps-region"><?php esc_html_e( 'State / region', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input id="swps-region" type="text" class="regular-text"
+								name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[region]"
+								value="<?php echo esc_attr( $d['region'] ); ?>" />
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="swps-zip"><?php esc_html_e( 'Postal code', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input id="swps-zip" type="text" class="regular-text"
+								name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[postal_code]"
+								value="<?php echo esc_attr( $d['postal_code'] ); ?>" />
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="swps-country"><?php esc_html_e( 'Country', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input id="swps-country" type="text" class="regular-text"
+								name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[country]"
+								value="<?php echo esc_attr( $d['country'] ); ?>"
+								placeholder="US, GB, DE..." />
+						<p class="description"><?php esc_html_e( 'Two-letter ISO code preferred (US, GB, DE, AU…). Full names also work.', 'stratawp-seo' ); ?></p>
+					</td>
+				</tr>
+				</tbody>
+			</table>
+		</div>
 
-        <!-- Geo + place -->
-        <div class="swps-card" style="margin-bottom:16px">
-            <h2 style="margin-top:0"><?php esc_html_e( 'Map & geo', 'stratawp-seo' ); ?></h2>
-            <table class="form-table" role="presentation">
-                <tbody>
-                <tr>
-                    <th scope="row"><label for="swps-lat"><?php esc_html_e( 'Latitude', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input id="swps-lat" type="text" class="regular-text"
-                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[latitude]"
-                               value="<?php echo esc_attr( $d['latitude'] ); ?>"
-                               placeholder="-37.8136" />
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="swps-lng"><?php esc_html_e( 'Longitude', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input id="swps-lng" type="text" class="regular-text"
-                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[longitude]"
-                               value="<?php echo esc_attr( $d['longitude'] ); ?>"
-                               placeholder="144.9631" />
-                        <p class="description"><?php esc_html_e( 'Open Google Maps, right-click your location, click the lat/lng to copy.', 'stratawp-seo' ); ?></p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><label for="swps-place"><?php esc_html_e( 'Google Place ID', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input id="swps-place" type="text" class="regular-text"
-                               name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[place_id]"
-                               value="<?php echo esc_attr( $d['place_id'] ); ?>"
-                               placeholder="ChIJ..." />
-                        <p class="description">
-                            <?php
-                            printf(
-                                /* translators: %s: place ID finder URL */
-                                esc_html__( 'Optional. Find yours at %s.', 'stratawp-seo' ),
-                                '<a href="https://developers.google.com/maps/documentation/javascript/examples/places-placeid-finder" target="_blank" rel="noopener noreferrer">developers.google.com</a>' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-                            );
-                            ?>
-                        </p>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
-        </div>
+		<!-- Geo + place -->
+		<div class="swps-card" style="margin-bottom:16px">
+			<h2 style="margin-top:0"><?php esc_html_e( 'Map & geo', 'stratawp-seo' ); ?></h2>
+			<table class="form-table" role="presentation">
+				<tbody>
+				<tr>
+					<th scope="row"><label for="swps-lat"><?php esc_html_e( 'Latitude', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input id="swps-lat" type="text" class="regular-text"
+								name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[latitude]"
+								value="<?php echo esc_attr( $d['latitude'] ); ?>"
+								placeholder="-37.8136" />
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="swps-lng"><?php esc_html_e( 'Longitude', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input id="swps-lng" type="text" class="regular-text"
+								name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[longitude]"
+								value="<?php echo esc_attr( $d['longitude'] ); ?>"
+								placeholder="144.9631" />
+						<p class="description"><?php esc_html_e( 'Open Google Maps, right-click your location, click the lat/lng to copy.', 'stratawp-seo' ); ?></p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><label for="swps-place"><?php esc_html_e( 'Google Place ID', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input id="swps-place" type="text" class="regular-text"
+								name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[place_id]"
+								value="<?php echo esc_attr( $d['place_id'] ); ?>"
+								placeholder="ChIJ..." />
+						<p class="description">
+							<?php
+							printf(
+								/* translators: %s: place ID finder URL */
+								esc_html__( 'Optional. Find yours at %s.', 'stratawp-seo' ),
+								'<a href="https://developers.google.com/maps/documentation/javascript/examples/places-placeid-finder" target="_blank" rel="noopener noreferrer">developers.google.com</a>' // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							);
+							?>
+						</p>
+					</td>
+				</tr>
+				</tbody>
+			</table>
+		</div>
 
-        <!-- Hours -->
-        <div class="swps-card" style="margin-bottom:16px">
-            <h2 style="margin-top:0"><?php esc_html_e( 'Opening hours', 'stratawp-seo' ); ?></h2>
-            <p class="description" style="margin-top:0">
-                <?php esc_html_e( 'Use 24-hour format (e.g. 09:00 / 17:30). Tick "Closed" for days you are not open.', 'stratawp-seo' ); ?>
-            </p>
-            <table class="widefat striped" style="max-width:680px">
-                <thead>
-                    <tr>
-                        <th><?php esc_html_e( 'Day', 'stratawp-seo' ); ?></th>
-                        <th><?php esc_html_e( 'Open', 'stratawp-seo' ); ?></th>
-                        <th><?php esc_html_e( 'Close', 'stratawp-seo' ); ?></th>
-                        <th><?php esc_html_e( 'Closed', 'stratawp-seo' ); ?></th>
-                    </tr>
-                </thead>
-                <tbody>
-                <?php foreach ( $days as $day_key => $day_short ) :
-                    $row    = $d['hours'][ $day_key ] ?? [ 'open' => '', 'close' => '', 'closed' => 0 ];
-                    $name   = SWPS_Local_SEO::OPTION_KEY . '[hours][' . $day_key . ']';
-                ?>
-                    <tr>
-                        <td><strong><?php echo esc_html( $day_key ); ?></strong></td>
-                        <td>
-                            <input type="time" name="<?php echo esc_attr( $name ); ?>[open]"
-                                   value="<?php echo esc_attr( $row['open'] ?? '' ); ?>" />
-                        </td>
-                        <td>
-                            <input type="time" name="<?php echo esc_attr( $name ); ?>[close]"
-                                   value="<?php echo esc_attr( $row['close'] ?? '' ); ?>" />
-                        </td>
-                        <td>
-                            <label>
-                                <input type="checkbox" name="<?php echo esc_attr( $name ); ?>[closed]" value="1"
-                                       <?php checked( ! empty( $row['closed'] ) ); ?> />
-                                <?php esc_html_e( 'Closed', 'stratawp-seo' ); ?>
-                            </label>
-                        </td>
-                    </tr>
-                <?php endforeach; ?>
-                </tbody>
-            </table>
-        </div>
+		<!-- Hours -->
+		<div class="swps-card" style="margin-bottom:16px">
+			<h2 style="margin-top:0"><?php esc_html_e( 'Opening hours', 'stratawp-seo' ); ?></h2>
+			<p class="description" style="margin-top:0">
+				<?php esc_html_e( 'Use 24-hour format (e.g. 09:00 / 17:30). Tick "Closed" for days you are not open.', 'stratawp-seo' ); ?>
+			</p>
+			<table class="widefat striped" style="max-width:680px">
+				<thead>
+					<tr>
+						<th><?php esc_html_e( 'Day', 'stratawp-seo' ); ?></th>
+						<th><?php esc_html_e( 'Open', 'stratawp-seo' ); ?></th>
+						<th><?php esc_html_e( 'Close', 'stratawp-seo' ); ?></th>
+						<th><?php esc_html_e( 'Closed', 'stratawp-seo' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+				<?php
+				foreach ( $days as $day_key => $day_short ) :
+					$row  = $d['hours'][ $day_key ] ?? array(
+						'open'   => '',
+						'close'  => '',
+						'closed' => 0,
+					);
+					$name = SWPS_Local_SEO::OPTION_KEY . '[hours][' . $day_key . ']';
+					?>
+					<tr>
+						<td><strong><?php echo esc_html( $day_key ); ?></strong></td>
+						<td>
+							<input type="time" name="<?php echo esc_attr( $name ); ?>[open]"
+									value="<?php echo esc_attr( $row['open'] ?? '' ); ?>" />
+						</td>
+						<td>
+							<input type="time" name="<?php echo esc_attr( $name ); ?>[close]"
+									value="<?php echo esc_attr( $row['close'] ?? '' ); ?>" />
+						</td>
+						<td>
+							<label>
+								<input type="checkbox" name="<?php echo esc_attr( $name ); ?>[closed]" value="1"
+										<?php checked( ! empty( $row['closed'] ) ); ?> />
+								<?php esc_html_e( 'Closed', 'stratawp-seo' ); ?>
+							</label>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				</tbody>
+			</table>
+		</div>
 
-        <!-- Area served -->
-        <div class="swps-card" style="margin-bottom:16px">
-            <h2 style="margin-top:0"><?php esc_html_e( 'Area served', 'stratawp-seo' ); ?></h2>
-            <p class="description" style="margin-top:0">
-                <?php esc_html_e( 'For service-area businesses (plumbers, electricians, etc.). One city or region per line — up to 25.', 'stratawp-seo' ); ?>
-            </p>
-            <textarea name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[area_served]"
-                      rows="6" class="large-text code"
-                      placeholder="Melbourne, VIC&#10;Geelong, VIC&#10;Ballarat, VIC"><?php echo esc_textarea( $d['area_served'] ); ?></textarea>
-        </div>
+		<!-- Area served -->
+		<div class="swps-card" style="margin-bottom:16px">
+			<h2 style="margin-top:0"><?php esc_html_e( 'Area served', 'stratawp-seo' ); ?></h2>
+			<p class="description" style="margin-top:0">
+				<?php esc_html_e( 'For service-area businesses (plumbers, electricians, etc.). One city or region per line — up to 25.', 'stratawp-seo' ); ?>
+			</p>
+			<textarea name="<?php echo esc_attr( SWPS_Local_SEO::OPTION_KEY ); ?>[area_served]"
+						rows="6" class="large-text code"
+						placeholder="Melbourne, VIC&#10;Geelong, VIC&#10;Ballarat, VIC"><?php echo esc_textarea( $d['area_served'] ); ?></textarea>
+		</div>
 
-        <?php submit_button( __( 'Save Local SEO settings', 'stratawp-seo' ) ); ?>
-    </form>
+		<?php submit_button( __( 'Save Local SEO settings', 'stratawp-seo' ) ); ?>
+	</form>
 
-    <?php if ( ! empty( $preview ) ) : ?>
-        <div class="swps-card" style="margin-top:24px">
-            <h2 style="margin-top:0"><?php esc_html_e( 'Schema preview', 'stratawp-seo' ); ?></h2>
-            <p class="description" style="margin-top:0">
-                <?php esc_html_e( 'This is the JSON-LD that will be injected into your homepage <head>. Test it with Google\'s Rich Results Test once your homepage is live.', 'stratawp-seo' ); ?>
-            </p>
-            <pre style="background:var(--swps-surface-2,#0f1115);color:var(--swps-text,#e7e9ee);padding:14px;border-radius:6px;overflow:auto;max-height:420px;font-size:12px;line-height:1.5"><?php echo esc_html( wp_json_encode( $preview, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
-        </div>
-    <?php endif; ?>
+	<?php if ( ! empty( $preview ) ) : ?>
+		<div class="swps-card" style="margin-top:24px">
+			<h2 style="margin-top:0"><?php esc_html_e( 'Schema preview', 'stratawp-seo' ); ?></h2>
+			<p class="description" style="margin-top:0">
+				<?php esc_html_e( 'This is the JSON-LD that will be injected into your homepage <head>. Test it with Google\'s Rich Results Test once your homepage is live.', 'stratawp-seo' ); ?>
+			</p>
+			<pre style="background:var(--swps-surface-2,#0f1115);color:var(--swps-text,#e7e9ee);padding:14px;border-radius:6px;overflow:auto;max-height:420px;font-size:12px;line-height:1.5"><?php echo esc_html( wp_json_encode( $preview, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+		</div>
+	<?php endif; ?>
 </div>

--- a/templates/meta-editor-metabox.php
+++ b/templates/meta-editor-metabox.php
@@ -6,165 +6,176 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 ?>
 <div class="swps-meta-editor" data-post-id="<?php echo esc_attr( $post->ID ); ?>">
 
-    <!-- Google Preview -->
-    <div class="swps-serp-preview">
-        <h4><?php esc_html_e( 'Google Preview', 'stratawp-seo' ); ?></h4>
-        <div class="swps-serp-mock">
-            <div class="swps-serp-title" id="swps-serp-title"><?php echo esc_html( $meta_title ?: $post->post_title ); ?></div>
-            <div class="swps-serp-url"><?php echo esc_url( get_permalink( $post->ID ) ); ?></div>
-            <div class="swps-serp-desc" id="swps-serp-desc"><?php echo esc_html( $meta_description ?: wp_trim_words( $post->post_content, 25, '...' ) ); ?></div>
-        </div>
-    </div>
+	<!-- Google Preview -->
+	<div class="swps-serp-preview">
+		<h4><?php esc_html_e( 'Google Preview', 'stratawp-seo' ); ?></h4>
+		<div class="swps-serp-mock">
+			<div class="swps-serp-title" id="swps-serp-title"><?php echo esc_html( $meta_title ?: $post->post_title ); ?></div>
+			<div class="swps-serp-url"><?php echo esc_url( get_permalink( $post->ID ) ); ?></div>
+			<div class="swps-serp-desc" id="swps-serp-desc"><?php echo esc_html( $meta_description ?: wp_trim_words( $post->post_content, 25, '...' ) ); ?></div>
+		</div>
+	</div>
 
-    <!-- Focus Keyword -->
-    <div class="swps-meta-row">
-        <label for="_swps_focus_keyword"><strong><?php esc_html_e( 'Focus Keyword', 'stratawp-seo' ); ?></strong></label>
-        <input type="text" name="_swps_focus_keyword" id="_swps_focus_keyword"
-               value="<?php echo esc_attr( $focus_keyword ); ?>" class="widefat"
-               placeholder="<?php esc_attr_e( 'e.g., best running shoes', 'stratawp-seo' ); ?>" />
-    </div>
+	<!-- Focus Keyword -->
+	<div class="swps-meta-row">
+		<label for="_swps_focus_keyword"><strong><?php esc_html_e( 'Focus Keyword', 'stratawp-seo' ); ?></strong></label>
+		<input type="text" name="_swps_focus_keyword" id="_swps_focus_keyword"
+				value="<?php echo esc_attr( $focus_keyword ); ?>" class="widefat"
+				placeholder="<?php esc_attr_e( 'e.g., best running shoes', 'stratawp-seo' ); ?>" />
+	</div>
 
-    <div class="swps-meta-row">
-        <label for="_swps_secondary_keywords"><?php esc_html_e( 'Secondary Keywords', 'stratawp-seo' ); ?></label>
-        <input type="text" name="_swps_secondary_keywords" id="_swps_secondary_keywords"
-               value="<?php echo esc_attr( $secondary_kws ); ?>" class="widefat"
-               placeholder="<?php esc_attr_e( 'Comma-separated: running gear, marathon training', 'stratawp-seo' ); ?>" />
-    </div>
+	<div class="swps-meta-row">
+		<label for="_swps_secondary_keywords"><?php esc_html_e( 'Secondary Keywords', 'stratawp-seo' ); ?></label>
+		<input type="text" name="_swps_secondary_keywords" id="_swps_secondary_keywords"
+				value="<?php echo esc_attr( $secondary_kws ); ?>" class="widefat"
+				placeholder="<?php esc_attr_e( 'Comma-separated: running gear, marathon training', 'stratawp-seo' ); ?>" />
+	</div>
 
-    <!-- Meta Title -->
-    <div class="swps-meta-row">
-        <label for="_swps_meta_title">
-            <?php esc_html_e( 'Meta Title', 'stratawp-seo' ); ?>
-            <span class="swps-char-count" id="swps-title-count">0</span>
-        </label>
-        <input type="text" name="_swps_meta_title" id="_swps_meta_title"
-               value="<?php echo esc_attr( $meta_title ); ?>" class="widefat"
-               placeholder="<?php echo esc_attr( $post->post_title ); ?>" />
-        <button type="button" class="button button-small" id="swps-ai-generate-meta">
-            <?php esc_html_e( 'AI Generate', 'stratawp-seo' ); ?>
-        </button>
-    </div>
+	<!-- Meta Title -->
+	<div class="swps-meta-row">
+		<label for="_swps_meta_title">
+			<?php esc_html_e( 'Meta Title', 'stratawp-seo' ); ?>
+			<span class="swps-char-count" id="swps-title-count">0</span>
+		</label>
+		<input type="text" name="_swps_meta_title" id="_swps_meta_title"
+				value="<?php echo esc_attr( $meta_title ); ?>" class="widefat"
+				placeholder="<?php echo esc_attr( $post->post_title ); ?>" />
+		<button type="button" class="button button-small" id="swps-ai-generate-meta">
+			<?php esc_html_e( 'AI Generate', 'stratawp-seo' ); ?>
+		</button>
+	</div>
 
-    <!-- Meta Description -->
-    <div class="swps-meta-row">
-        <label for="_swps_meta_description">
-            <?php esc_html_e( 'Meta Description', 'stratawp-seo' ); ?>
-            <span class="swps-char-count" id="swps-desc-count">0</span>
-        </label>
-        <textarea name="_swps_meta_description" id="_swps_meta_description" class="widefat" rows="3"
-                  placeholder="<?php esc_attr_e( 'Compelling description for search results...', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $meta_description ); ?></textarea>
-    </div>
+	<!-- Meta Description -->
+	<div class="swps-meta-row">
+		<label for="_swps_meta_description">
+			<?php esc_html_e( 'Meta Description', 'stratawp-seo' ); ?>
+			<span class="swps-char-count" id="swps-desc-count">0</span>
+		</label>
+		<textarea name="_swps_meta_description" id="_swps_meta_description" class="widefat" rows="3"
+					placeholder="<?php esc_attr_e( 'Compelling description for search results...', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $meta_description ); ?></textarea>
+	</div>
 
-    <!-- SEO Checklist -->
-    <div class="swps-seo-checklist" id="swps-seo-checklist">
-        <h4><?php esc_html_e( 'SEO Checklist', 'stratawp-seo' ); ?></h4>
-        <ul>
-            <li data-check="keyword-in-title"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in meta title', 'stratawp-seo' ); ?></li>
-            <li data-check="keyword-in-desc"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in meta description', 'stratawp-seo' ); ?></li>
-            <li data-check="title-length"><span class="swps-check-icon"></span> <?php esc_html_e( 'Meta title length (50-60 chars)', 'stratawp-seo' ); ?></li>
-            <li data-check="desc-length"><span class="swps-check-icon"></span> <?php esc_html_e( 'Meta description length (140-160 chars)', 'stratawp-seo' ); ?></li>
-            <li data-check="keyword-in-content"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in first paragraph', 'stratawp-seo' ); ?></li>
-            <li data-check="keyword-in-h2"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in at least one H2', 'stratawp-seo' ); ?></li>
-        </ul>
-    </div>
+	<!-- SEO Checklist -->
+	<div class="swps-seo-checklist" id="swps-seo-checklist">
+		<h4><?php esc_html_e( 'SEO Checklist', 'stratawp-seo' ); ?></h4>
+		<ul>
+			<li data-check="keyword-in-title"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in meta title', 'stratawp-seo' ); ?></li>
+			<li data-check="keyword-in-desc"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in meta description', 'stratawp-seo' ); ?></li>
+			<li data-check="title-length"><span class="swps-check-icon"></span> <?php esc_html_e( 'Meta title length (50-60 chars)', 'stratawp-seo' ); ?></li>
+			<li data-check="desc-length"><span class="swps-check-icon"></span> <?php esc_html_e( 'Meta description length (140-160 chars)', 'stratawp-seo' ); ?></li>
+			<li data-check="keyword-in-content"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in first paragraph', 'stratawp-seo' ); ?></li>
+			<li data-check="keyword-in-h2"><span class="swps-check-icon"></span> <?php esc_html_e( 'Focus keyword in at least one H2', 'stratawp-seo' ); ?></li>
+		</ul>
+	</div>
 
-    <!-- Advanced: Canonical, Robots, Breadcrumb -->
-    <details class="swps-meta-advanced">
-        <summary><?php esc_html_e( 'Advanced', 'stratawp-seo' ); ?></summary>
+	<!-- Advanced: Canonical, Robots, Breadcrumb -->
+	<details class="swps-meta-advanced">
+		<summary><?php esc_html_e( 'Advanced', 'stratawp-seo' ); ?></summary>
 
-        <div class="swps-meta-row">
-            <label for="_swps_canonical_url"><?php esc_html_e( 'Canonical URL', 'stratawp-seo' ); ?></label>
-            <input type="url" name="_swps_canonical_url" id="_swps_canonical_url"
-                   value="<?php echo esc_url( $canonical_url ); ?>" class="widefat"
-                   placeholder="<?php echo esc_url( get_permalink( $post->ID ) ); ?>" />
-        </div>
+		<div class="swps-meta-row">
+			<label for="_swps_canonical_url"><?php esc_html_e( 'Canonical URL', 'stratawp-seo' ); ?></label>
+			<input type="url" name="_swps_canonical_url" id="_swps_canonical_url"
+					value="<?php echo esc_url( $canonical_url ); ?>" class="widefat"
+					placeholder="<?php echo esc_url( get_permalink( $post->ID ) ); ?>" />
+		</div>
 
-        <div class="swps-meta-row">
-            <label for="_swps_robots"><?php esc_html_e( 'Robots Meta', 'stratawp-seo' ); ?></label>
-            <select name="_swps_robots" id="_swps_robots">
-                <option value="" <?php selected( $robots, '' ); ?>><?php esc_html_e( 'Default (index, follow)', 'stratawp-seo' ); ?></option>
-                <option value="noindex, follow" <?php selected( $robots, 'noindex, follow' ); ?>><?php esc_html_e( 'noindex, follow', 'stratawp-seo' ); ?></option>
-                <option value="index, nofollow" <?php selected( $robots, 'index, nofollow' ); ?>><?php esc_html_e( 'index, nofollow', 'stratawp-seo' ); ?></option>
-                <option value="noindex, nofollow" <?php selected( $robots, 'noindex, nofollow' ); ?>><?php esc_html_e( 'noindex, nofollow', 'stratawp-seo' ); ?></option>
-            </select>
-        </div>
+		<div class="swps-meta-row">
+			<label for="_swps_robots"><?php esc_html_e( 'Robots Meta', 'stratawp-seo' ); ?></label>
+			<select name="_swps_robots" id="_swps_robots">
+				<option value="" <?php selected( $robots, '' ); ?>><?php esc_html_e( 'Default (index, follow)', 'stratawp-seo' ); ?></option>
+				<option value="noindex, follow" <?php selected( $robots, 'noindex, follow' ); ?>><?php esc_html_e( 'noindex, follow', 'stratawp-seo' ); ?></option>
+				<option value="index, nofollow" <?php selected( $robots, 'index, nofollow' ); ?>><?php esc_html_e( 'index, nofollow', 'stratawp-seo' ); ?></option>
+				<option value="noindex, nofollow" <?php selected( $robots, 'noindex, nofollow' ); ?>><?php esc_html_e( 'noindex, nofollow', 'stratawp-seo' ); ?></option>
+			</select>
+		</div>
 
-        <div class="swps-meta-row">
-            <label for="_swps_breadcrumb_title"><?php esc_html_e( 'Breadcrumb Title', 'stratawp-seo' ); ?></label>
-            <input type="text" name="_swps_breadcrumb_title" id="_swps_breadcrumb_title"
-                   value="<?php echo esc_attr( $breadcrumb_title ); ?>" class="widefat"
-                   placeholder="<?php echo esc_attr( $post->post_title ); ?>" />
-        </div>
-    </details>
+		<div class="swps-meta-row">
+			<label for="_swps_breadcrumb_title"><?php esc_html_e( 'Breadcrumb Title', 'stratawp-seo' ); ?></label>
+			<input type="text" name="_swps_breadcrumb_title" id="_swps_breadcrumb_title"
+					value="<?php echo esc_attr( $breadcrumb_title ); ?>" class="widefat"
+					placeholder="<?php echo esc_attr( $post->post_title ); ?>" />
+		</div>
+	</details>
 
-    <!-- Social Preview -->
-    <details class="swps-meta-social">
-        <summary><?php esc_html_e( 'Social Previews', 'stratawp-seo' ); ?></summary>
+	<!-- Social Preview -->
+	<details class="swps-meta-social">
+		<summary><?php esc_html_e( 'Social Previews', 'stratawp-seo' ); ?></summary>
 
-        <div class="swps-meta-row">
-            <label for="_swps_social_title"><?php esc_html_e( 'Social Title', 'stratawp-seo' ); ?></label>
-            <input type="text" name="_swps_social_title" id="_swps_social_title"
-                   value="<?php echo esc_attr( $social_title ); ?>" class="widefat"
-                   placeholder="<?php esc_attr_e( 'Falls back to meta title', 'stratawp-seo' ); ?>" />
-        </div>
+		<div class="swps-meta-row">
+			<label for="_swps_social_title"><?php esc_html_e( 'Social Title', 'stratawp-seo' ); ?></label>
+			<input type="text" name="_swps_social_title" id="_swps_social_title"
+					value="<?php echo esc_attr( $social_title ); ?>" class="widefat"
+					placeholder="<?php esc_attr_e( 'Falls back to meta title', 'stratawp-seo' ); ?>" />
+		</div>
 
-        <div class="swps-meta-row">
-            <label for="_swps_social_description"><?php esc_html_e( 'Social Description', 'stratawp-seo' ); ?></label>
-            <textarea name="_swps_social_description" id="_swps_social_description" class="widefat" rows="2"
-                      placeholder="<?php esc_attr_e( 'Falls back to meta description', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $social_desc ); ?></textarea>
-        </div>
+		<div class="swps-meta-row">
+			<label for="_swps_social_description"><?php esc_html_e( 'Social Description', 'stratawp-seo' ); ?></label>
+			<textarea name="_swps_social_description" id="_swps_social_description" class="widefat" rows="2"
+						placeholder="<?php esc_attr_e( 'Falls back to meta description', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $social_desc ); ?></textarea>
+		</div>
 
-        <div class="swps-meta-row">
-            <label for="_swps_social_image"><?php esc_html_e( 'Social Image URL', 'stratawp-seo' ); ?></label>
-            <input type="url" name="_swps_social_image" id="_swps_social_image"
-                   value="<?php echo esc_url( $social_image ); ?>" class="widefat"
-                   placeholder="<?php esc_attr_e( 'Falls back to featured image', 'stratawp-seo' ); ?>" />
-        </div>
+		<div class="swps-meta-row">
+			<label for="_swps_social_image"><?php esc_html_e( 'Social Image URL', 'stratawp-seo' ); ?></label>
+			<input type="url" name="_swps_social_image" id="_swps_social_image"
+					value="<?php echo esc_url( $social_image ); ?>" class="widefat"
+					placeholder="<?php esc_attr_e( 'Falls back to featured image', 'stratawp-seo' ); ?>" />
+		</div>
 
-        <!-- Facebook Preview Mock -->
-        <div class="swps-social-preview swps-fb-preview">
-            <h5><?php esc_html_e( 'Facebook Preview', 'stratawp-seo' ); ?></h5>
-            <div class="swps-social-card">
-                <div class="swps-social-image" id="swps-fb-image"></div>
-                <div class="swps-social-text">
-                    <div class="swps-social-domain"><?php echo esc_html( wp_parse_url( home_url(), PHP_URL_HOST ) ); ?></div>
-                    <div class="swps-social-title" id="swps-fb-title"></div>
-                    <div class="swps-social-desc" id="swps-fb-desc"></div>
-                </div>
-            </div>
-        </div>
-    </details>
+		<!-- Facebook Preview Mock -->
+		<div class="swps-social-preview swps-fb-preview">
+			<h5><?php esc_html_e( 'Facebook Preview', 'stratawp-seo' ); ?></h5>
+			<div class="swps-social-card">
+				<div class="swps-social-image" id="swps-fb-image"></div>
+				<div class="swps-social-text">
+					<div class="swps-social-domain"><?php echo esc_html( wp_parse_url( home_url(), PHP_URL_HOST ) ); ?></div>
+					<div class="swps-social-title" id="swps-fb-title"></div>
+					<div class="swps-social-desc" id="swps-fb-desc"></div>
+				</div>
+			</div>
+		</div>
+	</details>
 
-    <!-- Sitemap -->
-    <div class="swps-field-group">
-        <h4><?php esc_html_e( 'Sitemap', 'stratawp-seo' ); ?></h4>
-        <label>
-            <input type="checkbox" name="swps_sitemap_exclude" value="1" <?php checked( $sitemap_exclude ); ?>>
-            <?php esc_html_e( 'Exclude from sitemap', 'stratawp-seo' ); ?>
-        </label>
-        <p>
-            <label><?php esc_html_e( 'Priority:', 'stratawp-seo' ); ?>
-                <select name="swps_sitemap_priority">
-                    <option value=""><?php esc_html_e( 'Auto', 'stratawp-seo' ); ?></option>
-                    <?php foreach ( [ '1.0', '0.9', '0.8', '0.7', '0.6', '0.5', '0.4', '0.3', '0.2', '0.1' ] as $p ) : ?>
-                        <option value="<?php echo esc_attr( $p ); ?>" <?php selected( $sitemap_priority, $p ); ?>><?php echo esc_html( $p ); ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </label>
-        </p>
-        <p>
-            <label><?php esc_html_e( 'Change Frequency:', 'stratawp-seo' ); ?>
-                <select name="swps_sitemap_changefreq">
-                    <?php foreach ( [ '' => 'Auto', 'always' => 'Always', 'hourly' => 'Hourly', 'daily' => 'Daily', 'weekly' => 'Weekly', 'monthly' => 'Monthly', 'yearly' => 'Yearly', 'never' => 'Never' ] as $val => $label ) : ?>
-                        <option value="<?php echo esc_attr( $val ); ?>" <?php selected( $sitemap_changefreq, $val ); ?>><?php echo esc_html( $label ); ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </label>
-        </p>
-    </div>
+	<!-- Sitemap -->
+	<div class="swps-field-group">
+		<h4><?php esc_html_e( 'Sitemap', 'stratawp-seo' ); ?></h4>
+		<label>
+			<input type="checkbox" name="swps_sitemap_exclude" value="1" <?php checked( $sitemap_exclude ); ?>>
+			<?php esc_html_e( 'Exclude from sitemap', 'stratawp-seo' ); ?>
+		</label>
+		<p>
+			<label><?php esc_html_e( 'Priority:', 'stratawp-seo' ); ?>
+				<select name="swps_sitemap_priority">
+					<option value=""><?php esc_html_e( 'Auto', 'stratawp-seo' ); ?></option>
+					<?php foreach ( array( '1.0', '0.9', '0.8', '0.7', '0.6', '0.5', '0.4', '0.3', '0.2', '0.1' ) as $p ) : ?>
+						<option value="<?php echo esc_attr( $p ); ?>" <?php selected( $sitemap_priority, $p ); ?>><?php echo esc_html( $p ); ?></option>
+					<?php endforeach; ?>
+				</select>
+			</label>
+		</p>
+		<p>
+			<label><?php esc_html_e( 'Change Frequency:', 'stratawp-seo' ); ?>
+				<select name="swps_sitemap_changefreq">
+					<?php
+					foreach ( array(
+						''        => 'Auto',
+						'always'  => 'Always',
+						'hourly'  => 'Hourly',
+						'daily'   => 'Daily',
+						'weekly'  => 'Weekly',
+						'monthly' => 'Monthly',
+						'yearly'  => 'Yearly',
+						'never'   => 'Never',
+					) as $val => $label ) :
+						?>
+						<option value="<?php echo esc_attr( $val ); ?>" <?php selected( $sitemap_changefreq, $val ); ?>><?php echo esc_html( $label ); ?></option>
+					<?php endforeach; ?>
+				</select>
+			</label>
+		</p>
+	</div>
 </div>

--- a/templates/migration-page.php
+++ b/templates/migration-page.php
@@ -6,7 +6,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 /** @var SWPS_Migration $migration */
@@ -18,154 +18,154 @@ $preview = get_transient( 'swps_migration_preview_' . get_current_user_id() );
 $report  = $migration->get_last_report();
 ?>
 <div class="wrap swps-migration-page">
-    <h1><?php esc_html_e( 'Migrate from Yoast / Rank Math', 'stratawp-seo' ); ?></h1>
-    <p><?php esc_html_e( 'Import per-post SEO meta (titles, descriptions, focus keyword, canonicals, breadcrumb titles, social overrides) from Yoast SEO or Rank Math into StrataWP SEO.', 'stratawp-seo' ); ?></p>
+	<h1><?php esc_html_e( 'Migrate from Yoast / Rank Math', 'stratawp-seo' ); ?></h1>
+	<p><?php esc_html_e( 'Import per-post SEO meta (titles, descriptions, focus keyword, canonicals, breadcrumb titles, social overrides) from Yoast SEO or Rank Math into StrataWP SEO.', 'stratawp-seo' ); ?></p>
 
-    <?php if ( 'done' === $status && ! empty( $report ) ) : ?>
-        <div class="notice notice-success">
-            <p>
-                <strong><?php esc_html_e( 'Migration complete.', 'stratawp-seo' ); ?></strong>
-                <?php
-                printf(
-                    /* translators: 1: posts 2: fields written 3: fields skipped 4: fields overwritten 5: options written 6: redirects written */
-                    esc_html__( 'Processed %1$d posts, wrote %2$d post fields (skipped %3$d, overwrote %4$d), %5$d settings, %6$d redirects.', 'stratawp-seo' ),
-                    (int) ( $report['posts_processed'] ?? 0 ),
-                    (int) ( $report['fields_written'] ?? 0 ),
-                    (int) ( $report['fields_skipped'] ?? 0 ),
-                    (int) ( $report['fields_overwritten'] ?? 0 ),
-                    (int) ( $report['options_written'] ?? 0 ),
-                    (int) ( $report['redirects_written'] ?? 0 )
-                );
-                ?>
-            </p>
-            <?php if ( ! empty( $report['redirects_errors'] ) ) : ?>
-                <details><summary><?php esc_html_e( 'Redirect issues', 'stratawp-seo' ); ?> (<?php echo (int) count( $report['redirects_errors'] ); ?>)</summary>
-                    <ul style="margin-left:16px;list-style:disc;">
-                    <?php foreach ( $report['redirects_errors'] as $err ) : ?>
-                        <li><code><?php echo esc_html( $err ); ?></code></li>
-                    <?php endforeach; ?>
-                    </ul>
-                </details>
-            <?php endif; ?>
-        </div>
-    <?php elseif ( 'undone' === $status ) : ?>
-        <div class="notice notice-success"><p><?php esc_html_e( 'Migration reverted.', 'stratawp-seo' ); ?></p></div>
-    <?php elseif ( 'preview' === $status && is_array( $preview ) ) : ?>
-        <div class="notice notice-info">
-            <p>
-                <strong><?php esc_html_e( 'Preview', 'stratawp-seo' ); ?>:</strong>
-                <?php
-                printf(
-                    /* translators: 1: posts 2: post fields 3: settings 4: redirects */
-                    esc_html__( 'Would scan %1$d posts, write %2$d post fields, %3$d settings, %4$d redirects.', 'stratawp-seo' ),
-                    (int) ( $preview['stats']['posts_scanned'] ?? 0 ),
-                    (int) ( $preview['stats']['fields_to_write'] ?? 0 ),
-                    (int) ( $preview['stats']['options_to_write'] ?? 0 ),
-                    (int) ( $preview['stats']['redirects_to_write'] ?? 0 )
-                );
-                ?>
-            </p>
-        </div>
-    <?php endif; ?>
+	<?php if ( 'done' === $status && ! empty( $report ) ) : ?>
+		<div class="notice notice-success">
+			<p>
+				<strong><?php esc_html_e( 'Migration complete.', 'stratawp-seo' ); ?></strong>
+				<?php
+				printf(
+					/* translators: 1: posts 2: fields written 3: fields skipped 4: fields overwritten 5: options written 6: redirects written */
+					esc_html__( 'Processed %1$d posts, wrote %2$d post fields (skipped %3$d, overwrote %4$d), %5$d settings, %6$d redirects.', 'stratawp-seo' ),
+					(int) ( $report['posts_processed'] ?? 0 ),
+					(int) ( $report['fields_written'] ?? 0 ),
+					(int) ( $report['fields_skipped'] ?? 0 ),
+					(int) ( $report['fields_overwritten'] ?? 0 ),
+					(int) ( $report['options_written'] ?? 0 ),
+					(int) ( $report['redirects_written'] ?? 0 )
+				);
+				?>
+			</p>
+			<?php if ( ! empty( $report['redirects_errors'] ) ) : ?>
+				<details><summary><?php esc_html_e( 'Redirect issues', 'stratawp-seo' ); ?> (<?php echo (int) count( $report['redirects_errors'] ); ?>)</summary>
+					<ul style="margin-left:16px;list-style:disc;">
+					<?php foreach ( $report['redirects_errors'] as $err ) : ?>
+						<li><code><?php echo esc_html( $err ); ?></code></li>
+					<?php endforeach; ?>
+					</ul>
+				</details>
+			<?php endif; ?>
+		</div>
+	<?php elseif ( 'undone' === $status ) : ?>
+		<div class="notice notice-success"><p><?php esc_html_e( 'Migration reverted.', 'stratawp-seo' ); ?></p></div>
+	<?php elseif ( 'preview' === $status && is_array( $preview ) ) : ?>
+		<div class="notice notice-info">
+			<p>
+				<strong><?php esc_html_e( 'Preview', 'stratawp-seo' ); ?>:</strong>
+				<?php
+				printf(
+					/* translators: 1: posts 2: post fields 3: settings 4: redirects */
+					esc_html__( 'Would scan %1$d posts, write %2$d post fields, %3$d settings, %4$d redirects.', 'stratawp-seo' ),
+					(int) ( $preview['stats']['posts_scanned'] ?? 0 ),
+					(int) ( $preview['stats']['fields_to_write'] ?? 0 ),
+					(int) ( $preview['stats']['options_to_write'] ?? 0 ),
+					(int) ( $preview['stats']['redirects_to_write'] ?? 0 )
+				);
+				?>
+			</p>
+		</div>
+	<?php endif; ?>
 
-    <?php if ( empty( $sources ) ) : ?>
-        <div class="postbox">
-            <div class="inside">
-                <p><?php esc_html_e( 'No Yoast SEO or Rank Math data was detected on this site. There is nothing to migrate.', 'stratawp-seo' ); ?></p>
-            </div>
-        </div>
-        <?php return; ?>
-    <?php endif; ?>
+	<?php if ( empty( $sources ) ) : ?>
+		<div class="postbox">
+			<div class="inside">
+				<p><?php esc_html_e( 'No Yoast SEO or Rank Math data was detected on this site. There is nothing to migrate.', 'stratawp-seo' ); ?></p>
+			</div>
+		</div>
+		<?php return; ?>
+	<?php endif; ?>
 
-    <h2><?php esc_html_e( 'Detected sources', 'stratawp-seo' ); ?></h2>
-    <table class="widefat striped">
-        <thead>
-            <tr>
-                <th><?php esc_html_e( 'Plugin', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Posts with SEO data', 'stratawp-seo' ); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php foreach ( $sources as $slug => $info ) : ?>
-                <tr>
-                    <td><strong><?php echo esc_html( $info['label'] ); ?></strong></td>
-                    <td><?php echo esc_html( number_format_i18n( $info['post_count'] ) ); ?></td>
-                </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
+	<h2><?php esc_html_e( 'Detected sources', 'stratawp-seo' ); ?></h2>
+	<table class="widefat striped">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Plugin', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Posts with SEO data', 'stratawp-seo' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<?php foreach ( $sources as $slug => $info ) : ?>
+				<tr>
+					<td><strong><?php echo esc_html( $info['label'] ); ?></strong></td>
+					<td><?php echo esc_html( number_format_i18n( $info['post_count'] ) ); ?></td>
+				</tr>
+			<?php endforeach; ?>
+		</tbody>
+	</table>
 
-    <h2 style="margin-top:24px;"><?php esc_html_e( 'Run migration', 'stratawp-seo' ); ?></h2>
-    <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-        <input type="hidden" name="action" value="swps_run_migration">
-        <?php wp_nonce_field( 'swps_run_migration' ); ?>
+	<h2 style="margin-top:24px;"><?php esc_html_e( 'Run migration', 'stratawp-seo' ); ?></h2>
+	<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+		<input type="hidden" name="action" value="swps_run_migration">
+		<?php wp_nonce_field( 'swps_run_migration' ); ?>
 
-        <table class="form-table">
-            <tr>
-                <th scope="row"><label for="swps-migration-source"><?php esc_html_e( 'Source', 'stratawp-seo' ); ?></label></th>
-                <td>
-                    <select id="swps-migration-source" name="source">
-                        <?php foreach ( $sources as $slug => $info ) : ?>
-                            <option value="<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $info['label'] ); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row"><?php esc_html_e( 'What to migrate', 'stratawp-seo' ); ?></th>
-                <td>
-                    <label><input type="checkbox" name="phases[]" value="post_meta" checked> <?php esc_html_e( 'Per-post SEO meta (titles, descriptions, focus keyword, canonical, social)', 'stratawp-seo' ); ?></label><br>
-                    <label><input type="checkbox" name="phases[]" value="settings" checked> <?php esc_html_e( 'Global settings (title separator, title templates, archive noindex flags)', 'stratawp-seo' ); ?></label><br>
-                    <label><input type="checkbox" name="phases[]" value="redirects" checked> <?php esc_html_e( 'Redirects (Yoast Premium / Rank Math Pro)', 'stratawp-seo' ); ?></label>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row"><?php esc_html_e( 'When StrataWP value already exists', 'stratawp-seo' ); ?></th>
-                <td>
-                    <label><input type="radio" name="conflict_policy" value="skip" checked> <?php esc_html_e( 'Skip — keep existing StrataWP value', 'stratawp-seo' ); ?></label><br>
-                    <label><input type="radio" name="conflict_policy" value="overwrite"> <?php esc_html_e( 'Overwrite with imported value', 'stratawp-seo' ); ?></label>
-                    <p class="description"><?php esc_html_e( 'A backup of overwritten values is kept so the migration can be undone. (Redirects are always inserted as new rows; undo deletes them.)', 'stratawp-seo' ); ?></p>
-                </td>
-            </tr>
-        </table>
+		<table class="form-table">
+			<tr>
+				<th scope="row"><label for="swps-migration-source"><?php esc_html_e( 'Source', 'stratawp-seo' ); ?></label></th>
+				<td>
+					<select id="swps-migration-source" name="source">
+						<?php foreach ( $sources as $slug => $info ) : ?>
+							<option value="<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $info['label'] ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'What to migrate', 'stratawp-seo' ); ?></th>
+				<td>
+					<label><input type="checkbox" name="phases[]" value="post_meta" checked> <?php esc_html_e( 'Per-post SEO meta (titles, descriptions, focus keyword, canonical, social)', 'stratawp-seo' ); ?></label><br>
+					<label><input type="checkbox" name="phases[]" value="settings" checked> <?php esc_html_e( 'Global settings (title separator, title templates, archive noindex flags)', 'stratawp-seo' ); ?></label><br>
+					<label><input type="checkbox" name="phases[]" value="redirects" checked> <?php esc_html_e( 'Redirects (Yoast Premium / Rank Math Pro)', 'stratawp-seo' ); ?></label>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'When StrataWP value already exists', 'stratawp-seo' ); ?></th>
+				<td>
+					<label><input type="radio" name="conflict_policy" value="skip" checked> <?php esc_html_e( 'Skip — keep existing StrataWP value', 'stratawp-seo' ); ?></label><br>
+					<label><input type="radio" name="conflict_policy" value="overwrite"> <?php esc_html_e( 'Overwrite with imported value', 'stratawp-seo' ); ?></label>
+					<p class="description"><?php esc_html_e( 'A backup of overwritten values is kept so the migration can be undone. (Redirects are always inserted as new rows; undo deletes them.)', 'stratawp-seo' ); ?></p>
+				</td>
+			</tr>
+		</table>
 
-        <p class="submit">
-            <button type="submit" name="mode" value="preview" class="button"><?php esc_html_e( 'Preview', 'stratawp-seo' ); ?></button>
-            <button type="submit" name="mode" value="run" class="button button-primary" onclick="return confirm('<?php echo esc_js( __( 'Run the migration now? A backup will be saved so this can be undone.', 'stratawp-seo' ) ); ?>');"><?php esc_html_e( 'Run migration', 'stratawp-seo' ); ?></button>
-        </p>
-    </form>
+		<p class="submit">
+			<button type="submit" name="mode" value="preview" class="button"><?php esc_html_e( 'Preview', 'stratawp-seo' ); ?></button>
+			<button type="submit" name="mode" value="run" class="button button-primary" onclick="return confirm('<?php echo esc_js( __( 'Run the migration now? A backup will be saved so this can be undone.', 'stratawp-seo' ) ); ?>');"><?php esc_html_e( 'Run migration', 'stratawp-seo' ); ?></button>
+		</p>
+	</form>
 
-    <?php if ( $migration->has_backup() ) : ?>
-        <h2 style="margin-top:24px;"><?php esc_html_e( 'Undo last migration', 'stratawp-seo' ); ?></h2>
-        <p><?php esc_html_e( 'Restores the StrataWP meta values that were overwritten by the most recent migration.', 'stratawp-seo' ); ?></p>
-        <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-            <input type="hidden" name="action" value="swps_undo_migration">
-            <?php wp_nonce_field( 'swps_undo_migration' ); ?>
-            <button type="submit" class="button" onclick="return confirm('<?php echo esc_js( __( 'Revert the last migration?', 'stratawp-seo' ) ); ?>');"><?php esc_html_e( 'Undo last migration', 'stratawp-seo' ); ?></button>
-        </form>
-    <?php endif; ?>
+	<?php if ( $migration->has_backup() ) : ?>
+		<h2 style="margin-top:24px;"><?php esc_html_e( 'Undo last migration', 'stratawp-seo' ); ?></h2>
+		<p><?php esc_html_e( 'Restores the StrataWP meta values that were overwritten by the most recent migration.', 'stratawp-seo' ); ?></p>
+		<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+			<input type="hidden" name="action" value="swps_undo_migration">
+			<?php wp_nonce_field( 'swps_undo_migration' ); ?>
+			<button type="submit" class="button" onclick="return confirm('<?php echo esc_js( __( 'Revert the last migration?', 'stratawp-seo' ) ); ?>');"><?php esc_html_e( 'Undo last migration', 'stratawp-seo' ); ?></button>
+		</form>
+	<?php endif; ?>
 
-    <h2 style="margin-top:24px;"><?php esc_html_e( 'What gets migrated', 'stratawp-seo' ); ?></h2>
-    <table class="widefat striped">
-        <thead>
-            <tr>
-                <th><?php esc_html_e( 'Field', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Yoast key', 'stratawp-seo' ); ?></th>
-                <th><?php esc_html_e( 'Rank Math key', 'stratawp-seo' ); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr><td><?php esc_html_e( 'Meta title', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_title</code></td><td><code>rank_math_title</code></td></tr>
-            <tr><td><?php esc_html_e( 'Meta description', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_metadesc</code></td><td><code>rank_math_description</code></td></tr>
-            <tr><td><?php esc_html_e( 'Focus keyword', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_focuskw</code></td><td><code>rank_math_focus_keyword</code></td></tr>
-            <tr><td><?php esc_html_e( 'Canonical URL', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_canonical</code></td><td><code>rank_math_canonical_url</code></td></tr>
-            <tr><td><?php esc_html_e( 'Breadcrumb title', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_bctitle</code></td><td><code>rank_math_breadcrumb_title</code></td></tr>
-            <tr><td><?php esc_html_e( 'Social title', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_opengraph-title</code></td><td><code>rank_math_facebook_title</code></td></tr>
-            <tr><td><?php esc_html_e( 'Social description', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_opengraph-description</code></td><td><code>rank_math_facebook_description</code></td></tr>
-            <tr><td><?php esc_html_e( 'Social image', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_opengraph-image</code></td><td><code>rank_math_facebook_image</code></td></tr>
-        </tbody>
-    </table>
-    <p class="description" style="margin-top:8px;">
-        <?php esc_html_e( 'Global settings imported: title separator, title templates per post type / taxonomy / archive (with template-variable rewriting for Rank Math), and per-post-type noindex flags. Redirects imported from Yoast Premium (wpseo-premium-redirects-base) and Rank Math Pro (wp_rank_math_redirections table); 301/302/307/410 are supported, regex sources are kept as regex.', 'stratawp-seo' ); ?>
-    </p>
+	<h2 style="margin-top:24px;"><?php esc_html_e( 'What gets migrated', 'stratawp-seo' ); ?></h2>
+	<table class="widefat striped">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Field', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Yoast key', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Rank Math key', 'stratawp-seo' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td><?php esc_html_e( 'Meta title', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_title</code></td><td><code>rank_math_title</code></td></tr>
+			<tr><td><?php esc_html_e( 'Meta description', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_metadesc</code></td><td><code>rank_math_description</code></td></tr>
+			<tr><td><?php esc_html_e( 'Focus keyword', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_focuskw</code></td><td><code>rank_math_focus_keyword</code></td></tr>
+			<tr><td><?php esc_html_e( 'Canonical URL', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_canonical</code></td><td><code>rank_math_canonical_url</code></td></tr>
+			<tr><td><?php esc_html_e( 'Breadcrumb title', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_bctitle</code></td><td><code>rank_math_breadcrumb_title</code></td></tr>
+			<tr><td><?php esc_html_e( 'Social title', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_opengraph-title</code></td><td><code>rank_math_facebook_title</code></td></tr>
+			<tr><td><?php esc_html_e( 'Social description', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_opengraph-description</code></td><td><code>rank_math_facebook_description</code></td></tr>
+			<tr><td><?php esc_html_e( 'Social image', 'stratawp-seo' ); ?></td><td><code>_yoast_wpseo_opengraph-image</code></td><td><code>rank_math_facebook_image</code></td></tr>
+		</tbody>
+	</table>
+	<p class="description" style="margin-top:8px;">
+		<?php esc_html_e( 'Global settings imported: title separator, title templates per post type / taxonomy / archive (with template-variable rewriting for Rank Math), and per-post-type noindex flags. Redirects imported from Yoast Premium (wpseo-premium-redirects-base) and Rank Math Pro (wp_rank_math_redirections table); 301/302/307/410 are supported, regex sources are kept as regex.', 'stratawp-seo' ); ?>
+	</p>
 </div>

--- a/templates/partials/page-header.php
+++ b/templates/partials/page-header.php
@@ -14,38 +14,40 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 $swps_title    = isset( $title ) ? (string) $title : '';
 $swps_subtitle = isset( $subtitle ) ? (string) $subtitle : '';
-$swps_actions  = ( isset( $actions ) && is_array( $actions ) ) ? $actions : [];
+$swps_actions  = ( isset( $actions ) && is_array( $actions ) ) ? $actions : array();
 ?>
 <div class="swps-page-head">
-    <div class="swps-page-head-text">
-        <h1><?php echo esc_html( $swps_title ); ?></h1>
-        <?php if ( '' !== $swps_subtitle ) : ?>
-            <p class="swps-page-head-sub"><?php echo wp_kses_post( $swps_subtitle ); ?></p>
-        <?php endif; ?>
-    </div>
+	<div class="swps-page-head-text">
+		<h1><?php echo esc_html( $swps_title ); ?></h1>
+		<?php if ( '' !== $swps_subtitle ) : ?>
+			<p class="swps-page-head-sub"><?php echo wp_kses_post( $swps_subtitle ); ?></p>
+		<?php endif; ?>
+	</div>
 
-    <?php if ( ! empty( $swps_actions ) ) : ?>
-        <div class="swps-page-head-actions">
-            <?php foreach ( $swps_actions as $swps_action ) :
-                $a_label = isset( $swps_action['label'] ) ? (string) $swps_action['label'] : '';
-                $a_url   = isset( $swps_action['url'] )   ? (string) $swps_action['url']   : '';
-                $a_class = isset( $swps_action['class'] ) ? (string) $swps_action['class'] : 'swps-btn-secondary';
-                $a_attrs = isset( $swps_action['attrs'] ) ? (string) $swps_action['attrs'] : '';
-                if ( '' !== $a_url ) : ?>
-                    <a class="swps-btn <?php echo esc_attr( $a_class ); ?>" href="<?php echo esc_url( $a_url ); ?>" <?php echo $a_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-                        <?php echo esc_html( $a_label ); ?>
-                    </a>
-                <?php else : ?>
-                    <button type="button" class="swps-btn <?php echo esc_attr( $a_class ); ?>" <?php echo $a_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-                        <?php echo esc_html( $a_label ); ?>
-                    </button>
-                <?php endif; ?>
-            <?php endforeach; ?>
-        </div>
-    <?php endif; ?>
+	<?php if ( ! empty( $swps_actions ) ) : ?>
+		<div class="swps-page-head-actions">
+			<?php
+			foreach ( $swps_actions as $swps_action ) :
+				$a_label = isset( $swps_action['label'] ) ? (string) $swps_action['label'] : '';
+				$a_url   = isset( $swps_action['url'] ) ? (string) $swps_action['url'] : '';
+				$a_class = isset( $swps_action['class'] ) ? (string) $swps_action['class'] : 'swps-btn-secondary';
+				$a_attrs = isset( $swps_action['attrs'] ) ? (string) $swps_action['attrs'] : '';
+				if ( '' !== $a_url ) :
+					?>
+					<a class="swps-btn <?php echo esc_attr( $a_class ); ?>" href="<?php echo esc_url( $a_url ); ?>" <?php echo $a_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+						<?php echo esc_html( $a_label ); ?>
+					</a>
+				<?php else : ?>
+					<button type="button" class="swps-btn <?php echo esc_attr( $a_class ); ?>" <?php echo $a_attrs; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+						<?php echo esc_html( $a_label ); ?>
+					</button>
+				<?php endif; ?>
+			<?php endforeach; ?>
+		</div>
+	<?php endif; ?>
 </div>

--- a/templates/redirects-page.php
+++ b/templates/redirects-page.php
@@ -6,126 +6,126 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 ?>
 <div class="wrap swps-redirects-page swps-settings-wrap">
 
-    <?php
-    $title    = __( 'Redirects', 'stratawp-seo' );
-    $subtitle = __( 'Manage 301/302/307/410 redirects and monitor 404 errors. Click "Create redirect" on any 404 row to fix it instantly.', 'stratawp-seo' );
-    $actions  = [];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'Redirects', 'stratawp-seo' );
+	$subtitle = __( 'Manage 301/302/307/410 redirects and monitor 404 errors. Click "Create redirect" on any 404 row to fix it instantly.', 'stratawp-seo' );
+	$actions  = array();
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <div class="nav-tab-wrapper swps-settings-tabs" role="tablist">
-        <a href="#redirects" class="nav-tab nav-tab-active" data-tab="redirects" role="tab" aria-selected="true"><?php esc_html_e( 'Redirects', 'stratawp-seo' ); ?></a>
-        <a href="#404s" class="nav-tab" data-tab="404s" role="tab" aria-selected="false"><?php esc_html_e( '404 Errors', 'stratawp-seo' ); ?></a>
-    </div>
+	<div class="nav-tab-wrapper swps-settings-tabs" role="tablist">
+		<a href="#redirects" class="nav-tab nav-tab-active" data-tab="redirects" role="tab" aria-selected="true"><?php esc_html_e( 'Redirects', 'stratawp-seo' ); ?></a>
+		<a href="#404s" class="nav-tab" data-tab="404s" role="tab" aria-selected="false"><?php esc_html_e( '404 Errors', 'stratawp-seo' ); ?></a>
+	</div>
 
-    <div id="tab-redirects" class="swps-tab-content swps-settings-panel" data-tab="redirects" role="tabpanel">
-        <h2 style="margin-top:0"><?php esc_html_e( 'Add Redirect', 'stratawp-seo' ); ?></h2>
-        <table class="form-table">
-            <tr>
-                <th><label for="swps-redirect-source"><?php esc_html_e( 'Source URL', 'stratawp-seo' ); ?></label></th>
-                <td><input type="text" id="swps-redirect-source" class="large-text" placeholder="/old-page"></td>
-            </tr>
-            <tr>
-                <th><label for="swps-redirect-target"><?php esc_html_e( 'Target URL', 'stratawp-seo' ); ?></label></th>
-                <td><input type="text" id="swps-redirect-target" class="large-text" placeholder="/new-page"></td>
-            </tr>
-            <tr>
-                <th><label for="swps-redirect-type"><?php esc_html_e( 'Type', 'stratawp-seo' ); ?></label></th>
-                <td>
-                    <select id="swps-redirect-type">
-                        <option value="301"><?php esc_html_e( '301 Permanent', 'stratawp-seo' ); ?></option>
-                        <option value="302"><?php esc_html_e( '302 Temporary', 'stratawp-seo' ); ?></option>
-                        <option value="307"><?php esc_html_e( '307 Temporary (preserve method)', 'stratawp-seo' ); ?></option>
-                        <option value="410"><?php esc_html_e( '410 Gone', 'stratawp-seo' ); ?></option>
-                    </select>
-                </td>
-            </tr>
-            <tr>
-                <th></th>
-                <td>
-                    <label><input type="checkbox" id="swps-redirect-regex"> <?php esc_html_e( 'Regex match', 'stratawp-seo' ); ?></label>
-                </td>
-            </tr>
-        </table>
-        <p style="margin-top:16px"><button class="swps-btn swps-btn-grad" id="swps-add-redirect"><?php esc_html_e( 'Add Redirect', 'stratawp-seo' ); ?></button></p>
+	<div id="tab-redirects" class="swps-tab-content swps-settings-panel" data-tab="redirects" role="tabpanel">
+		<h2 style="margin-top:0"><?php esc_html_e( 'Add Redirect', 'stratawp-seo' ); ?></h2>
+		<table class="form-table">
+			<tr>
+				<th><label for="swps-redirect-source"><?php esc_html_e( 'Source URL', 'stratawp-seo' ); ?></label></th>
+				<td><input type="text" id="swps-redirect-source" class="large-text" placeholder="/old-page"></td>
+			</tr>
+			<tr>
+				<th><label for="swps-redirect-target"><?php esc_html_e( 'Target URL', 'stratawp-seo' ); ?></label></th>
+				<td><input type="text" id="swps-redirect-target" class="large-text" placeholder="/new-page"></td>
+			</tr>
+			<tr>
+				<th><label for="swps-redirect-type"><?php esc_html_e( 'Type', 'stratawp-seo' ); ?></label></th>
+				<td>
+					<select id="swps-redirect-type">
+						<option value="301"><?php esc_html_e( '301 Permanent', 'stratawp-seo' ); ?></option>
+						<option value="302"><?php esc_html_e( '302 Temporary', 'stratawp-seo' ); ?></option>
+						<option value="307"><?php esc_html_e( '307 Temporary (preserve method)', 'stratawp-seo' ); ?></option>
+						<option value="410"><?php esc_html_e( '410 Gone', 'stratawp-seo' ); ?></option>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<th></th>
+				<td>
+					<label><input type="checkbox" id="swps-redirect-regex"> <?php esc_html_e( 'Regex match', 'stratawp-seo' ); ?></label>
+				</td>
+			</tr>
+		</table>
+		<p style="margin-top:16px"><button class="swps-btn swps-btn-grad" id="swps-add-redirect"><?php esc_html_e( 'Add Redirect', 'stratawp-seo' ); ?></button></p>
 
-        <h2 style="margin-top:32px"><?php esc_html_e( 'Existing Redirects', 'stratawp-seo' ); ?></h2>
-        <table class="widefat striped" id="swps-redirects-table">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e( 'Source', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Target', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Type', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Hits', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
-    </div>
+		<h2 style="margin-top:32px"><?php esc_html_e( 'Existing Redirects', 'stratawp-seo' ); ?></h2>
+		<table class="widefat striped" id="swps-redirects-table">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Source', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Target', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Type', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Hits', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody></tbody>
+		</table>
+	</div>
 
-    <div id="tab-404s" class="swps-tab-content swps-settings-panel" data-tab="404s" role="tabpanel" style="display:none;">
-        <h2 style="margin-top:0"><?php esc_html_e( '404 Errors', 'stratawp-seo' ); ?></h2>
+	<div id="tab-404s" class="swps-tab-content swps-settings-panel" data-tab="404s" role="tabpanel" style="display:none;">
+		<h2 style="margin-top:0"><?php esc_html_e( '404 Errors', 'stratawp-seo' ); ?></h2>
 
-        <div class="swps-404-bulk-bar" style="display:none; margin-bottom:12px; padding:10px 14px; background:var(--swps-info-bg); border:1px solid var(--swps-accent-1); border-radius:var(--swps-radius-sm); color:var(--swps-text-primary)">
-            <span id="swps-404-selected-count">0</span> <?php esc_html_e( 'selected', 'stratawp-seo' ); ?> —
-            <button class="swps-btn swps-btn-secondary" id="swps-bulk-dismiss-404s" style="padding:4px 10px;font-size:11px"><?php esc_html_e( 'Dismiss Selected', 'stratawp-seo' ); ?></button>
-            <button class="swps-btn swps-btn-secondary" id="swps-bulk-redirect-404s" style="padding:4px 10px;font-size:11px"><?php esc_html_e( 'Redirect Selected to...', 'stratawp-seo' ); ?></button>
-            <span id="swps-bulk-redirect-target-wrap" style="display:none;">
-                <input type="text" id="swps-bulk-redirect-target" class="regular-text" placeholder="<?php esc_attr_e( '/target-page', 'stratawp-seo' ); ?>">
-                <button class="swps-btn swps-btn-grad" id="swps-bulk-redirect-confirm" style="padding:4px 10px;font-size:11px"><?php esc_html_e( 'Go', 'stratawp-seo' ); ?></button>
-                <button class="swps-btn swps-btn-secondary" id="swps-bulk-redirect-cancel" style="padding:4px 10px;font-size:11px"><?php esc_html_e( 'Cancel', 'stratawp-seo' ); ?></button>
-            </span>
-        </div>
+		<div class="swps-404-bulk-bar" style="display:none; margin-bottom:12px; padding:10px 14px; background:var(--swps-info-bg); border:1px solid var(--swps-accent-1); border-radius:var(--swps-radius-sm); color:var(--swps-text-primary)">
+			<span id="swps-404-selected-count">0</span> <?php esc_html_e( 'selected', 'stratawp-seo' ); ?> —
+			<button class="swps-btn swps-btn-secondary" id="swps-bulk-dismiss-404s" style="padding:4px 10px;font-size:11px"><?php esc_html_e( 'Dismiss Selected', 'stratawp-seo' ); ?></button>
+			<button class="swps-btn swps-btn-secondary" id="swps-bulk-redirect-404s" style="padding:4px 10px;font-size:11px"><?php esc_html_e( 'Redirect Selected to...', 'stratawp-seo' ); ?></button>
+			<span id="swps-bulk-redirect-target-wrap" style="display:none;">
+				<input type="text" id="swps-bulk-redirect-target" class="regular-text" placeholder="<?php esc_attr_e( '/target-page', 'stratawp-seo' ); ?>">
+				<button class="swps-btn swps-btn-grad" id="swps-bulk-redirect-confirm" style="padding:4px 10px;font-size:11px"><?php esc_html_e( 'Go', 'stratawp-seo' ); ?></button>
+				<button class="swps-btn swps-btn-secondary" id="swps-bulk-redirect-cancel" style="padding:4px 10px;font-size:11px"><?php esc_html_e( 'Cancel', 'stratawp-seo' ); ?></button>
+			</span>
+		</div>
 
-        <table class="widefat striped" id="swps-404s-table">
-            <thead>
-                <tr>
-                    <th style="width:30px;"><input type="checkbox" id="swps-404-select-all"></th>
-                    <th><?php esc_html_e( 'URL', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Referrer', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Hits', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Suggested Target', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Last Seen', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
-    </div>
+		<table class="widefat striped" id="swps-404s-table">
+			<thead>
+				<tr>
+					<th style="width:30px;"><input type="checkbox" id="swps-404-select-all"></th>
+					<th><?php esc_html_e( 'URL', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Referrer', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Hits', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Suggested Target', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Last Seen', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody></tbody>
+		</table>
+	</div>
 </div>
 
 <script>
 (function () {
-    'use strict';
-    document.addEventListener('DOMContentLoaded', function () {
-        var wrap = document.querySelector('.swps-redirects-page');
-        if (!wrap) return;
-        var tabs = wrap.querySelectorAll('.swps-settings-tabs .nav-tab');
-        var panels = wrap.querySelectorAll('.swps-tab-content');
-        function activate(key) {
-            tabs.forEach(function (t) {
-                var match = t.dataset.tab === key;
-                t.classList.toggle('nav-tab-active', match);
-                t.setAttribute('aria-selected', match ? 'true' : 'false');
-            });
-            panels.forEach(function (p) {
-                p.style.display = p.dataset.tab === key ? '' : 'none';
-            });
-        }
-        tabs.forEach(function (t) {
-            t.addEventListener('click', function (e) {
-                e.preventDefault();
-                activate(t.dataset.tab);
-            });
-        });
-        var hash = window.location.hash.replace(/^#/, '');
-        if (hash && wrap.querySelector('.nav-tab[data-tab="' + hash + '"]')) activate(hash);
-    });
+	'use strict';
+	document.addEventListener('DOMContentLoaded', function () {
+		var wrap = document.querySelector('.swps-redirects-page');
+		if (!wrap) return;
+		var tabs = wrap.querySelectorAll('.swps-settings-tabs .nav-tab');
+		var panels = wrap.querySelectorAll('.swps-tab-content');
+		function activate(key) {
+			tabs.forEach(function (t) {
+				var match = t.dataset.tab === key;
+				t.classList.toggle('nav-tab-active', match);
+				t.setAttribute('aria-selected', match ? 'true' : 'false');
+			});
+			panels.forEach(function (p) {
+				p.style.display = p.dataset.tab === key ? '' : 'none';
+			});
+		}
+		tabs.forEach(function (t) {
+			t.addEventListener('click', function (e) {
+				e.preventDefault();
+				activate(t.dataset.tab);
+			});
+		});
+		var hash = window.location.hash.replace(/^#/, '');
+		if (hash && wrap.querySelector('.nav-tab[data-tab="' + hash + '"]')) activate(hash);
+	});
 })();
 </script>

--- a/templates/search-appearance-page.php
+++ b/templates/search-appearance-page.php
@@ -6,224 +6,226 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 ?>
 <div class="wrap swps-search-appearance">
-    <h1><?php esc_html_e( 'Search Appearance', 'stratawp-seo' ); ?></h1>
+	<h1><?php esc_html_e( 'Search Appearance', 'stratawp-seo' ); ?></h1>
 
-    <form method="post" action="options.php">
-        <?php settings_fields( 'swps_search_appearance' ); ?>
+	<form method="post" action="options.php">
+		<?php settings_fields( 'swps_search_appearance' ); ?>
 
-        <h2><?php esc_html_e( 'Title Separator', 'stratawp-seo' ); ?></h2>
-        <table class="form-table">
-            <tr>
-                <th scope="row"><?php esc_html_e( 'Separator', 'stratawp-seo' ); ?></th>
-                <td>
-                    <?php
-                    $current_sep = get_option( 'swps_title_separator', '-' );
-                    $separators  = [ '|', '-', '–', '—', '·', '•', '»' ];
-                    foreach ( $separators as $sep ) :
-                    ?>
-                        <label style="margin-right: 15px; cursor: pointer;">
-                            <input type="radio" name="swps_title_separator" value="<?php echo esc_attr( $sep ); ?>"
-                                <?php checked( $current_sep, $sep ); ?>>
-                            <?php echo esc_html( $sep ); ?>
-                        </label>
-                    <?php endforeach; ?>
-                </td>
-            </tr>
-        </table>
+		<h2><?php esc_html_e( 'Title Separator', 'stratawp-seo' ); ?></h2>
+		<table class="form-table">
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Separator', 'stratawp-seo' ); ?></th>
+				<td>
+					<?php
+					$current_sep = get_option( 'swps_title_separator', '-' );
+					$separators  = array( '|', '-', '–', '—', '·', '•', '»' );
+					foreach ( $separators as $sep ) :
+						?>
+						<label style="margin-right: 15px; cursor: pointer;">
+							<input type="radio" name="swps_title_separator" value="<?php echo esc_attr( $sep ); ?>"
+								<?php checked( $current_sep, $sep ); ?>>
+							<?php echo esc_html( $sep ); ?>
+						</label>
+					<?php endforeach; ?>
+				</td>
+			</tr>
+		</table>
 
-        <?php
-        // Post types section.
-        $post_types = get_post_types( [ 'public' => true ], 'objects' );
-        foreach ( $post_types as $pt ) :
-            if ( 'attachment' === $pt->name ) {
-                continue;
-            }
-        ?>
-            <h2><?php echo esc_html( $pt->labels->name ); ?></h2>
-            <table class="form-table">
-                <tr>
-                    <th scope="row"><?php esc_html_e( 'Title Template', 'stratawp-seo' ); ?></th>
-                    <td>
-                        <input type="text" class="large-text swps-title-template"
-                            name="swps_title_template_<?php echo esc_attr( $pt->name ); ?>"
-                            value="<?php echo esc_attr( get_option( "swps_title_template_{$pt->name}", '%%title%% %%sep%% %%sitename%%' ) ); ?>">
-                        <p class="description swps-template-preview"></p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php esc_html_e( 'Description Template', 'stratawp-seo' ); ?></th>
-                    <td>
-                        <textarea class="large-text" rows="2"
-                            name="swps_desc_template_<?php echo esc_attr( $pt->name ); ?>"
-                        ><?php echo esc_textarea( get_option( "swps_desc_template_{$pt->name}", '%%excerpt%%' ) ); ?></textarea>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php esc_html_e( 'Show in Search Results', 'stratawp-seo' ); ?></th>
-                    <td>
-                        <label>
-                            <input type="hidden" name="swps_noindex_<?php echo esc_attr( $pt->name ); ?>" value="0">
-                            <input type="checkbox" name="swps_noindex_<?php echo esc_attr( $pt->name ); ?>" value="1"
-                                <?php checked( get_option( "swps_noindex_{$pt->name}", 0 ) ); ?>>
-                            <?php esc_html_e( 'Noindex this post type (hide from search engines)', 'stratawp-seo' ); ?>
-                        </label>
-                    </td>
-                </tr>
-            </table>
-        <?php endforeach; ?>
+		<?php
+		// Post types section.
+		$post_types = get_post_types( array( 'public' => true ), 'objects' );
+		foreach ( $post_types as $pt ) :
+			if ( 'attachment' === $pt->name ) {
+				continue;
+			}
+			?>
+			<h2><?php echo esc_html( $pt->labels->name ); ?></h2>
+			<table class="form-table">
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Title Template', 'stratawp-seo' ); ?></th>
+					<td>
+						<input type="text" class="large-text swps-title-template"
+							name="swps_title_template_<?php echo esc_attr( $pt->name ); ?>"
+							value="<?php echo esc_attr( get_option( "swps_title_template_{$pt->name}", '%%title%% %%sep%% %%sitename%%' ) ); ?>">
+						<p class="description swps-template-preview"></p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Description Template', 'stratawp-seo' ); ?></th>
+					<td>
+						<textarea class="large-text" rows="2"
+							name="swps_desc_template_<?php echo esc_attr( $pt->name ); ?>"
+						><?php echo esc_textarea( get_option( "swps_desc_template_{$pt->name}", '%%excerpt%%' ) ); ?></textarea>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Show in Search Results', 'stratawp-seo' ); ?></th>
+					<td>
+						<label>
+							<input type="hidden" name="swps_noindex_<?php echo esc_attr( $pt->name ); ?>" value="0">
+							<input type="checkbox" name="swps_noindex_<?php echo esc_attr( $pt->name ); ?>" value="1"
+								<?php checked( get_option( "swps_noindex_{$pt->name}", 0 ) ); ?>>
+							<?php esc_html_e( 'Noindex this post type (hide from search engines)', 'stratawp-seo' ); ?>
+						</label>
+					</td>
+				</tr>
+			</table>
+		<?php endforeach; ?>
 
-        <?php
-        // Taxonomies section.
-        $taxonomies = get_taxonomies( [ 'public' => true ], 'objects' );
-        foreach ( $taxonomies as $tax ) :
-            if ( 'post_format' === $tax->name ) {
-                continue;
-            }
-        ?>
-            <h2><?php echo esc_html( $tax->labels->name ); ?></h2>
-            <table class="form-table">
-                <tr>
-                    <th scope="row"><?php esc_html_e( 'Title Template', 'stratawp-seo' ); ?></th>
-                    <td>
-                        <input type="text" class="large-text swps-title-template"
-                            name="swps_title_template_<?php echo esc_attr( $tax->name ); ?>"
-                            value="<?php echo esc_attr( get_option( "swps_title_template_{$tax->name}", '%%title%% %%sep%% %%sitename%%' ) ); ?>">
-                        <p class="description swps-template-preview"></p>
-                    </td>
-                </tr>
-                <tr>
-                    <th scope="row"><?php esc_html_e( 'Show in Search Results', 'stratawp-seo' ); ?></th>
-                    <td>
-                        <label>
-                            <input type="hidden" name="swps_noindex_<?php echo esc_attr( $tax->name ); ?>" value="0">
-                            <input type="checkbox" name="swps_noindex_<?php echo esc_attr( $tax->name ); ?>" value="1"
-                                <?php checked( get_option( "swps_noindex_{$tax->name}", 0 ) ); ?>>
-                            <?php esc_html_e( 'Noindex this taxonomy', 'stratawp-seo' ); ?>
-                        </label>
-                    </td>
-                </tr>
-            </table>
-        <?php endforeach; ?>
+		<?php
+		// Taxonomies section.
+		$taxonomies = get_taxonomies( array( 'public' => true ), 'objects' );
+		foreach ( $taxonomies as $tax ) :
+			if ( 'post_format' === $tax->name ) {
+				continue;
+			}
+			?>
+			<h2><?php echo esc_html( $tax->labels->name ); ?></h2>
+			<table class="form-table">
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Title Template', 'stratawp-seo' ); ?></th>
+					<td>
+						<input type="text" class="large-text swps-title-template"
+							name="swps_title_template_<?php echo esc_attr( $tax->name ); ?>"
+							value="<?php echo esc_attr( get_option( "swps_title_template_{$tax->name}", '%%title%% %%sep%% %%sitename%%' ) ); ?>">
+						<p class="description swps-template-preview"></p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row"><?php esc_html_e( 'Show in Search Results', 'stratawp-seo' ); ?></th>
+					<td>
+						<label>
+							<input type="hidden" name="swps_noindex_<?php echo esc_attr( $tax->name ); ?>" value="0">
+							<input type="checkbox" name="swps_noindex_<?php echo esc_attr( $tax->name ); ?>" value="1"
+								<?php checked( get_option( "swps_noindex_{$tax->name}", 0 ) ); ?>>
+							<?php esc_html_e( 'Noindex this taxonomy', 'stratawp-seo' ); ?>
+						</label>
+					</td>
+				</tr>
+			</table>
+		<?php endforeach; ?>
 
-        <h2><?php esc_html_e( 'Special Pages', 'stratawp-seo' ); ?></h2>
-        <table class="form-table">
-            <tr>
-                <th scope="row"><?php esc_html_e( 'Search Page Title', 'stratawp-seo' ); ?></th>
-                <td>
-                    <input type="text" class="large-text swps-title-template"
-                        name="swps_title_template_search"
-                        value="<?php echo esc_attr( get_option( 'swps_title_template_search', 'Search: %%searchphrase%% %%sep%% %%sitename%%' ) ); ?>">
-                </td>
-            </tr>
-            <tr>
-                <th scope="row"><?php esc_html_e( '404 Page Title', 'stratawp-seo' ); ?></th>
-                <td>
-                    <input type="text" class="large-text swps-title-template"
-                        name="swps_title_template_404"
-                        value="<?php echo esc_attr( get_option( 'swps_title_template_404', 'Page Not Found %%sep%% %%sitename%%' ) ); ?>">
-                </td>
-            </tr>
-            <tr>
-                <th scope="row"><?php esc_html_e( 'Author Archive Title', 'stratawp-seo' ); ?></th>
-                <td>
-                    <input type="text" class="large-text swps-title-template"
-                        name="swps_title_template_author"
-                        value="<?php echo esc_attr( get_option( 'swps_title_template_author', '%%author%% %%sep%% %%sitename%%' ) ); ?>">
-                </td>
-            </tr>
-            <tr>
-                <th scope="row"><?php esc_html_e( 'Date Archive Title', 'stratawp-seo' ); ?></th>
-                <td>
-                    <input type="text" class="large-text swps-title-template"
-                        name="swps_title_template_date"
-                        value="<?php echo esc_attr( get_option( 'swps_title_template_date', '%%title%% %%sep%% %%sitename%%' ) ); ?>">
-                </td>
-            </tr>
-        </table>
+		<h2><?php esc_html_e( 'Special Pages', 'stratawp-seo' ); ?></h2>
+		<table class="form-table">
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Search Page Title', 'stratawp-seo' ); ?></th>
+				<td>
+					<input type="text" class="large-text swps-title-template"
+						name="swps_title_template_search"
+						value="<?php echo esc_attr( get_option( 'swps_title_template_search', 'Search: %%searchphrase%% %%sep%% %%sitename%%' ) ); ?>">
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><?php esc_html_e( '404 Page Title', 'stratawp-seo' ); ?></th>
+				<td>
+					<input type="text" class="large-text swps-title-template"
+						name="swps_title_template_404"
+						value="<?php echo esc_attr( get_option( 'swps_title_template_404', 'Page Not Found %%sep%% %%sitename%%' ) ); ?>">
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Author Archive Title', 'stratawp-seo' ); ?></th>
+				<td>
+					<input type="text" class="large-text swps-title-template"
+						name="swps_title_template_author"
+						value="<?php echo esc_attr( get_option( 'swps_title_template_author', '%%author%% %%sep%% %%sitename%%' ) ); ?>">
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Date Archive Title', 'stratawp-seo' ); ?></th>
+				<td>
+					<input type="text" class="large-text swps-title-template"
+						name="swps_title_template_date"
+						value="<?php echo esc_attr( get_option( 'swps_title_template_date', '%%title%% %%sep%% %%sitename%%' ) ); ?>">
+				</td>
+			</tr>
+		</table>
 
-        <h2><?php esc_html_e( 'Breadcrumbs', 'stratawp-seo' ); ?></h2>
-        <table class="form-table">
-            <tr>
-                <th scope="row"><?php esc_html_e( 'Enable Breadcrumbs', 'stratawp-seo' ); ?></th>
-                <td>
-                    <label>
-                        <input type="checkbox" name="swps_breadcrumbs_enabled" value="1"
-                            <?php checked( get_option( 'swps_breadcrumbs_enabled', 1 ) ); ?>>
-                        <?php esc_html_e( 'Enable HTML breadcrumb output', 'stratawp-seo' ); ?>
-                    </label>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row"><label for="swps-breadcrumbs-sep"><?php esc_html_e( 'Separator', 'stratawp-seo' ); ?></label></th>
-                <td>
-                    <input type="text" id="swps-breadcrumbs-sep" name="swps_breadcrumbs_separator" class="small-text"
-                        value="<?php echo esc_attr( get_option( 'swps_breadcrumbs_separator', '&raquo;' ) ); ?>">
-                </td>
-            </tr>
-            <tr>
-                <th scope="row"><label for="swps-breadcrumbs-home"><?php esc_html_e( 'Home Label', 'stratawp-seo' ); ?></label></th>
-                <td>
-                    <input type="text" id="swps-breadcrumbs-home" name="swps_breadcrumbs_home_label" class="regular-text"
-                        value="<?php echo esc_attr( get_option( 'swps_breadcrumbs_home_label', 'Home' ) ); ?>">
-                </td>
-            </tr>
-        </table>
-        <p class="description">
-            <?php esc_html_e( 'Use swps_breadcrumbs() in your theme template or the [swps_breadcrumbs] shortcode to display breadcrumbs.', 'stratawp-seo' ); ?>
-        </p>
+		<h2><?php esc_html_e( 'Breadcrumbs', 'stratawp-seo' ); ?></h2>
+		<table class="form-table">
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Enable Breadcrumbs', 'stratawp-seo' ); ?></th>
+				<td>
+					<label>
+						<input type="checkbox" name="swps_breadcrumbs_enabled" value="1"
+							<?php checked( get_option( 'swps_breadcrumbs_enabled', 1 ) ); ?>>
+						<?php esc_html_e( 'Enable HTML breadcrumb output', 'stratawp-seo' ); ?>
+					</label>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><label for="swps-breadcrumbs-sep"><?php esc_html_e( 'Separator', 'stratawp-seo' ); ?></label></th>
+				<td>
+					<input type="text" id="swps-breadcrumbs-sep" name="swps_breadcrumbs_separator" class="small-text"
+						value="<?php echo esc_attr( get_option( 'swps_breadcrumbs_separator', '&raquo;' ) ); ?>">
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><label for="swps-breadcrumbs-home"><?php esc_html_e( 'Home Label', 'stratawp-seo' ); ?></label></th>
+				<td>
+					<input type="text" id="swps-breadcrumbs-home" name="swps_breadcrumbs_home_label" class="regular-text"
+						value="<?php echo esc_attr( get_option( 'swps_breadcrumbs_home_label', 'Home' ) ); ?>">
+				</td>
+			</tr>
+		</table>
+		<p class="description">
+			<?php esc_html_e( 'Use swps_breadcrumbs() in your theme template or the [swps_breadcrumbs] shortcode to display breadcrumbs.', 'stratawp-seo' ); ?>
+		</p>
 
-        <h2><?php esc_html_e( 'Post List SEO Column', 'stratawp-seo' ); ?></h2>
-        <table class="form-table">
-            <tr>
-                <th scope="row"><?php esc_html_e( 'Enable SEO Column', 'stratawp-seo' ); ?></th>
-                <td>
-                    <?php
-                    $enabled_types = (array) get_option( 'swps_seo_column_post_types', [ 'post', 'page' ] );
-                    $all_types     = get_post_types( [ 'public' => true ], 'objects' );
-                    foreach ( $all_types as $pt ) :
-                        if ( 'attachment' === $pt->name ) continue;
-                    ?>
-                        <label style="display: block; margin-bottom: 6px;">
-                            <input type="checkbox" name="swps_seo_column_post_types[]"
-                                value="<?php echo esc_attr( $pt->name ); ?>"
-                                <?php checked( in_array( $pt->name, $enabled_types, true ) ); ?>>
-                            <?php echo esc_html( $pt->labels->name ); ?>
-                        </label>
-                    <?php endforeach; ?>
-                    <p class="description"><?php esc_html_e( 'Show the SEO score column on these post type list screens.', 'stratawp-seo' ); ?></p>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row"><label for="swps-seo-content-min"><?php esc_html_e( 'Minimum Content Length', 'stratawp-seo' ); ?></label></th>
-                <td>
-                    <input type="number" id="swps-seo-content-min" name="swps_seo_score_content_min"
-                        value="<?php echo esc_attr( get_option( 'swps_seo_score_content_min', 300 ) ); ?>"
-                        min="100" max="5000" step="50" class="small-text">
-                    <span><?php esc_html_e( 'words', 'stratawp-seo' ); ?></span>
-                    <p class="description"><?php esc_html_e( 'Minimum word count for the content length check in the SEO score.', 'stratawp-seo' ); ?></p>
-                </td>
-            </tr>
-        </table>
+		<h2><?php esc_html_e( 'Post List SEO Column', 'stratawp-seo' ); ?></h2>
+		<table class="form-table">
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Enable SEO Column', 'stratawp-seo' ); ?></th>
+				<td>
+					<?php
+					$enabled_types = (array) get_option( 'swps_seo_column_post_types', array( 'post', 'page' ) );
+					$all_types     = get_post_types( array( 'public' => true ), 'objects' );
+					foreach ( $all_types as $pt ) :
+						if ( 'attachment' === $pt->name ) {
+							continue;
+						}
+						?>
+						<label style="display: block; margin-bottom: 6px;">
+							<input type="checkbox" name="swps_seo_column_post_types[]"
+								value="<?php echo esc_attr( $pt->name ); ?>"
+								<?php checked( in_array( $pt->name, $enabled_types, true ) ); ?>>
+							<?php echo esc_html( $pt->labels->name ); ?>
+						</label>
+					<?php endforeach; ?>
+					<p class="description"><?php esc_html_e( 'Show the SEO score column on these post type list screens.', 'stratawp-seo' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><label for="swps-seo-content-min"><?php esc_html_e( 'Minimum Content Length', 'stratawp-seo' ); ?></label></th>
+				<td>
+					<input type="number" id="swps-seo-content-min" name="swps_seo_score_content_min"
+						value="<?php echo esc_attr( get_option( 'swps_seo_score_content_min', 300 ) ); ?>"
+						min="100" max="5000" step="50" class="small-text">
+					<span><?php esc_html_e( 'words', 'stratawp-seo' ); ?></span>
+					<p class="description"><?php esc_html_e( 'Minimum word count for the content length check in the SEO score.', 'stratawp-seo' ); ?></p>
+				</td>
+			</tr>
+		</table>
 
-        <?php submit_button(); ?>
-    </form>
+		<?php submit_button(); ?>
+	</form>
 
-    <div class="swps-template-help">
-        <h3><?php esc_html_e( 'Available Variables', 'stratawp-seo' ); ?></h3>
-        <ul>
-            <li><code>%%title%%</code> — <?php esc_html_e( 'Post/page/term title', 'stratawp-seo' ); ?></li>
-            <li><code>%%sitename%%</code> — <?php esc_html_e( 'Site name', 'stratawp-seo' ); ?></li>
-            <li><code>%%sep%%</code> — <?php esc_html_e( 'Separator character', 'stratawp-seo' ); ?></li>
-            <li><code>%%excerpt%%</code> — <?php esc_html_e( 'Post excerpt', 'stratawp-seo' ); ?></li>
-            <li><code>%%category%%</code> — <?php esc_html_e( 'Primary category', 'stratawp-seo' ); ?></li>
-            <li><code>%%author%%</code> — <?php esc_html_e( 'Author name', 'stratawp-seo' ); ?></li>
-            <li><code>%%date%%</code> — <?php esc_html_e( 'Published date', 'stratawp-seo' ); ?></li>
-            <li><code>%%searchphrase%%</code> — <?php esc_html_e( 'Search query', 'stratawp-seo' ); ?></li>
-            <li><code>%%page%%</code> — <?php esc_html_e( 'Page number', 'stratawp-seo' ); ?></li>
-        </ul>
-    </div>
+	<div class="swps-template-help">
+		<h3><?php esc_html_e( 'Available Variables', 'stratawp-seo' ); ?></h3>
+		<ul>
+			<li><code>%%title%%</code> — <?php esc_html_e( 'Post/page/term title', 'stratawp-seo' ); ?></li>
+			<li><code>%%sitename%%</code> — <?php esc_html_e( 'Site name', 'stratawp-seo' ); ?></li>
+			<li><code>%%sep%%</code> — <?php esc_html_e( 'Separator character', 'stratawp-seo' ); ?></li>
+			<li><code>%%excerpt%%</code> — <?php esc_html_e( 'Post excerpt', 'stratawp-seo' ); ?></li>
+			<li><code>%%category%%</code> — <?php esc_html_e( 'Primary category', 'stratawp-seo' ); ?></li>
+			<li><code>%%author%%</code> — <?php esc_html_e( 'Author name', 'stratawp-seo' ); ?></li>
+			<li><code>%%date%%</code> — <?php esc_html_e( 'Published date', 'stratawp-seo' ); ?></li>
+			<li><code>%%searchphrase%%</code> — <?php esc_html_e( 'Search query', 'stratawp-seo' ); ?></li>
+			<li><code>%%page%%</code> — <?php esc_html_e( 'Page number', 'stratawp-seo' ); ?></li>
+		</ul>
+	</div>
 </div>

--- a/templates/settings-page.php
+++ b/templates/settings-page.php
@@ -9,7 +9,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 $settings = stratawp_seo()->settings;
@@ -19,138 +19,138 @@ $default  = $tab_keys[0] ?? 'ai-content';
 ?>
 <div class="wrap swps-settings-wrap">
 
-    <?php
-    $title    = __( 'Settings', 'stratawp-seo' );
-    $subtitle = __( 'Configure your AI provider, content defaults, schedule, schema, analytics, and more. Changes save when you hit Save.', 'stratawp-seo' );
-    $actions  = [];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'Settings', 'stratawp-seo' );
+	$subtitle = __( 'Configure your AI provider, content defaults, schedule, schema, analytics, and more. Changes save when you hit Save.', 'stratawp-seo' );
+	$actions  = array();
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <div class="swps-header-bar">
-        <p>
-            <?php esc_html_e( 'Fill in your site details and preferences, then head to', 'stratawp-seo' ); ?>
-            <a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-generate' ) ); ?>"><?php esc_html_e( 'Generate Content', 'stratawp-seo' ); ?></a>
-            <?php esc_html_e( 'to create your first post.', 'stratawp-seo' ); ?>
-        </p>
-    </div>
+	<div class="swps-header-bar">
+		<p>
+			<?php esc_html_e( 'Fill in your site details and preferences, then head to', 'stratawp-seo' ); ?>
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-generate' ) ); ?>"><?php esc_html_e( 'Generate Content', 'stratawp-seo' ); ?></a>
+			<?php esc_html_e( 'to create your first post.', 'stratawp-seo' ); ?>
+		</p>
+	</div>
 
-    <div class="nav-tab-wrapper swps-settings-tabs" role="tablist">
-        <?php foreach ( $tabs as $key => $tab ) : ?>
-            <a
-                href="#<?php echo esc_attr( $key ); ?>"
-                class="nav-tab<?php echo $key === $default ? ' nav-tab-active' : ''; ?>"
-                data-tab="<?php echo esc_attr( $key ); ?>"
-                role="tab"
-                aria-selected="<?php echo $key === $default ? 'true' : 'false'; ?>"
-            >
-                <?php echo esc_html( $tab['label'] ); ?>
-            </a>
-        <?php endforeach; ?>
-    </div>
+	<div class="nav-tab-wrapper swps-settings-tabs" role="tablist">
+		<?php foreach ( $tabs as $key => $tab ) : ?>
+			<a
+				href="#<?php echo esc_attr( $key ); ?>"
+				class="nav-tab<?php echo $key === $default ? ' nav-tab-active' : ''; ?>"
+				data-tab="<?php echo esc_attr( $key ); ?>"
+				role="tab"
+				aria-selected="<?php echo $key === $default ? 'true' : 'false'; ?>"
+			>
+				<?php echo esc_html( $tab['label'] ); ?>
+			</a>
+		<?php endforeach; ?>
+	</div>
 
-    <form method="post" action="options.php">
-        <?php settings_fields( 'stratawp-seo' ); ?>
+	<form method="post" action="options.php">
+		<?php settings_fields( 'stratawp-seo' ); ?>
 
-        <?php foreach ( $tabs as $key => $tab ) : ?>
-            <div
-                class="swps-settings-panel"
-                data-tab="<?php echo esc_attr( $key ); ?>"
-                role="tabpanel"
-                <?php echo $key === $default ? '' : 'style="display:none;"'; ?>
-            >
-                <?php $settings->render_sections_for_tab( $tab['sections'] ); ?>
-            </div>
-        <?php endforeach; ?>
+		<?php foreach ( $tabs as $key => $tab ) : ?>
+			<div
+				class="swps-settings-panel"
+				data-tab="<?php echo esc_attr( $key ); ?>"
+				role="tabpanel"
+				<?php echo $key === $default ? '' : 'style="display:none;"'; ?>
+			>
+				<?php $settings->render_sections_for_tab( $tab['sections'] ); ?>
+			</div>
+		<?php endforeach; ?>
 
-        <?php submit_button( __( 'Save Settings', 'stratawp-seo' ), 'primary', 'submit', true, [ 'class' => 'swps-btn-grad' ] ); ?>
-    </form>
+		<?php submit_button( __( 'Save Settings', 'stratawp-seo' ), 'primary', 'submit', true, array( 'class' => 'swps-btn-grad' ) ); ?>
+	</form>
 
-    <div class="swps-card">
-        <h2><?php esc_html_e( 'Cache Management', 'stratawp-seo' ); ?></h2>
-        <p><?php esc_html_e( 'The site analyzer caches results for 1 hour to improve performance. Clear the cache if you\'ve made significant content changes and want fresh analysis data.', 'stratawp-seo' ); ?></p>
-        <button type="button" id="swps-clear-cache-btn" class="button button-secondary">
-            <?php esc_html_e( 'Clear Cache', 'stratawp-seo' ); ?>
-        </button>
-    </div>
+	<div class="swps-card">
+		<h2><?php esc_html_e( 'Cache Management', 'stratawp-seo' ); ?></h2>
+		<p><?php esc_html_e( 'The site analyzer caches results for 1 hour to improve performance. Clear the cache if you\'ve made significant content changes and want fresh analysis data.', 'stratawp-seo' ); ?></p>
+		<button type="button" id="swps-clear-cache-btn" class="button button-secondary">
+			<?php esc_html_e( 'Clear Cache', 'stratawp-seo' ); ?>
+		</button>
+	</div>
 
-    <?php
-    $log = get_option( 'swps_generation_log', [] );
-    if ( ! empty( $log ) ) :
-    ?>
-    <div class="swps-log-section">
-        <h2><?php esc_html_e( 'Recent Activity', 'stratawp-seo' ); ?></h2>
-        <table class="widefat striped">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e( 'Time', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Message', 'stratawp-seo' ); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ( array_reverse( $log ) as $entry ) : ?>
-                <tr>
-                    <td><?php echo esc_html( $entry['time'] ); ?></td>
-                    <td><?php echo esc_html( $entry['message'] ); ?></td>
-                </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
-    </div>
-    <?php endif; ?>
+	<?php
+	$log = get_option( 'swps_generation_log', array() );
+	if ( ! empty( $log ) ) :
+		?>
+	<div class="swps-log-section">
+		<h2><?php esc_html_e( 'Recent Activity', 'stratawp-seo' ); ?></h2>
+		<table class="widefat striped">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Time', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Message', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( array_reverse( $log ) as $entry ) : ?>
+				<tr>
+					<td><?php echo esc_html( $entry['time'] ); ?></td>
+					<td><?php echo esc_html( $entry['message'] ); ?></td>
+				</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+	</div>
+	<?php endif; ?>
 </div>
 
 <script>
 (function () {
-    'use strict';
-    document.addEventListener('DOMContentLoaded', function () {
-        var wrap = document.querySelector('.swps-settings-wrap');
-        if (!wrap) return;
+	'use strict';
+	document.addEventListener('DOMContentLoaded', function () {
+		var wrap = document.querySelector('.swps-settings-wrap');
+		if (!wrap) return;
 
-        var tabs = wrap.querySelectorAll('.swps-settings-tabs .nav-tab');
-        var panels = wrap.querySelectorAll('.swps-settings-panel');
+		var tabs = wrap.querySelectorAll('.swps-settings-tabs .nav-tab');
+		var panels = wrap.querySelectorAll('.swps-settings-panel');
 
-        function activate(key) {
-            var found = false;
-            tabs.forEach(function (t) {
-                var match = t.dataset.tab === key;
-                t.classList.toggle('nav-tab-active', match);
-                t.setAttribute('aria-selected', match ? 'true' : 'false');
-                if (match) found = true;
-            });
-            panels.forEach(function (p) {
-                p.style.display = p.dataset.tab === key ? '' : 'none';
-            });
-            if (found && history.replaceState) {
-                history.replaceState(null, '', '#' + key);
-            }
-        }
+		function activate(key) {
+			var found = false;
+			tabs.forEach(function (t) {
+				var match = t.dataset.tab === key;
+				t.classList.toggle('nav-tab-active', match);
+				t.setAttribute('aria-selected', match ? 'true' : 'false');
+				if (match) found = true;
+			});
+			panels.forEach(function (p) {
+				p.style.display = p.dataset.tab === key ? '' : 'none';
+			});
+			if (found && history.replaceState) {
+				history.replaceState(null, '', '#' + key);
+			}
+		}
 
-        tabs.forEach(function (t) {
-            t.addEventListener('click', function (e) {
-                e.preventDefault();
-                activate(t.dataset.tab);
-            });
-        });
+		tabs.forEach(function (t) {
+			t.addEventListener('click', function (e) {
+				e.preventDefault();
+				activate(t.dataset.tab);
+			});
+		});
 
-        var hash = window.location.hash.replace(/^#/, '');
-        if (hash && wrap.querySelector('.swps-settings-tabs .nav-tab[data-tab="' + hash + '"]')) {
-            activate(hash);
-        }
+		var hash = window.location.hash.replace(/^#/, '');
+		if (hash && wrap.querySelector('.swps-settings-tabs .nav-tab[data-tab="' + hash + '"]')) {
+			activate(hash);
+		}
 
-        var form = wrap.querySelector('form');
-        if (form) {
-            form.addEventListener('submit', function () {
-                var active = wrap.querySelector('.swps-settings-tabs .nav-tab-active');
-                if (active && active.dataset.tab) {
-                    var input = document.createElement('input');
-                    input.type = 'hidden';
-                    input.name = '_swps_active_tab';
-                    input.value = active.dataset.tab;
-                    form.appendChild(input);
-                    form.action = form.action.split('#')[0] + '#' + active.dataset.tab;
-                }
-            });
-        }
-    });
+		var form = wrap.querySelector('form');
+		if (form) {
+			form.addEventListener('submit', function () {
+				var active = wrap.querySelector('.swps-settings-tabs .nav-tab-active');
+				if (active && active.dataset.tab) {
+					var input = document.createElement('input');
+					input.type = 'hidden';
+					input.name = '_swps_active_tab';
+					input.value = active.dataset.tab;
+					form.appendChild(input);
+					form.action = form.action.split('#')[0] + '#' + active.dataset.tab;
+				}
+			});
+		}
+	});
 })();
 </script>

--- a/templates/sitemaps-page.php
+++ b/templates/sitemaps-page.php
@@ -6,81 +6,81 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 ?>
 <div class="wrap swps-sitemaps-page">
-    <h1><?php esc_html_e( 'Sitemaps', 'stratawp-seo' ); ?></h1>
+	<h1><?php esc_html_e( 'Sitemaps', 'stratawp-seo' ); ?></h1>
 
-    <h2 class="nav-tab-wrapper">
-        <a href="#dashboard" class="nav-tab nav-tab-active" data-tab="dashboard"><?php esc_html_e( 'Dashboard', 'stratawp-seo' ); ?></a>
-        <a href="#settings" class="nav-tab" data-tab="settings"><?php esc_html_e( 'Settings', 'stratawp-seo' ); ?></a>
-    </h2>
+	<h2 class="nav-tab-wrapper">
+		<a href="#dashboard" class="nav-tab nav-tab-active" data-tab="dashboard"><?php esc_html_e( 'Dashboard', 'stratawp-seo' ); ?></a>
+		<a href="#settings" class="nav-tab" data-tab="settings"><?php esc_html_e( 'Settings', 'stratawp-seo' ); ?></a>
+	</h2>
 
-    <div id="tab-dashboard" class="swps-tab-content" data-tab="dashboard">
-        <div class="postbox">
-            <div class="inside">
-                <h3><?php esc_html_e( 'Sitemap Index', 'stratawp-seo' ); ?></h3>
-                <p>
-                    <a href="<?php echo esc_url( home_url( '/sitemap_index.xml' ) ); ?>" target="_blank" rel="noopener noreferrer">
-                        <?php echo esc_url( home_url( '/sitemap_index.xml' ) ); ?>
-                    </a>
-                </p>
-            </div>
-        </div>
+	<div id="tab-dashboard" class="swps-tab-content" data-tab="dashboard">
+		<div class="postbox">
+			<div class="inside">
+				<h3><?php esc_html_e( 'Sitemap Index', 'stratawp-seo' ); ?></h3>
+				<p>
+					<a href="<?php echo esc_url( home_url( '/sitemap_index.xml' ) ); ?>" target="_blank" rel="noopener noreferrer">
+						<?php echo esc_url( home_url( '/sitemap_index.xml' ) ); ?>
+					</a>
+				</p>
+			</div>
+		</div>
 
-        <h3><?php esc_html_e( 'Sitemaps', 'stratawp-seo' ); ?></h3>
-        <table class="widefat striped" id="swps-sitemaps-table">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e( 'Sitemap', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'URL', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'URLs', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Last Modified', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Status', 'stratawp-seo' ); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td colspan="5"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
+		<h3><?php esc_html_e( 'Sitemaps', 'stratawp-seo' ); ?></h3>
+		<table class="widefat striped" id="swps-sitemaps-table">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Sitemap', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'URL', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'URLs', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Last Modified', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Status', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td colspan="5"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
 
-    <div id="tab-settings" class="swps-tab-content" data-tab="settings" style="display:none;">
-        <form method="post" action="options.php">
-            <?php settings_fields( 'swps_sitemap_settings' ); ?>
-            <table class="form-table">
-                <tr>
-                    <th><label for="swps_sitemap_exclude_images"><?php esc_html_e( 'Exclude Images', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input type="hidden" name="swps_sitemap_exclude_images" value="0">
-                        <input type="checkbox" id="swps_sitemap_exclude_images" name="swps_sitemap_exclude_images" value="1" <?php checked( get_option( 'swps_sitemap_exclude_images' ), 1 ); ?>>
-                    </td>
-                </tr>
-                <tr>
-                    <th><label for="swps_sitemap_exclude_author"><?php esc_html_e( 'Exclude Author Sitemap', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input type="hidden" name="swps_sitemap_exclude_author" value="0">
-                        <input type="checkbox" id="swps_sitemap_exclude_author" name="swps_sitemap_exclude_author" value="1" <?php checked( get_option( 'swps_sitemap_exclude_author' ), 1 ); ?>>
-                    </td>
-                </tr>
-                <tr>
-                    <th><label for="swps_auto_redirect_slug_change"><?php esc_html_e( 'Auto-Redirect on Slug Change', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input type="hidden" name="swps_auto_redirect_slug_change" value="0">
-                        <input type="checkbox" id="swps_auto_redirect_slug_change" name="swps_auto_redirect_slug_change" value="1" <?php checked( get_option( 'swps_auto_redirect_slug_change', 1 ), 1 ); ?>>
-                    </td>
-                </tr>
-                <tr>
-                    <th><label for="swps_sitemap_urls_per_page"><?php esc_html_e( 'URLs Per Sitemap', 'stratawp-seo' ); ?></label></th>
-                    <td>
-                        <input type="number" id="swps_sitemap_urls_per_page" name="swps_sitemap_urls_per_page" min="100" max="50000" step="100" value="<?php echo esc_attr( get_option( 'swps_sitemap_urls_per_page', 1000 ) ); ?>" class="small-text">
-                    </td>
-                </tr>
-            </table>
-            <?php submit_button(); ?>
-        </form>
-    </div>
+	<div id="tab-settings" class="swps-tab-content" data-tab="settings" style="display:none;">
+		<form method="post" action="options.php">
+			<?php settings_fields( 'swps_sitemap_settings' ); ?>
+			<table class="form-table">
+				<tr>
+					<th><label for="swps_sitemap_exclude_images"><?php esc_html_e( 'Exclude Images', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input type="hidden" name="swps_sitemap_exclude_images" value="0">
+						<input type="checkbox" id="swps_sitemap_exclude_images" name="swps_sitemap_exclude_images" value="1" <?php checked( get_option( 'swps_sitemap_exclude_images' ), 1 ); ?>>
+					</td>
+				</tr>
+				<tr>
+					<th><label for="swps_sitemap_exclude_author"><?php esc_html_e( 'Exclude Author Sitemap', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input type="hidden" name="swps_sitemap_exclude_author" value="0">
+						<input type="checkbox" id="swps_sitemap_exclude_author" name="swps_sitemap_exclude_author" value="1" <?php checked( get_option( 'swps_sitemap_exclude_author' ), 1 ); ?>>
+					</td>
+				</tr>
+				<tr>
+					<th><label for="swps_auto_redirect_slug_change"><?php esc_html_e( 'Auto-Redirect on Slug Change', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input type="hidden" name="swps_auto_redirect_slug_change" value="0">
+						<input type="checkbox" id="swps_auto_redirect_slug_change" name="swps_auto_redirect_slug_change" value="1" <?php checked( get_option( 'swps_auto_redirect_slug_change', 1 ), 1 ); ?>>
+					</td>
+				</tr>
+				<tr>
+					<th><label for="swps_sitemap_urls_per_page"><?php esc_html_e( 'URLs Per Sitemap', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input type="number" id="swps_sitemap_urls_per_page" name="swps_sitemap_urls_per_page" min="100" max="50000" step="100" value="<?php echo esc_attr( get_option( 'swps_sitemap_urls_per_page', 1000 ) ); ?>" class="small-text">
+					</td>
+				</tr>
+			</table>
+			<?php submit_button(); ?>
+		</form>
+	</div>
 </div>

--- a/templates/voice-profile-edit.php
+++ b/templates/voice-profile-edit.php
@@ -4,98 +4,98 @@ $is_new     = empty( $profile_id );
 $profile    = $is_new ? null : stratawp_seo()->voice_profile->get( $profile_id );
 
 if ( ! $is_new && ! $profile ) {
-    echo '<div class="wrap"><div class="notice notice-error"><p>' . esc_html__( 'Voice profile not found.', 'stratawp-seo' ) . '</p></div></div>';
-    return;
+	echo '<div class="wrap"><div class="notice notice-error"><p>' . esc_html__( 'Voice profile not found.', 'stratawp-seo' ) . '</p></div></div>';
+	return;
 }
 ?>
 <div class="wrap swps-wrap">
-    <h1>
-        <?php echo $is_new ? esc_html__( 'Add New Voice Profile', 'stratawp-seo' ) : esc_html__( 'Edit Voice Profile', 'stratawp-seo' ); ?>
-    </h1>
+	<h1>
+		<?php echo $is_new ? esc_html__( 'Add New Voice Profile', 'stratawp-seo' ) : esc_html__( 'Edit Voice Profile', 'stratawp-seo' ); ?>
+	</h1>
 
-    <form id="swps-voice-profile-form" class="swps-card" style="max-width: 700px; padding: 20px;">
-        <?php wp_nonce_field( 'swps_nonce', 'nonce' ); ?>
-        <input type="hidden" name="profile_id" value="<?php echo esc_attr( $profile_id ); ?>" />
+	<form id="swps-voice-profile-form" class="swps-card" style="max-width: 700px; padding: 20px;">
+		<?php wp_nonce_field( 'swps_nonce', 'nonce' ); ?>
+		<input type="hidden" name="profile_id" value="<?php echo esc_attr( $profile_id ); ?>" />
 
-        <table class="form-table">
-            <tr>
-                <th><label for="vp-name"><?php esc_html_e( 'Profile Name', 'stratawp-seo' ); ?></label></th>
-                <td><input type="text" id="vp-name" name="name" class="regular-text" required value="<?php echo esc_attr( $profile['name'] ?? '' ); ?>" placeholder="<?php esc_attr_e( 'e.g., Brand Voice, Technical Blog', 'stratawp-seo' ); ?>" /></td>
-            </tr>
-            <tr>
-                <th><label for="vp-tone"><?php esc_html_e( 'Tone', 'stratawp-seo' ); ?></label></th>
-                <td>
-                    <select id="vp-tone" name="tone">
-                        <?php foreach ( [ 'professional', 'casual', 'authoritative', 'friendly', 'formal', 'witty', 'conversational' ] as $t ) : ?>
-                            <option value="<?php echo esc_attr( $t ); ?>" <?php selected( $profile['tone'] ?? 'professional', $t ); ?>><?php echo esc_html( ucfirst( $t ) ); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </td>
-            </tr>
-            <tr>
-                <th><label for="vp-formality"><?php esc_html_e( 'Formality', 'stratawp-seo' ); ?></label></th>
-                <td>
-                    <input type="range" id="vp-formality" name="formality" min="1" max="10" value="<?php echo esc_attr( $profile['formality'] ?? 5 ); ?>" />
-                    <span id="vp-formality-label"><?php echo esc_html( $profile['formality'] ?? 5 ); ?>/10</span>
-                    <p class="description"><?php esc_html_e( '1 = very casual, 10 = very formal', 'stratawp-seo' ); ?></p>
-                </td>
-            </tr>
-            <tr>
-                <th><label for="vp-sentence-length"><?php esc_html_e( 'Sentence Length', 'stratawp-seo' ); ?></label></th>
-                <td>
-                    <select id="vp-sentence-length" name="sentence_length">
-                        <?php foreach ( [ 'short', 'medium', 'long', 'varied' ] as $sl ) : ?>
-                            <option value="<?php echo esc_attr( $sl ); ?>" <?php selected( $profile['sentence_length'] ?? 'varied', $sl ); ?>><?php echo esc_html( ucfirst( $sl ) ); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </td>
-            </tr>
-            <tr>
-                <th><label for="vp-vocabulary"><?php esc_html_e( 'Vocabulary Level', 'stratawp-seo' ); ?></label></th>
-                <td>
-                    <select id="vp-vocabulary" name="vocabulary_level">
-                        <?php foreach ( [ 'simple', 'moderate', 'advanced', 'technical' ] as $vl ) : ?>
-                            <option value="<?php echo esc_attr( $vl ); ?>" <?php selected( $profile['vocabulary_level'] ?? 'moderate', $vl ); ?>><?php echo esc_html( ucfirst( $vl ) ); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                </td>
-            </tr>
-            <tr>
-                <th><label for="vp-person"><?php esc_html_e( 'Person', 'stratawp-seo' ); ?></label></th>
-                <td>
-                    <select id="vp-person" name="person">
-                        <option value="first" <?php selected( $profile['person'] ?? 'second', 'first' ); ?>><?php esc_html_e( 'First (I/we)', 'stratawp-seo' ); ?></option>
-                        <option value="second" <?php selected( $profile['person'] ?? 'second', 'second' ); ?>><?php esc_html_e( 'Second (you)', 'stratawp-seo' ); ?></option>
-                        <option value="third" <?php selected( $profile['person'] ?? 'second', 'third' ); ?>><?php esc_html_e( 'Third (they/one)', 'stratawp-seo' ); ?></option>
-                    </select>
-                </td>
-            </tr>
-            <tr>
-                <th><label for="vp-example"><?php esc_html_e( 'Example Content', 'stratawp-seo' ); ?></label></th>
-                <td>
-                    <textarea id="vp-example" name="example_content" class="large-text" rows="5" placeholder="<?php esc_attr_e( 'Paste 1-2 paragraphs that represent your ideal writing style...', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $profile['example_content'] ?? '' ); ?></textarea>
-                    <p class="description"><?php esc_html_e( 'The AI will use this as a style reference (first 500 characters).', 'stratawp-seo' ); ?></p>
-                </td>
-            </tr>
-            <tr>
-                <th><label for="vp-avoid"><?php esc_html_e( 'Avoid Phrases', 'stratawp-seo' ); ?></label></th>
-                <td>
-                    <textarea id="vp-avoid" name="avoid_phrases" class="large-text" rows="2" placeholder="<?php esc_attr_e( 'game-changer, leverage, synergy, cutting-edge', 'stratawp-seo' ); ?>"><?php echo esc_textarea( implode( ', ', $profile['avoid_phrases'] ?? [] ) ); ?></textarea>
-                    <p class="description"><?php esc_html_e( 'Comma-separated list of phrases the AI should never use.', 'stratawp-seo' ); ?></p>
-                </td>
-            </tr>
-            <tr>
-                <th><label for="vp-prefer"><?php esc_html_e( 'Preferred Phrases', 'stratawp-seo' ); ?></label></th>
-                <td>
-                    <textarea id="vp-prefer" name="preferred_phrases" class="large-text" rows="2" placeholder="<?php esc_attr_e( 'practical, straightforward, hands-on', 'stratawp-seo' ); ?>"><?php echo esc_textarea( implode( ', ', $profile['preferred_phrases'] ?? [] ) ); ?></textarea>
-                    <p class="description"><?php esc_html_e( 'Comma-separated list of preferred expressions.', 'stratawp-seo' ); ?></p>
-                </td>
-            </tr>
-        </table>
+		<table class="form-table">
+			<tr>
+				<th><label for="vp-name"><?php esc_html_e( 'Profile Name', 'stratawp-seo' ); ?></label></th>
+				<td><input type="text" id="vp-name" name="name" class="regular-text" required value="<?php echo esc_attr( $profile['name'] ?? '' ); ?>" placeholder="<?php esc_attr_e( 'e.g., Brand Voice, Technical Blog', 'stratawp-seo' ); ?>" /></td>
+			</tr>
+			<tr>
+				<th><label for="vp-tone"><?php esc_html_e( 'Tone', 'stratawp-seo' ); ?></label></th>
+				<td>
+					<select id="vp-tone" name="tone">
+						<?php foreach ( array( 'professional', 'casual', 'authoritative', 'friendly', 'formal', 'witty', 'conversational' ) as $t ) : ?>
+							<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $profile['tone'] ?? 'professional', $t ); ?>><?php echo esc_html( ucfirst( $t ) ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<th><label for="vp-formality"><?php esc_html_e( 'Formality', 'stratawp-seo' ); ?></label></th>
+				<td>
+					<input type="range" id="vp-formality" name="formality" min="1" max="10" value="<?php echo esc_attr( $profile['formality'] ?? 5 ); ?>" />
+					<span id="vp-formality-label"><?php echo esc_html( $profile['formality'] ?? 5 ); ?>/10</span>
+					<p class="description"><?php esc_html_e( '1 = very casual, 10 = very formal', 'stratawp-seo' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th><label for="vp-sentence-length"><?php esc_html_e( 'Sentence Length', 'stratawp-seo' ); ?></label></th>
+				<td>
+					<select id="vp-sentence-length" name="sentence_length">
+						<?php foreach ( array( 'short', 'medium', 'long', 'varied' ) as $sl ) : ?>
+							<option value="<?php echo esc_attr( $sl ); ?>" <?php selected( $profile['sentence_length'] ?? 'varied', $sl ); ?>><?php echo esc_html( ucfirst( $sl ) ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<th><label for="vp-vocabulary"><?php esc_html_e( 'Vocabulary Level', 'stratawp-seo' ); ?></label></th>
+				<td>
+					<select id="vp-vocabulary" name="vocabulary_level">
+						<?php foreach ( array( 'simple', 'moderate', 'advanced', 'technical' ) as $vl ) : ?>
+							<option value="<?php echo esc_attr( $vl ); ?>" <?php selected( $profile['vocabulary_level'] ?? 'moderate', $vl ); ?>><?php echo esc_html( ucfirst( $vl ) ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<th><label for="vp-person"><?php esc_html_e( 'Person', 'stratawp-seo' ); ?></label></th>
+				<td>
+					<select id="vp-person" name="person">
+						<option value="first" <?php selected( $profile['person'] ?? 'second', 'first' ); ?>><?php esc_html_e( 'First (I/we)', 'stratawp-seo' ); ?></option>
+						<option value="second" <?php selected( $profile['person'] ?? 'second', 'second' ); ?>><?php esc_html_e( 'Second (you)', 'stratawp-seo' ); ?></option>
+						<option value="third" <?php selected( $profile['person'] ?? 'second', 'third' ); ?>><?php esc_html_e( 'Third (they/one)', 'stratawp-seo' ); ?></option>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<th><label for="vp-example"><?php esc_html_e( 'Example Content', 'stratawp-seo' ); ?></label></th>
+				<td>
+					<textarea id="vp-example" name="example_content" class="large-text" rows="5" placeholder="<?php esc_attr_e( 'Paste 1-2 paragraphs that represent your ideal writing style...', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $profile['example_content'] ?? '' ); ?></textarea>
+					<p class="description"><?php esc_html_e( 'The AI will use this as a style reference (first 500 characters).', 'stratawp-seo' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th><label for="vp-avoid"><?php esc_html_e( 'Avoid Phrases', 'stratawp-seo' ); ?></label></th>
+				<td>
+					<textarea id="vp-avoid" name="avoid_phrases" class="large-text" rows="2" placeholder="<?php esc_attr_e( 'game-changer, leverage, synergy, cutting-edge', 'stratawp-seo' ); ?>"><?php echo esc_textarea( implode( ', ', $profile['avoid_phrases'] ?? array() ) ); ?></textarea>
+					<p class="description"><?php esc_html_e( 'Comma-separated list of phrases the AI should never use.', 'stratawp-seo' ); ?></p>
+				</td>
+			</tr>
+			<tr>
+				<th><label for="vp-prefer"><?php esc_html_e( 'Preferred Phrases', 'stratawp-seo' ); ?></label></th>
+				<td>
+					<textarea id="vp-prefer" name="preferred_phrases" class="large-text" rows="2" placeholder="<?php esc_attr_e( 'practical, straightforward, hands-on', 'stratawp-seo' ); ?>"><?php echo esc_textarea( implode( ', ', $profile['preferred_phrases'] ?? array() ) ); ?></textarea>
+					<p class="description"><?php esc_html_e( 'Comma-separated list of preferred expressions.', 'stratawp-seo' ); ?></p>
+				</td>
+			</tr>
+		</table>
 
-        <p class="submit">
-            <button type="submit" class="button button-primary" id="swps-save-profile"><?php echo $is_new ? esc_html__( 'Create Profile', 'stratawp-seo' ) : esc_html__( 'Update Profile', 'stratawp-seo' ); ?></button>
-            <a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-voice-profiles' ) ); ?>" class="button"><?php esc_html_e( 'Cancel', 'stratawp-seo' ); ?></a>
-        </p>
-    </form>
+		<p class="submit">
+			<button type="submit" class="button button-primary" id="swps-save-profile"><?php echo $is_new ? esc_html__( 'Create Profile', 'stratawp-seo' ) : esc_html__( 'Update Profile', 'stratawp-seo' ); ?></button>
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-voice-profiles' ) ); ?>" class="button"><?php esc_html_e( 'Cancel', 'stratawp-seo' ); ?></a>
+		</p>
+	</form>
 </div>

--- a/templates/voice-profiles-page.php
+++ b/templates/voice-profiles-page.php
@@ -1,60 +1,60 @@
 <div class="wrap swps-voice-profiles-wrap">
-    <?php
-    $title    = __( 'Voice Profiles', 'stratawp-seo' );
-    $subtitle = __( 'Reusable brand-voice presets injected into the AI system prompt: tone, formality, sentence length, vocabulary level, person, avoid/preferred phrases, sample text.', 'stratawp-seo' );
-    $actions  = [
-        [
-            'label' => __( 'Add New', 'stratawp-seo' ),
-            'url'   => admin_url( 'admin.php?page=swps-voice-profiles&action=new' ),
-            'class' => 'swps-btn-grad',
-        ],
-    ];
-    require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
-    ?>
+	<?php
+	$title    = __( 'Voice Profiles', 'stratawp-seo' );
+	$subtitle = __( 'Reusable brand-voice presets injected into the AI system prompt: tone, formality, sentence length, vocabulary level, person, avoid/preferred phrases, sample text.', 'stratawp-seo' );
+	$actions  = array(
+		array(
+			'label' => __( 'Add New', 'stratawp-seo' ),
+			'url'   => admin_url( 'admin.php?page=swps-voice-profiles&action=new' ),
+			'class' => 'swps-btn-grad',
+		),
+	);
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
 
-    <?php
-    $active_id = (int) get_option( 'swps_voice_profile', 0 );
-    $profiles  = stratawp_seo()->voice_profile->get_all();
-    ?>
+	<?php
+	$active_id = (int) get_option( 'swps_voice_profile', 0 );
+	$profiles  = stratawp_seo()->voice_profile->get_all();
+	?>
 
-    <?php if ( empty( $profiles ) ) : ?>
-        <div class="swps-card">
-            <p><?php esc_html_e( 'No voice profiles yet. Create one to define a consistent brand voice for your AI-generated content.', 'stratawp-seo' ); ?></p>
-        </div>
-    <?php else : ?>
-        <table class="widefat striped">
-            <thead>
-                <tr>
-                    <th><?php esc_html_e( 'Name', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Tone', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Formality', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Person', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Status', 'stratawp-seo' ); ?></th>
-                    <th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ( $profiles as $profile ) : ?>
-                <tr>
-                    <td><strong><?php echo esc_html( $profile['name'] ); ?></strong></td>
-                    <td><?php echo esc_html( ucfirst( $profile['tone'] ) ); ?></td>
-                    <td><?php echo esc_html( $profile['formality'] . '/10' ); ?></td>
-                    <td><?php echo esc_html( ucfirst( $profile['person'] ) ); ?></td>
-                    <td>
-                        <?php if ( $profile['id'] === $active_id ) : ?>
-                            <span class="swps-score-badge swps-score-badge--excellent"><?php esc_html_e( 'Active', 'stratawp-seo' ); ?></span>
-                        <?php else : ?>
-                            <span style="color: #646970;"><?php esc_html_e( 'Inactive', 'stratawp-seo' ); ?></span>
-                        <?php endif; ?>
-                    </td>
-                    <td>
-                        <a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-voice-profiles&action=edit&profile_id=' . $profile['id'] ) ); ?>"><?php esc_html_e( 'Edit', 'stratawp-seo' ); ?></a>
-                        |
-                        <a href="#" class="swps-delete-profile" data-id="<?php echo esc_attr( $profile['id'] ); ?>" style="color: #d63638;"><?php esc_html_e( 'Delete', 'stratawp-seo' ); ?></a>
-                    </td>
-                </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
-    <?php endif; ?>
+	<?php if ( empty( $profiles ) ) : ?>
+		<div class="swps-card">
+			<p><?php esc_html_e( 'No voice profiles yet. Create one to define a consistent brand voice for your AI-generated content.', 'stratawp-seo' ); ?></p>
+		</div>
+	<?php else : ?>
+		<table class="widefat striped">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Name', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Tone', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Formality', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Person', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Status', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ( $profiles as $profile ) : ?>
+				<tr>
+					<td><strong><?php echo esc_html( $profile['name'] ); ?></strong></td>
+					<td><?php echo esc_html( ucfirst( $profile['tone'] ) ); ?></td>
+					<td><?php echo esc_html( $profile['formality'] . '/10' ); ?></td>
+					<td><?php echo esc_html( ucfirst( $profile['person'] ) ); ?></td>
+					<td>
+						<?php if ( $profile['id'] === $active_id ) : ?>
+							<span class="swps-score-badge swps-score-badge--excellent"><?php esc_html_e( 'Active', 'stratawp-seo' ); ?></span>
+						<?php else : ?>
+							<span style="color: #646970;"><?php esc_html_e( 'Inactive', 'stratawp-seo' ); ?></span>
+						<?php endif; ?>
+					</td>
+					<td>
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-voice-profiles&action=edit&profile_id=' . $profile['id'] ) ); ?>"><?php esc_html_e( 'Edit', 'stratawp-seo' ); ?></a>
+						|
+						<a href="#" class="swps-delete-profile" data-id="<?php echo esc_attr( $profile['id'] ); ?>" style="color: #d63638;"><?php esc_html_e( 'Delete', 'stratawp-seo' ); ?></a>
+					</td>
+				</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+	<?php endif; ?>
 </div>

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,7 +8,7 @@
  */
 
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
-    exit;
+	exit;
 }
 
 global $wpdb;
@@ -20,15 +20,17 @@ $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE 'swps\_%'" );
 $wpdb->query( "DELETE FROM {$wpdb->postmeta} WHERE meta_key LIKE '\_swps\_%'" );
 
 // 3. Delete all swps_topic CPT posts.
-$topics = get_posts( [
-    'post_type'      => 'swps_topic',
-    'post_status'    => 'any',
-    'posts_per_page' => -1,
-    'fields'         => 'ids',
-] );
+$topics = get_posts(
+	array(
+		'post_type'      => 'swps_topic',
+		'post_status'    => 'any',
+		'posts_per_page' => -1,
+		'fields'         => 'ids',
+	)
+);
 
 foreach ( $topics as $topic_id ) {
-    wp_delete_post( $topic_id, true );
+	wp_delete_post( $topic_id, true );
 }
 
 // 4. Remove cron events.
@@ -37,13 +39,13 @@ wp_unschedule_hook( 'swps_process_topic' );
 
 // 5. Remove transients.
 $wpdb->query(
-    "DELETE FROM {$wpdb->options} WHERE option_name LIKE '%\_transient\_swps\_%' OR option_name LIKE '%\_transient\_timeout\_swps\_%'"
+	"DELETE FROM {$wpdb->options} WHERE option_name LIKE '%\_transient\_swps\_%' OR option_name LIKE '%\_transient\_timeout\_swps\_%'"
 );
 
 // 6. Clear any Action Scheduler entries if available.
 if ( function_exists( 'as_unschedule_all_actions' ) ) {
-    as_unschedule_all_actions( 'swps_process_topic' );
-    as_unschedule_all_actions( 'swps_generate_scheduled_post' );
+	as_unschedule_all_actions( 'swps_process_topic' );
+	as_unschedule_all_actions( 'swps_generate_scheduled_post' );
 }
 
 // 7. Drop v3.0 custom tables.


### PR DESCRIPTION
Follow-up to #28 — clears the auto-fixable WordPress Coding Standards backlog.

> **Stacked on #28.** Base is `chore/composer-ci-quality` (it needs that PR's `phpcs.xml.dist` ruleset). Merge #28 first; this PR's base will retarget to `main` automatically once #28 lands, or rebase then.

## What this is

A single mechanical `phpcbf` pass. **No logic changes** — only whitespace, indentation, alignment, Yoda conditions, brace/spacing style, etc. The diff is large (101 files, ~+23.9k/-22k) purely because that's the scale of formatting drift in a 27k-LOC codebase adopting WPCS. Best reviewed with whitespace-insensitive diff (`git diff -w` / GitHub's "Hide whitespace").

## Impact

| | Before | After |
|---|--------|-------|
| PHPCS errors | 23,754 | **1,339** |
| PHPCS warnings | 1,308 | 301 |
| Auto-fixed | — | 23,424 |

The remaining 1,339 errors / 301 warnings are **not** auto-fixable — they need human judgement (output escaping, nonce verification, etc.) and are intentionally out of scope here.

## Verification (local, PHP 8.4)

- `php -l` across all 101 files → **no syntax errors**
- `composer analyze` → **`[OK] No errors`, exit 0** — PHPStan findings unchanged vs the #28 baseline (formatting doesn't move logic-based findings)

## Not in this PR (deliberate)

- PHPCS stays **advisory** in CI — flipping it to blocking still needs the 1,339 manual fixes done first.
- Recommended next step: a focused PR addressing the remaining manual WPCS errors (prioritise the security-relevant escaping/nonce sniffs), then promote PHPCS to a hard gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)