### PR TITLE
v4.6.5 — fix(aeo): JS swallowed AJAX error messages — surface real errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.6.4-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.6.5-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1274,6 +1274,9 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.6.5 — May 2026
+- Fix: AEO Optimize "Request failed." alerts now surface the actual server error. The JS `.fail()` handlers were displaying the generic fallback message regardless of what the response body said — so AI-provider errors (rate limit, invalid API key, JSON parse failure) were being swallowed. New `extractErrorMessage()` helper digs into `jqXHR.responseJSON.data.message`, falls back to the HTTP status, and appends a "Check StrataWP SEO → Debug for the raw AI response" hint for likely AI-side failures. Applies to scan / proposal / apply.
 
 ### v4.6.4 — May 2026
 - Fix: Schema Generator no longer rejects QAPage (and other nested-shape) posts with `empty required field: mainEntity`. The previous prompt told the AI to "use empty arrays / null for fields you cannot derive" — that instruction conflicted with the validator's reject-empty-required-fields behavior. The prompt now explicitly distinguishes REQUIRED (must populate) from RECOMMENDED (omit if not derivable), and includes per-type shape guidance derived from the schema-fields manifest (e.g. `mainEntity should be a Question object with fields: name, text, acceptedAnswer, ...`) so the AI knows how to construct nested objects. Two new tests cover the prompt contents and the regression case.

--- a/admin/js/aeo-optimizer.js
+++ b/admin/js/aeo-optimizer.js
@@ -15,6 +15,43 @@
         return $('<i>').text(String(s == null ? '' : s)).html();
     }
 
+    // Extract a useful error message from a jQuery AJAX failure.
+    // wp_send_json_error( $data, $http_status ) sends HTTP 4xx/5xx with a
+    // body like {success:false, data:{message:"..."}}. jQuery's .fail()
+    // doesn't auto-parse that — this helper digs the message out, falls
+    // back to the HTTP status, then to the generic i18n string. Includes
+    // a hint to check the Debug page for likely AI-provider failures.
+    function extractErrorMessage(jqXHR, prefix) {
+        var msg = '';
+        if (jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data.message) {
+            msg = String(jqXHR.responseJSON.data.message);
+        } else if (jqXHR && jqXHR.responseText) {
+            // Fall back to raw response when JSON parsing failed.
+            try {
+                var parsed = JSON.parse(jqXHR.responseText);
+                if (parsed && parsed.data && parsed.data.message) {
+                    msg = String(parsed.data.message);
+                }
+            } catch (e) { /* ignore */ }
+        }
+        if (!msg && jqXHR && jqXHR.status) {
+            msg = 'HTTP ' + jqXHR.status + (jqXHR.statusText ? ' ' + jqXHR.statusText : '');
+        }
+        if (!msg) {
+            msg = swpsAeo.i18n.genericFail;
+        }
+        // Cap very-long AI provider error messages so the alert stays readable.
+        if (msg.length > 600) {
+            msg = msg.substring(0, 600) + '...';
+        }
+        // Hint at the Debug page for AI-side failures (rate limits, JSON parse, etc.).
+        var hint = '';
+        if (/json|parse|invalid|api|rate|quota|token|provider/i.test(msg)) {
+            hint = '\n\nCheck StrataWP SEO → Debug for the raw AI response.';
+        }
+        return (prefix ? prefix + ': ' : '') + msg + hint;
+    }
+
     function scoreClass(s) {
         if (s < 50) return 'low';
         if (s < 75) return 'mid';
@@ -111,7 +148,8 @@
             offset: offset
         }).done(function (resp) {
             if (!resp || !resp.success) {
-                $progressText.text(swpsAeo.i18n.genericFail);
+                $progressText.text((resp && resp.data && resp.data.message) || swpsAeo.i18n.genericFail);
+                $progress.hide();
                 return;
             }
             allResults = allResults.concat(resp.data.results || []);
@@ -127,9 +165,9 @@
             } else {
                 scanChunk(resp.data.next_offset);
             }
-        }).fail(function () {
-            $progressText.text(swpsAeo.i18n.genericFail);
-            $progress.hide();
+        }).fail(function (jqXHR) {
+            $progressText.text(extractErrorMessage(jqXHR, 'Scan failed'));
+            // Keep the progress block visible so the user can read the error.
         });
     }
 
@@ -143,14 +181,14 @@
         }).done(function (resp) {
             $btn.prop('disabled', false);
             if (!resp || !resp.success) {
-                alert((resp && resp.data && resp.data.message) || swpsAeo.i18n.genericFail);
                 $btn.text(swpsAeo.i18n.generate);
+                alert('Proposal failed: ' + ((resp && resp.data && resp.data.message) || swpsAeo.i18n.genericFail));
                 return;
             }
             openModal(postId, resp.data.proposal || {});
-        }).fail(function () {
+        }).fail(function (jqXHR) {
             $btn.prop('disabled', false).text(swpsAeo.i18n.generate);
-            alert(swpsAeo.i18n.genericFail);
+            alert(extractErrorMessage(jqXHR, 'Proposal failed'));
         });
     }
 
@@ -219,7 +257,7 @@
             schema:  schema ? 1 : 0
         }).done(function (resp) {
             if (!resp || !resp.success) {
-                alert((resp && resp.data && resp.data.message) || swpsAeo.i18n.genericFail);
+                alert('Apply failed: ' + ((resp && resp.data && resp.data.message) || swpsAeo.i18n.genericFail));
                 return;
             }
             // Update local cache.
@@ -232,7 +270,7 @@
             $modal.hide();
             updateTiles();
             renderQueue();
-        }).fail(function () { alert(swpsAeo.i18n.genericFail); });
+        }).fail(function (jqXHR) { alert(extractErrorMessage(jqXHR, 'Apply failed')); });
     }
 
     function dismiss(postId) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.6.4
+Stable tag: 4.6.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -252,6 +252,9 @@ Yes. The built-in analytics tracker is cookie-free and does not use any external
 No. GSC integration is optional. The on-site analytics works entirely without any external services. Add Google OAuth credentials only if you want search clicks, impressions, and ranking data.
 
 == Changelog ==
+
+= 4.6.5 — 2026-05-24 =
+* Fix: AEO Optimize "Request failed." alerts now show the actual error message. The JS `.fail()` handler previously displayed the generic fallback regardless of what the server returned — so AI-provider errors (rate limits, invalid API key, JSON parse failures, etc.) were being swallowed. A new `extractErrorMessage()` helper digs into `jqXHR.responseJSON.data.message`, falls back to the HTTP status, and appends a "Check StrataWP SEO → Debug" hint for AI-side failures.
 
 = 4.6.4 — 2026-05-24 =
 * Fix: Schema Generator prompt no longer tells the AI to "use empty arrays / null for fields you cannot derive" — that instruction conflicted with the validator's "required fields must be populated" rule, so QAPage posts (and other nested-shape types) frequently failed with `Schema generation failed validation: empty required field: mainEntity`. The prompt now explicitly distinguishes REQUIRED (must populate, never empty) from RECOMMENDED (omit if not derivable), and includes per-type shape guidance (e.g. `mainEntity should be a Question object with fields: name, text, acceptedAnswer, …`) so the AI knows how to construct nested objects.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.6.4
+ * Version: 4.6.5
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.6.4' );
+define( 'SWPS_VERSION', '4.6.5' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Summary

**Bug report from the live site:**

> "still getting Request failed. :("

The AEO Optimizer's "Generate proposal" button (and re-scan, and apply) was showing "Request failed." for *any* server-side failure — masking what was actually wrong (AI rate limit, invalid API key, JSON parse failure, etc.).

## Root cause

`SWPS_AEO_Optimizer::do_propose()` returns errors as `['error' => '…', 'http_status' => 500]`. The AJAX wrapper translates that into `wp_send_json_error( ['message' => '…'], 500 )` — which sends a perfectly good JSON body **with HTTP status 500**.

jQuery's `$.post().done()` only fires on HTTP 2xx. On 500, `.fail(jqXHR)` fires instead — and the existing `.fail()` handlers ignored `jqXHR` entirely:

```javascript
}).fail(function () { alert(swpsAeo.i18n.genericFail); });
```

So whatever the server said (`mainEntity validation failed`, `rate limit exceeded`, `invalid API key`, etc.) was thrown away.

## Fix

**New `extractErrorMessage(jqXHR, prefix)` helper:**

```javascript
function extractErrorMessage(jqXHR, prefix) {
    var msg = '';
    if (jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.data && jqXHR.responseJSON.data.message) {
        msg = String(jqXHR.responseJSON.data.message);
    } else if (jqXHR && jqXHR.responseText) {
        try {
            var parsed = JSON.parse(jqXHR.responseText);
            if (parsed && parsed.data && parsed.data.message) {
                msg = String(parsed.data.message);
            }
        } catch (e) { /* ignore */ }
    }
    if (!msg && jqXHR && jqXHR.status) {
        msg = 'HTTP ' + jqXHR.status + (jqXHR.statusText ? ' ' + jqXHR.statusText : '');
    }
    if (!msg) msg = swpsAeo.i18n.genericFail;

    // Cap overly long AI errors so the alert stays readable.
    if (msg.length > 600) msg = msg.substring(0, 600) + '...';

    // Hint at the Debug page for AI-side failures.
    var hint = '';
    if (/json|parse|invalid|api|rate|quota|token|provider/i.test(msg)) {
        hint = '\n\nCheck StrataWP SEO → Debug for the raw AI response.';
    }
    return (prefix ? prefix + ': ' : '') + msg + hint;
}
```

**Wired into all 3 `.fail()` handlers:** scan, propose, apply. Each gets a prefix like `'Scan failed'`, `'Proposal failed'`, `'Apply failed'` so the user knows which step blew up.

**`.done()`-path improvements:** when `resp.success === false`, the existing handlers already extracted `resp.data.message`, but I prefixed the alert with the operation name for consistency.

## What you'll see now

Before:
```
⚠ Request failed.
```

After (rate limit example):
```
⚠ Proposal failed: 429 Too Many Requests — please wait 30 seconds before retrying.

Check StrataWP SEO → Debug for the raw AI response.
```

After (validation error example):
```
⚠ Proposal failed: empty required field: mainEntity
```

## Files changed

| File | Change |
|---|---|
| `admin/js/aeo-optimizer.js` | New `extractErrorMessage()`; 3 `.fail()` handlers updated; 3 `.done()`-path messages prefixed |
| `stratawp-seo.php` | Version 4.6.4 → 4.6.5 |
| `readme.txt` | Stable tag + changelog entry |
| `README.md` | Version badge + changelog entry |

## Verification

- `composer check` — PHPCS clean, PHPStan no errors
- `composer test` — 39/39 still passing
- `php -l stratawp-seo.php` — clean

## Note

This is a UX fix, not a fix to the underlying failures themselves. If the user is still seeing errors after installing v4.6.5, the new alert will tell us *what* is failing — most likely candidates: AI provider API key, rate limit, AI returning malformed JSON despite the 5-stage repair pipeline. Worth a look at **StrataWP SEO → Debug** to see the raw last-failed response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)