### PR TITLE
feat: AI model auto-discovery + selectable Gemini image model (v4.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.6.5-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.8.0-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1274,6 +1274,10 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.8.0 — May 2026
+- **Feature — model auto-discovery:** AI models are discovered daily from each configured provider's API and merged into the model dropdown automatically, with a dismissible new-model alert. Curated lists remain the labeled fallback; nothing auto-switches.
+- **Feature — selectable Gemini image model:** the Gemini image model is now a Settings dropdown (auto-discovered), replacing the hardcoded constant.
 
 ### v4.6.5 — May 2026
 - Fix: AEO Optimize "Request failed." alerts now surface the actual server error. The JS `.fail()` handlers were displaying the generic fallback message regardless of what the response body said — so AI-provider errors (rate limit, invalid API key, JSON parse failure) were being swallowed. New `extractErrorMessage()` helper digs into `jqXHR.responseJSON.data.message`, falls back to the HTTP status, and appends a "Check StrataWP SEO → Debug for the raw AI response" hint for likely AI-side failures. Applies to scan / proposal / apply.

--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -763,4 +763,15 @@
         });
     });
 
+    // =====================================================================
+    // Admin notice: dismiss new-model alert via AJAX
+    // =====================================================================
+
+    $(document).on('click', '.swps-model-alert .notice-dismiss', function() {
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_dismiss_model_alert',
+            nonce: swpsAdmin.nonce,
+        });
+    });
+
 })(jQuery);

--- a/docs/superpowers/plans/2026-05-29-model-discovery.md
+++ b/docs/superpowers/plans/2026-05-29-model-discovery.md
@@ -1,0 +1,702 @@
+# Model Discovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-discover available AI text models and the Gemini image model from each provider's list-models API (daily, cached), surface them in the dropdowns, and alert on never-seen models — without auto-switching anything.
+
+**Architecture:** A new `SWPS_Model_Discovery` service merges each provider's curated list with a daily-refreshed cache of API-discovered models. Per-provider `fetch_remote_models()` calls the provider's `/models` endpoint (each with a pure, unit-testable `parse_models_response()`); a `swps_refresh_models` daily cron refreshes the cache and flags new models for a dismissible admin notice. The Gemini image model becomes a selectable setting (`swps_gemini_image_model`) instead of a hardcoded constant.
+
+**Tech Stack:** PHP 8.0+, WordPress, WP-Cron, provider REST APIs. Gate: PHPStan green + no new PHPCS errors + PHPUnit (`composer test`).
+
+**Spec:** `docs/superpowers/specs/2026-05-29-model-discovery-design.md`
+
+---
+
+## Base & sequencing (read first)
+
+- **Branch off `main`**, independent of the async-image PR (#41). If #41 merges first, rebase — overlap is limited to `admin.js` (image-row visibility), `settings.php` (Featured Images section), and the Gemini provider; all minor.
+- **Gate model (same as the image fix):** `composer check` is pre-existingly red from a WPCS backlog. The per-task gate is **PHPStan stays green (`vendor/bin/phpstan analyse`) + no NEW PHPCS errors on touched lines + `composer test` (PHPUnit) green.** Pure parser/merge logic gets real PHPUnit tests in the `unit` suite (added in #41; if not yet merged, this plan's Task 3 re-adds the suite wiring — check `phpunit.xml.dist` first and skip if present).
+- All new methods need full WPCS docblocks (`@param`/`@return`) — the provider/factory/settings files are largely WPCS-clean, so missing docblocks = new errors.
+- API keys are stored encrypted; `get_api_key()` returns the decrypted value — use it, don't read the option directly.
+
+## File structure
+
+| File | Change | Responsibility |
+|------|--------|----------------|
+| `includes/class-ai-provider.php` | modify | Default `fetch_remote_models()` returning `[]` (providers opt in) |
+| `includes/providers/ai/class-anthropic-provider.php` | modify | `fetch_remote_models()` + pure `parse_models_response()` |
+| `includes/providers/ai/class-openai-provider.php` | modify | same (with chat-model filter) |
+| `includes/providers/ai/class-google-provider.php` | modify | same (`generateContent` filter) |
+| `includes/providers/ai/class-xai-provider.php` | modify | same (`grok-*` filter) |
+| `includes/providers/images/class-gemini-provider.php` | modify | `fetch_remote_models()` (image models) + read `swps_gemini_image_model` setting |
+| `includes/class-model-discovery.php` | create | Merge/diff/refresh/cache + dismiss; pure merge & diff helpers |
+| `includes/class-provider-factory.php` | modify | `get_models_for_provider()` returns merged list |
+| `includes/class-settings.php` | modify | Register + render `swps_gemini_image_model` dropdown |
+| `admin/js/admin.js` | modify | Show the image-model row when provider = Gemini |
+| `stratawp-seo.php` | modify | Instantiate service; register cron, admin_notices, dismiss AJAX; default option |
+| `includes/class-model-cron.php` | create | Daily `swps_refresh_models` schedule/unschedule/callback |
+| `tests/unit/*Test.php` | create | Pure parser, merge, and diff tests |
+
+---
+
+## Task 1: Base provider opt-in hook
+
+**Files:** Modify `includes/class-ai-provider.php`
+
+- [ ] **Step 1: Add a default `fetch_remote_models()`** (after `get_available_models()` abstract, add a concrete default so providers opt in):
+
+```php
+	/**
+	 * Fetch the live model list from the provider's API.
+	 *
+	 * Providers override this to query their /models endpoint. The default
+	 * returns an empty list, so discovery is a no-op for providers that
+	 * don't implement it.
+	 *
+	 * @return array<string, string> Model ID => display name (empty on error/unsupported).
+	 */
+	public function fetch_remote_models(): array {
+		return array();
+	}
+```
+
+- [ ] **Step 2: Gate** — `vendor/bin/phpstan analyse --memory-limit=2G --no-progress` → `[OK]`; `vendor/bin/phpcs includes/class-ai-provider.php` shows no new errors at the added lines.
+- [ ] **Step 3: Commit** — `git commit -m "feat: add fetch_remote_models() opt-in hook to AI provider base"` (append `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`).
+
+---
+
+## Task 2: Per-provider text-model fetchers + pure parsers (TDD)
+
+**Files:** Modify the 4 AI providers; create `tests/unit/RemoteModelsParserTest.php`
+
+Each provider gets a thin `fetch_remote_models()` (HTTP) delegating to a **pure static `parse_models_response(array $body): array`** (filter/map). Use each provider's existing `chat()` auth pattern (Anthropic: `x-api-key` + `anthropic-version`; OpenAI/xAI: `Authorization: Bearer`; Google: `?key=` query arg).
+
+- [ ] **Step 1: Write the failing parser tests** — `tests/unit/RemoteModelsParserTest.php`:
+
+```php
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-ai-provider.php';
+require_once __DIR__ . '/../../includes/providers/ai/class-anthropic-provider.php';
+require_once __DIR__ . '/../../includes/providers/ai/class-openai-provider.php';
+require_once __DIR__ . '/../../includes/providers/ai/class-google-provider.php';
+require_once __DIR__ . '/../../includes/providers/ai/class-xai-provider.php';
+
+final class RemoteModelsParserTest extends TestCase {
+
+	public function test_anthropic_maps_id_to_display_name(): void {
+		$body = array( 'data' => array(
+			array( 'id' => 'claude-opus-4-8', 'display_name' => 'Claude Opus 4.8', 'type' => 'model' ),
+		) );
+		$this->assertSame(
+			array( 'claude-opus-4-8' => 'Claude Opus 4.8' ),
+			SWPS_Anthropic_Provider::parse_models_response( $body )
+		);
+	}
+
+	public function test_openai_keeps_chat_models_only(): void {
+		$body = array( 'data' => array(
+			array( 'id' => 'gpt-5' ),
+			array( 'id' => 'o4-mini' ),
+			array( 'id' => 'text-embedding-3-large' ),
+			array( 'id' => 'whisper-1' ),
+			array( 'id' => 'dall-e-3' ),
+		) );
+		$out = SWPS_OpenAI_Provider::parse_models_response( $body );
+		$this->assertArrayHasKey( 'gpt-5', $out );
+		$this->assertArrayHasKey( 'o4-mini', $out );
+		$this->assertArrayNotHasKey( 'text-embedding-3-large', $out );
+		$this->assertArrayNotHasKey( 'whisper-1', $out );
+		$this->assertArrayNotHasKey( 'dall-e-3', $out );
+	}
+
+	public function test_google_keeps_generatecontent_only(): void {
+		$body = array( 'models' => array(
+			array( 'name' => 'models/gemini-3.0-pro', 'displayName' => 'Gemini 3.0 Pro', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/text-embedding-004', 'displayName' => 'Embedding 004', 'supportedGenerationMethods' => array( 'embedContent' ) ),
+		) );
+		$out = SWPS_Google_Provider::parse_models_response( $body );
+		$this->assertSame( array( 'gemini-3.0-pro' => 'Gemini 3.0 Pro' ), $out );
+	}
+
+	public function test_xai_keeps_grok_only(): void {
+		$body = array( 'data' => array(
+			array( 'id' => 'grok-5' ),
+			array( 'id' => 'grok-2-image' ),
+			array( 'id' => 'text-embedding' ),
+		) );
+		$out = SWPS_XAI_Provider::parse_models_response( $body );
+		$this->assertArrayHasKey( 'grok-5', $out );
+		$this->assertArrayNotHasKey( 'text-embedding', $out );
+	}
+
+	public function test_malformed_body_returns_empty(): void {
+		$this->assertSame( array(), SWPS_Anthropic_Provider::parse_models_response( array() ) );
+		$this->assertSame( array(), SWPS_OpenAI_Provider::parse_models_response( array( 'nope' => 1 ) ) );
+	}
+}
+```
+
+- [ ] **Step 2: Run → fail** — `vendor/bin/phpunit --testsuite unit` → errors (methods undefined).
+
+- [ ] **Step 3: Implement.** Add to **Anthropic**:
+
+```php
+	public function fetch_remote_models(): array {
+		$api_key = $this->get_api_key();
+		if ( empty( $api_key ) ) {
+			return array();
+		}
+		$response = wp_remote_get(
+			'https://api.anthropic.com/v1/models?limit=100',
+			array(
+				'timeout' => 15,
+				'headers' => array(
+					'x-api-key'         => $api_key,
+					'anthropic-version' => '2023-06-01',
+				),
+			)
+		);
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return array();
+		}
+		return self::parse_models_response( (array) json_decode( wp_remote_retrieve_body( $response ), true ) );
+	}
+
+	/**
+	 * Map an Anthropic /v1/models body to [ id => display_name ].
+	 *
+	 * @param array $body Decoded response body.
+	 * @return array<string, string>
+	 */
+	public static function parse_models_response( array $body ): array {
+		$models = array();
+		foreach ( $body['data'] ?? array() as $m ) {
+			if ( ! empty( $m['id'] ) ) {
+				$models[ (string) $m['id'] ] = (string) ( $m['display_name'] ?? $m['id'] );
+			}
+		}
+		return $models;
+	}
+```
+
+Add to **OpenAI** (auth: `Authorization: Bearer`; endpoint `https://api.openai.com/v1/models`):
+
+```php
+	public function fetch_remote_models(): array {
+		$api_key = $this->get_api_key();
+		if ( empty( $api_key ) ) {
+			return array();
+		}
+		$response = wp_remote_get(
+			'https://api.openai.com/v1/models',
+			array(
+				'timeout' => 15,
+				'headers' => array( 'Authorization' => 'Bearer ' . $api_key ),
+			)
+		);
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return array();
+		}
+		return self::parse_models_response( (array) json_decode( wp_remote_retrieve_body( $response ), true ) );
+	}
+
+	/**
+	 * Keep chat-capable models only (gpt-* / o-series), excluding embeddings,
+	 * audio, image, realtime, and moderation models.
+	 *
+	 * @param array $body Decoded response body.
+	 * @return array<string, string>
+	 */
+	public static function parse_models_response( array $body ): array {
+		$models = array();
+		foreach ( $body['data'] ?? array() as $m ) {
+			$id = (string) ( $m['id'] ?? '' );
+			if ( '' === $id ) {
+				continue;
+			}
+			$is_chat = (bool) preg_match( '/^(gpt-|o\d)/', $id );
+			$exclude = (bool) preg_match( '/(embedding|whisper|tts|dall-e|realtime|moderation|audio|image|transcribe|search|sora)/', $id );
+			if ( $is_chat && ! $exclude ) {
+				$models[ $id ] = $id;
+			}
+		}
+		return $models;
+	}
+```
+
+Add to **Google** (auth: `?key=`; endpoint `https://generativelanguage.googleapis.com/v1beta/models`):
+
+```php
+	public function fetch_remote_models(): array {
+		$api_key = $this->get_api_key();
+		if ( empty( $api_key ) ) {
+			return array();
+		}
+		$response = wp_remote_get(
+			'https://generativelanguage.googleapis.com/v1beta/models?pageSize=200&key=' . rawurlencode( $api_key ),
+			array( 'timeout' => 15 )
+		);
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return array();
+		}
+		return self::parse_models_response( (array) json_decode( wp_remote_retrieve_body( $response ), true ) );
+	}
+
+	/**
+	 * Keep text-generation models (supportedGenerationMethods contains
+	 * generateContent), excluding embedding/image-only models.
+	 *
+	 * @param array $body Decoded response body.
+	 * @return array<string, string>
+	 */
+	public static function parse_models_response( array $body ): array {
+		$models = array();
+		foreach ( $body['models'] ?? array() as $m ) {
+			$name    = (string) ( $m['name'] ?? '' );
+			$methods = (array) ( $m['supportedGenerationMethods'] ?? array() );
+			if ( '' === $name || ! in_array( 'generateContent', $methods, true ) ) {
+				continue;
+			}
+			$id            = preg_replace( '#^models/#', '', $name );
+			$models[ $id ] = (string) ( $m['displayName'] ?? $id );
+		}
+		return $models;
+	}
+```
+
+Add to **xAI** (auth: `Authorization: Bearer`; endpoint `https://api.x.ai/v1/models`):
+
+```php
+	public function fetch_remote_models(): array {
+		$api_key = $this->get_api_key();
+		if ( empty( $api_key ) ) {
+			return array();
+		}
+		$response = wp_remote_get(
+			'https://api.x.ai/v1/models',
+			array(
+				'timeout' => 15,
+				'headers' => array( 'Authorization' => 'Bearer ' . $api_key ),
+			)
+		);
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return array();
+		}
+		return self::parse_models_response( (array) json_decode( wp_remote_retrieve_body( $response ), true ) );
+	}
+
+	/**
+	 * Keep grok-* chat models only.
+	 *
+	 * @param array $body Decoded response body.
+	 * @return array<string, string>
+	 */
+	public static function parse_models_response( array $body ): array {
+		$models = array();
+		foreach ( $body['data'] ?? array() as $m ) {
+			$id = (string) ( $m['id'] ?? '' );
+			if ( '' !== $id && 0 === strpos( $id, 'grok-' ) && false === strpos( $id, 'image' ) ) {
+				$models[ $id ] = $id;
+			}
+		}
+		return $models;
+	}
+```
+
+- [ ] **Step 4: Run → pass** — `vendor/bin/phpunit --testsuite unit`.
+- [ ] **Step 5: Gate** — PHPStan `[OK]`; PHPCS no new errors on the 4 providers.
+- [ ] **Step 6: Commit** — `feat: per-provider fetch_remote_models() + pure parsers (+unit tests)`.
+
+> **Verify-against-live (implementation note, not a placeholder):** the include/exclude regexes are conservative starting points. After implementing, run one live `fetch_remote_models()` per provider you have a key for (via `wp eval`) and confirm the returned set looks right; tighten the filters if a provider surfaces an unexpected family. Curated lists remain the canonical labels regardless.
+
+---
+
+## Task 3: `SWPS_Model_Discovery` service (TDD for merge + diff)
+
+**Files:** Create `includes/class-model-discovery.php`; create `tests/unit/ModelDiscoveryTest.php`. (If `phpunit.xml.dist` lacks a `unit` testsuite — i.e. #41 not merged — add it: a `<testsuite name="unit"><directory>tests/unit</directory></testsuite>` entry.)
+
+- [ ] **Step 1: Failing tests** — `tests/unit/ModelDiscoveryTest.php` covering the two pure helpers:
+
+```php
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-model-discovery.php';
+
+final class ModelDiscoveryTest extends TestCase {
+
+	public function test_merge_prefers_curated_label_and_order(): void {
+		$curated    = array( 'a' => 'Curated A', 'b' => 'Curated B' );
+		$discovered = array( 'b' => 'Discovered B', 'c' => 'Discovered C' );
+		$merged     = SWPS_Model_Discovery::merge_models( $curated, $discovered );
+		// Curated entries keep their label and come first; new discovered appended.
+		$this->assertSame(
+			array( 'a' => 'Curated A', 'b' => 'Curated B', 'c' => 'Discovered C' ),
+			$merged
+		);
+	}
+
+	public function test_diff_returns_only_unknown_ids(): void {
+		$known     = array( 'a', 'b' );
+		$current   = array( 'a', 'b', 'c', 'd' );
+		$this->assertSame( array( 'c', 'd' ), SWPS_Model_Discovery::diff_new_ids( $known, $current ) );
+	}
+
+	public function test_diff_empty_known_returns_all(): void {
+		$this->assertSame( array( 'a' ), SWPS_Model_Discovery::diff_new_ids( array(), array( 'a' ) ) );
+	}
+}
+```
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement** `includes/class-model-discovery.php`:
+
+```php
+<?php
+/**
+ * Discovers available models from provider APIs and merges them with the
+ * curated lists. Refreshed daily; never auto-switches the selected model.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_Model_Discovery {
+
+	private const OPTION_DISCOVERED = 'swps_discovered_models'; // [ slug => [id=>label] ].
+	private const OPTION_KNOWN      = 'swps_known_model_ids';   // [ id, ... ].
+	private const OPTION_NEW        = 'swps_new_models_available'; // [ id => label ].
+
+	/** Curated ∪ discovered text models for a provider. */
+	public function get_text_models( string $provider_slug ): array {
+		$curated    = SWPS_Provider_Factory::curated_models_for_provider( $provider_slug );
+		$discovered = ( get_option( self::OPTION_DISCOVERED, array() )[ $provider_slug ] ?? array() );
+		return self::merge_models( $curated, $discovered );
+	}
+
+	/** Curated ∪ discovered Gemini image models. */
+	public function get_image_models(): array {
+		$curated    = SWPS_Gemini_Image_Provider::curated_models();
+		$discovered = ( get_option( self::OPTION_DISCOVERED, array() )['gemini-image'] ?? array() );
+		return self::merge_models( $curated, $discovered );
+	}
+
+	/** Daily cron: refresh discovered models for every configured provider. */
+	public function refresh(): void {
+		$store = (array) get_option( self::OPTION_DISCOVERED, array() );
+		$seen  = array();
+
+		foreach ( SWPS_Provider_Factory::all_ai_providers() as $slug => $provider ) {
+			$found = $provider->fetch_remote_models();
+			if ( ! empty( $found ) ) {
+				$store[ $slug ] = $found;            // keep last-good if empty.
+			}
+			$seen = array_merge( $seen, array_keys( $store[ $slug ] ?? array() ) );
+		}
+
+		$image_provider = new SWPS_Gemini_Image_Provider();
+		$found_image    = $image_provider->fetch_remote_models();
+		if ( ! empty( $found_image ) ) {
+			$store['gemini-image'] = $found_image;
+		}
+		$seen = array_merge( $seen, array_keys( $store['gemini-image'] ?? array() ) );
+
+		update_option( self::OPTION_DISCOVERED, $store );
+
+		$known = (array) get_option( self::OPTION_KNOWN, array() );
+		if ( empty( $known ) ) {
+			update_option( self::OPTION_KNOWN, array_values( array_unique( $seen ) ) ); // seed silently.
+			return;
+		}
+
+		$new = self::diff_new_ids( $known, array_values( array_unique( $seen ) ) );
+		if ( ! empty( $new ) ) {
+			$labels = self::labels_for( $store, $new );
+			update_option( self::OPTION_NEW, array_replace( (array) get_option( self::OPTION_NEW, array() ), $labels ) );
+			update_option( self::OPTION_KNOWN, array_values( array_unique( array_merge( $known, $new ) ) ) );
+		}
+	}
+
+	public function dismiss_alert(): void {
+		delete_option( self::OPTION_NEW );
+	}
+
+	public function new_models(): array {
+		return (array) get_option( self::OPTION_NEW, array() );
+	}
+
+	/** Curated ∪ discovered; curated label + order wins, new discovered appended. */
+	public static function merge_models( array $curated, array $discovered ): array {
+		$merged = $curated;
+		foreach ( $discovered as $id => $label ) {
+			if ( ! array_key_exists( $id, $merged ) ) {
+				$merged[ $id ] = $label;
+			}
+		}
+		return $merged;
+	}
+
+	/** IDs in $current not present in $known. */
+	public static function diff_new_ids( array $known, array $current ): array {
+		return array_values( array_diff( $current, $known ) );
+	}
+
+	/** Look up labels for IDs across the per-slug discovered store. */
+	private static function labels_for( array $store, array $ids ): array {
+		$flat = array();
+		foreach ( $store as $models ) {
+			$flat += (array) $models;
+		}
+		$out = array();
+		foreach ( $ids as $id ) {
+			$out[ $id ] = $flat[ $id ] ?? $id;
+		}
+		return $out;
+	}
+}
+```
+
+- [ ] **Step 4: Run → pass** (`--testsuite unit`).
+- [ ] **Step 5: Gate** — PHPStan `[OK]` (note: this references `SWPS_Provider_Factory::curated_models_for_provider/all_ai_providers` and `SWPS_Gemini_Image_Provider::curated_models` — added in Tasks 4 & 5; if implementing strictly in order, those methods land in Task 4/5 and PHPStan goes green then. Sequence Task 4 immediately after.)
+- [ ] **Step 6: Commit** — `feat: SWPS_Model_Discovery service (merge/diff/refresh/dismiss + unit tests)`.
+
+---
+
+## Task 4: Factory wiring — merged dropdown + helpers
+
+**Files:** Modify `includes/class-provider-factory.php`
+
+- [ ] **Step 1:** Add a `curated_models_for_provider()` (the current `get_models_for_provider` body) and an `all_ai_providers()` helper, then make `get_models_for_provider()` return the **merged** list:
+
+```php
+	/** Curated (hardcoded) models for a provider — the canonical labels/order. */
+	public static function curated_models_for_provider( string $slug ): array {
+		$class = self::AI_PROVIDERS[ $slug ] ?? null;
+		if ( ! $class ) {
+			return array();
+		}
+		return ( new $class() )->get_available_models();
+	}
+
+	/** Instantiate every AI provider, keyed by slug. */
+	public static function all_ai_providers(): array {
+		$out = array();
+		foreach ( self::AI_PROVIDERS as $slug => $class ) {
+			$out[ $slug ] = new $class();
+		}
+		return $out;
+	}
+
+	/** Curated ∪ discovered models for the dropdown. */
+	public static function get_models_for_provider( string $slug ): array {
+		return ( new SWPS_Model_Discovery() )->get_text_models( $slug );
+	}
+```
+
+(`get_text_models()` itself calls `curated_models_for_provider()`, so the curated list is always the floor even if discovery is empty.)
+
+- [ ] **Step 2: Gate** — PHPStan `[OK]`; `composer test` green (Task 3's service now resolves). PHPCS no new errors.
+- [ ] **Step 3: Commit** — `feat: factory returns curated ∪ discovered models`.
+
+---
+
+## Task 5: Gemini image model — discovery + selectable setting
+
+**Files:** Modify `includes/providers/images/class-gemini-provider.php`, `includes/class-settings.php`, `admin/js/admin.js`, `stratawp-seo.php` (default)
+
+- [ ] **Step 1:** In `class-gemini-provider.php`, add curated image models + remote fetch, and read the setting. Replace the bare `self::MODEL` usage in `generate_image()`'s URL with the configured model:
+
+```php
+	/** Curated Gemini image models — MODEL is the default/fallback. */
+	public static function curated_models(): array {
+		return array(
+			self::MODEL => 'Gemini Image (default)',
+		);
+	}
+
+	/** The configured image model, falling back to the constant. */
+	private function image_model(): string {
+		$model = (string) get_option( 'swps_gemini_image_model', '' );
+		return '' !== $model ? $model : self::MODEL;
+	}
+
+	public function fetch_remote_models(): array {
+		$api_key = $this->get_api_key();
+		if ( empty( $api_key ) ) {
+			return array();
+		}
+		$response = wp_remote_get(
+			'https://generativelanguage.googleapis.com/v1beta/models?pageSize=200&key=' . rawurlencode( $api_key ),
+			array( 'timeout' => 15 )
+		);
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return array();
+		}
+		return self::parse_models_response( (array) json_decode( wp_remote_retrieve_body( $response ), true ) );
+	}
+
+	/**
+	 * Keep image-generation-capable Gemini models.
+	 *
+	 * @param array $body Decoded /v1beta/models body.
+	 * @return array<string, string>
+	 */
+	public static function parse_models_response( array $body ): array {
+		$models = array();
+		foreach ( $body['models'] ?? array() as $m ) {
+			$name = (string) ( $m['name'] ?? '' );
+			if ( '' === $name || false === strpos( $name, 'image' ) ) {
+				continue;
+			}
+			$id            = preg_replace( '#^models/#', '', $name );
+			$models[ $id ] = (string) ( $m['displayName'] ?? $id );
+		}
+		return $models;
+	}
+```
+
+Then in `generate_image()`, change the URL build from `self::API_BASE . self::MODEL . ':generateContent...'` to `self::API_BASE . $this->image_model() . ':generateContent...'`.
+
+> **Verify-against-live:** confirm the `image`-in-name filter matches Google's actual image-model naming for your key; widen to a `supportedGenerationMethods` check if needed.
+
+- [ ] **Step 2:** Register the setting + default. In `stratawp-seo.php` defaults array add `'gemini_image_model' => ''`. In `class-settings.php`, in the Featured Images section, register `swps_gemini_image_model` and add a `select` field (after the Gemini key info row) whose options come from `( new SWPS_Model_Discovery() )->get_image_models()`, with `row_class => 'swps-image-key-row swps-image-provider-gemini'` so it shows only when Gemini is the image provider (existing visibility pattern). Mirror the existing `add_field`/`register_setting` calls in that section.
+
+- [ ] **Step 3:** `admin.js` — the image-model row uses the existing `swps-image-provider-gemini` class, so `updateImageKeyVisibility()` already shows/hides it with the other Gemini rows. Confirm no JS change needed (verify the row class matches); if the field needs to show regardless of the "featured images enabled" gate, adjust the selector. `node --check admin/js/admin.js`.
+
+- [ ] **Step 4: Gate** — PHPStan `[OK]`; PHPCS no new errors; `composer test` green.
+- [ ] **Step 5: Commit** — `feat: selectable Gemini image model with discovery + fallback`.
+
+---
+
+## Task 6: Daily refresh cron
+
+**Files:** Create `includes/class-model-cron.php`; modify `stratawp-seo.php`
+
+- [ ] **Step 1:** Create `includes/class-model-cron.php` mirroring `SWPS_Cron`'s schedule pattern:
+
+```php
+<?php
+/**
+ * Daily WP-Cron job that refreshes discovered models.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_Model_Cron {
+
+	private const HOOK = 'swps_refresh_models';
+
+	private SWPS_Model_Discovery $discovery;
+
+	public function __construct( SWPS_Model_Discovery $discovery ) {
+		$this->discovery = $discovery;
+		add_action( self::HOOK, array( $this, 'run' ) );
+		add_action( 'init', array( $this, 'ensure_scheduled' ) );
+	}
+
+	public function ensure_scheduled(): void {
+		if ( ! wp_next_scheduled( self::HOOK ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', self::HOOK );
+		}
+	}
+
+	public function run(): void {
+		$this->discovery->refresh();
+	}
+
+	public static function unschedule(): void {
+		$ts = wp_next_scheduled( self::HOOK );
+		if ( $ts ) {
+			wp_unschedule_event( $ts, self::HOOK );
+		}
+		wp_unschedule_hook( self::HOOK );
+	}
+}
+```
+
+- [ ] **Step 2:** In `stratawp-seo.php`, instantiate the service + cron once (near the other subsystem init): `$discovery = new SWPS_Model_Discovery(); new SWPS_Model_Cron( $discovery );`. Call `SWPS_Model_Cron::unschedule()` in the plugin's deactivation handler (find the existing `register_deactivation_hook` / deactivate method and add it alongside the other unschedules).
+- [ ] **Step 3: Gate** — PHPStan `[OK]`; PHPCS no new errors.
+- [ ] **Step 4: Integration check (WP-CLI, staging):** `wp cron event run swps_refresh_models`; then `wp option get swps_discovered_models --format=json` (populated for configured providers) and `wp option get swps_known_model_ids --format=json` (seeded). `wp option get swps_new_models_available` empty on first run (silent seed).
+- [ ] **Step 5: Commit** — `feat: daily swps_refresh_models cron`.
+
+---
+
+## Task 7: New-model admin notice + dismiss
+
+**Files:** Modify `stratawp-seo.php` (or a small admin class)
+
+- [ ] **Step 1:** Register an `admin_notices` handler + a dismiss AJAX action:
+
+```php
+	public function model_alert_notice(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		$new = ( new SWPS_Model_Discovery() )->new_models();
+		if ( empty( $new ) ) {
+			return;
+		}
+		$names = implode( ', ', array_map( 'esc_html', array_values( $new ) ) );
+		$url   = esc_url( admin_url( 'admin.php?page=swps-settings' ) );
+		printf(
+			'<div class="notice notice-info is-dismissible swps-model-alert"><p>%s <a href="%s">%s</a></p></div>',
+			sprintf(
+				/* translators: %s = comma-separated model names */
+				esc_html__( 'StrataWP SEO: new AI model(s) available — %s.', 'stratawp-seo' ),
+				$names // already escaped above.
+			),
+			$url,
+			esc_html__( 'Choose in Settings', 'stratawp-seo' )
+		);
+	}
+
+	public function ajax_dismiss_model_alert(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error();
+		}
+		( new SWPS_Model_Discovery() )->dismiss_alert();
+		wp_send_json_success();
+	}
+```
+
+Hook them: `add_action( 'admin_notices', array( $this, 'model_alert_notice' ) );` and `add_action( 'wp_ajax_swps_dismiss_model_alert', array( $this, 'ajax_dismiss_model_alert' ) );`. Wire the WP `is-dismissible` close button to the AJAX action in `admin.js` (jQuery `.on('click', '.swps-model-alert .notice-dismiss', ...)` POSTing `action=swps_dismiss_model_alert` + `swpsAdmin.nonce`).
+
+> The `$names` string is pre-escaped via `array_map('esc_html', ...)`; pass it through `%s` without re-escaping. Verify PHPCS is satisfied (it may want a `wp_kses_post` wrapper — adjust to satisfy the sniff without double-escaping).
+
+- [ ] **Step 2: Gate** — PHPStan `[OK]`; PHPCS no new errors; `node --check admin/js/admin.js`.
+- [ ] **Step 3: Integration check (staging):** with `swps_new_models_available` set, load any admin page → notice shows; dismiss → option cleared (`wp option get swps_new_models_available` → empty/false).
+- [ ] **Step 4: Commit** — `feat: dismissible new-model admin notice`.
+
+---
+
+## Task 8: Version bump, changelog, zip
+
+**Files:** `stratawp-seo.php`, `README.md`, `readme.txt`
+
+- [ ] **Step 1:** Bump version (read the current values first — depends on whether #41 merged: likely **4.8.0** if #41 (4.7.0) is in, else reconcile). Update the header `Version:`, `SWPS_VERSION`, `readme.txt` `Stable tag:`, and the `README.md` badge to the chosen version.
+- [ ] **Step 2:** Changelog entries (dated `= X.Y.Z — 2026-MM-DD =` in readme.txt; `### vX.Y.Z — Month Year` in README.md):
+  - "Feature: AI models are now auto-discovered from each configured provider's API (daily) and added to the model dropdown automatically, with a dismissible alert when a new model appears."
+  - "Feature: the Gemini image model is now selectable in Settings (auto-discovered), replacing the hardcoded model — no more breakage when Google renames the image model."
+- [ ] **Step 3: Gate** — PHPStan `[OK]`; `composer test` green.
+- [ ] **Step 4:** Rebuild the deployment zip (same exclude list as the prior release; exclude `docs/`, `tests/`, `vendor/`, `.git/`, dev config, `.phpunit.cache/`).
+- [ ] **Step 5: Commit** — `chore: release vX.Y.0 — model discovery`.
+
+---
+
+## Self-review (completed)
+
+- **Spec coverage:** §1 service → Task 3; §2 per-provider fetch+parse → Tasks 1–2 (text) + Task 5 (image); §3 dropdown wiring → Task 4 (text) + Task 5 (image setting); §4 cron → Task 6; §5 alert → Task 7; rollout → Task 8. Graceful-degradation (empty/error → curated) baked into `fetch_remote_models()` (returns `[]`) + `merge_models()` floor. First-run silent seed → Task 3 `refresh()`. No-auto-switch → discovery only adds options; selection unchanged.
+- **Method-name consistency:** `fetch_remote_models`, `parse_models_response`, `merge_models`, `diff_new_ids`, `get_text_models`, `get_image_models`, `refresh`, `dismiss_alert`, `new_models`, `curated_models_for_provider`, `all_ai_providers`, `curated_models`, `image_model` — used identically across tasks.
+- **Cross-task dependency:** Task 3's service references factory/provider helpers defined in Tasks 4 & 5 — implement in order 1→2→3→4→5→6→7→8; PHPStan goes green at Task 4/5 (note in Task 3). 
+- **Testing reality:** pure parsers/merge/diff are unit-tested (no WP); HTTP, cron, settings, notice verified via WP-CLI/browser on staging.

--- a/docs/superpowers/specs/2026-05-29-model-discovery-design.md
+++ b/docs/superpowers/specs/2026-05-29-model-discovery-design.md
@@ -1,0 +1,103 @@
+# Model Discovery — Design
+
+**Date:** 2026-05-29
+**Status:** Approved (design), pending implementation plan
+**Affects:** AI Model dropdown, Featured Images settings (new Gemini Image Model field), AI/image provider classes
+**Branch:** its own branch off `main`, independent of the async-image PR (#41). Version finalizes at release based on merge order.
+
+## Problem
+
+AI text models and the Gemini image model are hardcoded — each AI provider's `get_available_models()` and a `MODEL` constant in `SWPS_Gemini_Image_Provider`. When a provider ships a new model (e.g. Claude Opus 4.8) or renames an image model, the plugin can't use it until someone edits the code and ships a release. The Gemini image-model constant has gone **stale and broken image generation before** (git history: `gemini-2.5-flash-preview-image-generation` → corrected). Users want new models to surface automatically, with a heads-up.
+
+## Goals
+
+- New text models from each *configured* provider appear in the AI Model dropdown automatically (daily refresh).
+- The Gemini image model becomes **selectable** (new dropdown) and stays current — ending stale-constant breakage.
+- A **dismissible admin alert** when a never-before-seen model appears.
+- **Graceful degradation:** if a provider API is unreachable or no key is set, fall back to the curated lists (dropdown never empty or full of noise).
+
+## Non-goals
+
+- **No auto-switching** of the user's selected model (text or image). Discovery only adds options + alerts.
+- No plugin-version auto-update changes (the existing `SWPS_GitHub_Updater` is untouched).
+- No discovery for stock image providers (Unsplash/Pexels/Pixabay have no model versioning).
+
+## Approach
+
+Curated ∪ discovered, refreshed by a daily WP-Cron job, cached, with a dismissible admin notice on new models. The curated lists remain the labeled/ordered source of truth and fallback.
+
+## Architecture
+
+### 1. `SWPS_Model_Discovery` (new class)
+
+- `get_text_models( string $provider_slug ): array` — curated (`$provider->get_available_models()`) **∪** cached-discovered for that provider, deduped by ID with curated label/order winning.
+- `get_image_models(): array` — curated Gemini image models **∪** cached-discovered image-capable Gemini models.
+- `refresh(): void` — daily-cron callback. For each provider with a configured API key:
+  1. `fetch_remote_models()`; if it returns `[]` (error/no key), keep the last-good cached value (don't clobber).
+  2. Store the result in a persistent option `swps_discovered_models` keyed by provider slug. The daily cron *is* the refresh cadence, so the option is the cache — always available to the dropdown between runs, and it survives transient expiry by design.
+  3. Diff discovered IDs against `swps_known_model_ids`. **If the known set is empty (first run), seed it silently — no alert.** Otherwise, newly-seen IDs are appended to `swps_new_models_available` (for the alert) and added to the known set.
+- `dismiss_alert(): void` — clears `swps_new_models_available`.
+
+### 2. Per-provider `fetch_remote_models(): array`
+
+Returns `[ model_id => display_name ]`. On `WP_Error` / non-200 / malformed body → return `[]`. To keep it unit-testable, split each into a thin HTTP method + a **pure static `parse_models_response( array $body ): array`** (the filter/map logic).
+
+- **Anthropic** `GET https://api.anthropic.com/v1/models` (headers `x-api-key`, `anthropic-version: 2023-06-01`) → `data[].{id, display_name}`. All entries are chat models; map `id → display_name`.
+- **OpenAI** `GET https://api.openai.com/v1/models` (Bearer) → `data[].id`; **filter to chat models** (keep `gpt-*` and `o*`; exclude `*embedding*`, `whisper*`, `tts*`, `dall-e*`, `*realtime*`, `*moderation*`, `*audio*`); prettify id → label.
+- **Google** `GET https://generativelanguage.googleapis.com/v1beta/models?key={key}` → `models[]`; keep where `supportedGenerationMethods` contains `generateContent` and the model is not image/embedding-only; map `name` (strip `models/`) → `displayName`.
+- **xAI** `GET https://api.x.ai/v1/models` (Bearer) → `data[].id`; filter `grok-*` (exclude image/embedding variants).
+- **Gemini image** (`SWPS_Gemini_Image_Provider::fetch_remote_models()`): same Google endpoint; keep models whose capabilities/name indicate **image generation** (e.g. name contains `image`); map `name` → `displayName`.
+
+### 3. Wiring the dropdowns
+
+- `SWPS_Provider_Factory::get_models_for_provider( $slug )` → return `SWPS_Model_Discovery::get_text_models( $slug )`. This already feeds the AI Model dropdown via `ajax_get_models()` and the initial settings render, so **discovered text models appear with no other UI change**.
+- **New setting `swps_gemini_image_model`** (default = the current constant value), registered in the Featured Images section, rendered as a `select` populated by `SWPS_Model_Discovery::get_image_models()`, shown only when image provider = Gemini (reuse the `admin.js` row-visibility pattern from the §6 fix).
+- `SWPS_Gemini_Image_Provider` reads `get_option( 'swps_gemini_image_model', self::MODEL )` instead of the bare constant — the constant becomes the documented default/fallback.
+
+### 4. Daily refresh cron
+
+- Register a daily `swps_refresh_models` event (mirror `SWPS_Cron`'s schedule/unschedule pattern). Callback → `SWPS_Model_Discovery::refresh()`. Ensure-scheduled on init; unschedule on deactivation.
+
+### 5. Alert (admin notice)
+
+- `admin_notices` handler: if `swps_new_models_available` is non-empty, render a **dismissible** notice listing the new models + a link to Settings. Dismiss via a small AJAX action `swps_dismiss_model_alert` (nonce + `manage_options`) → `dismiss_alert()`. Shown on StrataWP-SEO admin pages.
+
+## Data flow
+
+```
+daily cron → refresh()
+  └─ per configured provider: fetch_remote_models() → store in swps_discovered_models[slug]
+       → diff vs swps_known_model_ids → new IDs → swps_new_models_available
+
+settings render / ajax_get_models → get_text_models()/get_image_models() → curated ∪ cached → dropdown
+
+admin_notices → swps_new_models_available non-empty → dismissible notice → dismiss clears it
+```
+
+## Edge cases / safeguards
+
+- **No API key** for a provider → skipped in `refresh()`; `get_*_models()` returns curated only.
+- **API down / rate-limited / malformed** → `fetch_remote_models()` returns `[]`; curated fallback; **don't overwrite the cached option with empty** (keep last-good).
+- **First run** seeds `swps_known_model_ids` silently (no alert on the existing baseline).
+- **Duplicate** (discovered model already curated) → merged by ID, curated label/order wins.
+- **Deprecated/removed** models still in curated → kept (discovery only adds; never prunes curated).
+- **Cost/rate:** one list call per configured provider per day, cached → negligible.
+
+## Testing
+
+- **Pure unit (PHPUnit, no WP)** — add to the `unit` testsuite:
+  - `parse_models_response()` per provider against captured JSON fixtures: OpenAI excludes embeddings/audio/image; Google keeps only `generateContent`; Anthropic maps `display_name`; xAI keeps `grok-*`; Gemini-image keeps image models.
+  - Merge logic: curated ∪ discovered dedupes by ID, curated label wins, order stable.
+  - Diff logic: empty known-set seeds silently (no new-model output); a subsequent unknown ID is reported once.
+- **Integration (WP-CLI, manual, staging)** — `wp cron event run swps_refresh_models`; assert transient/option populated, `swps_new_models_available` set on a genuinely new model, dropdown includes discovered models, notice renders and dismisses.
+
+## Rollout
+
+- Minor version bump — next after the async-image release (likely **4.8.0**; finalize at release depending on merge order with PR #41).
+- New option `swps_gemini_image_model` defaults to the current constant → **no behavior change** until the user selects a different image model.
+- README.md + readme.txt changelog; build deployment zip.
+
+## Open items (resolve during implementation)
+
+- Exact per-provider include/exclude filter rules — refine against live API responses; keep filters permissive and rely on curated for canonical labels/ordering.
+- Final version number (merge-order dependent with PR #41).

--- a/includes/class-ai-provider.php
+++ b/includes/class-ai-provider.php
@@ -56,6 +56,19 @@ abstract class SWPS_AI_Provider {
 	abstract public function get_available_models(): array;
 
 	/**
+	 * Fetch the live model list from the provider's API.
+	 *
+	 * Providers override this to query their /models endpoint. The default
+	 * returns an empty list, so discovery is a no-op for providers that
+	 * don't implement it.
+	 *
+	 * @return array<string, string> Model ID => display name (empty on error/unsupported).
+	 */
+	public function fetch_remote_models(): array {
+		return array();
+	}
+
+	/**
 	 * Get the provider slug (e.g., 'anthropic', 'openai').
 	 */
 	abstract public function get_slug(): string;

--- a/includes/class-model-cron.php
+++ b/includes/class-model-cron.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Daily WP-Cron job that refreshes discovered models.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Schedules and runs the daily swps_refresh_models cron event.
+ */
+class SWPS_Model_Cron {
+
+	/**
+	 * The WP-Cron hook name.
+	 */
+	private const HOOK = 'swps_refresh_models';
+
+	/**
+	 * The model discovery service instance.
+	 *
+	 * @var SWPS_Model_Discovery
+	 */
+	private SWPS_Model_Discovery $discovery;
+
+	/**
+	 * Constructor — registers cron callback and schedule-ensure hook.
+	 *
+	 * @param SWPS_Model_Discovery $discovery Model discovery service.
+	 */
+	public function __construct( SWPS_Model_Discovery $discovery ) {
+		$this->discovery = $discovery;
+		add_action( self::HOOK, array( $this, 'run' ) );
+		add_action( 'init', array( $this, 'ensure_scheduled' ) );
+	}
+
+	/**
+	 * Schedule the daily event if it is not already queued.
+	 *
+	 * Runs on the `init` hook so WP functions are available. Delays the first
+	 * run by one hour to avoid slowing page loads on first activation.
+	 *
+	 * @return void
+	 */
+	public function ensure_scheduled(): void {
+		if ( ! wp_next_scheduled( self::HOOK ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', self::HOOK );
+		}
+	}
+
+	/**
+	 * Cron callback — delegates to the discovery service refresh.
+	 *
+	 * @return void
+	 */
+	public function run(): void {
+		$this->discovery->refresh();
+	}
+
+	/**
+	 * Unschedule all pending instances of the cron event.
+	 *
+	 * Called on plugin deactivation.
+	 *
+	 * @return void
+	 */
+	public static function unschedule(): void {
+		$ts = wp_next_scheduled( self::HOOK );
+		if ( $ts ) {
+			wp_unschedule_event( $ts, self::HOOK );
+		}
+		wp_unschedule_hook( self::HOOK );
+	}
+}

--- a/includes/class-model-discovery.php
+++ b/includes/class-model-discovery.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Discovers available models from provider APIs and merges them with the
+ * curated lists. Refreshed daily; never auto-switches the selected model.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Merges curated and API-discovered models, refreshes the discovered cache,
+ * and tracks newly-seen model IDs for a dismissible admin notice.
+ */
+class SWPS_Model_Discovery {
+
+	/**
+	 * Option: per-slug discovered models. Shape: [ slug => [ id => label ] ].
+	 */
+	private const OPTION_DISCOVERED = 'swps_discovered_models';
+
+	/**
+	 * Option: flat list of model IDs we've already seen. Shape: [ id, ... ].
+	 */
+	private const OPTION_KNOWN = 'swps_known_model_ids';
+
+	/**
+	 * Option: newly-seen models awaiting an admin notice. Shape: [ id => label ].
+	 */
+	private const OPTION_NEW = 'swps_new_models_available';
+
+	/**
+	 * Get the curated ∪ discovered text models for a provider.
+	 *
+	 * @param string $provider_slug AI provider slug.
+	 * @return array<string, string> model ID => display name.
+	 */
+	public function get_text_models( string $provider_slug ): array {
+		$curated    = SWPS_Provider_Factory::curated_models_for_provider( $provider_slug );
+		$discovered = ( get_option( self::OPTION_DISCOVERED, array() )[ $provider_slug ] ?? array() );
+		return self::merge_models( $curated, (array) $discovered );
+	}
+
+	/**
+	 * Get the curated ∪ discovered Gemini image models.
+	 *
+	 * @return array<string, string> model ID => display name.
+	 */
+	public function get_image_models(): array {
+		$curated    = SWPS_Gemini_Image_Provider::curated_models();
+		$discovered = ( get_option( self::OPTION_DISCOVERED, array() )['gemini-image'] ?? array() );
+		return self::merge_models( $curated, (array) $discovered );
+	}
+
+	/**
+	 * Daily cron: refresh discovered models for every configured provider.
+	 *
+	 * Keeps the last-good list when a provider returns nothing, seeds the
+	 * known-IDs list silently on first run, and flags genuinely new IDs for
+	 * a dismissible admin notice. Never changes the selected model.
+	 *
+	 * @return void
+	 */
+	public function refresh(): void {
+		$store = (array) get_option( self::OPTION_DISCOVERED, array() );
+		$seen  = array();
+
+		foreach ( SWPS_Provider_Factory::all_ai_providers() as $slug => $provider ) {
+			$found = $provider->fetch_remote_models();
+			if ( ! empty( $found ) ) {
+				$store[ $slug ] = $found; // Keep last-good if empty.
+			}
+			$seen = array_merge( $seen, array_keys( $store[ $slug ] ?? array() ) );
+		}
+
+		$image_provider = new SWPS_Gemini_Image_Provider();
+		$found_image    = $image_provider->fetch_remote_models();
+		if ( ! empty( $found_image ) ) {
+			$store['gemini-image'] = $found_image;
+		}
+		$seen = array_merge( $seen, array_keys( $store['gemini-image'] ?? array() ) );
+
+		update_option( self::OPTION_DISCOVERED, $store );
+
+		$known = (array) get_option( self::OPTION_KNOWN, array() );
+		if ( empty( $known ) ) {
+			update_option( self::OPTION_KNOWN, array_values( array_unique( $seen ) ) ); // Seed silently.
+			return;
+		}
+
+		$new = self::diff_new_ids( $known, array_values( array_unique( $seen ) ) );
+		if ( ! empty( $new ) ) {
+			$labels = self::labels_for( $store, $new );
+			update_option( self::OPTION_NEW, array_replace( (array) get_option( self::OPTION_NEW, array() ), $labels ) );
+			update_option( self::OPTION_KNOWN, array_values( array_unique( array_merge( $known, $new ) ) ) );
+		}
+	}
+
+	/**
+	 * Clear the pending new-model alert.
+	 *
+	 * @return void
+	 */
+	public function dismiss_alert(): void {
+		delete_option( self::OPTION_NEW );
+	}
+
+	/**
+	 * Get the pending new-model alert payload.
+	 *
+	 * @return array<string, string> model ID => display name.
+	 */
+	public function new_models(): array {
+		return (array) get_option( self::OPTION_NEW, array() );
+	}
+
+	/**
+	 * Merge curated ∪ discovered models; curated label + order wins, new
+	 * discovered entries are appended.
+	 *
+	 * @param array<string, string> $curated    Curated model ID => label.
+	 * @param array<string, string> $discovered Discovered model ID => label.
+	 * @return array<string, string> Merged model ID => label.
+	 */
+	public static function merge_models( array $curated, array $discovered ): array {
+		$merged = $curated;
+		foreach ( $discovered as $id => $label ) {
+			if ( ! array_key_exists( $id, $merged ) ) {
+				$merged[ $id ] = $label;
+			}
+		}
+		return $merged;
+	}
+
+	/**
+	 * Compute the IDs in $current that are not present in $known.
+	 *
+	 * @param array<int, string> $known   Known model IDs.
+	 * @param array<int, string> $current Currently-discovered model IDs.
+	 * @return array<int, string> IDs in $current absent from $known.
+	 */
+	public static function diff_new_ids( array $known, array $current ): array {
+		return array_values( array_diff( $current, $known ) );
+	}
+
+	/**
+	 * Look up labels for IDs across the per-slug discovered store.
+	 *
+	 * @param array<string, array<string, string>> $store Per-slug discovered models.
+	 * @param array<int, string>                   $ids   Model IDs to resolve.
+	 * @return array<string, string> model ID => label (falls back to the ID).
+	 */
+	private static function labels_for( array $store, array $ids ): array {
+		$flat = array();
+		foreach ( $store as $models ) {
+			$flat += (array) $models;
+		}
+		$out = array();
+		foreach ( $ids as $id ) {
+			$out[ $id ] = $flat[ $id ] ?? $id;
+		}
+		return $out;
+	}
+}

--- a/includes/class-provider-factory.php
+++ b/includes/class-provider-factory.php
@@ -80,11 +80,12 @@ class SWPS_Provider_Factory {
 	}
 
 	/**
-	 * Get available models for a specific AI provider slug.
+	 * Get the curated (hardcoded) models for a provider — the canonical labels/order.
 	 *
+	 * @param string $slug AI provider slug.
 	 * @return array<string, string> model ID => display name.
 	 */
-	public static function get_models_for_provider( string $slug ): array {
+	public static function curated_models_for_provider( string $slug ): array {
 		$class = self::AI_PROVIDERS[ $slug ] ?? null;
 
 		if ( ! $class ) {
@@ -93,5 +94,28 @@ class SWPS_Provider_Factory {
 
 		$instance = new $class();
 		return $instance->get_available_models();
+	}
+
+	/**
+	 * Instantiate every AI provider, keyed by slug.
+	 *
+	 * @return array<string, SWPS_AI_Provider> slug => provider instance.
+	 */
+	public static function all_ai_providers(): array {
+		$out = array();
+		foreach ( self::AI_PROVIDERS as $slug => $class ) {
+			$out[ $slug ] = new $class();
+		}
+		return $out;
+	}
+
+	/**
+	 * Get available models for a specific AI provider slug (curated ∪ discovered).
+	 *
+	 * @param string $slug AI provider slug.
+	 * @return array<string, string> model ID => display name.
+	 */
+	public static function get_models_for_provider( string $slug ): array {
+		return ( new SWPS_Model_Discovery() )->get_text_models( $slug );
 	}
 }

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -303,6 +303,17 @@ class SWPS_Settings {
 		);
 
 		$this->add_field(
+			'gemini_image_model',
+			__( 'Gemini Image Model', 'stratawp-seo' ),
+			'select',
+			'swps_images_section',
+			array(
+				'options'   => ( new SWPS_Model_Discovery() )->get_image_models(),
+				'row_class' => 'swps-image-key-row swps-image-provider-gemini',
+			)
+		);
+
+		$this->add_field(
 			'insert_content_images',
 			__( 'In-Content Images', 'stratawp-seo' ),
 			'checkbox',

--- a/includes/providers/ai/class-anthropic-provider.php
+++ b/includes/providers/ai/class-anthropic-provider.php
@@ -125,6 +125,48 @@ class SWPS_Anthropic_Provider extends SWPS_AI_Provider {
 		return $text;
 	}
 
+	/**
+	 * Fetch live text models from the Anthropic /v1/models endpoint.
+	 *
+	 * @return array<string, string> Model ID => display name (empty on error).
+	 */
+	public function fetch_remote_models(): array {
+		$api_key = $this->get_api_key();
+		if ( empty( $api_key ) ) {
+			return array();
+		}
+		$response = wp_remote_get(
+			'https://api.anthropic.com/v1/models?limit=100',
+			array(
+				'timeout' => 15,
+				'headers' => array(
+					'x-api-key'         => $api_key,
+					'anthropic-version' => '2023-06-01',
+				),
+			)
+		);
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return array();
+		}
+		return self::parse_models_response( (array) json_decode( wp_remote_retrieve_body( $response ), true ) );
+	}
+
+	/**
+	 * Map an Anthropic /v1/models body to [ id => display_name ].
+	 *
+	 * @param array $body Decoded response body.
+	 * @return array<string, string>
+	 */
+	public static function parse_models_response( array $body ): array {
+		$models = array();
+		foreach ( $body['data'] ?? array() as $m ) {
+			if ( ! empty( $m['id'] ) ) {
+				$models[ (string) $m['id'] ] = (string) ( $m['display_name'] ?? $m['id'] );
+			}
+		}
+		return $models;
+	}
+
 	public function test_key( string $api_key ): bool|WP_Error {
 		$response = wp_remote_post(
 			self::API_URL,

--- a/includes/providers/ai/class-google-provider.php
+++ b/includes/providers/ai/class-google-provider.php
@@ -112,6 +112,47 @@ class SWPS_Google_Provider extends SWPS_AI_Provider {
 		return $body['candidates'][0]['content']['parts'][0]['text'];
 	}
 
+	/**
+	 * Fetch live models from the Google /v1beta/models endpoint.
+	 *
+	 * @return array<string, string> Model ID => display name (empty on error).
+	 */
+	public function fetch_remote_models(): array {
+		$api_key = $this->get_api_key();
+		if ( empty( $api_key ) ) {
+			return array();
+		}
+		$response = wp_remote_get(
+			'https://generativelanguage.googleapis.com/v1beta/models?pageSize=200&key=' . rawurlencode( $api_key ),
+			array( 'timeout' => 15 )
+		);
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return array();
+		}
+		return self::parse_models_response( (array) json_decode( wp_remote_retrieve_body( $response ), true ) );
+	}
+
+	/**
+	 * Keep text-generation models (supportedGenerationMethods contains
+	 * generateContent), excluding embedding/image-only models.
+	 *
+	 * @param array $body Decoded response body.
+	 * @return array<string, string>
+	 */
+	public static function parse_models_response( array $body ): array {
+		$models = array();
+		foreach ( $body['models'] ?? array() as $m ) {
+			$name    = (string) ( $m['name'] ?? '' );
+			$methods = (array) ( $m['supportedGenerationMethods'] ?? array() );
+			if ( '' === $name || ! in_array( 'generateContent', $methods, true ) ) {
+				continue;
+			}
+			$id            = preg_replace( '#^models/#', '', $name );
+			$models[ $id ] = (string) ( $m['displayName'] ?? $id );
+		}
+		return $models;
+	}
+
 	public function test_key( string $api_key ): bool|WP_Error {
 		$model = $this->get_validated_model();
 		$url   = self::API_BASE . $model . ':generateContent?key=' . $api_key;

--- a/includes/providers/ai/class-openai-provider.php
+++ b/includes/providers/ai/class-openai-provider.php
@@ -112,6 +112,52 @@ class SWPS_OpenAI_Provider extends SWPS_AI_Provider {
 		return $body['choices'][0]['message']['content'];
 	}
 
+	/**
+	 * Fetch live models from the OpenAI /v1/models endpoint.
+	 *
+	 * @return array<string, string> Model ID => display name (empty on error).
+	 */
+	public function fetch_remote_models(): array {
+		$api_key = $this->get_api_key();
+		if ( empty( $api_key ) ) {
+			return array();
+		}
+		$response = wp_remote_get(
+			'https://api.openai.com/v1/models',
+			array(
+				'timeout' => 15,
+				'headers' => array( 'Authorization' => 'Bearer ' . $api_key ),
+			)
+		);
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return array();
+		}
+		return self::parse_models_response( (array) json_decode( wp_remote_retrieve_body( $response ), true ) );
+	}
+
+	/**
+	 * Keep chat-capable models only (gpt-* / o-series), excluding embeddings,
+	 * audio, image, realtime, and moderation models.
+	 *
+	 * @param array $body Decoded response body.
+	 * @return array<string, string>
+	 */
+	public static function parse_models_response( array $body ): array {
+		$models = array();
+		foreach ( $body['data'] ?? array() as $m ) {
+			$id = (string) ( $m['id'] ?? '' );
+			if ( '' === $id ) {
+				continue;
+			}
+			$is_chat = (bool) preg_match( '/^(gpt-|o\d|chatgpt-)/', $id );
+			$exclude = (bool) preg_match( '/(embedding|whisper|tts|dall-e|realtime|moderation|audio|image|transcribe|search|sora)/', $id );
+			if ( $is_chat && ! $exclude ) {
+				$models[ $id ] = $id;
+			}
+		}
+		return $models;
+	}
+
 	public function test_key( string $api_key ): bool|WP_Error {
 		$response = wp_remote_post(
 			self::API_URL,

--- a/includes/providers/ai/class-xai-provider.php
+++ b/includes/providers/ai/class-xai-provider.php
@@ -109,6 +109,46 @@ class SWPS_XAI_Provider extends SWPS_AI_Provider {
 		return $body['choices'][0]['message']['content'];
 	}
 
+	/**
+	 * Fetch live models from the xAI /v1/models endpoint.
+	 *
+	 * @return array<string, string> Model ID => display name (empty on error).
+	 */
+	public function fetch_remote_models(): array {
+		$api_key = $this->get_api_key();
+		if ( empty( $api_key ) ) {
+			return array();
+		}
+		$response = wp_remote_get(
+			'https://api.x.ai/v1/models',
+			array(
+				'timeout' => 15,
+				'headers' => array( 'Authorization' => 'Bearer ' . $api_key ),
+			)
+		);
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return array();
+		}
+		return self::parse_models_response( (array) json_decode( wp_remote_retrieve_body( $response ), true ) );
+	}
+
+	/**
+	 * Keep grok-* chat models only.
+	 *
+	 * @param array $body Decoded response body.
+	 * @return array<string, string>
+	 */
+	public static function parse_models_response( array $body ): array {
+		$models = array();
+		foreach ( $body['data'] ?? array() as $m ) {
+			$id = (string) ( $m['id'] ?? '' );
+			if ( '' !== $id && 0 === strpos( $id, 'grok-' ) && false === strpos( $id, 'image' ) ) {
+				$models[ $id ] = $id;
+			}
+		}
+		return $models;
+	}
+
 	public function test_key( string $api_key ): bool|WP_Error {
 		$response = wp_remote_post(
 			self::API_URL,

--- a/includes/providers/images/class-gemini-provider.php
+++ b/includes/providers/images/class-gemini-provider.php
@@ -40,6 +40,66 @@ class SWPS_Gemini_Image_Provider extends SWPS_Image_Provider {
 	}
 
 	/**
+	 * Get the curated Gemini image models — MODEL is the default/fallback.
+	 *
+	 * @return array<string, string> model ID => display name.
+	 */
+	public static function curated_models(): array {
+		return array(
+			self::MODEL => 'Gemini Image (default)',
+		);
+	}
+
+	/**
+	 * Get the configured image model, falling back to the constant.
+	 *
+	 * @return string The model ID to use for image generation.
+	 */
+	private function image_model(): string {
+		$model = (string) get_option( 'swps_gemini_image_model', '' );
+		return '' !== $model ? $model : self::MODEL;
+	}
+
+	/**
+	 * Fetch live image-capable models from the Google /v1beta/models endpoint.
+	 *
+	 * @return array<string, string> Model ID => display name (empty on error).
+	 */
+	public function fetch_remote_models(): array {
+		$api_key = $this->get_api_key();
+		if ( empty( $api_key ) ) {
+			return array();
+		}
+		$response = wp_remote_get(
+			'https://generativelanguage.googleapis.com/v1beta/models?pageSize=200&key=' . rawurlencode( $api_key ),
+			array( 'timeout' => 15 )
+		);
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return array();
+		}
+		return self::parse_models_response( (array) json_decode( wp_remote_retrieve_body( $response ), true ) );
+	}
+
+	/**
+	 * Keep image-generation-capable Gemini models.
+	 *
+	 * @param array $body Decoded /v1beta/models body.
+	 * @return array<string, string> Model ID => display name.
+	 */
+	public static function parse_models_response( array $body ): array {
+		$models = array();
+		foreach ( $body['models'] ?? array() as $m ) {
+			$name = (string) ( $m['name'] ?? '' );
+			if ( '' === $name || false === strpos( $name, 'image' ) ) {
+				continue;
+			}
+			$id            = preg_replace( '#^models/#', '', $name );
+			$models[ $id ] = (string) ( $m['displayName'] ?? $id );
+		}
+		return $models;
+	}
+
+	/**
 	 * Gemini benefits from descriptive prompts, so we don't strip words.
 	 */
 	protected function simplify_query( string $query ): string {
@@ -88,7 +148,7 @@ class SWPS_Gemini_Image_Provider extends SWPS_Image_Provider {
 	 * @return string|WP_Error Temp file path on success.
 	 */
 	public function generate_image( string $prompt, string $api_key, string $aspect = '1:1' ): string|WP_Error {
-		$url = self::API_BASE . self::MODEL . ':generateContent?key=' . $api_key;
+		$url = self::API_BASE . $this->image_model() . ':generateContent?key=' . $api_key;
 
 		$response = wp_remote_post(
 			$url,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,5 +17,8 @@
         <testsuite name="aeo-unit">
             <directory>tests/aeo</directory>
         </testsuite>
+        <testsuite name="unit">
+            <directory>tests/unit</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.6.5
+Stable tag: 4.8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -252,6 +252,10 @@ Yes. The built-in analytics tracker is cookie-free and does not use any external
 No. GSC integration is optional. The on-site analytics works entirely without any external services. Add Google OAuth credentials only if you want search clicks, impressions, and ranking data.
 
 == Changelog ==
+
+= 4.8.0 — 2026-05-29 =
+* Feature: AI models are now auto-discovered from each configured provider's API (Anthropic, OpenAI, Google, xAI) once a day and added to the model dropdown automatically, with a dismissible alert when a new model appears.
+* Feature: the Gemini image model is now selectable in Settings (auto-discovered), replacing the hardcoded model so image generation no longer breaks when Google renames the image model.
 
 = 4.6.5 — 2026-05-24 =
 * Fix: AEO Optimize "Request failed." alerts now show the actual error message. The JS `.fail()` handler previously displayed the generic fallback regardless of what the server returned — so AI-provider errors (rate limits, invalid API key, JSON parse failures, etc.) were being swallowed. A new `extractErrorMessage()` helper digs into `jqXHR.responseJSON.data.message`, falls back to the HTTP status, and appends a "Check StrataWP SEO → Debug" hint for AI-side failures.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -149,6 +149,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-cron.php';
 // v2.0 classes that depend on core.
 require_once SWPS_PLUGIN_DIR . 'includes/class-calendar.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-background-processor.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-model-cron.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-rest-api.php';
 
 // GitHub-based plugin updater.
@@ -322,6 +323,8 @@ final class StrataWP_SEO {
 		// Initialize v2.0 subsystems.
 		$this->calendar             = new SWPS_Calendar( $this->topic_queue );
 		$this->background_processor = new SWPS_Background_Processor();
+		$discovery                  = new SWPS_Model_Discovery();
+		new SWPS_Model_Cron( $discovery );
 		$this->rest_api             = new SWPS_REST_API();
 
 		// v4.0 admin shell — only relevant in admin, but instantiate always so REST routes register.
@@ -1216,6 +1219,7 @@ register_activation_hook( __FILE__, 'swps_activate' );
  */
 function swps_deactivate(): void {
 	SWPS_Cron::unschedule();
+	SWPS_Model_Cron::unschedule();
 	SWPS_SEO_Audit::unschedule_cron();
 	SWPS_Analytics_Tracker::unschedule_cron();
 	SWPS_Bot_Analytics_Tracker::unschedule_cron();

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -1100,6 +1100,13 @@ final class StrataWP_SEO {
 			return;
 		}
 
+		// Only render on StrataWP-SEO admin pages — that's where the dismiss
+		// handler JS is enqueued, so dismissals always persist.
+		$screen = get_current_screen();
+		if ( ! $screen || false === strpos( $screen->id, 'stratawp-seo' ) ) {
+			return;
+		}
+
 		$new = ( new SWPS_Model_Discovery() )->new_models();
 		if ( empty( $new ) ) {
 			return;

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.6.5
+ * Version: 4.8.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.6.5' );
+define( 'SWPS_VERSION', '4.8.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -1094,6 +1094,7 @@ function swps_activate(): void {
 		'pexels_api_key'              => '',
 		'pixabay_api_key'             => '',
 		// Gemini image provider reuses google_api_key — no separate key needed.
+		'gemini_image_model'          => '',
 		'model'                       => 'claude-sonnet-4-6',
 		'featured_images'             => 1,
 		'site_niche'                  => '',

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -47,6 +47,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/providers/images/class-gemini-provider.
 
 // Factory.
 require_once SWPS_PLUGIN_DIR . 'includes/class-provider-factory.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-model-discovery.php';
 
 // Legacy aliases (must load after concrete providers they extend).
 require_once SWPS_PLUGIN_DIR . 'includes/class-api.php';

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -351,10 +351,16 @@ final class StrataWP_SEO {
 		// Frontend assets.
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_frontend_assets' ) );
 
+		// Admin notices.
+		add_action( 'admin_notices', array( $this, 'model_alert_notice' ) );
+
 		// AJAX handlers — original.
 		add_action( 'wp_ajax_swps_generate_post', array( $this, 'ajax_generate_post' ) );
 		add_action( 'wp_ajax_swps_analyze_site', array( $this, 'ajax_analyze_site' ) );
 		add_action( 'wp_ajax_swps_get_models', array( $this, 'ajax_get_models' ) );
+
+		// AJAX handlers — model alert dismiss.
+		add_action( 'wp_ajax_swps_dismiss_model_alert', array( $this, 'ajax_dismiss_model_alert' ) );
 
 		// AJAX handlers — v2.0.
 		add_action( 'wp_ajax_swps_bulk_generate', array( $this, 'ajax_bulk_generate' ) );
@@ -1079,6 +1085,57 @@ final class StrataWP_SEO {
 				'results' => $this->seo_audit->get_cached_results(),
 			)
 		);
+	}
+
+	/**
+	 * Admin notice: show a dismissible alert when new AI models are discovered.
+	 *
+	 * Renders a `.notice.notice-info.is-dismissible.swps-model-alert` listing the
+	 * newly discovered model names with a link to the settings page.
+	 *
+	 * @return void
+	 */
+	public function model_alert_notice(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$new = ( new SWPS_Model_Discovery() )->new_models();
+		if ( empty( $new ) ) {
+			return;
+		}
+
+		$names = implode( ', ', array_map( 'esc_html', array_values( $new ) ) );
+		$url   = esc_url( admin_url( 'admin.php?page=swps-settings' ) );
+
+		/* translators: %s = comma-separated list of new AI model names */
+		$message = sprintf( esc_html__( 'StrataWP SEO: new AI model(s) available — %s.', 'stratawp-seo' ), $names );
+
+		printf(
+			'<div class="notice notice-info is-dismissible swps-model-alert"><p>%s <a href="%s">%s</a></p></div>',
+			$message, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- sprintf(esc_html__()) with pre-escaped $names.
+			$url, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- value is esc_url() output.
+			esc_html__( 'Choose in Settings', 'stratawp-seo' )
+		);
+	}
+
+	/**
+	 * AJAX handler: dismiss the new-model admin notice.
+	 *
+	 * Clears the `swps_new_models_available` option so the notice no longer shows.
+	 *
+	 * @return void
+	 */
+	public function ajax_dismiss_model_alert(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error();
+		}
+
+		( new SWPS_Model_Discovery() )->dismiss_alert();
+
+		wp_send_json_success();
 	}
 }
 

--- a/tests/unit/ModelDiscoveryTest.php
+++ b/tests/unit/ModelDiscoveryTest.php
@@ -1,0 +1,28 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-model-discovery.php';
+
+final class ModelDiscoveryTest extends TestCase {
+
+	public function test_merge_prefers_curated_label_and_order(): void {
+		$curated    = array( 'a' => 'Curated A', 'b' => 'Curated B' );
+		$discovered = array( 'b' => 'Discovered B', 'c' => 'Discovered C' );
+		$merged     = SWPS_Model_Discovery::merge_models( $curated, $discovered );
+		// Curated entries keep their label and come first; new discovered appended.
+		$this->assertSame(
+			array( 'a' => 'Curated A', 'b' => 'Curated B', 'c' => 'Discovered C' ),
+			$merged
+		);
+	}
+
+	public function test_diff_returns_only_unknown_ids(): void {
+		$known   = array( 'a', 'b' );
+		$current = array( 'a', 'b', 'c', 'd' );
+		$this->assertSame( array( 'c', 'd' ), SWPS_Model_Discovery::diff_new_ids( $known, $current ) );
+	}
+
+	public function test_diff_empty_known_returns_all(): void {
+		$this->assertSame( array( 'a' ), SWPS_Model_Discovery::diff_new_ids( array(), array( 'a' ) ) );
+	}
+}

--- a/tests/unit/RemoteModelsParserTest.php
+++ b/tests/unit/RemoteModelsParserTest.php
@@ -1,0 +1,68 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-ai-provider.php';
+require_once __DIR__ . '/../../includes/providers/ai/class-anthropic-provider.php';
+require_once __DIR__ . '/../../includes/providers/ai/class-openai-provider.php';
+require_once __DIR__ . '/../../includes/providers/ai/class-google-provider.php';
+require_once __DIR__ . '/../../includes/providers/ai/class-xai-provider.php';
+
+final class RemoteModelsParserTest extends TestCase {
+
+	public function test_anthropic_maps_id_to_display_name(): void {
+		$body = array( 'data' => array(
+			array( 'id' => 'claude-opus-4-8', 'display_name' => 'Claude Opus 4.8', 'type' => 'model' ),
+		) );
+		$this->assertSame(
+			array( 'claude-opus-4-8' => 'Claude Opus 4.8' ),
+			SWPS_Anthropic_Provider::parse_models_response( $body )
+		);
+	}
+
+	public function test_openai_keeps_chat_models_only(): void {
+		$body = array( 'data' => array(
+			array( 'id' => 'gpt-5' ),
+			array( 'id' => 'o4-mini' ),
+			array( 'id' => 'text-embedding-3-large' ),
+			array( 'id' => 'whisper-1' ),
+			array( 'id' => 'dall-e-3' ),
+		) );
+		$out = SWPS_OpenAI_Provider::parse_models_response( $body );
+		$this->assertArrayHasKey( 'gpt-5', $out );
+		$this->assertArrayHasKey( 'o4-mini', $out );
+		$this->assertArrayNotHasKey( 'text-embedding-3-large', $out );
+		$this->assertArrayNotHasKey( 'whisper-1', $out );
+		$this->assertArrayNotHasKey( 'dall-e-3', $out );
+	}
+
+	public function test_google_keeps_generatecontent_only(): void {
+		$body = array( 'models' => array(
+			array( 'name' => 'models/gemini-3.0-pro', 'displayName' => 'Gemini 3.0 Pro', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/text-embedding-004', 'displayName' => 'Embedding 004', 'supportedGenerationMethods' => array( 'embedContent' ) ),
+		) );
+		$out = SWPS_Google_Provider::parse_models_response( $body );
+		$this->assertSame( array( 'gemini-3.0-pro' => 'Gemini 3.0 Pro' ), $out );
+	}
+
+	public function test_xai_keeps_grok_only(): void {
+		$body = array( 'data' => array(
+			array( 'id' => 'grok-5' ),
+			array( 'id' => 'grok-2-image' ),
+			array( 'id' => 'text-embedding' ),
+		) );
+		$out = SWPS_XAI_Provider::parse_models_response( $body );
+		$this->assertArrayHasKey( 'grok-5', $out );
+		$this->assertArrayNotHasKey( 'text-embedding', $out );
+		$this->assertArrayNotHasKey( 'grok-2-image', $out );
+	}
+
+	public function test_openai_keeps_chatgpt_latest_alias(): void {
+		$body = array( 'data' => array( array( 'id' => 'chatgpt-4o-latest' ) ) );
+		$this->assertArrayHasKey( 'chatgpt-4o-latest', SWPS_OpenAI_Provider::parse_models_response( $body ) );
+	}
+
+	public function test_malformed_body_returns_empty(): void {
+		$this->assertSame( array(), SWPS_Anthropic_Provider::parse_models_response( array() ) );
+		$this->assertSame( array(), SWPS_OpenAI_Provider::parse_models_response( array( 'nope' => 1 ) ) );
+	}
+}


### PR DESCRIPTION
## Summary
AI text models and the Gemini image model were hardcoded, so new provider models (e.g. Claude Opus 4.8) couldn't be used until someone edited the code and shipped a release — and the Gemini image-model constant has gone stale and broken image generation before. This adds automatic model discovery.

## What changed
- **`SWPS_Model_Discovery` service** merges each provider's curated list with a daily-refreshed cache of API-discovered models.
- **Per-provider `fetch_remote_models()`** + a pure, unit-tested `parse_models_response()` for Anthropic, OpenAI, Google, xAI (text) and Gemini (image), each hitting the provider's `/models` endpoint with graceful `[]` fallback on error/no-key.
- **Daily `swps_refresh_models` cron** refreshes the cache and flags never-seen models (first run seeds silently — no alert on the existing baseline).
- **AI Model dropdown** auto-merges discovered text models (via `get_models_for_provider()`); a new **Gemini Image Model** setting lets you pick the image model (auto-discovered), replacing the hardcoded constant (which becomes the fallback default).
- **Dismissible admin notice** when a new model appears. Curated lists remain the labeled fallback; nothing auto-switches.

Design + plan: `docs/superpowers/specs/2026-05-29-model-discovery-design.md`, `docs/superpowers/plans/2026-05-29-model-discovery.md`.

## ⚠️ Merge order
Targets **v4.8.0**, assuming #41 (async image generation, v4.7.0) merges **first**. This branch is off `main` (4.6.5) and overlaps #41 on the Gemini provider, `admin.js`, and `settings.php` — merge #41 first, then reconcile/rebase this if needed.

## Test plan
Verified locally: PHPStan green, PHPUnit 48/93 (incl. new parser + merge/diff unit tests), no new PHPCS errors, independent per-task + holistic review (no Critical/Important issues), both new classes confirmed loadable at runtime (this plugin has no runtime autoloader).

To verify on a WP environment (provider API keys set):
- [ ] `wp cron event run swps_refresh_models` → `wp option get swps_discovered_models --format=json` populated; `swps_known_model_ids` seeded silently (no alert on first run).
- [ ] AI Model dropdown (Settings) includes discovered models; the Gemini Image Model dropdown appears when image provider = Gemini.
- [ ] After a genuinely new model appears, the dismissible notice renders on plugin pages and the dismissal persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)