### PR TITLE
v4.6.3 — feat(aeo): version assets via filemtime() for auto cache-busting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.6.2-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.6.3-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1274,6 +1274,9 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.6.3 — May 2026
+- Developer: AEO asset enqueues now use `filemtime()` for cache-busting instead of `SWPS_VERSION`. Any edit to `admin/css/aeo.css`, `admin/js/aeo-optimizer.js`, or `admin/js/aeo-editor-panel.js` will automatically invalidate browser caches without needing a plugin-wide version bump. Falls back to `SWPS_VERSION` if the file isn't readable (defensive for unusual deploy / symlink setups).
 
 ### v4.6.2 — May 2026
 - Fix: AEO Optimize queue persists across page navigation. The scored-posts list is now loaded from post meta server-side on every page render (delivered via `wp_localize_script`'s `swpsAeo.initialResults`) so navigating away and coming back no longer shows an empty queue. Re-scan still works the same way (overwrites with fresh scores).

--- a/includes/class-aeo-optimizer.php
+++ b/includes/class-aeo-optimizer.php
@@ -92,14 +92,14 @@ class SWPS_AEO_Optimizer {
 		// Admin page assets (Task 15/16 provide aeo.css and aeo-optimizer.js).
 		if ( 'stratawp-seo_page_swps-aeo-optimize' === $hook ) {
 			if ( file_exists( SWPS_PLUGIN_DIR . 'admin/css/aeo.css' ) ) {
-				wp_enqueue_style( 'swps-aeo', SWPS_PLUGIN_URL . 'admin/css/aeo.css', array(), SWPS_VERSION );
+				wp_enqueue_style( 'swps-aeo', SWPS_PLUGIN_URL . 'admin/css/aeo.css', array(), $this->asset_ver( 'admin/css/aeo.css' ) );
 			}
 			if ( file_exists( SWPS_PLUGIN_DIR . 'admin/js/aeo-optimizer.js' ) ) {
 				wp_enqueue_script(
 					'swps-aeo-optimizer',
 					SWPS_PLUGIN_URL . 'admin/js/aeo-optimizer.js',
 					array( 'jquery' ),
-					SWPS_VERSION,
+					$this->asset_ver( 'admin/js/aeo-optimizer.js' ),
 					true
 				);
 				wp_localize_script( 'swps-aeo-optimizer', 'swpsAeo', $this->localize_data( true ) );
@@ -109,16 +109,37 @@ class SWPS_AEO_Optimizer {
 		// Editor-panel assets (Task 17/18). Optimizer enqueues them on post edit screens.
 		if ( in_array( $hook, array( 'post.php', 'post-new.php' ), true )
 			&& file_exists( SWPS_PLUGIN_DIR . 'admin/js/aeo-editor-panel.js' ) ) {
-			wp_enqueue_style( 'swps-aeo', SWPS_PLUGIN_URL . 'admin/css/aeo.css', array(), SWPS_VERSION );
+			wp_enqueue_style( 'swps-aeo', SWPS_PLUGIN_URL . 'admin/css/aeo.css', array(), $this->asset_ver( 'admin/css/aeo.css' ) );
 			wp_enqueue_script(
 				'swps-aeo-editor-panel',
 				SWPS_PLUGIN_URL . 'admin/js/aeo-editor-panel.js',
 				array( 'jquery', 'wp-plugins', 'wp-edit-post', 'wp-element', 'wp-components', 'wp-data' ),
-				SWPS_VERSION,
+				$this->asset_ver( 'admin/js/aeo-editor-panel.js' ),
 				true
 			);
 			wp_localize_script( 'swps-aeo-editor-panel', 'swpsAeo', $this->localize_data( false ) );
 		}
+	}
+
+	/**
+	 * Build a cache-busting asset version from the file's mtime, falling
+	 * back to SWPS_VERSION if the file isn't readable.
+	 *
+	 * Using mtime means any code change to an AEO asset auto-invalidates
+	 * the browser cache without requiring a SWPS_VERSION bump — fixing the
+	 * pattern that caused v4.6.0/4.6.1/4.6.2 to each need a version bump
+	 * just to ship a bugfix. PHP's stat cache makes filemtime() ~free on
+	 * repeated calls within the same request.
+	 *
+	 * Scope: AEO assets only. Other plugin assets keep SWPS_VERSION until
+	 * a broader cleanup adopts the same pattern.
+	 *
+	 * @param string $relative_path Path relative to SWPS_PLUGIN_DIR (no leading slash).
+	 */
+	private function asset_ver( string $relative_path ): string {
+		$full  = SWPS_PLUGIN_DIR . $relative_path;
+		$mtime = is_readable( $full ) ? filemtime( $full ) : false;
+		return false !== $mtime ? (string) $mtime : SWPS_VERSION;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.6.2
+Stable tag: 4.6.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -252,6 +252,9 @@ Yes. The built-in analytics tracker is cookie-free and does not use any external
 No. GSC integration is optional. The on-site analytics works entirely without any external services. Add Google OAuth credentials only if you want search clicks, impressions, and ranking data.
 
 == Changelog ==
+
+= 4.6.3 — 2026-05-24 =
+* Developer: AEO asset enqueues (aeo.css, aeo-optimizer.js, aeo-editor-panel.js) now version via `filemtime()` instead of the global `SWPS_VERSION` constant. This means any edit to those files automatically busts browser caches without needing a plugin-wide version bump. Falls back to `SWPS_VERSION` if the file isn't readable.
 
 = 4.6.2 — 2026-05-24 =
 * Fix: AEO Optimize queue no longer blanks when you navigate away and come back. The scored-posts list is now loaded from post meta on every page render (via `wp_localize_script`) so the queue survives a reload — re-scan still overwrites with fresh scores. Fixes a confusing UX where the queue appeared "lost" after browsing away.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.6.2
+ * Version: 4.6.3
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.6.2' );
+define( 'SWPS_VERSION', '4.6.3' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Summary

The v4.6 release cycle bumped `SWPS_VERSION` three times in a row (4.6.0 → 4.6.1 → 4.6.2) **purely** to force browsers / CDNs / caching plugins to fetch updated CSS or JS. The bug each time was the same shape: edit an asset → ship → user re-installs → still sees the cached old asset → ship again with a version bump.

This PR removes the need for that pattern on AEO assets.

## What changed

`SWPS_AEO_Optimizer::enqueue_assets()` no longer passes `SWPS_VERSION` as the `$ver` arg to `wp_enqueue_style/script`. Instead it calls a new private helper:

```php
private function asset_ver( string $relative_path ): string {
    $full  = SWPS_PLUGIN_DIR . $relative_path;
    $mtime = is_readable( $full ) ? filemtime( $full ) : false;
    return false !== $mtime ? (string) $mtime : SWPS_VERSION;
}
```

Now `aeo.css?ver={mtime}` updates on every file edit. PHP's stat cache makes `filemtime()` effectively free within a request. Falls back to `SWPS_VERSION` if the file isn't readable — defensive for unusual deploy / symlink setups.

All 4 AEO enqueue sites updated:
- `aeo.css` (on the optimizer page)
- `aeo-optimizer.js`
- `aeo.css` (on post edit screens — yes, it's enqueued twice with the same handle, WP dedupes)
- `aeo-editor-panel.js`

## Scope decision

**AEO assets only.** Other plugin enqueues keep `SWPS_VERSION` until a broader cleanup adopts the same pattern. The `asset_ver()` helper is intentionally a private instance method on `SWPS_AEO_Optimizer` — not a static utility — to keep the scope tight and avoid implying "use this everywhere now". When another feature wants the same behavior, the helper is trivial to extract into a shared `SWPS_Assets::version()`.

## Files changed

| File | Change |
|---|---|
| `includes/class-aeo-optimizer.php` | Add `asset_ver()` private method; replace 4 `SWPS_VERSION` enqueue args |
| `stratawp-seo.php` | Version 4.6.2 → 4.6.3 (plugin header + `SWPS_VERSION`) |
| `readme.txt` | Stable tag + changelog entry under "Developer:" |
| `README.md` | Version badge + changelog entry |

## Verification

- `composer check` — PHPCS clean, PHPStan no errors (87 files)
- `composer test` — 37/37 PHPUnit tests still passing
- `php -l stratawp-seo.php` — clean

## Note

This is the final version bump that will require manual action. After this merges, future AEO bugfixes that only touch CSS or JS will be picked up on the next page load automatically — no `SWPS_VERSION` bump, no re-install hassle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)