### PR TITLE
feat: dynamic AI model catalog with heuristic labels (v4.9.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.8.0-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.9.0-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -62,7 +62,7 @@ It's designed to **replace** Yoast/RankMath/AIOSEO if you want to, or **coexist*
 ## Features
 
 ### AI Content Generation
-- **Multi-provider AI** — Anthropic (Claude Opus 4.7, Opus 4.6, Sonnet 4.6/4.5, Haiku 4.5), OpenAI (GPT), Google (Gemini), xAI (Grok)
+- **Multi-provider AI** — Anthropic (Claude), OpenAI (GPT), Google (Gemini), xAI (Grok) — model lists are discovered live from each provider's API and refreshed daily
 - **Site-aware generation** — analyzes existing posts, categories, and internal links before writing
 - **7 content templates** — Auto, Listicle, How-To Guide, Comparison, Case Study, News Analysis, Tutorial
 - **Voice profiles** — reusable writing personas (tone, formality 1-10, sentence length, vocabulary, person, avoid/preferred phrases, sample text)
@@ -1274,6 +1274,13 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.9.0 — May 2026
+- **Feature — fully dynamic model lists:** AI model dropdowns are now pulled live from each provider's API and refreshed daily, so new models appear automatically without a plugin update.
+- **Feature — dynamic superlative labels:** Most powerful, Cheapest, Costs most, and Best value tags are now computed dynamically across each provider's discovered model set, always reflecting the current lineup.
+- **Feature — tighter Google filtering:** image output, TTS, music (Lyria), and robotics models are excluded from the Gemini text-model picker.
+- **Feature — auto-priced new models:** cost tracking now prices newly discovered models via family heuristics; new model IDs no longer fall through to a $0 default.
+- **Fix — selected model now sticks:** a discovered model selected in Settings was silently falling back to the hardcoded default at generation time due to a validation gap. Fixed.
 
 ### v4.8.0 — May 2026
 - **Feature — model auto-discovery:** AI models are discovered daily from each configured provider's API and merged into the model dropdown automatically, with a dismissible new-model alert. Curated lists remain the labeled fallback; nothing auto-switches.

--- a/docs/superpowers/plans/2026-05-29-dynamic-model-catalog.md
+++ b/docs/superpowers/plans/2026-05-29-dynamic-model-catalog.md
@@ -1,0 +1,878 @@
+# Dynamic Model Catalog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace hardcoded AI-model lists and hand-written labels with a fully dynamic list (live discovery, filtered to text-gen models) and heuristic-driven superlative tags (Most powerful / Cheapest / Costs most / Best value) across all four providers.
+
+**Architecture:** A new pure-PHP `SWPS_Model_Catalog` derives family → power rank + default price from a model ID and decorates a model list with superlative tags. `SWPS_Model_Discovery::get_text_models()` serves discovered-or-fallback models decorated by the Catalog; the cost tracker and the model validator both read from the same source, fixing the bug where a discovered model silently reverts at generation time.
+
+**Tech Stack:** PHP 8.x, WordPress plugin (no runtime autoloader — every class is `require_once`'d in `stratawp-seo.php`), PHPUnit (pure-PHP unit tests, no WP bootstrap — see `tests/bootstrap.php`), PHPCS (WordPress standard), PHPStan.
+
+**Conventions:** Match the codebase — `array()` long syntax, Yoda conditions, tabs for indentation, `1_000_000` numeric separators. Run a single test with `vendor/bin/phpunit --filter <name>`; the whole suite with `composer test`.
+
+---
+
+### Task 1: `SWPS_Model_Catalog` — metadata + power score
+
+**Files:**
+- Create: `includes/class-model-catalog.php`
+- Test: `tests/unit/ModelCatalogTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/ModelCatalogTest.php`:
+
+```php
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-model-catalog.php';
+
+final class ModelCatalogTest extends TestCase {
+
+	public function test_metadata_detects_anthropic_opus(): void {
+		$m = SWPS_Model_Catalog::metadata( 'claude-opus-4-8' );
+		$this->assertSame( 'anthropic', $m['provider'] );
+		$this->assertSame( 30048, $m['power_score'] );
+		$this->assertSame( 75.0, $m['price_out'] );
+	}
+
+	public function test_metadata_strips_date_suffix_for_version(): void {
+		$this->assertSame( 30041, SWPS_Model_Catalog::metadata( 'claude-opus-4-1-20250805' )['power_score'] );
+		$this->assertSame( 30040, SWPS_Model_Catalog::metadata( 'claude-opus-4-20250514' )['power_score'] );
+	}
+
+	public function test_power_score_orders_by_tier_then_version(): void {
+		$score = fn( string $id ) => SWPS_Model_Catalog::metadata( $id )['power_score'];
+		$this->assertGreaterThan( $score( 'claude-opus-4-7' ), $score( 'claude-opus-4-8' ) );
+		$this->assertGreaterThan( $score( 'claude-sonnet-4-6' ), $score( 'claude-opus-4-6' ) );
+		$this->assertGreaterThan( $score( 'claude-haiku-4-5-20251001' ), $score( 'claude-sonnet-4-6' ) );
+	}
+
+	public function test_metadata_detects_other_providers(): void {
+		$this->assertSame( 'openai', SWPS_Model_Catalog::metadata( 'gpt-4.1' )['provider'] );
+		$this->assertSame( 'google', SWPS_Model_Catalog::metadata( 'gemini-2.5-pro' )['provider'] );
+		$this->assertSame( 'xai', SWPS_Model_Catalog::metadata( 'grok-3' )['provider'] );
+	}
+
+	public function test_metadata_unknown_model_is_null(): void {
+		$m = SWPS_Model_Catalog::metadata( 'totally-unknown-model' );
+		$this->assertNull( $m['provider'] );
+		$this->assertNull( $m['power_score'] );
+		$this->assertNull( $m['price_out'] );
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter ModelCatalogTest`
+Expected: FAIL — `Error: Failed opening required '.../class-model-catalog.php'` (file does not exist yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `includes/class-model-catalog.php`:
+
+```php
+<?php
+/**
+ * Heuristic model catalog: derives provider, power rank, and default pricing
+ * from a model ID, and computes dynamic superlative labels for a model list.
+ *
+ * Pure PHP — no WordPress calls — so it is unit-testable without a WP bootstrap.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_Model_Catalog {
+
+	/**
+	 * Per-provider heuristic rules. Provider is detected by the `id` pattern;
+	 * the family (power rank + default USD price per 1M input/output) is the
+	 * first matching `match`, evaluated in order (most specific first, with a
+	 * catch-all last so unknown sub-families still get a sane mid-tier default).
+	 */
+	private const RULES = array(
+		'anthropic' => array(
+			'id'       => '/^claude-/',
+			'families' => array(
+				array( 'match' => '/opus/',   'rank' => 30, 'in' => 15.00, 'out' => 75.00 ),
+				array( 'match' => '/sonnet/', 'rank' => 20, 'in' => 3.00,  'out' => 15.00 ),
+				array( 'match' => '/haiku/',  'rank' => 10, 'in' => 0.80,  'out' => 4.00 ),
+				array( 'match' => '/claude/', 'rank' => 20, 'in' => 3.00,  'out' => 15.00 ),
+			),
+		),
+		'openai'    => array(
+			'id'       => '/^(gpt-|o\d|chatgpt-)/',
+			'families' => array(
+				array( 'match' => '/nano/',   'rank' => 10, 'in' => 0.10, 'out' => 0.40 ),
+				array( 'match' => '/mini/',   'rank' => 15, 'in' => 0.40, 'out' => 1.60 ),
+				array( 'match' => '/^o\d/',   'rank' => 30, 'in' => 1.10, 'out' => 4.40 ),
+				array( 'match' => '/gpt-4o/', 'rank' => 22, 'in' => 2.50, 'out' => 10.00 ),
+				array( 'match' => '/gpt-/',   'rank' => 25, 'in' => 2.00, 'out' => 8.00 ),
+			),
+		),
+		'google'    => array(
+			'id'       => '/^(gemini|gemma)/',
+			'families' => array(
+				array( 'match' => '/flash-lite/', 'rank' => 10, 'in' => 0.075, 'out' => 0.30 ),
+				array( 'match' => '/flash/',      'rank' => 20, 'in' => 0.15,  'out' => 0.60 ),
+				array( 'match' => '/pro/',        'rank' => 30, 'in' => 1.25,  'out' => 10.00 ),
+				array( 'match' => '/gemma/',      'rank' => 5,  'in' => 0.00,  'out' => 0.00 ),
+				array( 'match' => '/gemini/',     'rank' => 20, 'in' => 0.15,  'out' => 0.60 ),
+			),
+		),
+		'xai'       => array(
+			'id'       => '/^grok/',
+			'families' => array(
+				array( 'match' => '/mini/', 'rank' => 10, 'in' => 0.30, 'out' => 0.50 ),
+				array( 'match' => '/fast/', 'rank' => 20, 'in' => 5.00, 'out' => 25.00 ),
+				array( 'match' => '/grok/', 'rank' => 20, 'in' => 3.00, 'out' => 15.00 ),
+			),
+		),
+	);
+
+	/**
+	 * Default price (USD per 1M input/output) for models with no family match.
+	 */
+	private const DEFAULT_PRICE = array( 'input' => 3.00, 'output' => 15.00 );
+
+	/**
+	 * Derive heuristic metadata for a model ID.
+	 *
+	 * @param string $id Model identifier.
+	 * @return array{provider: string|null, power_score: int|null, price_in: float|null, price_out: float|null}
+	 */
+	public static function metadata( string $id ): array {
+		$none = array(
+			'provider'    => null,
+			'power_score' => null,
+			'price_in'    => null,
+			'price_out'   => null,
+		);
+
+		foreach ( self::RULES as $provider => $rules ) {
+			if ( ! preg_match( $rules['id'], $id ) ) {
+				continue;
+			}
+			foreach ( $rules['families'] as $family ) {
+				if ( preg_match( $family['match'], $id ) ) {
+					$version = self::parse_version( $id );
+					return array(
+						'provider'    => $provider,
+						'power_score' => (int) ( $family['rank'] * 1000 + (int) round( $version * 10 ) ),
+						'price_in'    => (float) $family['in'],
+						'price_out'   => (float) $family['out'],
+					);
+				}
+			}
+			return array_merge( $none, array( 'provider' => $provider ) );
+		}
+
+		return $none;
+	}
+
+	/**
+	 * Parse a numeric version from a model ID for ordering within a tier.
+	 *
+	 * Strips a trailing date suffix, then reads the first number, treating the
+	 * first internal separator as a decimal point (e.g. `opus-4-8` => 4.8).
+	 *
+	 * @param string $id Model identifier.
+	 * @return float
+	 */
+	private static function parse_version( string $id ): float {
+		$id = preg_replace( '/-\d{8}$/', '', $id );
+		$id = preg_replace( '/-\d{4}-\d{2}-\d{2}$/', '', $id );
+		if ( preg_match( '/(\d+)(?:[.-](\d+))?/', $id, $m ) ) {
+			return (float) ( $m[1] . ( isset( $m[2] ) ? '.' . $m[2] : '' ) );
+		}
+		return 0.0;
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit --filter ModelCatalogTest`
+Expected: PASS — `OK (5 tests, ...)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/class-model-catalog.php tests/unit/ModelCatalogTest.php
+git commit -m "feat: add SWPS_Model_Catalog metadata + power score heuristics"
+```
+
+---
+
+### Task 2: Catalog — `price_for()`
+
+**Files:**
+- Modify: `includes/class-model-catalog.php`
+- Test: `tests/unit/ModelCatalogTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/ModelCatalogTest.php`:
+
+```php
+	public function test_price_for_known_model(): void {
+		$this->assertSame( array( 'input' => 15.0, 'output' => 75.0 ), SWPS_Model_Catalog::price_for( 'claude-opus-4-8' ) );
+		$this->assertSame( array( 'input' => 0.8, 'output' => 4.0 ), SWPS_Model_Catalog::price_for( 'claude-haiku-4-5-20251001' ) );
+	}
+
+	public function test_price_for_unknown_model_uses_default(): void {
+		$this->assertSame( array( 'input' => 3.0, 'output' => 15.0 ), SWPS_Model_Catalog::price_for( 'who-knows-9000' ) );
+	}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter test_price_for`
+Expected: FAIL — `Error: Call to undefined method SWPS_Model_Catalog::price_for()`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add this method to `SWPS_Model_Catalog` (after `metadata()`):
+
+```php
+	/**
+	 * Resolve input/output price (USD per 1M tokens) for a model, falling back
+	 * to a default for unknown models. Used by the cost tracker.
+	 *
+	 * @param string $id Model identifier.
+	 * @return array{input: float, output: float}
+	 */
+	public static function price_for( string $id ): array {
+		$m = self::metadata( $id );
+		if ( null !== $m['price_in'] ) {
+			return array(
+				'input'  => $m['price_in'],
+				'output' => $m['price_out'],
+			);
+		}
+		return self::DEFAULT_PRICE;
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit --filter ModelCatalogTest`
+Expected: PASS — `OK (7 tests, ...)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/class-model-catalog.php tests/unit/ModelCatalogTest.php
+git commit -m "feat: add SWPS_Model_Catalog::price_for"
+```
+
+---
+
+### Task 3: Catalog — `decorate_labels()` (superlatives)
+
+**Files:**
+- Modify: `includes/class-model-catalog.php`
+- Test: `tests/unit/ModelCatalogTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/ModelCatalogTest.php`:
+
+```php
+	public function test_decorate_labels_tags_superlatives(): void {
+		$models = array(
+			'claude-opus-4-8'           => 'Claude Opus 4.8',
+			'claude-opus-4-7'           => 'Claude Opus 4.7',
+			'claude-sonnet-4-6'         => 'Claude Sonnet 4.6',
+			'claude-haiku-4-5-20251001' => 'Claude Haiku 4.5',
+		);
+		$out = SWPS_Model_Catalog::decorate_labels( $models );
+		$this->assertSame( 'Claude Opus 4.8 — Most powerful · Costs most', $out['claude-opus-4-8'] );
+		$this->assertSame( 'Claude Sonnet 4.6 — Best value', $out['claude-sonnet-4-6'] );
+		$this->assertSame( 'Claude Haiku 4.5 — Cheapest', $out['claude-haiku-4-5-20251001'] );
+		$this->assertSame( 'Claude Opus 4.7', $out['claude-opus-4-7'] );
+	}
+
+	public function test_decorate_labels_noop_for_single_model(): void {
+		$models = array( 'claude-opus-4-8' => 'Claude Opus 4.8' );
+		$this->assertSame( $models, SWPS_Model_Catalog::decorate_labels( $models ) );
+	}
+
+	public function test_decorate_labels_no_price_tags_when_all_same_price(): void {
+		$models = array(
+			'claude-opus-4-8' => 'Claude Opus 4.8',
+			'claude-opus-4-7' => 'Claude Opus 4.7',
+		);
+		$out = SWPS_Model_Catalog::decorate_labels( $models );
+		$this->assertSame( 'Claude Opus 4.8 — Most powerful', $out['claude-opus-4-8'] );
+		$this->assertSame( 'Claude Opus 4.7', $out['claude-opus-4-7'] );
+	}
+
+	public function test_decorate_labels_leaves_unknown_models_untagged(): void {
+		$models = array( 'mystery-a' => 'Mystery A', 'mystery-b' => 'Mystery B' );
+		$this->assertSame( $models, SWPS_Model_Catalog::decorate_labels( $models ) );
+	}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter test_decorate_labels`
+Expected: FAIL — `Error: Call to undefined method SWPS_Model_Catalog::decorate_labels()`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add this method to `SWPS_Model_Catalog` (after `price_for()`):
+
+```php
+	/**
+	 * Decorate a provider's `id => display_name` map with dynamic superlative
+	 * tags computed across the set. Keys (model IDs) are never modified.
+	 *
+	 * @param array<string, string> $models id => display name.
+	 * @return array<string, string> id => decorated label.
+	 */
+	public static function decorate_labels( array $models ): array {
+		if ( count( $models ) < 2 ) {
+			return $models;
+		}
+
+		$meta = array();
+		foreach ( $models as $id => $label ) {
+			$meta[ $id ] = self::metadata( (string) $id );
+		}
+
+		$tags = array();
+
+		// Most powerful: highest power score.
+		$top_power = null;
+		$top_id    = null;
+		foreach ( $meta as $id => $m ) {
+			if ( null !== $m['power_score'] && ( null === $top_power || $m['power_score'] > $top_power ) ) {
+				$top_power = $m['power_score'];
+				$top_id    = $id;
+			}
+		}
+		if ( null !== $top_id ) {
+			$tags[ $top_id ][] = 'Most powerful';
+		}
+
+		// Price-based tags only when there is an actual spread.
+		$priced = array();
+		foreach ( $meta as $id => $m ) {
+			if ( null !== $m['price_out'] ) {
+				$priced[ $id ] = $m['price_out'];
+			}
+		}
+		if ( count( $priced ) >= 2 ) {
+			$max_out = max( $priced );
+			$min_out = min( $priced );
+			if ( $max_out > $min_out ) {
+				$costliest = array_search( $max_out, $priced, true );
+				$cheapest  = array_search( $min_out, $priced, true );
+				if ( false !== $costliest ) {
+					$tags[ $costliest ][] = 'Costs most';
+				}
+				if ( false !== $cheapest ) {
+					$tags[ $cheapest ][] = 'Cheapest';
+				}
+
+				// Best value: highest power among models priced below the max.
+				$bv_power = null;
+				$bv_id    = null;
+				foreach ( $priced as $id => $out ) {
+					if ( $out >= $max_out ) {
+						continue;
+					}
+					$p = $meta[ $id ]['power_score'];
+					if ( null !== $p && ( null === $bv_power || $p > $bv_power ) ) {
+						$bv_power = $p;
+						$bv_id    = $id;
+					}
+				}
+				if ( null !== $bv_id ) {
+					$tags[ $bv_id ][] = 'Best value';
+				}
+			}
+		}
+
+		$out = array();
+		foreach ( $models as $id => $label ) {
+			$out[ $id ] = isset( $tags[ $id ] )
+				? $label . ' — ' . implode( ' · ', $tags[ $id ] )
+				: $label;
+		}
+		return $out;
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit --filter ModelCatalogTest`
+Expected: PASS — `OK (11 tests, ...)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/class-model-catalog.php tests/unit/ModelCatalogTest.php
+git commit -m "feat: add SWPS_Model_Catalog::decorate_labels superlative tagging"
+```
+
+---
+
+### Task 4: Register the Catalog class (no runtime autoloader)
+
+**Files:**
+- Modify: `stratawp-seo.php:50` (just before the model-discovery require)
+
+- [ ] **Step 1: Add the require**
+
+In `stratawp-seo.php`, immediately **before** the existing line `require_once SWPS_PLUGIN_DIR . 'includes/class-model-discovery.php';` (line 50), add:
+
+```php
+require_once SWPS_PLUGIN_DIR . 'includes/class-model-catalog.php';
+```
+
+- [ ] **Step 2: Verify it parses and is wired**
+
+Run: `php -l includes/class-model-catalog.php`
+Expected: `No syntax errors detected`.
+
+Run: `grep -n "class-model-catalog.php" stratawp-seo.php`
+Expected: one line showing the new require above the model-discovery require.
+
+- [ ] **Step 3: Run the full suite (no regressions)**
+
+Run: `composer test`
+Expected: PASS — all suites green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add stratawp-seo.php
+git commit -m "feat: require SWPS_Model_Catalog in plugin bootstrap"
+```
+
+---
+
+### Task 5: Tighten the Google model filter
+
+**Files:**
+- Modify: `includes/providers/ai/class-google-provider.php:142-154` (`parse_models_response`)
+- Test: `tests/unit/RemoteModelsParserTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/RemoteModelsParserTest.php`:
+
+```php
+	public function test_google_excludes_nontext_models_reporting_generatecontent(): void {
+		$body = array( 'models' => array(
+			array( 'name' => 'models/gemini-3-pro', 'displayName' => 'Gemini 3 Pro', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/gemma-4-31b-it', 'displayName' => 'Gemma 4 31B', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/gemini-2.5-flash-image', 'displayName' => 'Nano Banana', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/gemini-2.5-flash-preview-tts', 'displayName' => 'TTS', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/lyria-3-pro-preview', 'displayName' => 'Lyria', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/gemini-robotics-er-1.5-preview', 'displayName' => 'Robotics', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/nano-banana-pro-preview', 'displayName' => 'Nano Banana Pro', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+		) );
+		$out = SWPS_Google_Provider::parse_models_response( $body );
+		$this->assertArrayHasKey( 'gemini-3-pro', $out );
+		$this->assertArrayHasKey( 'gemma-4-31b-it', $out );
+		$this->assertArrayNotHasKey( 'gemini-2.5-flash-image', $out );
+		$this->assertArrayNotHasKey( 'gemini-2.5-flash-preview-tts', $out );
+		$this->assertArrayNotHasKey( 'lyria-3-pro-preview', $out );
+		$this->assertArrayNotHasKey( 'gemini-robotics-er-1.5-preview', $out );
+		$this->assertArrayNotHasKey( 'nano-banana-pro-preview', $out );
+	}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter test_google_excludes_nontext_models_reporting_generatecontent`
+Expected: FAIL — the image/TTS/Lyria/robotics models are still present (current filter only checks `generateContent`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `class-google-provider.php`, replace the body of `parse_models_response()` with:
+
+```php
+	public static function parse_models_response( array $body ): array {
+		$models = array();
+		foreach ( $body['models'] ?? array() as $m ) {
+			$name    = (string) ( $m['name'] ?? '' );
+			$methods = (array) ( $m['supportedGenerationMethods'] ?? array() );
+			if ( '' === $name || ! in_array( 'generateContent', $methods, true ) ) {
+				continue;
+			}
+			$id = preg_replace( '#^models/#', '', $name );
+			// Drop non-text-generation models that still report generateContent
+			// (image, TTS, music, robotics, agents, etc.).
+			if ( preg_match( '/(image|tts|lyria|veo|imagen|robotics|computer-use|deep-research|antigravity|nano-banana|aqa)/i', $id ) ) {
+				continue;
+			}
+			$models[ $id ] = (string) ( $m['displayName'] ?? $id );
+		}
+		return $models;
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit --filter RemoteModelsParserTest`
+Expected: PASS — all parser tests including the new one and the existing `test_google_keeps_generatecontent_only`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/providers/ai/class-google-provider.php tests/unit/RemoteModelsParserTest.php
+git commit -m "fix: exclude non-text Google models (image/tts/music/robotics) from discovery"
+```
+
+---
+
+### Task 6: Cost tracker reads pricing from the Catalog
+
+**Files:**
+- Modify: `includes/class-cost-tracker.php` (remove `PRICING` const lines 20-97; rewrite `calculate_cost` lines 156-166)
+- Test: `tests/unit/CostTrackerTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/CostTrackerTest.php`:
+
+```php
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-model-catalog.php';
+require_once __DIR__ . '/../../includes/class-cost-tracker.php';
+
+final class CostTrackerTest extends TestCase {
+
+	public function test_opus_4_8_is_priced_via_catalog(): void {
+		$tracker = new SWPS_Cost_Tracker();
+		// 1M input + 1M output at Opus pricing (15 + 75) = 90.0.
+		$this->assertEqualsWithDelta( 90.0, $tracker->calculate_cost( 'claude-opus-4-8', 1_000_000, 1_000_000 ), 0.0001 );
+	}
+
+	public function test_unknown_model_uses_default_pricing(): void {
+		$tracker = new SWPS_Cost_Tracker();
+		// Default 3 + 15 = 18.0.
+		$this->assertEqualsWithDelta( 18.0, $tracker->calculate_cost( 'who-knows-9000', 1_000_000, 1_000_000 ), 0.0001 );
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter CostTrackerTest`
+Expected: FAIL — `test_opus_4_8_is_priced_via_catalog` fails: current `PRICING` has no `claude-opus-4-8`, so it falls to the hardcoded default 3/15 → 18.0, not 90.0.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `class-cost-tracker.php`, delete the entire `private const PRICING = array( ... );` block (lines 16-97, including its docblock). Then replace `calculate_cost()` (lines 156-166) with:
+
+```php
+	public function calculate_cost( string $model, int $input_tokens, int $output_tokens ): float {
+		$pricing = SWPS_Model_Catalog::price_for( $model );
+
+		$input_cost  = ( $input_tokens / 1_000_000 ) * $pricing['input'];
+		$output_cost = ( $output_tokens / 1_000_000 ) * $pricing['output'];
+
+		return $input_cost + $output_cost;
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit --filter CostTrackerTest`
+Expected: PASS — `OK (2 tests, ...)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/class-cost-tracker.php tests/unit/CostTrackerTest.php
+git commit -m "refactor: cost tracker derives pricing from SWPS_Model_Catalog"
+```
+
+---
+
+### Task 7: Dynamic list + validation helper in `SWPS_Model_Discovery`
+
+**Files:**
+- Modify: `includes/class-model-discovery.php` (rewrite `get_text_models()`; add `available_model_ids()`, private `resolve_models()`, static `validate_selection()`)
+- Test: `tests/unit/ModelDiscoveryTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/ModelDiscoveryTest.php`:
+
+```php
+	public function test_validate_selection_keeps_valid_stored_model(): void {
+		$ids = array( 'claude-opus-4-8', 'claude-opus-4-7' );
+		$this->assertSame( 'claude-opus-4-8', SWPS_Model_Discovery::validate_selection( 'claude-opus-4-8', $ids ) );
+	}
+
+	public function test_validate_selection_falls_back_to_first_when_invalid(): void {
+		$ids = array( 'claude-opus-4-8', 'claude-opus-4-7' );
+		$this->assertSame( 'claude-opus-4-8', SWPS_Model_Discovery::validate_selection( 'gone-model', $ids ) );
+		$this->assertSame( 'claude-opus-4-8', SWPS_Model_Discovery::validate_selection( '', $ids ) );
+	}
+
+	public function test_validate_selection_empty_ids_returns_empty_string(): void {
+		$this->assertSame( '', SWPS_Model_Discovery::validate_selection( 'anything', array() ) );
+	}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter test_validate_selection`
+Expected: FAIL — `Error: Call to undefined method SWPS_Model_Discovery::validate_selection()`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `class-model-discovery.php`, replace `get_text_models()` with the following, and add the three new methods alongside it:
+
+```php
+	/**
+	 * Get the decorated text models for a provider (discovered, else fallback).
+	 *
+	 * @param string $provider_slug AI provider slug.
+	 * @return array<string, string> model ID => decorated display label.
+	 */
+	public function get_text_models( string $provider_slug ): array {
+		return SWPS_Model_Catalog::decorate_labels( $this->resolve_models( $provider_slug ) );
+	}
+
+	/**
+	 * Valid model IDs for a provider (discovered, else fallback) — used to
+	 * validate the saved model selection.
+	 *
+	 * @param string $provider_slug AI provider slug.
+	 * @return array<int, string>
+	 */
+	public function available_model_ids( string $provider_slug ): array {
+		return array_keys( $this->resolve_models( $provider_slug ) );
+	}
+
+	/**
+	 * Resolve the raw model map: discovered (filtered) if present, else the
+	 * provider's curated fallback list.
+	 *
+	 * @param string $provider_slug AI provider slug.
+	 * @return array<string, string> model ID => display name.
+	 */
+	private function resolve_models( string $provider_slug ): array {
+		$discovered = (array) ( get_option( self::OPTION_DISCOVERED, array() )[ $provider_slug ] ?? array() );
+		if ( ! empty( $discovered ) ) {
+			return $discovered;
+		}
+		return SWPS_Provider_Factory::curated_models_for_provider( $provider_slug );
+	}
+
+	/**
+	 * Validate a stored model selection against the list of valid IDs, falling
+	 * back to the first available ID. Pure — no WordPress calls.
+	 *
+	 * @param string             $stored Stored model ID.
+	 * @param array<int, string> $ids    Valid model IDs.
+	 * @return string
+	 */
+	public static function validate_selection( string $stored, array $ids ): string {
+		if ( '' !== $stored && in_array( $stored, $ids, true ) ) {
+			return $stored;
+		}
+		return $ids[0] ?? '';
+	}
+```
+
+Note: `get_image_models()` and `merge_models()` are unchanged — the image picker keeps its curated ∪ discovered behavior.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit --filter ModelDiscoveryTest`
+Expected: PASS — the three new tests plus the existing `merge`/`diff` tests (still green; `merge_models` is untouched).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/class-model-discovery.php tests/unit/ModelDiscoveryTest.php
+git commit -m "feat: dynamic text-model list + model-selection validator in discovery"
+```
+
+---
+
+### Task 8: Fix `get_validated_model()` so a discovered model sticks
+
+**Files:**
+- Modify: `includes/class-ai-provider.php:415-425` (`get_validated_model`)
+
+- [ ] **Step 1: Replace the method**
+
+In `class-ai-provider.php`, replace `get_validated_model()` (lines 415-425) with:
+
+```php
+	/**
+	 * Get the validated model — falls back to the first available model
+	 * (discovered, else curated fallback) if the stored model is not valid
+	 * for this provider. Validating against the dynamic list ensures a
+	 * discovered model the user selected is honoured at generation time.
+	 */
+	public function get_validated_model(): string {
+		$ids = ( new SWPS_Model_Discovery() )->available_model_ids( $this->get_slug() );
+		return SWPS_Model_Discovery::validate_selection( (string) get_option( 'swps_model', '' ), $ids );
+	}
+```
+
+- [ ] **Step 2: Verify it parses**
+
+Run: `php -l includes/class-ai-provider.php`
+Expected: `No syntax errors detected`.
+
+- [ ] **Step 3: Run the full suite (no regressions)**
+
+Run: `composer test`
+Expected: PASS — all suites green. (`RemoteModelsParserTest` requires the provider classes but never calls `get_validated_model`, so the new `SWPS_Model_Discovery` reference — used only inside the method body — does not need loading there.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add includes/class-ai-provider.php
+git commit -m "fix: validate selected model against dynamic list, not hardcoded list"
+```
+
+---
+
+### Task 9: Strip hand-written suffixes from fallback model lists
+
+**Files:**
+- Modify: `class-anthropic-provider.php:28-36`, `class-openai-provider.php:28-37`, `class-google-provider.php:28-35`, `class-xai-provider.php:28-34` (`get_available_models`)
+
+Rationale: these lists are now only a fallback (when there is no API key / discovery is empty). The Catalog adds superlative tags dynamically, so the hand-written `(Most powerful, …)` suffixes must be removed to avoid doubled-up labels.
+
+- [ ] **Step 1: Anthropic — replace `get_available_models()` body**
+
+```php
+	public function get_available_models(): array {
+		return array(
+			'claude-opus-4-7'            => 'Claude Opus 4.7',
+			'claude-opus-4-6'            => 'Claude Opus 4.6',
+			'claude-sonnet-4-6'          => 'Claude Sonnet 4.6',
+			'claude-sonnet-4-5-20250929' => 'Claude Sonnet 4.5',
+			'claude-haiku-4-5-20251001'  => 'Claude Haiku 4.5',
+		);
+	}
+```
+
+- [ ] **Step 2: OpenAI — replace `get_available_models()` body**
+
+```php
+	public function get_available_models(): array {
+		return array(
+			'gpt-4.1'      => 'GPT-4.1',
+			'gpt-4.1-mini' => 'GPT-4.1 Mini',
+			'gpt-4.1-nano' => 'GPT-4.1 Nano',
+			'gpt-4o'       => 'GPT-4o',
+			'gpt-4o-mini'  => 'GPT-4o Mini',
+			'o3-mini'      => 'o3-mini',
+		);
+	}
+```
+
+- [ ] **Step 3: Google — replace `get_available_models()` body**
+
+```php
+	public function get_available_models(): array {
+		return array(
+			'gemini-2.5-pro'        => 'Gemini 2.5 Pro',
+			'gemini-2.5-flash'      => 'Gemini 2.5 Flash',
+			'gemini-2.0-flash'      => 'Gemini 2.0 Flash',
+			'gemini-2.0-flash-lite' => 'Gemini 2.0 Flash Lite',
+		);
+	}
+```
+
+- [ ] **Step 4: xAI — replace `get_available_models()` body**
+
+```php
+	public function get_available_models(): array {
+		return array(
+			'grok-3'      => 'Grok 3',
+			'grok-3-mini' => 'Grok 3 Mini',
+			'grok-3-fast' => 'Grok 3 Fast',
+		);
+	}
+```
+
+- [ ] **Step 5: Verify parse + run suite**
+
+Run: `php -l includes/providers/ai/class-anthropic-provider.php && php -l includes/providers/ai/class-openai-provider.php && php -l includes/providers/ai/class-google-provider.php && php -l includes/providers/ai/class-xai-provider.php`
+Expected: `No syntax errors detected` for each.
+
+Run: `composer test`
+Expected: PASS — all suites green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add includes/providers/ai/class-anthropic-provider.php includes/providers/ai/class-openai-provider.php includes/providers/ai/class-google-provider.php includes/providers/ai/class-xai-provider.php
+git commit -m "refactor: plain labels in fallback model lists (Catalog tags dynamically)"
+```
+
+---
+
+### Task 10: Quality gate, manual smoke, version bump + docs + zip
+
+**Files:**
+- Modify: `stratawp-seo.php` (version header + `SWPS_VERSION`), `readme.txt`, `README.md`, any `docs/` changelog
+
+- [ ] **Step 1: Full quality gate**
+
+Run: `composer test && composer check`
+Expected: PHPUnit all green; PHPCS no errors; PHPStan no new errors. Fix any reported issues inline (do not add to the PHPStan baseline).
+
+- [ ] **Step 2: Manual WP-CLI smoke (on the live server, `~/www/jonimms.com/public_html`)**
+
+After deploying the branch build, run:
+
+```bash
+wp cron event run swps_refresh_models
+wp option get swps_discovered_models --format=json
+```
+Expected: Google list no longer contains image/TTS/Lyria/robotics IDs.
+
+In the admin model dropdown (Settings → StrataWP SEO), confirm: `Claude Opus 4.8 — Most powerful · Costs most` near the top of the discovered set, `Best value` on a Sonnet, `Cheapest` on Haiku. Select Opus 4.8, save, then:
+
+```bash
+wp option get swps_model
+```
+Expected: `claude-opus-4-8` (and a test generation actually uses it — confirm in cost/usage logs).
+
+- [ ] **Step 3: Bump version + docs**
+
+Bump the version in `stratawp-seo.php` (plugin header `Version:` and `define( 'SWPS_VERSION', ... )`) to the next minor (e.g. `4.9.0`), update `readme.txt` `Stable tag` + changelog and `README.md`, with a changelog entry summarizing: dynamic model listing, heuristic superlative labels, Google filter tightening, unified pricing, and the selected-model fix.
+
+- [ ] **Step 4: Build the deployment zip**
+
+Build the distributable zip per the project's existing packaging step.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "chore: release vX.Y.0 — dynamic model catalog"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Catalog heuristics (Tasks 1-3) ✓; require/no-autoloader (Task 4) ✓; Google filter tightening (Task 5, the only filtering gap per the addendum) ✓; unified pricing + cost-tracker bug (Task 6) ✓; dynamic list + fallback (Task 7) ✓; selected-model fix from the addendum (Tasks 7-8) ✓; strip hand-written labels (Task 9) ✓; tests throughout; version/docs/zip ritual (Task 10) ✓.
+- **Placeholder scan:** none — every code step contains complete code; every test step contains real assertions; every run step has an exact command + expected output.
+- **Type consistency:** `metadata()` returns `{provider, power_score, price_in, price_out}` and is consumed consistently by `price_for()` and `decorate_labels()`; `price_for()` returns `{input, output}` matching the cost tracker's usage; `validate_selection(string, array): string` and `available_model_ids(): array` line up between Tasks 7 and 8.

--- a/docs/superpowers/specs/2026-05-29-dynamic-model-catalog-design.md
+++ b/docs/superpowers/specs/2026-05-29-dynamic-model-catalog-design.md
@@ -56,8 +56,9 @@ Tier ranks and default prices (USD per 1M input/output). Higher tier_rank = more
 | anthropic | `sonnet` | 20 | 3.00 | 15.00 |
 | anthropic | `haiku` | 10 | 0.80 | 4.00 |
 | openai | `^o\d` (o-series) | 30 | 1.10 | 4.40 |
-| openai | `gpt-4.1` (non-mini/nano) | 25 | 2.00 | 8.00 |
-| openai | `gpt-4o` (non-mini) | 22 | 2.50 | 10.00 |
+| openai | `gpt-4.1` (non-mini/nano) | 26 | 2.00 | 8.00 |
+| openai | `gpt-4o` (non-mini) | 24 | 2.50 | 10.00 |
+| openai | `gpt-` catch-all | 22 | 2.00 | 8.00 |
 | openai | `*-mini` | 15 | 0.40 | 1.60 |
 | openai | `*-nano` | 10 | 0.10 | 0.40 |
 | google | `pro` | 30 | 1.25 | 10.00 |

--- a/docs/superpowers/specs/2026-05-29-dynamic-model-catalog-design.md
+++ b/docs/superpowers/specs/2026-05-29-dynamic-model-catalog-design.md
@@ -148,3 +148,11 @@ The curated-merge-as-primary is dropped. The existing hardcoded `get_available_m
 ## Open items for user review
 
 None outstanding — best-value rule and no-price label format confirmed during design.
+
+## Addendum — corrections after codebase exploration (2026-05-29)
+
+Two refinements found while preparing the implementation plan:
+
+1. **Provider filtering already largely exists.** Each provider's `parse_models_response()` already filters: OpenAI (`gpt-*`/`o\d`/`chatgpt-` minus embeddings/audio/image/etc.) and xAI (`grok-*` minus image) are complete; Anthropic needs none. Google already filters on `supportedGenerationMethods` containing `generateContent`, but **lacks name-based exclusion**, so image/TTS/Lyria/robotics models (which report `generateContent`) still leak through. **The filtering work shrinks to tightening only Google's parser.**
+
+2. **New required fix — the selected model must actually stick.** `SWPS_AI_Provider::get_validated_model()` validates the saved `swps_model` against the hardcoded `get_available_models()` only. A *discovered* model (e.g. `claude-opus-4-8`) therefore fails validation and silently falls back to the curated default at generation time — so listing 4.8 is useless until this is fixed. The validator must check the dynamic list (discovered ∪ fallback). Implemented as a pure, unit-tested `SWPS_Model_Discovery::validate_selection()` + `available_model_ids()`, called from `get_validated_model()`.

--- a/docs/superpowers/specs/2026-05-29-dynamic-model-catalog-design.md
+++ b/docs/superpowers/specs/2026-05-29-dynamic-model-catalog-design.md
@@ -1,0 +1,150 @@
+# Dynamic Model Catalog — Design Spec
+
+- **Date:** 2026-05-29
+- **Status:** Approved (design); pending implementation plan
+- **Topic:** Replace hardcoded AI model lists + hand-written labels with dynamic discovery, capability filtering, and heuristic-driven descriptive labels across all four AI providers.
+
+## Summary
+
+Today the AI-model dropdown shows a hardcoded "curated" list per provider with hand-written suffixes (e.g. `Claude Opus 4.7 (Most powerful, higher cost)`), and discovery merely *appends* API-found models beneath it with plain labels. The result: new models (e.g. `claude-opus-4-8`) land at the bottom, unlabeled, and the "Most powerful" tag is frozen on whatever was hardcoded.
+
+This feature makes the list **fully dynamic** (pulled live, filtered to text-generation chat models) and computes the descriptive tags — **Most powerful / Cheapest / Costs most / Best value** — from **family/pattern heuristics**, for **all four providers** (Anthropic, OpenAI, Google, xAI).
+
+## The governing constraint
+
+Provider model-list endpoints return essentially `id` + `display_name` only — **no price and no capability/power ranking**. Google additionally returns `supportedGenerationMethods`. Therefore:
+
+- The **list** can be fully dynamic from the API.
+- The **superlative labels** require price + power data that must live in the plugin. Per the chosen approach, that data is **derived heuristically from the model ID** (family → tier + default price), with **no per-model override table** (pure heuristics — accepts approximation as the trade-off for zero per-launch upkeep).
+
+## Goals
+
+1. List models pulled live per provider, filtered to usable text-generation chat models.
+2. Compute and display dynamic superlative tags over the active provider's filtered set.
+3. New models within a known family are priced and ranked automatically — no code edit per launch.
+4. Unify pricing into one source of truth shared by the dropdown labels and the cost tracker.
+
+## Non-goals / out of scope
+
+- Per-model price/rank override table (explicitly rejected — pure heuristics).
+- The image-model picker (Gemini image bucket) — unchanged.
+- Auto-switching the user's selected model (discovery never changes the selection; preserved).
+- New comparison UI — labels remain inline in the existing `<select>`.
+
+## Architecture
+
+### New component — `SWPS_Model_Catalog`
+
+A single class holding all heuristics as **per-provider rule tables**. Responsibilities:
+
+- `metadata( string $id, ?string $provider = null ): array` → `{ provider, family, tier_rank, version, power_score, price_in, price_out }`. Infers provider from family patterns when not supplied.
+- `price_for( string $id ): array` → `[ input, output ]` per 1M tokens (used by the cost tracker).
+- `power_score( string $id ): ?int`.
+- `decorate_labels( array $models, string $provider ): array` → takes `id => display_name`, returns `id => labelled_name`, computing superlatives across the set.
+
+Power score: `power_score = tier_rank * 1000 + round( version * 10 )`. Version is parsed from the ID after stripping a trailing date (`-YYYYMMDD`), taking the first numeric run after the family token and treating the first internal separator as a decimal point: `opus-4-8` → 4.8, `opus-4-1-20250805` → 4.1, `opus-4-20250514` → 4.0, `gemini-2.5-pro` → 2.5, `grok-3` → 3.0. Yields the intended order `opus-4-8 > opus-4-7 > opus-4-6 > opus-4-5 > opus-4-1 > opus-4 > sonnet-4-6 > … > haiku-4-5`.
+
+Unknown family → `metadata` returns nulls for tier/price; the model is still listed but receives no tags and is excluded from price-based superlatives.
+
+#### Seed heuristic tables (the maintained config)
+
+Tier ranks and default prices (USD per 1M input/output). Higher tier_rank = more powerful.
+
+| Provider | Family (ID match) | tier_rank | in | out |
+|---|---|---|---|---|
+| anthropic | `opus` | 30 | 15.00 | 75.00 |
+| anthropic | `sonnet` | 20 | 3.00 | 15.00 |
+| anthropic | `haiku` | 10 | 0.80 | 4.00 |
+| openai | `^o\d` (o-series) | 30 | 1.10 | 4.40 |
+| openai | `gpt-4.1` (non-mini/nano) | 25 | 2.00 | 8.00 |
+| openai | `gpt-4o` (non-mini) | 22 | 2.50 | 10.00 |
+| openai | `*-mini` | 15 | 0.40 | 1.60 |
+| openai | `*-nano` | 10 | 0.10 | 0.40 |
+| google | `pro` | 30 | 1.25 | 10.00 |
+| google | `flash` (non-lite) | 20 | 0.15 | 0.60 |
+| google | `flash-lite` | 10 | 0.075 | 0.30 |
+| google | `gemma` | 5 | 0.00 | 0.00 |
+| xai | `grok` + `fast` | 20 | 5.00 | 25.00 |
+| xai | `grok` (non-mini) | 20 | 3.00 | 15.00 |
+| xai | `grok` + `mini` | 10 | 0.30 | 0.50 |
+
+Matching is most-specific-first (e.g. `flash-lite` before `flash`, `mini`/`nano`/`fast` modifiers before the base family). Seed values are the agreed approximations; they are tuned by editing this table, not per model.
+
+### Filtering — each provider's `fetch_remote_models()`
+
+Filtering is the provider's responsibility, applied **before storage**, returning only text-generation models as `id => display_name`:
+
+- **Anthropic:** keep all `claude-*` (none excluded today; reserve image/tts patterns for the future).
+- **OpenAI:** include `^(gpt-|o\d|chatgpt)`; exclude IDs matching `whisper|dall-e|tts|text-embedding|omni-moderation|babbage|davinci|gpt-image` or the segments `-(audio|realtime|transcribe|tts|image|embedding|search)(-|$)`.
+- **Google:** keep only models whose `supportedGenerationMethods` includes `generateContent`, **and** whose name does **not** match `-(image|tts|embedding)|imagen|veo|lyria|aqa|robotics|computer-use|deep-research|antigravity`. (Note: `*-image` Gemini models support `generateContent` but are image-output → excluded by name.) Requires Google's `fetch_remote_models()` to read `supportedGenerationMethods`, which the current id-only parser discards.
+- **xAI:** include `grok-*`; exclude image-output (`-image`).
+
+Exclude/include lists are the per-provider maintained surface (the accepted trade-off of filtering choice A).
+
+### Labels — computed at render time
+
+`SWPS_Model_Catalog::decorate_labels()` scans the active provider's filtered set and assigns tags:
+
+- **Most powerful** = highest `power_score`.
+- **Costs most** / **Cheapest** = highest / lowest output price among models with known price.
+- **Best value** = the highest-`power_score` model whose output price is **strictly below** the set's maximum output price. Suppressed if no model is below the max (e.g. all same price).
+- Tags **combine** when they coincide (the flagship is often `Most powerful · Costs most`).
+- **Suppressed entirely** when the set has fewer than 2 models.
+- Models with unknown family/price are listed with their plain name and are ineligible for tags.
+
+Label string: `"{display_name} — {tags joined by ' · '}"`, or just `display_name` when untagged. **No price shown** (per decision). Plain text, no emoji. Example set (Anthropic):
+
+```
+Claude Opus 4.8 — Most powerful · Costs most
+Claude Opus 4.7
+Claude Sonnet 4.6 — Best value
+Claude Haiku 4.5 — Cheapest
+```
+
+### Dynamic list with fallback
+
+`SWPS_Model_Discovery::get_text_models( $slug )` becomes:
+
+1. `models = discovered[$slug]` if non-empty, else `fallback_list($slug)`.
+2. `return SWPS_Model_Catalog::decorate_labels( models, $slug )`.
+
+The curated-merge-as-primary is dropped. The existing hardcoded `get_available_models()` per provider is **retained but demoted to a fallback** (used only when there's no API key / discovery is empty so the dropdown is never blank) and its hand-written `(Most powerful, …)` suffixes are removed.
+
+### Unified pricing (fixes the cost-tracker gap)
+
+`SWPS_Cost_Tracker::calculate_cost()` currently reads a private `PRICING` const missing newer models (`claude-opus-4-8` is absent — why 4.8 generations wouldn't be costed). It will instead call `SWPS_Model_Catalog::price_for( $model )`, so cost tracking auto-covers new models through the same family heuristics. The `PRICING` const is retired; the Catalog tables are the single source of truth.
+
+## Data flow
+
+1. Daily cron `swps_refresh_models` → `SWPS_Model_Discovery::refresh()` → per provider `fetch_remote_models()` (now filtered) → stored in `swps_discovered_models[$slug]` as `id => display_name` (last-good retained on empty). Stored junk from prior unfiltered runs self-heals on the next refresh.
+2. Settings render → `get_current_model_options()` → `get_models_for_provider($slug)` → `get_text_models($slug)` → fallback-or-discovered → `Catalog::decorate_labels()`.
+3. Generation cost → `Cost_Tracker::track()` → `calculate_cost()` → `Catalog::price_for()`.
+
+## Files
+
+**New**
+- `includes/class-model-catalog.php` — the heuristics brain. **Must be `require_once`'d in `stratawp-seo.php`** (no runtime autoloader — a missing require is a runtime-only fatal).
+- `tests/unit/ModelCatalogTest.php`.
+
+**Modified**
+- `includes/providers/ai/class-anthropic-provider.php`, `class-openai-provider.php`, `class-google-provider.php`, `class-xai-provider.php` — add filtering to `fetch_remote_models()`; trim `get_available_models()` to a plain fallback (Google also parses `supportedGenerationMethods`).
+- `includes/class-model-discovery.php` — `get_text_models()` fallback + decoration; drop curated-merge.
+- `includes/class-cost-tracker.php` — delegate pricing to the Catalog; retire `PRICING`.
+- `stratawp-seo.php` — `require_once` the new class.
+- `tests/unit/ModelDiscoveryTest.php` — update for new behavior; per-provider filter tests with junk-filled fixture responses.
+
+## Testing
+
+- **Catalog:** family + version detection; `power_score` ordering across families and versions; default pricing lookup; superlative selection on a representative set (most powerful, cheapest, costs most, best value); label decoration and tag combination; unknown-family pass-through (listed, untagged); `<2` models → no tags; price ties → deterministic pick; best-value suppression when all prices equal.
+- **Per-provider filtering:** feed a fixture API response containing junk (TTS, image, embeddings, music, robotics) → assert only text-gen models survive. Google fixture exercises `supportedGenerationMethods` + name exclusion.
+- **Cost tracker:** `claude-opus-4-8` is now costed via the Catalog (regression for the original bug).
+
+## Risks & trade-offs
+
+- **Heuristic approximation:** an off-pattern price or an unusually-ranked model is wrong until the family table is edited. Accepted (chose pure heuristics over a per-model table).
+- **OpenAI/xAI capability filtering is pattern-based** (their APIs return no capability data), so a novel non-text model with a `gpt-`/`grok-` prefix could slip through until its pattern is added.
+- **Per-provider maintenance** shifts from "add each model" to "maintain family + exclusion rules" — far less frequent, but non-zero.
+
+## Open items for user review
+
+None outstanding — best-value rule and no-price label format confirmed during design.

--- a/includes/class-ai-provider.php
+++ b/includes/class-ai-provider.php
@@ -410,17 +410,12 @@ abstract class SWPS_AI_Provider {
 
 	/**
 	 * Get the validated model — falls back to the first available model
-	 * if the stored model is not valid for this provider.
+	 * (discovered, else curated fallback) if the stored model is not valid
+	 * for this provider. Validating against the dynamic list ensures a
+	 * discovered model the user selected is honoured at generation time.
 	 */
 	public function get_validated_model(): string {
-		$stored = get_option( 'swps_model', '' );
-		$models = $this->get_available_models();
-
-		if ( ! empty( $stored ) && array_key_exists( $stored, $models ) ) {
-			return $stored;
-		}
-
-		// Fall back to the first model for this provider.
-		return array_key_first( $models );
+		$ids = ( new SWPS_Model_Discovery() )->available_model_ids( $this->get_slug() );
+		return SWPS_Model_Discovery::validate_selection( (string) get_option( 'swps_model', '' ), $ids );
 	}
 }

--- a/includes/class-cost-tracker.php
+++ b/includes/class-cost-tracker.php
@@ -13,7 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class SWPS_Cost_Tracker {
 
-
 	/**
 	 * Track token usage for a generation.
 	 *

--- a/includes/class-cost-tracker.php
+++ b/includes/class-cost-tracker.php
@@ -13,88 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class SWPS_Cost_Tracker {
 
-	/**
-	 * Pricing per 1M tokens [model => [input, output]].
-	 * Prices in USD.
-	 */
-	private const PRICING = array(
-		// Anthropic
-		'claude-opus-4-7'            => array(
-			'input'  => 15.00,
-			'output' => 75.00,
-		),
-		'claude-opus-4-6'            => array(
-			'input'  => 15.00,
-			'output' => 75.00,
-		),
-		'claude-sonnet-4-6'          => array(
-			'input'  => 3.00,
-			'output' => 15.00,
-		),
-		'claude-sonnet-4-5-20250929' => array(
-			'input'  => 3.00,
-			'output' => 15.00,
-		),
-		'claude-haiku-4-5-20251001'  => array(
-			'input'  => 0.80,
-			'output' => 4.00,
-		),
-		// OpenAI
-		'gpt-4.1'                    => array(
-			'input'  => 2.00,
-			'output' => 8.00,
-		),
-		'gpt-4.1-mini'               => array(
-			'input'  => 0.40,
-			'output' => 1.60,
-		),
-		'gpt-4.1-nano'               => array(
-			'input'  => 0.10,
-			'output' => 0.40,
-		),
-		'gpt-4o'                     => array(
-			'input'  => 2.50,
-			'output' => 10.00,
-		),
-		'gpt-4o-mini'                => array(
-			'input'  => 0.15,
-			'output' => 0.60,
-		),
-		'o3-mini'                    => array(
-			'input'  => 1.10,
-			'output' => 4.40,
-		),
-		// Google
-		'gemini-2.5-pro'             => array(
-			'input'  => 1.25,
-			'output' => 10.00,
-		),
-		'gemini-2.5-flash'           => array(
-			'input'  => 0.15,
-			'output' => 0.60,
-		),
-		'gemini-2.0-flash'           => array(
-			'input'  => 0.10,
-			'output' => 0.40,
-		),
-		'gemini-2.0-flash-lite'      => array(
-			'input'  => 0.075,
-			'output' => 0.30,
-		),
-		// xAI
-		'grok-3'                     => array(
-			'input'  => 3.00,
-			'output' => 15.00,
-		),
-		'grok-3-mini'                => array(
-			'input'  => 0.30,
-			'output' => 0.50,
-		),
-		'grok-3-fast'                => array(
-			'input'  => 5.00,
-			'output' => 25.00,
-		),
-	);
 
 	/**
 	 * Track token usage for a generation.
@@ -154,10 +72,7 @@ class SWPS_Cost_Tracker {
 	 * @return float Cost in USD.
 	 */
 	public function calculate_cost( string $model, int $input_tokens, int $output_tokens ): float {
-		$pricing = self::PRICING[ $model ] ?? array(
-			'input'  => 3.00,
-			'output' => 15.00,
-		);
+		$pricing = SWPS_Model_Catalog::price_for( $model );
 
 		$input_cost  = ( $input_tokens / 1_000_000 ) * $pricing['input'];
 		$output_cost = ( $output_tokens / 1_000_000 ) * $pricing['output'];

--- a/includes/class-model-catalog.php
+++ b/includes/class-model-catalog.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Heuristic model catalog: derives provider, power rank, and default pricing
+ * from a model ID, and computes dynamic superlative labels for a model list.
+ *
+ * Pure PHP — no WordPress calls — so it is unit-testable without a WP bootstrap.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_Model_Catalog {
+
+	/**
+	 * Per-provider heuristic rules. Provider is detected by the `id` pattern;
+	 * the family (power rank + default USD price per 1M input/output) is the
+	 * first matching `match`, evaluated in order (most specific first, with a
+	 * catch-all last so unknown sub-families still get a sane mid-tier default).
+	 */
+	private const RULES = array(
+		'anthropic' => array(
+			'id'       => '/^claude-/',
+			'families' => array(
+				array( 'match' => '/opus/',   'rank' => 30, 'in' => 15.00, 'out' => 75.00 ),
+				array( 'match' => '/sonnet/', 'rank' => 20, 'in' => 3.00,  'out' => 15.00 ),
+				array( 'match' => '/haiku/',  'rank' => 10, 'in' => 0.80,  'out' => 4.00 ),
+				array( 'match' => '/claude/', 'rank' => 20, 'in' => 3.00,  'out' => 15.00 ),
+			),
+		),
+		'openai'    => array(
+			'id'       => '/^(gpt-|o\d|chatgpt-)/',
+			'families' => array(
+				array( 'match' => '/nano/',   'rank' => 10, 'in' => 0.10, 'out' => 0.40 ),
+				array( 'match' => '/mini/',   'rank' => 15, 'in' => 0.40, 'out' => 1.60 ),
+				array( 'match' => '/^o\d/',   'rank' => 30, 'in' => 1.10, 'out' => 4.40 ),
+				array( 'match' => '/gpt-4o/', 'rank' => 22, 'in' => 2.50, 'out' => 10.00 ),
+				array( 'match' => '/gpt-/',   'rank' => 25, 'in' => 2.00, 'out' => 8.00 ),
+			),
+		),
+		'google'    => array(
+			'id'       => '/^(gemini|gemma)/',
+			'families' => array(
+				array( 'match' => '/flash-lite/', 'rank' => 10, 'in' => 0.075, 'out' => 0.30 ),
+				array( 'match' => '/flash/',      'rank' => 20, 'in' => 0.15,  'out' => 0.60 ),
+				array( 'match' => '/pro/',        'rank' => 30, 'in' => 1.25,  'out' => 10.00 ),
+				array( 'match' => '/gemma/',      'rank' => 5,  'in' => 0.00,  'out' => 0.00 ),
+				array( 'match' => '/gemini/',     'rank' => 20, 'in' => 0.15,  'out' => 0.60 ),
+			),
+		),
+		'xai'       => array(
+			'id'       => '/^grok/',
+			'families' => array(
+				array( 'match' => '/mini/', 'rank' => 10, 'in' => 0.30, 'out' => 0.50 ),
+				array( 'match' => '/fast/', 'rank' => 20, 'in' => 5.00, 'out' => 25.00 ),
+				array( 'match' => '/grok/', 'rank' => 20, 'in' => 3.00, 'out' => 15.00 ),
+			),
+		),
+	);
+
+	/**
+	 * Default price (USD per 1M input/output) for models with no family match.
+	 */
+	private const DEFAULT_PRICE = array( 'input' => 3.00, 'output' => 15.00 );
+
+	/**
+	 * Derive heuristic metadata for a model ID.
+	 *
+	 * @param string $id Model identifier.
+	 * @return array{provider: string|null, power_score: int|null, price_in: float|null, price_out: float|null}
+	 */
+	public static function metadata( string $id ): array {
+		$none = array(
+			'provider'    => null,
+			'power_score' => null,
+			'price_in'    => null,
+			'price_out'   => null,
+		);
+
+		foreach ( self::RULES as $provider => $rules ) {
+			if ( ! preg_match( $rules['id'], $id ) ) {
+				continue;
+			}
+			foreach ( $rules['families'] as $family ) {
+				if ( preg_match( $family['match'], $id ) ) {
+					$version = self::parse_version( $id );
+					return array(
+						'provider'    => $provider,
+						'power_score' => (int) ( $family['rank'] * 1000 + (int) round( $version * 10 ) ),
+						'price_in'    => (float) $family['in'],
+						'price_out'   => (float) $family['out'],
+					);
+				}
+			}
+			return array_merge( $none, array( 'provider' => $provider ) );
+		}
+
+		return $none;
+	}
+
+	/**
+	 * Resolve input/output price (USD per 1M tokens) for a model, falling back
+	 * to a default for unknown models. Used by the cost tracker.
+	 *
+	 * @param string $id Model identifier.
+	 * @return array{input: float, output: float}
+	 */
+	public static function price_for( string $id ): array {
+		$m = self::metadata( $id );
+		if ( null !== $m['price_in'] ) {
+			return array(
+				'input'  => $m['price_in'],
+				'output' => $m['price_out'],
+			);
+		}
+		return self::DEFAULT_PRICE;
+	}
+
+	/**
+	 * Decorate a provider's `id => display_name` map with dynamic superlative
+	 * tags computed across the set. Keys (model IDs) are never modified.
+	 *
+	 * @param array<string, string> $models id => display name.
+	 * @return array<string, string> id => decorated label.
+	 */
+	public static function decorate_labels( array $models ): array {
+		if ( count( $models ) < 2 ) {
+			return $models;
+		}
+
+		$meta = array();
+		foreach ( $models as $id => $label ) {
+			$meta[ $id ] = self::metadata( (string) $id );
+		}
+
+		$tags = array();
+
+		// Most powerful: highest power score.
+		$top_power = null;
+		$top_id    = null;
+		foreach ( $meta as $id => $m ) {
+			if ( null !== $m['power_score'] && ( null === $top_power || $m['power_score'] > $top_power ) ) {
+				$top_power = $m['power_score'];
+				$top_id    = $id;
+			}
+		}
+		if ( null !== $top_id ) {
+			$tags[ $top_id ][] = 'Most powerful';
+		}
+
+		// Price-based tags only when there is an actual spread.
+		$priced = array();
+		foreach ( $meta as $id => $m ) {
+			if ( null !== $m['price_out'] ) {
+				$priced[ $id ] = $m['price_out'];
+			}
+		}
+		if ( count( $priced ) >= 2 ) {
+			$max_out = max( $priced );
+			$min_out = min( $priced );
+			if ( $max_out > $min_out ) {
+				$costliest = array_search( $max_out, $priced, true );
+				$cheapest  = array_search( $min_out, $priced, true );
+				if ( false !== $costliest ) {
+					$tags[ $costliest ][] = 'Costs most';
+				}
+				if ( false !== $cheapest ) {
+					$tags[ $cheapest ][] = 'Cheapest';
+				}
+
+				// Best value: highest power among models priced below the max.
+				$bv_power = null;
+				$bv_id    = null;
+				foreach ( $priced as $id => $out ) {
+					if ( $out >= $max_out ) {
+						continue;
+					}
+					$p = $meta[ $id ]['power_score'];
+					if ( null !== $p && ( null === $bv_power || $p > $bv_power ) ) {
+						$bv_power = $p;
+						$bv_id    = $id;
+					}
+				}
+				if ( null !== $bv_id ) {
+					$tags[ $bv_id ][] = 'Best value';
+				}
+			}
+		}
+
+		$out = array();
+		foreach ( $models as $id => $label ) {
+			$out[ $id ] = isset( $tags[ $id ] )
+				? $label . ' — ' . implode( ' · ', $tags[ $id ] )
+				: $label;
+		}
+		return $out;
+	}
+
+	/**
+	 * Parse a numeric version from a model ID for ordering within a tier.
+	 *
+	 * Strips a trailing date suffix, then reads the first number, treating the
+	 * first internal separator as a decimal point (e.g. `opus-4-8` => 4.8).
+	 *
+	 * @param string $id Model identifier.
+	 * @return float
+	 */
+	private static function parse_version( string $id ): float {
+		$id = preg_replace( '/-\d{8}$/', '', $id );
+		$id = preg_replace( '/-\d{4}-\d{2}-\d{2}$/', '', $id );
+		if ( preg_match( '/(\d+)(?:[.-](\d+))?/', $id, $m ) ) {
+			return (float) ( $m[1] . ( isset( $m[2] ) ? '.' . $m[2] : '' ) );
+		}
+		return 0.0;
+	}
+}

--- a/includes/class-model-catalog.php
+++ b/includes/class-model-catalog.php
@@ -12,6 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Heuristic model-metadata catalog: provider, power rank, and default pricing.
+ *
+ * @package StrataWP_SEO
+ */
 class SWPS_Model_Catalog {
 
 	/**
@@ -24,38 +29,130 @@ class SWPS_Model_Catalog {
 		'anthropic' => array(
 			'id'       => '/^claude-/',
 			'families' => array(
-				array( 'match' => '/opus/',   'rank' => 30, 'in' => 15.00, 'out' => 75.00 ),
-				array( 'match' => '/sonnet/', 'rank' => 20, 'in' => 3.00,  'out' => 15.00 ),
-				array( 'match' => '/haiku/',  'rank' => 10, 'in' => 0.80,  'out' => 4.00 ),
-				array( 'match' => '/claude/', 'rank' => 20, 'in' => 3.00,  'out' => 15.00 ),
+				array(
+					'match' => '/opus/',
+					'rank'  => 30,
+					'in'    => 15.00,
+					'out'   => 75.00,
+				),
+				array(
+					'match' => '/sonnet/',
+					'rank'  => 20,
+					'in'    => 3.00,
+					'out'   => 15.00,
+				),
+				array(
+					'match' => '/haiku/',
+					'rank'  => 10,
+					'in'    => 0.80,
+					'out'   => 4.00,
+				),
+				array(
+					'match' => '/claude/',
+					'rank'  => 20,
+					'in'    => 3.00,
+					'out'   => 15.00,
+				),
 			),
 		),
 		'openai'    => array(
 			'id'       => '/^(gpt-|o\d|chatgpt-)/',
 			'families' => array(
-				array( 'match' => '/nano/',   'rank' => 10, 'in' => 0.10, 'out' => 0.40 ),
-				array( 'match' => '/mini/',   'rank' => 15, 'in' => 0.40, 'out' => 1.60 ),
-				array( 'match' => '/^o\d/',   'rank' => 30, 'in' => 1.10, 'out' => 4.40 ),
-				array( 'match' => '/gpt-4o/', 'rank' => 22, 'in' => 2.50, 'out' => 10.00 ),
-				array( 'match' => '/gpt-/',   'rank' => 25, 'in' => 2.00, 'out' => 8.00 ),
+				// nano/mini are budget tiers — matched first regardless of base model.
+				array(
+					'match' => '/nano/',
+					'rank'  => 10,
+					'in'    => 0.10,
+					'out'   => 0.40,
+				),
+				array(
+					'match' => '/mini/',
+					'rank'  => 15,
+					'in'    => 0.40,
+					'out'   => 1.60,
+				),
+				array(
+					'match' => '/^o\d/',
+					'rank'  => 30,
+					'in'    => 1.10,
+					'out'   => 4.40,
+				),
+				array(
+					'match' => '/gpt-4\.1/',
+					'rank'  => 26,
+					'in'    => 2.00,
+					'out'   => 8.00,
+				),
+				array(
+					'match' => '/gpt-4o/',
+					'rank'  => 24,
+					'in'    => 2.50,
+					'out'   => 10.00,
+				),
+				array(
+					'match' => '/gpt-/',
+					'rank'  => 22,
+					'in'    => 2.00,
+					'out'   => 8.00,
+				),
 			),
 		),
 		'google'    => array(
 			'id'       => '/^(gemini|gemma)/',
 			'families' => array(
-				array( 'match' => '/flash-lite/', 'rank' => 10, 'in' => 0.075, 'out' => 0.30 ),
-				array( 'match' => '/flash/',      'rank' => 20, 'in' => 0.15,  'out' => 0.60 ),
-				array( 'match' => '/pro/',        'rank' => 30, 'in' => 1.25,  'out' => 10.00 ),
-				array( 'match' => '/gemma/',      'rank' => 5,  'in' => 0.00,  'out' => 0.00 ),
-				array( 'match' => '/gemini/',     'rank' => 20, 'in' => 0.15,  'out' => 0.60 ),
+				array(
+					'match' => '/flash-lite/',
+					'rank'  => 10,
+					'in'    => 0.075,
+					'out'   => 0.30,
+				),
+				array(
+					'match' => '/flash/',
+					'rank'  => 20,
+					'in'    => 0.15,
+					'out'   => 0.60,
+				),
+				array(
+					'match' => '/pro/',
+					'rank'  => 30,
+					'in'    => 1.25,
+					'out'   => 10.00,
+				),
+				array(
+					'match' => '/gemma/',
+					'rank'  => 5,
+					'in'    => 0.00,
+					'out'   => 0.00,
+				),
+				array(
+					'match' => '/gemini/',
+					'rank'  => 20,
+					'in'    => 0.15,
+					'out'   => 0.60,
+				),
 			),
 		),
 		'xai'       => array(
 			'id'       => '/^grok/',
 			'families' => array(
-				array( 'match' => '/mini/', 'rank' => 10, 'in' => 0.30, 'out' => 0.50 ),
-				array( 'match' => '/fast/', 'rank' => 20, 'in' => 5.00, 'out' => 25.00 ),
-				array( 'match' => '/grok/', 'rank' => 20, 'in' => 3.00, 'out' => 15.00 ),
+				array(
+					'match' => '/mini/',
+					'rank'  => 10,
+					'in'    => 0.30,
+					'out'   => 0.50,
+				),
+				array(
+					'match' => '/fast/',
+					'rank'  => 20,
+					'in'    => 5.00,
+					'out'   => 25.00,
+				),
+				array(
+					'match' => '/grok/',
+					'rank'  => 20,
+					'in'    => 3.00,
+					'out'   => 15.00,
+				),
 			),
 		),
 	);
@@ -63,7 +160,10 @@ class SWPS_Model_Catalog {
 	/**
 	 * Default price (USD per 1M input/output) for models with no family match.
 	 */
-	private const DEFAULT_PRICE = array( 'input' => 3.00, 'output' => 15.00 );
+	private const DEFAULT_PRICE = array(
+		'input'  => 3.00,
+		'output' => 15.00,
+	);
 
 	/**
 	 * Derive heuristic metadata for a model ID.
@@ -161,6 +261,7 @@ class SWPS_Model_Catalog {
 			$max_out = max( $priced );
 			$min_out = min( $priced );
 			if ( $max_out > $min_out ) {
+				// First key wins on a price tie — intentional, input order decides.
 				$costliest = array_search( $max_out, $priced, true );
 				$cheapest  = array_search( $min_out, $priced, true );
 				if ( false !== $costliest ) {

--- a/includes/class-model-discovery.php
+++ b/includes/class-model-discovery.php
@@ -32,15 +32,54 @@ class SWPS_Model_Discovery {
 	private const OPTION_NEW = 'swps_new_models_available';
 
 	/**
-	 * Get the curated ∪ discovered text models for a provider.
+	 * Get the decorated text models for a provider (discovered, else fallback).
+	 *
+	 * @param string $provider_slug AI provider slug.
+	 * @return array<string, string> model ID => decorated display label.
+	 */
+	public function get_text_models( string $provider_slug ): array {
+		return SWPS_Model_Catalog::decorate_labels( $this->resolve_models( $provider_slug ) );
+	}
+
+	/**
+	 * Valid model IDs for a provider (discovered, else fallback) — used to
+	 * validate the saved model selection.
+	 *
+	 * @param string $provider_slug AI provider slug.
+	 * @return array<int, string>
+	 */
+	public function available_model_ids( string $provider_slug ): array {
+		return array_keys( $this->resolve_models( $provider_slug ) );
+	}
+
+	/**
+	 * Resolve the raw model map: discovered (filtered) if present, else the
+	 * provider's curated fallback list.
 	 *
 	 * @param string $provider_slug AI provider slug.
 	 * @return array<string, string> model ID => display name.
 	 */
-	public function get_text_models( string $provider_slug ): array {
-		$curated    = SWPS_Provider_Factory::curated_models_for_provider( $provider_slug );
-		$discovered = ( get_option( self::OPTION_DISCOVERED, array() )[ $provider_slug ] ?? array() );
-		return self::merge_models( $curated, (array) $discovered );
+	private function resolve_models( string $provider_slug ): array {
+		$discovered = (array) ( get_option( self::OPTION_DISCOVERED, array() )[ $provider_slug ] ?? array() );
+		if ( ! empty( $discovered ) ) {
+			return $discovered;
+		}
+		return SWPS_Provider_Factory::curated_models_for_provider( $provider_slug );
+	}
+
+	/**
+	 * Validate a stored model selection against the list of valid IDs, falling
+	 * back to the first available ID. Pure — no WordPress calls.
+	 *
+	 * @param string             $stored Stored model ID.
+	 * @param array<int, string> $ids    Valid model IDs.
+	 * @return string
+	 */
+	public static function validate_selection( string $stored, array $ids ): string {
+		if ( '' !== $stored && in_array( $stored, $ids, true ) ) {
+			return $stored;
+		}
+		return $ids[0] ?? '';
 	}
 
 	/**

--- a/includes/providers/ai/class-anthropic-provider.php
+++ b/includes/providers/ai/class-anthropic-provider.php
@@ -27,11 +27,11 @@ class SWPS_Anthropic_Provider extends SWPS_AI_Provider {
 
 	public function get_available_models(): array {
 		return array(
-			'claude-opus-4-7'            => 'Claude Opus 4.7 (Most powerful, higher cost)',
-			'claude-opus-4-6'            => 'Claude Opus 4.6 (Previous generation)',
-			'claude-sonnet-4-6'          => 'Claude Sonnet 4.6 (Great balance of quality & cost)',
-			'claude-sonnet-4-5-20250929' => 'Claude Sonnet 4.5 (Previous generation)',
-			'claude-haiku-4-5-20251001'  => 'Claude Haiku 4.5 (Fastest, lowest cost)',
+			'claude-opus-4-7'            => 'Claude Opus 4.7',
+			'claude-opus-4-6'            => 'Claude Opus 4.6',
+			'claude-sonnet-4-6'          => 'Claude Sonnet 4.6',
+			'claude-sonnet-4-5-20250929' => 'Claude Sonnet 4.5',
+			'claude-haiku-4-5-20251001'  => 'Claude Haiku 4.5',
 		);
 	}
 

--- a/includes/providers/ai/class-google-provider.php
+++ b/includes/providers/ai/class-google-provider.php
@@ -27,10 +27,10 @@ class SWPS_Google_Provider extends SWPS_AI_Provider {
 
 	public function get_available_models(): array {
 		return array(
-			'gemini-2.5-pro'        => 'Gemini 2.5 Pro (Most capable)',
-			'gemini-2.5-flash'      => 'Gemini 2.5 Flash (Fast & capable)',
-			'gemini-2.0-flash'      => 'Gemini 2.0 Flash (Previous generation)',
-			'gemini-2.0-flash-lite' => 'Gemini 2.0 Flash Lite (Fastest, lowest cost)',
+			'gemini-2.5-pro'        => 'Gemini 2.5 Pro',
+			'gemini-2.5-flash'      => 'Gemini 2.5 Flash',
+			'gemini-2.0-flash'      => 'Gemini 2.0 Flash',
+			'gemini-2.0-flash-lite' => 'Gemini 2.0 Flash Lite',
 		);
 	}
 

--- a/includes/providers/ai/class-google-provider.php
+++ b/includes/providers/ai/class-google-provider.php
@@ -147,7 +147,12 @@ class SWPS_Google_Provider extends SWPS_AI_Provider {
 			if ( '' === $name || ! in_array( 'generateContent', $methods, true ) ) {
 				continue;
 			}
-			$id            = preg_replace( '#^models/#', '', $name );
+			$id = preg_replace( '#^models/#', '', $name );
+			// Drop non-text-generation models that still report generateContent
+			// (image, TTS, music, robotics, agents, etc.).
+			if ( preg_match( '/(image|tts|lyria|veo|imagen|robotics|computer-use|deep-research|antigravity|nano-banana|aqa)/i', $id ) ) {
+				continue;
+			}
 			$models[ $id ] = (string) ( $m['displayName'] ?? $id );
 		}
 		return $models;

--- a/includes/providers/ai/class-openai-provider.php
+++ b/includes/providers/ai/class-openai-provider.php
@@ -27,12 +27,12 @@ class SWPS_OpenAI_Provider extends SWPS_AI_Provider {
 
 	public function get_available_models(): array {
 		return array(
-			'gpt-4.1'      => 'GPT-4.1 (Most capable)',
-			'gpt-4.1-mini' => 'GPT-4.1 Mini (Fast & affordable)',
-			'gpt-4.1-nano' => 'GPT-4.1 Nano (Fastest, lowest cost)',
-			'gpt-4o'       => 'GPT-4o (Previous generation)',
-			'gpt-4o-mini'  => 'GPT-4o Mini (Previous generation)',
-			'o3-mini'      => 'o3-mini (Reasoning model)',
+			'gpt-4.1'      => 'GPT-4.1',
+			'gpt-4.1-mini' => 'GPT-4.1 Mini',
+			'gpt-4.1-nano' => 'GPT-4.1 Nano',
+			'gpt-4o'       => 'GPT-4o',
+			'gpt-4o-mini'  => 'GPT-4o Mini',
+			'o3-mini'      => 'o3-mini',
 		);
 	}
 

--- a/includes/providers/ai/class-xai-provider.php
+++ b/includes/providers/ai/class-xai-provider.php
@@ -27,9 +27,9 @@ class SWPS_XAI_Provider extends SWPS_AI_Provider {
 
 	public function get_available_models(): array {
 		return array(
-			'grok-3'      => 'Grok 3 (Most capable)',
-			'grok-3-mini' => 'Grok 3 Mini (Fast & efficient)',
-			'grok-3-fast' => 'Grok 3 Fast (Balanced)',
+			'grok-3'      => 'Grok 3',
+			'grok-3-mini' => 'Grok 3 Mini',
+			'grok-3-fast' => 'Grok 3 Fast',
 		);
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.8.0
+Stable tag: 4.9.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -252,6 +252,13 @@ Yes. The built-in analytics tracker is cookie-free and does not use any external
 No. GSC integration is optional. The on-site analytics works entirely without any external services. Add Google OAuth credentials only if you want search clicks, impressions, and ranking data.
 
 == Changelog ==
+
+= 4.9.0 — 2026-05-29 =
+* Feature: AI model lists are now fully dynamic — fetched live from each provider's API and refreshed daily, so new models appear automatically without a plugin update.
+* Feature: Superlative labels (Most powerful, Cheapest, Costs most, Best value) are now computed dynamically across each provider's full discovered model set, so the correct models are always highlighted even as new models are released.
+* Feature: Google model list is now filtered more tightly — image output, TTS, music (Lyria), and robotics models are excluded, leaving only text-generation models in the picker.
+* Feature: Cost tracking now prices newly discovered models automatically via family heuristics — new model IDs no longer fall through to a $0 default.
+* Fix: Selecting a discovered model in Settings now sticks at generation time. Previously, any model not in the original hardcoded list failed validation silently and the plugin fell back to the default, so discovery was effectively inoperative.
 
 = 4.8.0 — 2026-05-29 =
 * Feature: AI models are now auto-discovered from each configured provider's API (Anthropic, OpenAI, Google, xAI) once a day and added to the model dropdown automatically, with a dismissible alert when a new model appears.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.8.0
+ * Version: 4.9.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.8.0' );
+define( 'SWPS_VERSION', '4.9.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -47,6 +47,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/providers/images/class-gemini-provider.
 
 // Factory.
 require_once SWPS_PLUGIN_DIR . 'includes/class-provider-factory.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-model-catalog.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-model-discovery.php';
 
 // Legacy aliases (must load after concrete providers they extend).

--- a/tests/unit/CostTrackerTest.php
+++ b/tests/unit/CostTrackerTest.php
@@ -1,0 +1,20 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-model-catalog.php';
+require_once __DIR__ . '/../../includes/class-cost-tracker.php';
+
+final class CostTrackerTest extends TestCase {
+
+	public function test_opus_4_8_is_priced_via_catalog(): void {
+		$tracker = new SWPS_Cost_Tracker();
+		// 1M input + 1M output at Opus pricing (15 + 75) = 90.0.
+		$this->assertEqualsWithDelta( 90.0, $tracker->calculate_cost( 'claude-opus-4-8', 1_000_000, 1_000_000 ), 0.0001 );
+	}
+
+	public function test_unknown_model_uses_default_pricing(): void {
+		$tracker = new SWPS_Cost_Tracker();
+		// Default 3 + 15 = 18.0.
+		$this->assertEqualsWithDelta( 18.0, $tracker->calculate_cost( 'who-knows-9000', 1_000_000, 1_000_000 ), 0.0001 );
+	}
+}

--- a/tests/unit/ModelCatalogTest.php
+++ b/tests/unit/ModelCatalogTest.php
@@ -37,6 +37,13 @@ final class ModelCatalogTest extends TestCase {
 		$this->assertNull( $m['price_out'] );
 	}
 
+	public function test_metadata_openai_o_series_and_gpt_ordering(): void {
+		$score = fn( string $id ) => SWPS_Model_Catalog::metadata( $id )['power_score'];
+		$this->assertSame( 30030, $score( 'o3' ) );
+		$this->assertGreaterThan( $score( 'gpt-4o' ), $score( 'gpt-4.1' ) );
+		$this->assertGreaterThan( $score( 'gpt-4-turbo' ), $score( 'gpt-4o' ) );
+	}
+
 	public function test_price_for_known_model(): void {
 		$this->assertSame( array( 'input' => 15.0, 'output' => 75.0 ), SWPS_Model_Catalog::price_for( 'claude-opus-4-8' ) );
 		$this->assertSame( array( 'input' => 0.8, 'output' => 4.0 ), SWPS_Model_Catalog::price_for( 'claude-haiku-4-5-20251001' ) );

--- a/tests/unit/ModelCatalogTest.php
+++ b/tests/unit/ModelCatalogTest.php
@@ -45,4 +45,38 @@ final class ModelCatalogTest extends TestCase {
 	public function test_price_for_unknown_model_uses_default(): void {
 		$this->assertSame( array( 'input' => 3.0, 'output' => 15.0 ), SWPS_Model_Catalog::price_for( 'who-knows-9000' ) );
 	}
+
+	public function test_decorate_labels_tags_superlatives(): void {
+		$models = array(
+			'claude-opus-4-8'           => 'Claude Opus 4.8',
+			'claude-opus-4-7'           => 'Claude Opus 4.7',
+			'claude-sonnet-4-6'         => 'Claude Sonnet 4.6',
+			'claude-haiku-4-5-20251001' => 'Claude Haiku 4.5',
+		);
+		$out = SWPS_Model_Catalog::decorate_labels( $models );
+		$this->assertSame( 'Claude Opus 4.8 — Most powerful · Costs most', $out['claude-opus-4-8'] );
+		$this->assertSame( 'Claude Sonnet 4.6 — Best value', $out['claude-sonnet-4-6'] );
+		$this->assertSame( 'Claude Haiku 4.5 — Cheapest', $out['claude-haiku-4-5-20251001'] );
+		$this->assertSame( 'Claude Opus 4.7', $out['claude-opus-4-7'] );
+	}
+
+	public function test_decorate_labels_noop_for_single_model(): void {
+		$models = array( 'claude-opus-4-8' => 'Claude Opus 4.8' );
+		$this->assertSame( $models, SWPS_Model_Catalog::decorate_labels( $models ) );
+	}
+
+	public function test_decorate_labels_no_price_tags_when_all_same_price(): void {
+		$models = array(
+			'claude-opus-4-8' => 'Claude Opus 4.8',
+			'claude-opus-4-7' => 'Claude Opus 4.7',
+		);
+		$out = SWPS_Model_Catalog::decorate_labels( $models );
+		$this->assertSame( 'Claude Opus 4.8 — Most powerful', $out['claude-opus-4-8'] );
+		$this->assertSame( 'Claude Opus 4.7', $out['claude-opus-4-7'] );
+	}
+
+	public function test_decorate_labels_leaves_unknown_models_untagged(): void {
+		$models = array( 'mystery-a' => 'Mystery A', 'mystery-b' => 'Mystery B' );
+		$this->assertSame( $models, SWPS_Model_Catalog::decorate_labels( $models ) );
+	}
 }

--- a/tests/unit/ModelCatalogTest.php
+++ b/tests/unit/ModelCatalogTest.php
@@ -36,4 +36,13 @@ final class ModelCatalogTest extends TestCase {
 		$this->assertNull( $m['power_score'] );
 		$this->assertNull( $m['price_out'] );
 	}
+
+	public function test_price_for_known_model(): void {
+		$this->assertSame( array( 'input' => 15.0, 'output' => 75.0 ), SWPS_Model_Catalog::price_for( 'claude-opus-4-8' ) );
+		$this->assertSame( array( 'input' => 0.8, 'output' => 4.0 ), SWPS_Model_Catalog::price_for( 'claude-haiku-4-5-20251001' ) );
+	}
+
+	public function test_price_for_unknown_model_uses_default(): void {
+		$this->assertSame( array( 'input' => 3.0, 'output' => 15.0 ), SWPS_Model_Catalog::price_for( 'who-knows-9000' ) );
+	}
 }

--- a/tests/unit/ModelCatalogTest.php
+++ b/tests/unit/ModelCatalogTest.php
@@ -1,0 +1,39 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-model-catalog.php';
+
+final class ModelCatalogTest extends TestCase {
+
+	public function test_metadata_detects_anthropic_opus(): void {
+		$m = SWPS_Model_Catalog::metadata( 'claude-opus-4-8' );
+		$this->assertSame( 'anthropic', $m['provider'] );
+		$this->assertSame( 30048, $m['power_score'] );
+		$this->assertSame( 75.0, $m['price_out'] );
+	}
+
+	public function test_metadata_strips_date_suffix_for_version(): void {
+		$this->assertSame( 30041, SWPS_Model_Catalog::metadata( 'claude-opus-4-1-20250805' )['power_score'] );
+		$this->assertSame( 30040, SWPS_Model_Catalog::metadata( 'claude-opus-4-20250514' )['power_score'] );
+	}
+
+	public function test_power_score_orders_by_tier_then_version(): void {
+		$score = fn( string $id ) => SWPS_Model_Catalog::metadata( $id )['power_score'];
+		$this->assertGreaterThan( $score( 'claude-opus-4-7' ), $score( 'claude-opus-4-8' ) );
+		$this->assertGreaterThan( $score( 'claude-sonnet-4-6' ), $score( 'claude-opus-4-6' ) );
+		$this->assertGreaterThan( $score( 'claude-haiku-4-5-20251001' ), $score( 'claude-sonnet-4-6' ) );
+	}
+
+	public function test_metadata_detects_other_providers(): void {
+		$this->assertSame( 'openai', SWPS_Model_Catalog::metadata( 'gpt-4.1' )['provider'] );
+		$this->assertSame( 'google', SWPS_Model_Catalog::metadata( 'gemini-2.5-pro' )['provider'] );
+		$this->assertSame( 'xai', SWPS_Model_Catalog::metadata( 'grok-3' )['provider'] );
+	}
+
+	public function test_metadata_unknown_model_is_null(): void {
+		$m = SWPS_Model_Catalog::metadata( 'totally-unknown-model' );
+		$this->assertNull( $m['provider'] );
+		$this->assertNull( $m['power_score'] );
+		$this->assertNull( $m['price_out'] );
+	}
+}

--- a/tests/unit/ModelDiscoveryTest.php
+++ b/tests/unit/ModelDiscoveryTest.php
@@ -25,4 +25,19 @@ final class ModelDiscoveryTest extends TestCase {
 	public function test_diff_empty_known_returns_all(): void {
 		$this->assertSame( array( 'a' ), SWPS_Model_Discovery::diff_new_ids( array(), array( 'a' ) ) );
 	}
+
+	public function test_validate_selection_keeps_valid_stored_model(): void {
+		$ids = array( 'claude-opus-4-8', 'claude-opus-4-7' );
+		$this->assertSame( 'claude-opus-4-8', SWPS_Model_Discovery::validate_selection( 'claude-opus-4-8', $ids ) );
+	}
+
+	public function test_validate_selection_falls_back_to_first_when_invalid(): void {
+		$ids = array( 'claude-opus-4-8', 'claude-opus-4-7' );
+		$this->assertSame( 'claude-opus-4-8', SWPS_Model_Discovery::validate_selection( 'gone-model', $ids ) );
+		$this->assertSame( 'claude-opus-4-8', SWPS_Model_Discovery::validate_selection( '', $ids ) );
+	}
+
+	public function test_validate_selection_empty_ids_returns_empty_string(): void {
+		$this->assertSame( '', SWPS_Model_Discovery::validate_selection( 'anything', array() ) );
+	}
 }

--- a/tests/unit/RemoteModelsParserTest.php
+++ b/tests/unit/RemoteModelsParserTest.php
@@ -65,4 +65,24 @@ final class RemoteModelsParserTest extends TestCase {
 		$this->assertSame( array(), SWPS_Anthropic_Provider::parse_models_response( array() ) );
 		$this->assertSame( array(), SWPS_OpenAI_Provider::parse_models_response( array( 'nope' => 1 ) ) );
 	}
+
+	public function test_google_excludes_nontext_models_reporting_generatecontent(): void {
+		$body = array( 'models' => array(
+			array( 'name' => 'models/gemini-3-pro', 'displayName' => 'Gemini 3 Pro', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/gemma-4-31b-it', 'displayName' => 'Gemma 4 31B', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/gemini-2.5-flash-image', 'displayName' => 'Nano Banana', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/gemini-2.5-flash-preview-tts', 'displayName' => 'TTS', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/lyria-3-pro-preview', 'displayName' => 'Lyria', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/gemini-robotics-er-1.5-preview', 'displayName' => 'Robotics', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+			array( 'name' => 'models/nano-banana-pro-preview', 'displayName' => 'Nano Banana Pro', 'supportedGenerationMethods' => array( 'generateContent' ) ),
+		) );
+		$out = SWPS_Google_Provider::parse_models_response( $body );
+		$this->assertArrayHasKey( 'gemini-3-pro', $out );
+		$this->assertArrayHasKey( 'gemma-4-31b-it', $out );
+		$this->assertArrayNotHasKey( 'gemini-2.5-flash-image', $out );
+		$this->assertArrayNotHasKey( 'gemini-2.5-flash-preview-tts', $out );
+		$this->assertArrayNotHasKey( 'lyria-3-pro-preview', $out );
+		$this->assertArrayNotHasKey( 'gemini-robotics-er-1.5-preview', $out );
+		$this->assertArrayNotHasKey( 'nano-banana-pro-preview', $out );
+	}
 }


### PR DESCRIPTION
## Summary
- **New `SWPS_Model_Catalog`** — pure-PHP heuristics that derive provider, power rank, and default pricing from a model ID, and compute dynamic superlative tags (**Most powerful / Cheapest / Costs most / Best value**) across a provider's list.
- **Model lists are now dynamic** (discovery-driven) for all four providers; the old hardcoded curated lists are demoted to a no-API-key fallback, and the hand-written "(Most powerful, …)" suffixes are gone — labels are computed at render time.
- **Tighter Google filtering** — drops image/TTS/music (Lyria)/robotics/agent models that report `generateContent` but aren't text generators.
- **Unified pricing** — the cost tracker now reads `SWPS_Model_Catalog::price_for()`, so new models are auto-priced. Fixes `claude-opus-4-8` not being costed.
- **Fix: selected model now sticks** — `get_validated_model()` validates the saved model against the dynamic list (discovered ∪ fallback) instead of the hardcoded list, so a discovered model like `claude-opus-4-8` is honored at generation time instead of silently reverting.
- Bumped to **v4.9.0**. Design + plan under `docs/superpowers/`.

## Test Plan
- [x] `composer test` — 73 tests, 141 assertions, green
- [x] `phpstan analyse` — no errors; no new PHPCS violations in touched files
- [x] Spec-compliance + code-quality review per task, plus a final comprehensive review
- [x] Post-merge on jonimms.com: `wp cron event run swps_refresh_models` then confirm the Google list is clean and the model dropdown shows e.g. `Claude Opus 4.8 — Most powerful · Costs most`, `… — Best value`, `… — Cheapest`
- [x] Select Opus 4.8, save, confirm `wp option get swps_model` returns `claude-opus-4-8` and a generation actually uses it

🤖 Generated with [Claude Code](https://claude.com/claude-code)