### PR TITLE
v4.6.4 — fix(aeo): schema generation 'empty required field: mainEntity'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.6.3-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.6.4-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1274,6 +1274,9 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.6.4 — May 2026
+- Fix: Schema Generator no longer rejects QAPage (and other nested-shape) posts with `empty required field: mainEntity`. The previous prompt told the AI to "use empty arrays / null for fields you cannot derive" — that instruction conflicted with the validator's reject-empty-required-fields behavior. The prompt now explicitly distinguishes REQUIRED (must populate) from RECOMMENDED (omit if not derivable), and includes per-type shape guidance derived from the schema-fields manifest (e.g. `mainEntity should be a Question object with fields: name, text, acceptedAnswer, ...`) so the AI knows how to construct nested objects. Two new tests cover the prompt contents and the regression case.
 
 ### v4.6.3 — May 2026
 - Developer: AEO asset enqueues now use `filemtime()` for cache-busting instead of `SWPS_VERSION`. Any edit to `admin/css/aeo.css`, `admin/js/aeo-optimizer.js`, or `admin/js/aeo-editor-panel.js` will automatically invalidate browser caches without needing a plugin-wide version bump. Falls back to `SWPS_VERSION` if the file isn't readable (defensive for unusual deploy / symlink setups).

--- a/includes/class-aeo-schema-generator.php
+++ b/includes/class-aeo-schema-generator.php
@@ -71,18 +71,27 @@ class SWPS_AEO_Schema_Generator {
 		$required      = (array) ( $spec['required']    ?? array() );
 		$recommended   = (array) ( $spec['recommended'] ?? array() );
 		$expected_type = (string) ( $spec['type'] ?? '' );
+		$shape_notes   = $this->format_shape_notes( $spec );
 
 		$system = 'You generate schema.org JSON-LD from blog post content. ' .
-			'Only return fields you can derive from the post — do NOT invent.';
-		$user   = sprintf(
-			"Type: %s\nTitle: %s\n\nRequired fields: %s\nRecommended fields: %s\n\n" .
+			'Required fields MUST be populated by synthesizing from the post title and body ' .
+			'(do not leave them empty). Recommended fields should only be included when ' .
+			'derivable from the post. Do not invent facts not in the post.';
+
+		$user = sprintf(
+			"Type: %s\nTitle: %s\n\n" .
+			"REQUIRED fields (must be populated, never empty): %s\n" .
+			"RECOMMENDED fields (include when derivable, omit otherwise): %s\n" .
+			"%s\n" .
 			"Post HTML (truncated):\n%s\n\n" .
 			'Return a single JSON object: {"@context": "https://schema.org", "@type": "%s", ...fields...}. ' .
-			'Use empty arrays / null for fields you cannot derive.',
+			'For recommended fields you cannot derive, omit the key entirely (do NOT use null or empty arrays). ' .
+			'For required fields, always populate — synthesize from the title and body if necessary.',
 			$expected_type,
 			$title,
 			implode( ', ', $required ),
-			implode( ', ', $recommended ),
+			empty( $recommended ) ? '(none)' : implode( ', ', $recommended ),
+			'' === $shape_notes ? '' : "\nField shape guidance:\n" . $shape_notes,
 			mb_substr( wp_strip_all_tags( $html ), 0, 8000 ),
 			$expected_type
 		);
@@ -120,6 +129,59 @@ class SWPS_AEO_Schema_Generator {
 			'json'  => (array) $json,
 			'error' => null,
 		);
+	}
+
+	/**
+	 * Build human-readable shape guidance from the spec's *_shape entries.
+	 *
+	 * The schema-fields manifest defines nested-object shapes (e.g.
+	 * QAPage's main_entity_shape → Question, HowTo's step_shape →
+	 * HowToStep). Without telling the AI these shapes, it tends to
+	 * return empty arrays or null for the parent required field — which
+	 * the validator rejects. This method turns each *_shape entry into
+	 * a one-line prompt fragment the AI can use as a template.
+	 *
+	 * @param array<string, mixed> $spec One type's entry from the manifest.
+	 */
+	private function format_shape_notes( array $spec ): string {
+		$lines = array();
+		foreach ( $spec as $key => $value ) {
+			if ( ! is_array( $value ) || ! str_ends_with( (string) $key, '_shape' ) ) {
+				continue;
+			}
+
+			// Shape keys in the manifest are snake_case (e.g. main_entity_shape)
+			// but schema.org field names are camelCase (e.g. mainEntity). Convert
+			// here so the AI sees the actual schema field name. A shape entry can
+			// override with an explicit "field" key when the parent field name
+			// doesn't derive cleanly from the shape key (e.g. instruction_shape
+			// describes the items inside the recipeInstructions array).
+			$shape_key    = substr( (string) $key, 0, -strlen( '_shape' ) );
+			$parent_field = isset( $value['field'] ) && is_string( $value['field'] )
+				? $value['field']
+				: $this->snake_to_camel( $shape_key );
+
+			$type   = (string) ( $value['@type'] ?? '' );
+			$fields = (array)  ( $value['fields'] ?? array() );
+			if ( '' === $type || empty( $fields ) ) {
+				continue;
+			}
+			$lines[] = sprintf(
+				'  - %s should be a %s object with fields: %s',
+				$parent_field,
+				$type,
+				implode( ', ', $fields )
+			);
+		}
+		return implode( "\n", $lines );
+	}
+
+	/** Convert "snake_case_name" → "snakeCaseName". */
+	private function snake_to_camel( string $snake ): string {
+		if ( false === strpos( $snake, '_' ) ) {
+			return $snake;
+		}
+		return lcfirst( str_replace( ' ', '', ucwords( str_replace( '_', ' ', $snake ) ) ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.6.3
+Stable tag: 4.6.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -252,6 +252,9 @@ Yes. The built-in analytics tracker is cookie-free and does not use any external
 No. GSC integration is optional. The on-site analytics works entirely without any external services. Add Google OAuth credentials only if you want search clicks, impressions, and ranking data.
 
 == Changelog ==
+
+= 4.6.4 — 2026-05-24 =
+* Fix: Schema Generator prompt no longer tells the AI to "use empty arrays / null for fields you cannot derive" — that instruction conflicted with the validator's "required fields must be populated" rule, so QAPage posts (and other nested-shape types) frequently failed with `Schema generation failed validation: empty required field: mainEntity`. The prompt now explicitly distinguishes REQUIRED (must populate, never empty) from RECOMMENDED (omit if not derivable), and includes per-type shape guidance (e.g. `mainEntity should be a Question object with fields: name, text, acceptedAnswer, …`) so the AI knows how to construct nested objects.
 
 = 4.6.3 — 2026-05-24 =
 * Developer: AEO asset enqueues (aeo.css, aeo-optimizer.js, aeo-editor-panel.js) now version via `filemtime()` instead of the global `SWPS_VERSION` constant. This means any edit to those files automatically busts browser caches without needing a plugin-wide version bump. Falls back to `SWPS_VERSION` if the file isn't readable.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.6.3
+ * Version: 4.6.4
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.6.3' );
+define( 'SWPS_VERSION', '4.6.4' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/tests/aeo/AeoSchemaGeneratorTest.php
+++ b/tests/aeo/AeoSchemaGeneratorTest.php
@@ -96,4 +96,54 @@ final class AeoSchemaGeneratorTest extends TestCase {
 		$this->assertNull( $r['json'] );
 		$this->assertStringContainsString( 'AI provider error', (string) $r['error'] );
 	}
+
+	public function test_qapage_prompt_includes_main_entity_shape_guidance(): void {
+		$provider = new FakeAIProvider();
+		$provider->next_response = array(
+			'@context'   => 'https://schema.org',
+			'@type'      => 'QAPage',
+			'mainEntity' => array(
+				'@type'          => 'Question',
+				'name'           => 'How long does sourdough need to ferment?',
+				'text'           => 'How long does sourdough need to ferment?',
+				'acceptedAnswer' => array(
+					'@type' => 'Answer',
+					'text'  => '4-6 hours at room temperature.',
+				),
+			),
+		);
+		$gen = new SWPS_AEO_Schema_Generator( $provider, $this->fields_path() );
+		$r   = $gen->generate( 'qapage', 'How long does sourdough ferment?', '<p>4-6 hours.</p>' );
+
+		// The prompt must teach the AI the Question shape so mainEntity isn't empty.
+		$this->assertStringContainsString( 'mainEntity should be a Question object', $provider->last_user );
+		$this->assertStringContainsString( 'acceptedAnswer', $provider->last_user );
+
+		// Required-vs-recommended distinction must be explicit (regression for the
+		// "Use empty arrays for fields you cannot derive" instruction that conflicted
+		// with the validator's reject-empty-required-fields behavior).
+		$this->assertStringContainsString( 'REQUIRED fields', $provider->last_user );
+		$this->assertStringContainsString( 'never empty', $provider->last_user );
+
+		// And a well-formed QAPage passes validation end-to-end.
+		$this->assertSame( 'QAPage', $r['json']['@type'] );
+		$this->assertNull( $r['error'] );
+	}
+
+	public function test_qapage_with_empty_main_entity_still_rejected(): void {
+		// Regression for the live bug: AI returned mainEntity:[] for a QAPage,
+		// the validator (correctly) flagged it as "empty required field: mainEntity".
+		// The prompt fix reduces the likelihood; the validator still has the final say.
+		$provider = new FakeAIProvider();
+		$provider->next_response = array(
+			'@context'   => 'https://schema.org',
+			'@type'      => 'QAPage',
+			'mainEntity' => array(),
+		);
+		$gen = new SWPS_AEO_Schema_Generator( $provider, $this->fields_path() );
+		$r   = $gen->generate( 'qapage', 'X', '<p>Y</p>' );
+
+		$this->assertNull( $r['json'] );
+		$this->assertStringContainsString( 'mainEntity', (string) $r['error'] );
+	}
 }


### PR DESCRIPTION
## Summary

**Bug report from the live site:**

> Schema generation failed validation: empty required field: mainEntity

Hit when generating a proposal for a QAPage-detected post on jonimms.com. The AI returned a schema where `mainEntity` was empty (`null` or `[]`), the validator (correctly) rejected it, and the user saw the diff modal's red error banner.

## Root cause

The old Schema Generator prompt told the AI:

> "Use empty arrays / null for fields you cannot derive."

That instruction conflicted directly with the validator's "required fields must be populated and non-empty" rule. For QAPage specifically:
- The required field is `mainEntity`, a nested **Question** object.
- The old prompt only listed `mainEntity` by name — no shape guidance.
- Given the choice between making something up and returning empty, the AI returned empty (correct per the prompt, but rejected by the validator).

## Fix

**Two changes to the prompt:**

1. **Explicit REQUIRED vs RECOMMENDED instructions:**
   - Required fields → MUST be populated, synthesize from title/body if needed.
   - Recommended fields → omit the key entirely if not derivable (do NOT use null or empty arrays).

2. **Field shape guidance section** — built dynamically from the manifest's `*_shape` entries:
   ```
   Field shape guidance:
     - mainEntity should be a Question object with fields: name, text, answerCount, acceptedAnswer, upvoteCount, dateCreated, author
     - answer should be a Answer object with fields: text, dateCreated, upvoteCount, author
   ```

**Two helpers:**

- `format_shape_notes(array $spec)` — walks the spec for `*_shape` keys, emits one prompt line per shape.
- `snake_to_camel(string)` — converts manifest keys (`main_entity_shape`) to schema.org field names (`mainEntity`). An optional `"field"` override key on a shape entry can supply an explicit field name when snake_to_camel doesn't produce the right answer (e.g. `instruction_shape` → `recipeInstructions`). Override is reserved for a follow-up that wants to teach Recipe / Product / Review shapes.

## What did NOT change

- The validator. Still rejects empty required fields — it's the last line of defense if the AI ignores the prompt. The fix reduces the failure rate; doesn't eliminate it.
- The schema-fields manifest (other than this PR's docs — actual manifest data unchanged). The 3 cases where snake_to_camel doesn't reach the right field (`instruction_shape`, `offer_shape`, `rating_shape`) are not blocking the QAPage bug. They'll get explicit `field` overrides in a follow-up if Recipe/Product/Review schema generation starts showing similar failures.
- The 6 existing AeoSchemaGeneratorTest cases. Prompt changes are not test-observable since `FakeAIProvider` returns whatever `next_response` is set regardless of input.

## Tests added (2)

- `test_qapage_prompt_includes_main_entity_shape_guidance` — asserts the prompt contains `mainEntity should be a Question object`, the new `REQUIRED fields` / `never empty` language, AND that a properly-populated QAPage passes validation end-to-end.
- `test_qapage_with_empty_main_entity_still_rejected` — regression for the live bug. If the AI still returns `mainEntity:[]`, the validator still flags it.

## Files changed

| File | Change |
|---|---|
| `includes/class-aeo-schema-generator.php` | New prompt construction + `format_shape_notes()` + `snake_to_camel()` helpers |
| `tests/aeo/AeoSchemaGeneratorTest.php` | +2 tests |
| `stratawp-seo.php` | Version 4.6.3 → 4.6.4 |
| `readme.txt` | Stable tag + changelog entry |
| `README.md` | Version badge + changelog entry |

## Verification

- `composer check` — PHPCS clean, PHPStan no errors
- `composer test` — **39/39** passing (was 37, +2 new)
- `php -l stratawp-seo.php` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)