### PR TITLE
fix: harden secret encryption (AES-GCM + fail-safe) — v4.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1264,6 +1264,12 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 
 ## Changelog
 
+### 4.5.1
+- **Security/Fix — encryption hardened:** stored API keys and Google Search Console OAuth secrets now use authenticated **AES-256-GCM** (tamper detection) instead of AES-256-CBC.
+- **Fix — fail-safe decryption:** `SWPS_Encryption::decrypt()` previously returned the *still-encrypted* blob when decryption failed, so after a WordPress salt rotation a corrupt value was silently sent to AI / Search Console APIs as the credential. It now returns `''` and logs (under `WP_DEBUG`); the settings field renders blank, prompting re-entry.
+- **Fix — no plaintext fallback:** `encrypt()` no longer returns the raw secret (storing it unencrypted) if encryption fails.
+- **Compatibility:** legacy AES-256-CBC values written by earlier versions are still transparently decrypted and are upgraded to GCM the next time the owning setting is saved. No migration or action required on upgrade.
+
 ### 4.5.0
 - **New — AI Bot Analytics:** server-side tracking of hits from 15 known AI crawlers (GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-Web, anthropic-ai, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, CCBot, Meta-ExternalAgent, Bytespider, Amazonbot, DuckAssistBot). New `SWPS_Bot_Analytics_Tracker` captures on `shutdown` priority 999 so the post ID, `is_404()` state, and `http_response_code()` are settled; writes one row per bot request into `{$wpdb->prefix}swps_bot_hits`, then a daily cron rolls anything older than 7 days into `swps_bot_hits_daily` and prunes per `swps_bot_analytics_retention` (default 90). Excludes admin / AJAX / cron / REST / WP-CLI and configurable path prefixes (`/wp-admin`, `/wp-json`, `/feed`, `/xmlrpc.php` by default). Optional 0–100 % sample rate for high-traffic sites via `swps_bot_analytics_sample_rate`. No IP or referrer storage — keeps the GDPR-friendly stance of the existing pageview tracker.
 - **New — "AI Crawlers" section on the Analytics page:** total bot hits (with % delta vs prior 30 days), distinct active bots, 404s to bots, per-bot breakdown with last-seen, top crawled pages with 404 counts, AEO gap report (published posts no AI crawler has fetched in 30 days — actionable for sitemap re-submission and internal linking), and recent bot 404s for redirect candidates.

--- a/includes/class-encryption.php
+++ b/includes/class-encryption.php
@@ -1,6 +1,18 @@
 <?php
 /**
- * API key encryption using AES-256-CBC.
+ * API key / secret encryption.
+ *
+ * New values are encrypted with AES-256-GCM (authenticated encryption:
+ * tampering is detected). Legacy AES-256-CBC values written by earlier
+ * versions are still transparently decrypted, and are upgraded to GCM
+ * the next time the owning option is re-saved.
+ *
+ * The key is derived from wp_salt( 'auth' ). If the site's salts are
+ * rotated, previously stored values can no longer be decrypted — in
+ * that case decrypt() fails safe (returns '' and logs) rather than
+ * returning the still-encrypted blob, so a corrupt credential is never
+ * sent to a third-party API. The affected settings field renders empty,
+ * prompting the admin to re-enter the secret.
  *
  * @package StrataWP_SEO
  */
@@ -9,62 +21,166 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * AES-256-GCM encryption for stored API keys and OAuth secrets, with
+ * transparent decryption of legacy AES-256-CBC values.
+ */
 class SWPS_Encryption {
 
-	private const METHOD = 'aes-256-cbc';
+	private const METHOD_GCM    = 'aes-256-gcm';
+	private const METHOD_LEGACY = 'aes-256-cbc';
+
+	/** Prefix on every encrypted value (legacy CBC and current GCM). */
 	private const PREFIX = 'encrypted:';
 
+	/** Prefix identifying the authenticated (GCM) format. */
+	private const PREFIX_V2 = 'encrypted:v2:';
+
+	private const GCM_IV_LEN  = 12;
+	private const GCM_TAG_LEN = 16;
+
 	/**
-	 * Encrypt a value.
+	 * Encrypt a value with AES-256-GCM.
 	 *
 	 * @param string $value Plain text value.
-	 * @return string Encrypted string as "encrypted:iv:ciphertext".
+	 * @return string Encrypted "encrypted:v2:<base64(iv|tag|ciphertext)>",
+	 *                or '' if encryption failed (never the plaintext).
 	 */
 	public static function encrypt( string $value ): string {
-		if ( empty( $value ) || self::is_encrypted( $value ) ) {
+		if ( '' === $value || self::is_encrypted( $value ) ) {
 			return $value;
 		}
 
-		$key = self::get_key();
-		$iv  = openssl_random_pseudo_bytes( openssl_cipher_iv_length( self::METHOD ) );
-
-		$encrypted = openssl_encrypt( $value, self::METHOD, $key, 0, $iv );
-
-		if ( false === $encrypted ) {
-			return $value;
+		try {
+			$iv = random_bytes( self::GCM_IV_LEN );
+		} catch ( \Exception $e ) {
+			self::log( 'no CSPRNG available for IV generation' );
+			return '';
 		}
 
-		return self::PREFIX . base64_encode( $iv ) . ':' . $encrypted;
+		$tag        = '';
+		$ciphertext = openssl_encrypt(
+			$value,
+			self::METHOD_GCM,
+			self::get_key(),
+			OPENSSL_RAW_DATA,
+			$iv,
+			$tag,
+			'',
+			self::GCM_TAG_LEN
+		);
+
+		if ( false === $ciphertext ) {
+			// Do NOT fall back to storing the plaintext secret.
+			self::log( 'openssl_encrypt failed' );
+			return '';
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- transport encoding of raw ciphertext, not obfuscation.
+		return self::PREFIX_V2 . base64_encode( $iv . $tag . $ciphertext );
 	}
 
 	/**
 	 * Decrypt a value.
 	 *
-	 * @param string $value Encrypted string.
-	 * @return string Decrypted plain text.
+	 * Plain (unencrypted) input is returned unchanged — this supports
+	 * installs that stored a secret before encryption existed. A value
+	 * that IS encrypted but cannot be decrypted (rotated salts, tampered
+	 * or truncated blob) returns '' so callers treat it as "no secret"
+	 * instead of using a corrupt one.
+	 *
+	 * @param string $value Stored value.
+	 * @return string Decrypted plain text, '' on failure, or the input
+	 *                unchanged when it was never encrypted.
 	 */
 	public static function decrypt( string $value ): string {
-		if ( empty( $value ) || ! self::is_encrypted( $value ) ) {
+		if ( '' === $value ) {
 			return $value;
 		}
 
-		$parts = explode( ':', substr( $value, strlen( self::PREFIX ) ), 2 );
-
-		if ( count( $parts ) !== 2 ) {
-			return $value;
+		if ( str_starts_with( $value, self::PREFIX_V2 ) ) {
+			return self::decrypt_gcm( substr( $value, strlen( self::PREFIX_V2 ) ) );
 		}
 
-		$iv         = base64_decode( $parts[0] );
-		$ciphertext = $parts[1];
-		$key        = self::get_key();
+		if ( str_starts_with( $value, self::PREFIX ) ) {
+			return self::decrypt_legacy_cbc( substr( $value, strlen( self::PREFIX ) ) );
+		}
 
-		$decrypted = openssl_decrypt( $ciphertext, self::METHOD, $key, 0, $iv );
-
-		return false === $decrypted ? $value : $decrypted;
+		// Not encrypted — pre-encryption stored value.
+		return $value;
 	}
 
 	/**
-	 * Check if a value is already encrypted.
+	 * Decrypt an AES-256-GCM payload.
+	 *
+	 * @param string $payload base64( iv | tag | ciphertext ).
+	 * @return string Plain text, or '' on failure.
+	 */
+	private static function decrypt_gcm( string $payload ): string {
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- decoding our own ciphertext transport encoding.
+		$raw = base64_decode( $payload, true );
+
+		if ( false === $raw || strlen( $raw ) <= self::GCM_IV_LEN + self::GCM_TAG_LEN ) {
+			self::log( 'GCM payload malformed' );
+			return '';
+		}
+
+		$iv         = substr( $raw, 0, self::GCM_IV_LEN );
+		$tag        = substr( $raw, self::GCM_IV_LEN, self::GCM_TAG_LEN );
+		$ciphertext = substr( $raw, self::GCM_IV_LEN + self::GCM_TAG_LEN );
+
+		$plaintext = openssl_decrypt(
+			$ciphertext,
+			self::METHOD_GCM,
+			self::get_key(),
+			OPENSSL_RAW_DATA,
+			$iv,
+			$tag
+		);
+
+		if ( false === $plaintext ) {
+			self::log( 'GCM decrypt failed (rotated salts or tampered value)' );
+			return '';
+		}
+
+		return $plaintext;
+	}
+
+	/**
+	 * Decrypt a legacy AES-256-CBC payload written by older versions.
+	 *
+	 * @param string $payload "<base64(iv)>:<ciphertext>".
+	 * @return string Plain text, or '' on failure.
+	 */
+	private static function decrypt_legacy_cbc( string $payload ): string {
+		$parts = explode( ':', $payload, 2 );
+
+		if ( count( $parts ) !== 2 ) {
+			self::log( 'legacy payload malformed' );
+			return '';
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- decoding the legacy IV transport encoding.
+		$iv         = base64_decode( $parts[0], true );
+		$ciphertext = $parts[1];
+
+		if ( false === $iv ) {
+			self::log( 'legacy IV malformed' );
+			return '';
+		}
+
+		$plaintext = openssl_decrypt( $ciphertext, self::METHOD_LEGACY, self::get_key(), 0, $iv );
+
+		if ( false === $plaintext ) {
+			self::log( 'legacy CBC decrypt failed (rotated salts)' );
+			return '';
+		}
+
+		return $plaintext;
+	}
+
+	/**
+	 * Whether a value is in either encrypted format.
 	 *
 	 * @param string $value Value to check.
 	 * @return bool
@@ -74,11 +190,35 @@ class SWPS_Encryption {
 	}
 
 	/**
-	 * Get the encryption key derived from WordPress salts.
+	 * Whether a value is encrypted in the legacy (non-authenticated)
+	 * CBC format and should be re-encrypted on next save.
 	 *
-	 * @return string 32-byte key.
+	 * @param string $value Value to check.
+	 * @return bool
+	 */
+	public static function is_legacy_format( string $value ): bool {
+		return str_starts_with( $value, self::PREFIX )
+			&& ! str_starts_with( $value, self::PREFIX_V2 );
+	}
+
+	/**
+	 * Derive the 32-byte key from the WordPress auth salt.
+	 *
+	 * @return string Raw 32-byte key.
 	 */
 	private static function get_key(): string {
 		return hash( 'sha256', wp_salt( 'auth' ), true );
+	}
+
+	/**
+	 * Log an encryption failure without ever logging secret material.
+	 *
+	 * @param string $reason Short, non-sensitive description.
+	 * @return void
+	 */
+	private static function log( string $reason ): void {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			error_log( 'SWPS_Encryption: ' . $reason ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- diagnostic for an unrecoverable crypto failure; no secret material logged.
+		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.5.0
+Stable tag: 4.5.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -252,6 +252,12 @@ Yes. The built-in analytics tracker is cookie-free and does not use any external
 No. GSC integration is optional. The on-site analytics works entirely without any external services. Add Google OAuth credentials only if you want search clicks, impressions, and ranking data.
 
 == Changelog ==
+
+= 4.5.1 =
+* Security/Fix: Hardened encryption of stored API keys and Google Search Console OAuth secrets. New values now use authenticated AES-256-GCM (tampering is detected) instead of AES-256-CBC.
+* Fix: `decrypt()` previously returned the still-encrypted value if decryption failed — so after a WordPress security-salt rotation a corrupt string was silently sent to AI / Search Console APIs as the credential. It now fails safe (returns empty and logs when `WP_DEBUG` is on); the affected settings field renders blank, prompting you to re-enter the secret.
+* Fix: `encrypt()` no longer falls back to storing the secret in plain text if encryption fails.
+* Compatibility: Secrets written by earlier versions (AES-256-CBC) are still read transparently and upgrade to AES-256-GCM the next time you save that setting. No action required on upgrade.
 
 = 4.5.0 =
 * New: AI Bot Analytics. Server-side tracking of hits from known AI crawlers (GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-Web, anthropic-ai, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, CCBot, Meta-ExternalAgent, Bytespider, Amazonbot, DuckAssistBot). Captures on `shutdown` so post ID and status code are accurate, batches into a raw table for 7 days, then aggregates into a daily summary with configurable retention (default 90 days). Mirrors the existing analytics pattern — no JS, no external services, GDPR-friendly (no IP or referrer storage). Excludes admin/AJAX/REST/cron/CLI by default and supports a configurable path exclusion list and 0–100% sample rate for high-traffic sites.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.5.0
+ * Version: 4.5.1
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.5.0' );
+define( 'SWPS_VERSION', '4.5.1' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Analysis item **#3**. Hardens `SWPS_Encryption` (stored AI API keys + GSC OAuth secrets).

## The bug this fixes

`decrypt()` returned the **still-encrypted blob** when decryption failed. Callers (`class-search-console`, `class-duplicate-checker`) feed that straight into API auth — so after a WordPress salt rotation (standard post-incident hygiene), a corrupt string was silently sent to Anthropic/OpenAI/Google as the credential, with no error. `encrypt()` similarly fell back to returning the **plaintext secret**, which would persist it unencrypted.

## Changes

- **AES-256-CBC → AES-256-GCM** (authenticated; tampering is detected). Versioned prefix `encrypted:v2:`.
- **Fail-safe `decrypt()`**: on failure returns `''` + logs under `WP_DEBUG` (no secret material). Empty result → API auth fails cleanly and the settings field renders blank, prompting re-entry — instead of shipping a corrupt credential.
- **Fail-safe `encrypt()`**: returns `''` on failure, never the plaintext.
- **Backward compatible**: legacy CBC values written by ≤4.5.0 still decrypt transparently; they upgrade to GCM the next time the owning setting is saved. `is_legacy_format()` added for a future transparent re-encrypt pass. No migration or user action on upgrade.

## Verification

Self-contained harness (PHP 8.4), **24/24 pass**: GCM round-trip (incl. unicode, 2KB, colon-bearing values), idempotent re-encrypt, empty/plaintext passthrough, **legacy-CBC decrypt** (value produced by the old algorithm), **salt-rotation → `''` not the blob**, **GCM tamper rejection**, malformed/truncated payloads. Project gates: **PHPStan exit 0**, **PHPCS clean** (documented `phpcs:ignore` on the legitimate base64 transport-encoding calls).

## Per project rule

Version **4.5.0 → 4.5.1** (header + `SWPS_VERSION` + `readme.txt` Stable tag), changelog added to `README.md` and `readme.txt`, deployment zip rebuilt (`stratawp-seo-4.5.1.zip`, gitignored; CI regenerates on release).

## Note / follow-up

The key is still derived from `wp_salt('auth')` — changing the key *source* has the same rotation-breakage risk, so the real mitigation is the graceful-failure path here. A future option-stored plugin key with explicit rotation support could be a follow-up. Also unrelated-but-noticed: post-#28, `composer.json`/`phpstan.*`/`.phpstan/` now ship in the release zip (dev tooling, not secret) — worth a tiny `release.yml` exclude in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)