### PR TITLE
v4.6.6 — fix(aeo): 'invalid_proposal' on Apply — wp_slash JSON before update_post_meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.6.5-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.6.6-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1274,6 +1274,9 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.6.6 — May 2026
+- Fix: "Apply selected" on an AEO proposal failed with `invalid_proposal` (and the rendered front-end JSON-LD schema silently broke) because WordPress's `update_post_meta()` runs `wp_unslash()` internally — which stripped the `\"` escapes inside JSON strings, corrupting them on write. All three storage sites (`META_PROPOSAL`, `META_SNAPSHOT`, `META_SCHEMA_JSON` — including the undo restore) now call `wp_slash()` before `update_post_meta()` so the round-trip preserves valid JSON. Pre-v4.6.6 corrupted proposals are auto-cleared on the next apply with a friendly "please re-generate" message. The undo handler likewise auto-clears corrupted snapshots.
 
 ### v4.6.5 — May 2026
 - Fix: AEO Optimize "Request failed." alerts now surface the actual server error. The JS `.fail()` handlers were displaying the generic fallback message regardless of what the response body said — so AI-provider errors (rate limit, invalid API key, JSON parse failure) were being swallowed. New `extractErrorMessage()` helper digs into `jqXHR.responseJSON.data.message`, falls back to the HTTP status, and appends a "Check StrataWP SEO → Debug for the raw AI response" hint for likely AI-side failures. Applies to scan / proposal / apply.

--- a/includes/class-aeo-optimizer.php
+++ b/includes/class-aeo-optimizer.php
@@ -387,7 +387,13 @@ class SWPS_AEO_Optimizer {
 		/** Filter the AI-returned proposal. */
 		$proposal = (array) apply_filters( 'swps_aeo_proposal', $proposal, $post_id );
 
-		update_post_meta( $post_id, self::META_PROPOSAL, wp_json_encode( $proposal ) );
+		// IMPORTANT: wp_slash() before update_post_meta(). WordPress's
+		// update_metadata() internally calls wp_unslash() on the value, which
+		// would strip the \" escapes inside our JSON string and corrupt it.
+		// Pre-slashing means the round-trip leaves the stored value as valid
+		// JSON. The same pattern is applied to META_SNAPSHOT and
+		// META_SCHEMA_JSON below.
+		update_post_meta( $post_id, self::META_PROPOSAL, wp_slash( (string) wp_json_encode( $proposal ) ) );
 
 		return array( 'proposal' => $proposal );
 	}
@@ -428,20 +434,30 @@ class SWPS_AEO_Optimizer {
 
 		$raw = (string) get_post_meta( $post_id, self::META_PROPOSAL, true );
 		if ( '' === $raw ) {
-			return array( 'error' => 'no_proposal', 'http_status' => 400 );
+			return array(
+				'error'       => __( 'No proposal cached. Click "Generate proposal" again — the previous one may have expired (proposals are cleared after 24h) or never been saved.', 'stratawp-seo' ),
+				'http_status' => 400,
+			);
 		}
 		$proposal = json_decode( $raw, true );
 		if ( ! is_array( $proposal ) ) {
-			return array( 'error' => 'invalid_proposal', 'http_status' => 500 );
+			// Likely a stale proposal stored under the pre-v4.6.6 wp_unslash bug
+			// (JSON's \" escapes were stripped, breaking json_decode here). Auto-
+			// clear so the next "Generate proposal" overwrites cleanly.
+			delete_post_meta( $post_id, self::META_PROPOSAL );
+			return array(
+				'error'       => __( 'Cached proposal could not be parsed (likely corrupted by a pre-v4.6.6 storage bug). The bad proposal has been cleared — please click "Generate proposal" again.', 'stratawp-seo' ),
+				'http_status' => 400,
+			);
 		}
 
-		// Snapshot for undo.
-		update_post_meta( $post_id, self::META_SNAPSHOT, wp_json_encode( array(
+		// Snapshot for undo. wp_slash for the same reason as META_PROPOSAL above.
+		update_post_meta( $post_id, self::META_SNAPSHOT, wp_slash( (string) wp_json_encode( array(
 			'content'     => $post->post_content,
 			'schema_type' => get_post_meta( $post_id, self::META_SCHEMA_TYPE, true ),
 			'schema_json' => get_post_meta( $post_id, self::META_SCHEMA_JSON, true ),
 			'taken_at'    => time(),
-		) ) );
+		) ) ) );
 
 		$new_content = $post->post_content;
 		$applied     = 0;
@@ -497,7 +513,11 @@ class SWPS_AEO_Optimizer {
 			&& empty( $proposal['schema']['validation_error'] )
 		) {
 			update_post_meta( $post_id, self::META_SCHEMA_TYPE, (string) $proposal['schema']['type'] );
-			update_post_meta( $post_id, self::META_SCHEMA_JSON, wp_json_encode( $proposal['schema']['json'] ) );
+			// wp_slash for the same reason as META_PROPOSAL above. Without it
+			// the JSON-LD stored here would be corrupted by update_metadata's
+			// internal wp_unslash, and the frontend schema renderer would
+			// silently fail to emit the JSON-LD.
+			update_post_meta( $post_id, self::META_SCHEMA_JSON, wp_slash( (string) wp_json_encode( $proposal['schema']['json'] ) ) );
 			++$applied;
 		}
 
@@ -534,11 +554,18 @@ class SWPS_AEO_Optimizer {
 	public function do_undo( int $post_id ): array {
 		$raw = (string) get_post_meta( $post_id, self::META_SNAPSHOT, true );
 		if ( '' === $raw ) {
-			return array( 'error' => 'no_snapshot', 'http_status' => 404 );
+			return array(
+				'error'       => __( 'No snapshot available to undo (snapshots are taken automatically when you apply a proposal).', 'stratawp-seo' ),
+				'http_status' => 404,
+			);
 		}
 		$snap = json_decode( $raw, true );
 		if ( ! is_array( $snap ) ) {
-			return array( 'error' => 'invalid_snapshot', 'http_status' => 500 );
+			delete_post_meta( $post_id, self::META_SNAPSHOT );
+			return array(
+				'error'       => __( 'Snapshot could not be parsed (likely corrupted by a pre-v4.6.6 storage bug). The bad snapshot has been cleared.', 'stratawp-seo' ),
+				'http_status' => 400,
+			);
 		}
 
 		wp_update_post( array(
@@ -552,7 +579,9 @@ class SWPS_AEO_Optimizer {
 			delete_post_meta( $post_id, self::META_SCHEMA_TYPE );
 		}
 		if ( ! empty( $snap['schema_json'] ) ) {
-			update_post_meta( $post_id, self::META_SCHEMA_JSON, (string) $snap['schema_json'] );
+			// wp_slash so update_metadata's internal wp_unslash doesn't strip
+			// the JSON-LD's \" escapes (same issue as the store sites above).
+			update_post_meta( $post_id, self::META_SCHEMA_JSON, wp_slash( (string) $snap['schema_json'] ) );
 		} else {
 			delete_post_meta( $post_id, self::META_SCHEMA_JSON );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.6.5
+Stable tag: 4.6.6
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -252,6 +252,9 @@ Yes. The built-in analytics tracker is cookie-free and does not use any external
 No. GSC integration is optional. The on-site analytics works entirely without any external services. Add Google OAuth credentials only if you want search clicks, impressions, and ranking data.
 
 == Changelog ==
+
+= 4.6.6 — 2026-05-24 =
+* Fix: Applying an AEO proposal failed with "Apply failed: invalid_proposal" because `update_post_meta()` internally calls `wp_unslash()` on stored values, which stripped the JSON's `\"` escapes and corrupted the cached proposal. Same bug affected the snapshot (undo) and the rendered JSON-LD schema. All three storage sites now `wp_slash()` before storing so the round-trip preserves valid JSON. Pre-4.6.6 corrupted proposals are auto-cleared on next apply with a friendly "please re-generate" message.
 
 = 4.6.5 — 2026-05-24 =
 * Fix: AEO Optimize "Request failed." alerts now show the actual error message. The JS `.fail()` handler previously displayed the generic fallback regardless of what the server returned — so AI-provider errors (rate limits, invalid API key, JSON parse failures, etc.) were being swallowed. A new `extractErrorMessage()` helper digs into `jqXHR.responseJSON.data.message`, falls back to the HTTP status, and appends a "Check StrataWP SEO → Debug" hint for AI-side failures.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.6.5
+ * Version: 4.6.6
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.6.5' );
+define( 'SWPS_VERSION', '4.6.6' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Summary

**User reported:** clicking **Apply selected** on an AEO proposal → `Apply failed: invalid_proposal` (with the friendly Debug-page hint added in v4.6.5).

## Root cause

The cached proposal in `_swps_aeo_proposal` post meta existed but was corrupted. The bug: `update_metadata()` (WordPress core) runs `wp_unslash()` on the value before storing — this is legacy magic-quotes handling — and it strips the `\"` escapes inside our JSON strings.

Concretely:

```
$proposal = ['key' => 'value with "quotes"'];
wp_json_encode($proposal)               → {"key":"value with \"quotes\""}
update_post_meta(..., $json_string)
  └─ wp_unslash() inside update_metadata → {"key":"value with "quotes""}  ← BROKEN
get_post_meta(...)                       → returns the broken string
json_decode($broken, true)               → null
→ "invalid_proposal" branch
```

The proposal **looked correct in the modal** because the AJAX response (`wp_send_json_success`) sends a fresh JSON encoding of the in-memory `$proposal` array, bypassing the post-meta round-trip. The bug only manifests when re-reading from post meta — which is exactly what Apply does.

## Same bug in three other places

| Site | Symptom |
|---|---|
| `META_PROPOSAL` (`do_propose` store) | `Apply failed: invalid_proposal` |
| `META_SNAPSHOT` (`do_apply` store) | Undo would fail with `invalid_snapshot` |
| `META_SCHEMA_JSON` (`do_apply` store) | Front-end JSON-LD schema silently failed to emit (renderer's `json_decode` returned null) |
| `META_SCHEMA_JSON` (`do_undo` restore) | Double-corrupted on undo (wp_unslash applied twice) |

## Fix

`wp_slash()` before every `wp_json_encode → update_post_meta` call. `wp_slash` pre-escapes so `wp_unslash`'s strip restores the original clean JSON:

```php
update_post_meta(
    $post_id,
    self::META_PROPOSAL,
    wp_slash( (string) wp_json_encode( $proposal ) )
);
```

Four sites updated:
- `do_propose` stores `META_PROPOSAL`
- `do_apply` stores `META_SNAPSHOT`
- `do_apply` stores `META_SCHEMA_JSON`
- `do_undo` restores `META_SCHEMA_JSON` from the snapshot

## Recovery path for already-corrupted data

Both `do_apply` and `do_undo` now auto-delete the corrupted meta when `json_decode` fails and return a friendly message:

> Cached proposal could not be parsed (likely corrupted by a pre-v4.6.6 storage bug). The bad proposal has been cleared — please click "Generate proposal" again.

So the user clicks Apply → sees this message → clicks Generate proposal → tries Apply again → works.

## Files changed

| File | Change |
|---|---|
| `includes/class-aeo-optimizer.php` | 4 `wp_slash()` additions + 3 friendlier error messages + auto-cleanup of corrupted meta |
| `stratawp-seo.php` | Version 4.6.5 → 4.6.6 |
| `readme.txt` | Stable tag + changelog entry |
| `README.md` | Version badge + changelog entry |

## Verification

- `composer check` — PHPCS clean, PHPStan no errors
- `composer test` — 39/39 still passing
- `php -l stratawp-seo.php` — clean

Pure-PHP unit tests can't exercise the `wp_unslash` round-trip (no WP environment), so this is verified by user manual smoke after install. Expected result: re-generate the proposal on the same post, click Apply selected, edits/inserts/schema land cleanly without the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)