### PR TITLE
v4.6.2 — fix: AEO Optimize queue persists across page navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.6.1-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.6.2-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1274,6 +1274,9 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.6.2 — May 2026
+- Fix: AEO Optimize queue persists across page navigation. The scored-posts list is now loaded from post meta server-side on every page render (delivered via `wp_localize_script`'s `swpsAeo.initialResults`) so navigating away and coming back no longer shows an empty queue. Re-scan still works the same way (overwrites with fresh scores).
 
 ### v4.6.1 — May 2026
 - Fix: AEO Optimize admin page no longer renders a blank dark overlay on load. The modal template now uses inline `style="display:none;"` instead of the `hidden` attribute so jQuery's `.show()` / `.hide()` toggle naturally without fighting the modal's `display: flex` layout rule. Asset version bumped to force browser-cache refresh on existing installs.

--- a/admin/js/aeo-optimizer.js
+++ b/admin/js/aeo-optimizer.js
@@ -248,6 +248,16 @@
         });
     }
 
+    // Populate from persisted queue (localized server-side) so navigating
+    // away and back doesn't blank the queue. Re-scan still overwrites.
+    if (swpsAeo.initialResults && swpsAeo.initialResults.length > 0) {
+        allResults = swpsAeo.initialResults;
+        $(function () {
+            updateTiles();
+            renderQueue();
+        });
+    }
+
     // Wire events.
     $('#swps-aeo-rescan').on('click', rescan);
     $('#swps-aeo-threshold, #swps-aeo-post-type').on('change input', function () {

--- a/includes/class-aeo-optimizer.php
+++ b/includes/class-aeo-optimizer.php
@@ -102,7 +102,7 @@ class SWPS_AEO_Optimizer {
 					SWPS_VERSION,
 					true
 				);
-				wp_localize_script( 'swps-aeo-optimizer', 'swpsAeo', $this->localize_data() );
+				wp_localize_script( 'swps-aeo-optimizer', 'swpsAeo', $this->localize_data( true ) );
 			}
 		}
 
@@ -117,13 +117,18 @@ class SWPS_AEO_Optimizer {
 				SWPS_VERSION,
 				true
 			);
-			wp_localize_script( 'swps-aeo-editor-panel', 'swpsAeo', $this->localize_data() );
+			wp_localize_script( 'swps-aeo-editor-panel', 'swpsAeo', $this->localize_data( false ) );
 		}
 	}
 
-	/** @return array<string, mixed> */
-	private function localize_data(): array {
-		return array(
+	/**
+	 * @param bool $include_initial_results When true, includes the persisted queue
+	 *   data so the JS can render the queue on page load without re-scanning.
+	 *   Only the optimizer page needs this; the editor panel doesn't.
+	 * @return array<string, mixed>
+	 */
+	private function localize_data( bool $include_initial_results = false ): array {
+		$data = array(
 			'ajaxUrl'   => admin_url( 'admin-ajax.php' ),
 			'nonce'     => wp_create_nonce( 'swps_nonce' ),
 			'threshold' => (int) get_option( 'swps_aeo_threshold', SWPS_AEO_Scorer::DEFAULT_THRESHOLD ),
@@ -145,6 +150,67 @@ class SWPS_AEO_Optimizer {
 				'editsSection'   => __( 'Edits', 'stratawp-seo' ),
 			),
 		);
+		if ( $include_initial_results ) {
+			$data['initialResults'] = $this->get_scored_posts();
+		}
+		return $data;
+	}
+
+	/**
+	 * Load the persisted AEO queue from post meta — used to populate the
+	 * optimizer page on load (no AJAX, no re-scoring).
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function get_scored_posts(): array {
+		global $wpdb;
+		$types = (array) get_option( 'swps_aeo_post_types', array( 'post', 'page' ) );
+		if ( empty( $types ) ) {
+			return array();
+		}
+		// Build a safe IN(...) clause for post_type — types come from a sanitized option.
+		$placeholders = implode( ', ', array_fill( 0, count( $types ), '%s' ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery -- read-only queue load, no caching benefit.
+		$sql  = "SELECT p.ID, p.post_title, p.post_type, m.meta_value AS score
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->postmeta} m ON m.post_id = p.ID
+				WHERE m.meta_key = %s
+				  AND p.post_status = 'publish'
+				  AND p.post_type IN ( {$placeholders} )
+				ORDER BY CAST(m.meta_value AS UNSIGNED) ASC
+				LIMIT 500";
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $wpdb->get_results( $wpdb->prepare( $sql, array_merge( array( SWPS_AEO_Scorer::META_TOTAL ), $types ) ) );
+
+		if ( empty( $rows ) ) {
+			return array();
+		}
+
+		$results = array();
+		foreach ( $rows as $row ) {
+			$post_id = (int) $row->ID;
+			if ( get_post_meta( $post_id, self::META_DISMISSED, true ) ) {
+				continue;
+			}
+			$coverage = get_post_meta( $post_id, SWPS_AEO_Scorer::META_SUBSCORE_PREFIX . 'coverage', true );
+			$results[] = array(
+				'post_id'      => $post_id,
+				'title'        => (string) $row->post_title,
+				'permalink'    => get_permalink( $post_id ) ?: '',
+				'edit_url'     => get_edit_post_link( $post_id, 'raw' ) ?: '',
+				'post_type'    => (string) $row->post_type,
+				'score'        => (int) $row->score,
+				'subscores'    => array(
+					'extractability' => (int) get_post_meta( $post_id, SWPS_AEO_Scorer::META_SUBSCORE_PREFIX . 'extractability', true ),
+					'markup'         => (int) get_post_meta( $post_id, SWPS_AEO_Scorer::META_SUBSCORE_PREFIX . 'markup', true ),
+					'authority'      => (int) get_post_meta( $post_id, SWPS_AEO_Scorer::META_SUBSCORE_PREFIX . 'authority', true ),
+					'coverage'       => '' === $coverage ? null : (int) $coverage,
+				),
+				'has_proposal' => '' !== get_post_meta( $post_id, self::META_PROPOSAL, true ),
+			);
+		}
+		return $results;
 	}
 
 	private function verify_request(): void {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.6.1
+Stable tag: 4.6.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -252,6 +252,9 @@ Yes. The built-in analytics tracker is cookie-free and does not use any external
 No. GSC integration is optional. The on-site analytics works entirely without any external services. Add Google OAuth credentials only if you want search clicks, impressions, and ranking data.
 
 == Changelog ==
+
+= 4.6.2 — 2026-05-24 =
+* Fix: AEO Optimize queue no longer blanks when you navigate away and come back. The scored-posts list is now loaded from post meta on every page render (via `wp_localize_script`) so the queue survives a reload — re-scan still overwrites with fresh scores. Fixes a confusing UX where the queue appeared "lost" after browsing away.
 
 = 4.6.1 — 2026-05-24 =
 * Fix: AEO Optimize admin page rendered a blank dark overlay on load — the modal's CSS `display: flex` overrode the browser default `[hidden] { display: none }`. Modal now uses inline `style="display:none;"` so jQuery `.show()` / `.hide()` toggle naturally. Asset version bumped to force browser-cache refresh on existing installs.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.6.1
+ * Version: 4.6.2
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.6.1' );
+define( 'SWPS_VERSION', '4.6.2' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Summary

Found during smoke testing v4.6.1 on a live site.

**Symptom:** On the AEO Optimize page, click "Re-scan all posts" → queue populates correctly. Navigate to any other admin page → return to AEO Optimize → queue is empty. User must re-scan every time.

**Cause:** The JS kept `allResults` in browser memory only. The underlying score data was always persisted to post meta (`SWPS_AEO_Scorer::score_post()` writes `_swps_aeo_score`, `_swps_aeo_subscore_*`, etc.), but the UI never loaded it back on page revisit.

## Fix

- **New private method** `SWPS_AEO_Optimizer::get_scored_posts()` — reads the persisted scores from post meta in a single SQL join + per-row sub-score lookups, returning the same shape as `scan_chunk`'s results (so the JS doesn't need a code-path branch).
- **`localize_data()` gained an `$include_initial_results` bool** — only the optimizer page page-load needs it (editor panel doesn't, so we don't bloat its localized data).
- **`admin/js/aeo-optimizer.js`** — on document-ready, if `swpsAeo.initialResults.length > 0`, populate `allResults` from it and call `updateTiles()` + `renderQueue()` immediately. Re-scan still overwrites with fresh data.

## Cache-bust

Bumped `SWPS_VERSION` 4.6.1 → 4.6.2 so the new `aeo-optimizer.js?ver=4.6.2` URL forces existing browsers / CDNs / caching plugins to fetch the fresh JS. This is the third consecutive hotfix that bumped the version to bust a cached asset — worth keeping in mind for v4.7 (file-mtime-based versioning would eliminate this pattern).

## Files changed

| File | Reason |
|---|---|
| `includes/class-aeo-optimizer.php` | New `get_scored_posts()` method; `localize_data()` takes `$include_initial_results` bool |
| `admin/js/aeo-optimizer.js` | Populate `allResults` from `swpsAeo.initialResults` on load |
| `stratawp-seo.php` | Version 4.6.1 → 4.6.2 (plugin header + `SWPS_VERSION`) |
| `readme.txt` | Stable tag + changelog entry |
| `README.md` | Version badge + changelog entry |

## Verification

- `composer check` — PHPCS clean, PHPStan no errors
- `composer test` — 37/37 PHPUnit tests still passing
- `php -l stratawp-seo.php` — clean

Manual verification on jonimms.com pending merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)