### PR TITLE
fix: emit FAQPage instead of QAPage for AEO Q&A schema (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.9.0-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.9.1-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1274,6 +1274,11 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.9.1 — June 2026
+- **Fix — FAQPage instead of QAPage:** AEO Optimize now marks up Q&A sections as `FAQPage` rather than `QAPage`, clearing the "Q&A structured data issues" Google Search Console reports (issue #44). `QAPage` is for community pages with user-submitted answers and was the wrong type for site-authored FAQ content. Pages optimized before the fix are auto-converted on update (or run `wp swps migrate-qapage`), after which you can hit "Validate fix" in Search Console.
+- **Fix — stricter schema validation:** every FAQ question must now carry a real answer before JSON-LD is emitted, so incomplete Q&A markup can't reach Search Console.
+- **Note:** Google retired FAQ rich results for most sites in 2023, so FAQPage no longer renders the expandable Q&A snippet — but the markup is valid, error-free, and still helps AI answer engines parse your content.
 
 ### v4.9.0 — May 2026
 - **Feature — fully dynamic model lists:** AI model dropdowns are now pulled live from each provider's API and refreshed daily, so new models appear automatically without a plugin update.

--- a/includes/aeo/class-markup-scorer.php
+++ b/includes/aeo/class-markup-scorer.php
@@ -29,7 +29,7 @@ class SWPS_AEO_Markup_Scorer {
 	 * patterns. A type is considered a match when at least 2 of its signals
 	 * fire (avoids false positives from a single weak signal).
 	 *
-	 * Note: 'qapage' has no patterns here — it's inferred separately from
+	 * Note: 'faqpage' has no patterns here — it's inferred separately from
 	 * the title (ends in '?') or H2 question density (>=80% question H2s).
 	 */
 	private const TYPE_SIGNALS = array(
@@ -55,7 +55,7 @@ class SWPS_AEO_Markup_Scorer {
 			'/\b\d(?:\.\d)?\s*\/\s*5\b/',
 			'/★{3,5}/u',
 		),
-		'qapage' => array(),
+		'faqpage' => array(),
 	);
 
 	/**
@@ -147,15 +147,15 @@ class SWPS_AEO_Markup_Scorer {
 	 *
 	 * @param string $html  Raw post HTML.
 	 * @param string $title Post title.
-	 * @return string|null  One of: 'howto', 'recipe', 'product', 'review', 'qapage', or null.
+	 * @return string|null  One of: 'howto', 'recipe', 'product', 'review', 'faqpage', or null.
 	 */
 	public function infer_schema_type( string $html, string $title ): ?string {
 		$title    = strtolower( $title );
 		$haystack = $title . ' ' . $html;
 
-		// QAPage: title ends in '?' OR >=80% of H2s are questions.
+		// FAQPage: title ends in '?' OR >=80% of H2s are questions.
 		if ( str_ends_with( trim( $title ), '?' ) ) {
-			return 'qapage';
+			return 'faqpage';
 		}
 		if ( preg_match_all( '#<h2[^>]*>([^<]+)</h2>#i', $html, $h2s ) ) {
 			$total_h2 = count( $h2s[1] );
@@ -167,7 +167,7 @@ class SWPS_AEO_Markup_Scorer {
 					}
 				}
 				if ( $q_h2 / $total_h2 >= 0.8 ) {
-					return 'qapage';
+					return 'faqpage';
 				}
 			}
 		}
@@ -175,7 +175,7 @@ class SWPS_AEO_Markup_Scorer {
 		// Score remaining types by signal hits; require >=2 for a match.
 		$scores = array();
 		foreach ( self::TYPE_SIGNALS as $slug => $patterns ) {
-			if ( 'qapage' === $slug ) {
+			if ( 'faqpage' === $slug ) {
 				continue;
 			}
 			$hits = 0;

--- a/includes/class-aeo-optimizer.php
+++ b/includes/class-aeo-optimizer.php
@@ -358,7 +358,7 @@ class SWPS_AEO_Optimizer {
 			'Return JSON with exactly these keys: ' .
 			'{"edits":[{"find":"...","replace":"...","reason":"..."}], ' .
 			'"inserts":[{"kind":"qa|tldr|list|defn","anchor":"<h2 text> or top","html":"<...>","reason":"..."}], ' .
-			'"schema":{"type":"howto|recipe|product|review|qapage|null","reason":"..."}, ' .
+			'"schema":{"type":"howto|recipe|product|review|faqpage|null","reason":"..."}, ' .
 			'"projected_score":<int 0-100>}.',
 			$post->post_title,
 			$expected_type ?? 'none',

--- a/includes/class-aeo-schema-generator.php
+++ b/includes/class-aeo-schema-generator.php
@@ -1,7 +1,13 @@
 <?php
 /**
  * AEO Schema Generator — AI-driven dynamic JSON-LD for 5 schema types:
- * HowTo, Recipe, Product, Review, QAPage.
+ * HowTo, Recipe, Product, Review, FAQPage.
+ *
+ * Q&A content uses FAQPage (a list of questions each with one authoritative
+ * answer the site provides), NOT QAPage. QAPage is Google's type for pages
+ * built around a single user-submitted question with community answers
+ * (forum / Stack Overflow style); applying it to site-authored Q&A trips
+ * Search Console's QAPage validators. See issue #44.
  *
  * Workflow:
  *   1. Caller picks a type (typically from SWPS_AEO_Markup_Scorer::infer_schema_type()).
@@ -25,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class SWPS_AEO_Schema_Generator {
 
-	private const SUPPORTED_TYPES = array( 'howto', 'recipe', 'product', 'review', 'qapage' );
+	private const SUPPORTED_TYPES = array( 'howto', 'recipe', 'product', 'review', 'faqpage' );
 
 	/** @var object */
 	private $provider;
@@ -47,7 +53,7 @@ class SWPS_AEO_Schema_Generator {
 	/**
 	 * Generate JSON-LD for the given type.
 	 *
-	 * @param string $type  One of: howto, recipe, product, review, qapage.
+	 * @param string $type  One of: howto, recipe, product, review, faqpage.
 	 * @param string $title Post title.
 	 * @param string $html  Raw post HTML.
 	 * @return array{json: ?array<string, mixed>, error: ?string}
@@ -117,6 +123,13 @@ class SWPS_AEO_Schema_Generator {
 			$json = (array) apply_filters( 'swps_aeo_schema_json', $json, $type, null );
 		}
 
+		// FAQPage's mainEntity must be a list of Questions. The AI sometimes
+		// returns a single Question object for a one-question post; wrap it so
+		// the output matches Google's expected shape.
+		if ( 'FAQPage' === $expected_type ) {
+			$json = $this->normalize_faqpage( (array) $json );
+		}
+
 		$err = $this->validate( (array) $json, $expected_type, $required );
 		if ( null !== $err ) {
 			return array(
@@ -135,7 +148,7 @@ class SWPS_AEO_Schema_Generator {
 	 * Build human-readable shape guidance from the spec's *_shape entries.
 	 *
 	 * The schema-fields manifest defines nested-object shapes (e.g.
-	 * QAPage's main_entity_shape → Question, HowTo's step_shape →
+	 * FAQPage's main_entity_shape → Question, HowTo's step_shape →
 	 * HowToStep). Without telling the AI these shapes, it tends to
 	 * return empty arrays or null for the parent required field — which
 	 * the validator rejects. This method turns each *_shape entry into
@@ -166,12 +179,20 @@ class SWPS_AEO_Schema_Generator {
 			if ( '' === $type || empty( $fields ) ) {
 				continue;
 			}
-			$lines[] = sprintf(
-				'  - %s should be a %s object with fields: %s',
-				$parent_field,
-				$type,
-				implode( ', ', $fields )
-			);
+			$is_array = ! empty( $value['is_array'] );
+			$lines[]  = $is_array
+				? sprintf(
+					'  - %s should be an ARRAY of %s objects, each with fields: %s',
+					$parent_field,
+					$type,
+					implode( ', ', $fields )
+				)
+				: sprintf(
+					'  - %s should be a %s object with fields: %s',
+					$parent_field,
+					$type,
+					implode( ', ', $fields )
+				);
 		}
 		return implode( "\n", $lines );
 	}
@@ -198,6 +219,15 @@ class SWPS_AEO_Schema_Generator {
 		if ( ( $json['@type'] ?? '' ) !== $expected_type ) {
 			return 'invalid @type (expected ' . $expected_type . ')';
 		}
+
+		// FAQPage needs structural validation Google enforces but a flat
+		// required-fields check can't express: every Question must carry a
+		// non-empty name and an acceptedAnswer with non-empty text. Emitting
+		// markup that misses these is what trips Search Console (issue #44).
+		if ( 'FAQPage' === $expected_type ) {
+			return $this->validate_faqpage( $json );
+		}
+
 		foreach ( $required as $field ) {
 			if ( ! array_key_exists( $field, $json ) ) {
 				return "missing required field: {$field}";
@@ -205,6 +235,56 @@ class SWPS_AEO_Schema_Generator {
 			$v = $json[ $field ];
 			if ( null === $v || '' === $v || ( is_array( $v ) && empty( $v ) ) ) {
 				return "empty required field: {$field}";
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Coerce a FAQPage's mainEntity into a list of Question objects.
+	 *
+	 * The AI may return mainEntity as a single Question object (one-question
+	 * post). Google accepts a single item but its examples and validators
+	 * favour an array; we always emit a list for consistency.
+	 *
+	 * @param array<string, mixed> $json
+	 * @return array<string, mixed>
+	 */
+	private function normalize_faqpage( array $json ): array {
+		$entity = $json['mainEntity'] ?? null;
+		if ( is_array( $entity ) && isset( $entity['@type'] ) ) {
+			$json['mainEntity'] = array( $entity );
+		}
+		return $json;
+	}
+
+	/**
+	 * Validate a FAQPage's mainEntity question/answer structure.
+	 *
+	 * Requires a non-empty list of Question objects, each with a non-empty
+	 * name and an acceptedAnswer carrying non-empty text — the minimum Google
+	 * accepts for FAQPage.
+	 *
+	 * @param array<string, mixed> $json
+	 */
+	private function validate_faqpage( array $json ): ?string {
+		$entities = $json['mainEntity'] ?? null;
+		if ( ! is_array( $entities ) || empty( $entities ) ) {
+			return 'empty required field: mainEntity';
+		}
+
+		foreach ( $entities as $q ) {
+			if ( ! is_array( $q ) || ( $q['@type'] ?? '' ) !== 'Question' ) {
+				return 'mainEntity must be a list of Question objects';
+			}
+			$name = $q['name'] ?? '';
+			if ( ! is_string( $name ) || '' === trim( $name ) ) {
+				return 'Question missing name';
+			}
+			$answer = $q['acceptedAnswer'] ?? null;
+			$text   = is_array( $answer ) ? ( $answer['text'] ?? '' ) : '';
+			if ( ! is_string( $text ) || '' === trim( $text ) ) {
+				return 'Question missing acceptedAnswer text';
 			}
 		}
 		return null;

--- a/includes/class-aeo-schema-migrator.php
+++ b/includes/class-aeo-schema-migrator.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * AEO Schema Migrator — converts legacy QAPage JSON-LD to FAQPage.
+ *
+ * Background (issue #44): early AEO releases emitted QAPage structured data
+ * for site-authored Q&A content. QAPage is Google's type for community
+ * pages with user-submitted answers; using it for FAQ-style content trips
+ * Search Console's QAPage validators. The generator now emits FAQPage, but
+ * pages optimized before the fix have QAPage frozen into the
+ * _swps_aeo_schema_json / _swps_aeo_schema_type post meta. This class
+ * rewrites that stored meta in place so existing pages stop erroring.
+ *
+ * convert_schema() is pure (no WordPress) and unit-tested. migrate_all()
+ * is the WP-dependent bulk runner invoked from the one-time upgrade routine
+ * and the `wp swps migrate-qapage` CLI command.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Converts legacy QAPage AEO schema meta to FAQPage (issue #44).
+ */
+class SWPS_AEO_Schema_Migrator {
+
+	private const META_SCHEMA_TYPE = '_swps_aeo_schema_type';
+	private const META_SCHEMA_JSON = '_swps_aeo_schema_json';
+
+	/**
+	 * Convert a QAPage JSON-LD array to a valid FAQPage array.
+	 *
+	 * QAPage stores a single Question in mainEntity (Stack Overflow shape);
+	 * FAQPage wants a list of Questions, each with name + acceptedAnswer.text.
+	 * QAPage's suggestedAnswer (when there's no acceptedAnswer) becomes the
+	 * FAQPage answer. Questions with no usable answer are dropped. QAPage-only
+	 * fields (answerCount, upvoteCount, dateCreated, author) are stripped.
+	 *
+	 * @param array<string, mixed> $json Decoded QAPage JSON-LD.
+	 * @return array<string, mixed>|null FAQPage array, or null if nothing convertible.
+	 */
+	public static function convert_schema( array $json ): ?array {
+		$entity = $json['mainEntity'] ?? null;
+		if ( null === $entity ) {
+			return null;
+		}
+
+		// Normalize to a list of question candidates.
+		$questions = isset( $entity['@type'] ) ? array( $entity ) : (array) $entity;
+
+		$clean = array();
+		foreach ( $questions as $q ) {
+			if ( ! is_array( $q ) ) {
+				continue;
+			}
+			$built = self::build_question( $q );
+			if ( null !== $built ) {
+				$clean[] = $built;
+			}
+		}
+
+		if ( empty( $clean ) ) {
+			return null;
+		}
+
+		return array(
+			'@context'   => 'https://schema.org',
+			'@type'      => 'FAQPage',
+			'mainEntity' => $clean,
+		);
+	}
+
+	/**
+	 * Build a clean FAQPage Question from a QAPage Question, or null if it
+	 * has no usable name/answer.
+	 *
+	 * @param array<string, mixed> $q One QAPage Question node.
+	 * @return array<string, mixed>|null
+	 */
+	private static function build_question( array $q ): ?array {
+		$name = $q['name'] ?? ( $q['text'] ?? '' );
+		if ( ! is_string( $name ) || '' === trim( $name ) ) {
+			return null;
+		}
+
+		// Prefer acceptedAnswer; fall back to the first suggestedAnswer.
+		$answer = $q['acceptedAnswer'] ?? null;
+		if ( ! is_array( $answer ) || '' === trim( (string) ( $answer['text'] ?? '' ) ) ) {
+			$suggested = $q['suggestedAnswer'] ?? null;
+			if ( is_array( $suggested ) ) {
+				// suggestedAnswer may be a single Answer or a list of them.
+				$answer = isset( $suggested['text'] ) ? $suggested : ( $suggested[0] ?? null );
+			}
+		}
+
+		$text = is_array( $answer ) ? (string) ( $answer['text'] ?? '' ) : '';
+		if ( '' === trim( $text ) ) {
+			return null;
+		}
+
+		return array(
+			'@type'          => 'Question',
+			'name'           => trim( $name ),
+			'acceptedAnswer' => array(
+				'@type' => 'Answer',
+				'text'  => trim( $text ),
+			),
+		);
+	}
+
+	/**
+	 * Bulk-convert every post still storing QAPage schema meta to FAQPage.
+	 *
+	 * Idempotent: only touches posts whose _swps_aeo_schema_type is 'qapage'.
+	 * Posts whose stored JSON can't be converted have their AEO schema meta
+	 * cleared (so they stop emitting invalid QAPage) and are reported as
+	 * 'cleared' — the user can re-run AEO optimize to regenerate FAQPage.
+	 *
+	 * Also rewrites the swps_aeo_enabled_schema_types option so a saved
+	 * 'qapage' selection becomes 'faqpage'.
+	 *
+	 * @return array{converted:int, cleared:int} Counts.
+	 */
+	public static function migrate_all(): array {
+		self::migrate_enabled_types_option();
+
+		$post_ids = get_posts(
+			array(
+				'post_type'        => 'any',
+				'post_status'      => 'any',
+				'numberposts'      => -1,
+				'fields'           => 'ids',
+				'meta_key'         => self::META_SCHEMA_TYPE, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'       => 'qapage',                // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'suppress_filters' => true,
+			)
+		);
+
+		$converted = 0;
+		$cleared   = 0;
+
+		foreach ( (array) $post_ids as $post_id ) {
+			$post_id = (int) $post_id;
+			$raw     = (string) get_post_meta( $post_id, self::META_SCHEMA_JSON, true );
+			$decoded = '' !== $raw ? json_decode( $raw, true ) : null;
+			$faq     = is_array( $decoded ) ? self::convert_schema( $decoded ) : null;
+
+			if ( null === $faq ) {
+				// Nothing convertible — clear so the page stops emitting QAPage.
+				delete_post_meta( $post_id, self::META_SCHEMA_TYPE );
+				delete_post_meta( $post_id, self::META_SCHEMA_JSON );
+				++$cleared;
+				continue;
+			}
+
+			update_post_meta( $post_id, self::META_SCHEMA_TYPE, 'faqpage' );
+			// wp_slash before update_post_meta: update_metadata() runs wp_unslash
+			// internally, which would otherwise strip the \" escapes and corrupt
+			// the stored JSON (same pattern as SWPS_AEO_Optimizer).
+			update_post_meta(
+				$post_id,
+				self::META_SCHEMA_JSON,
+				wp_slash( (string) wp_json_encode( $faq ) )
+			);
+			++$converted;
+		}
+
+		return array(
+			'converted' => $converted,
+			'cleared'   => $cleared,
+		);
+	}
+
+	/**
+	 * Replace 'qapage' with 'faqpage' in the enabled-schema-types option.
+	 */
+	private static function migrate_enabled_types_option(): void {
+		$enabled = get_option( 'swps_aeo_enabled_schema_types', null );
+		if ( ! is_array( $enabled ) || ! in_array( 'qapage', $enabled, true ) ) {
+			return;
+		}
+		$enabled = array_values(
+			array_unique(
+				array_map(
+					static fn( $t ) => 'qapage' === $t ? 'faqpage' : $t,
+					$enabled
+				)
+			)
+		);
+		update_option( 'swps_aeo_enabled_schema_types', $enabled );
+	}
+}

--- a/includes/class-cli.php
+++ b/includes/class-cli.php
@@ -355,4 +355,34 @@ class SWPS_CLI {
 			);
 		}
 	}
+
+	/**
+	 * Convert legacy QAPage AEO schema to FAQPage (issue #44).
+	 *
+	 * Rewrites the _swps_aeo_schema_json / _swps_aeo_schema_type post meta on
+	 * pages optimized before the QAPage→FAQPage fix. Runs automatically once
+	 * after updating the plugin; this command re-runs it on demand (e.g. if
+	 * the auto-migration was skipped or you restored an old database).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp swps migrate-qapage
+	 *
+	 * @param array $args       Positional arguments.
+	 * @param array $assoc_args Named arguments.
+	 */
+	public function migrate_qapage( array $args, array $assoc_args ): void {
+		WP_CLI::log( 'Converting legacy QAPage schema to FAQPage...' );
+
+		$result = SWPS_AEO_Schema_Migrator::migrate_all();
+		update_option( 'swps_qapage_faqpage_migrated', 1 );
+
+		WP_CLI::success(
+			sprintf(
+				'%d post(s) converted to FAQPage, %d cleared (re-run AEO optimize to regenerate those).',
+				$result['converted'],
+				$result['cleared']
+			)
+		);
+	}
 }

--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -7,7 +7,7 @@
  *     Hooked at wp_head priority 1. Bails entirely if Yoast / RankMath /
  *     AIOSEO is active.
  *   - AEO (v4.6+): dynamic per-post HowTo / Recipe / Product / Review /
- *     QAPage from _swps_aeo_schema_json post meta. Hooked at wp_head
+ *     FAQPage from _swps_aeo_schema_json post meta. Hooked at wp_head
  *     priority 10. Defers to other SEO plugins by default; respects the
  *     swps_schema_override option for per-type re-enable.
  *
@@ -117,7 +117,7 @@ class SWPS_Schema {
 
 		$enabled = (array) get_option(
 			'swps_aeo_enabled_schema_types',
-			array( 'howto', 'recipe', 'product', 'review', 'qapage' )
+			array( 'howto', 'recipe', 'product', 'review', 'faqpage' )
 		);
 		if ( ! in_array( $type, $enabled, true ) ) {
 			return;

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1043,9 +1043,9 @@ class SWPS_Settings {
 					'recipe'  => 'Recipe',
 					'product' => 'Product',
 					'review'  => 'Review',
-					'qapage'  => 'QAPage',
+					'faqpage' => 'FAQPage',
 				),
-				'default'     => array( 'howto', 'recipe', 'product', 'review', 'qapage' ),
+				'default'     => array( 'howto', 'recipe', 'product', 'review', 'faqpage' ),
 				'description' => __( 'Which dynamic schema types the renderer emits. Defers automatically when Yoast / RankMath / AIOSEO is active.', 'stratawp-seo' ),
 			)
 		);

--- a/includes/data/aeo-schema-fields.json
+++ b/includes/data/aeo-schema-fields.json
@@ -35,17 +35,18 @@
             "fields": ["ratingValue", "bestRating", "worstRating"]
         }
     },
-    "qapage": {
-        "type": "QAPage",
+    "faqpage": {
+        "type": "FAQPage",
         "required": ["mainEntity"],
         "recommended": [],
         "main_entity_shape": {
             "@type": "Question",
-            "fields": ["name", "text", "answerCount", "acceptedAnswer", "upvoteCount", "dateCreated", "author"]
+            "is_array": true,
+            "fields": ["name", "acceptedAnswer"]
         },
         "answer_shape": {
             "@type": "Answer",
-            "fields": ["text", "dateCreated", "upvoteCount", "author"]
+            "fields": ["text"]
         }
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,12 +67,12 @@ parameters:
 
 		-
 			message: "#^Call to static method log\\(\\) on an unknown class WP_CLI\\.$#"
-			count: 28
+			count: 29
 			path: includes/class-cli.php
 
 		-
 			message: "#^Call to static method success\\(\\) on an unknown class WP_CLI\\.$#"
-			count: 4
+			count: 5
 			path: includes/class-cli.php
 
 		-

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.9.0
+Stable tag: 4.9.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -252,6 +252,11 @@ Yes. The built-in analytics tracker is cookie-free and does not use any external
 No. GSC integration is optional. The on-site analytics works entirely without any external services. Add Google OAuth credentials only if you want search clicks, impressions, and ranking data.
 
 == Changelog ==
+
+= 4.9.1 — 2026-06-02 =
+* Fix: AEO Optimize now emits FAQPage structured data for Q&A sections instead of QAPage, resolving the "Q&A structured data issues" Google Search Console flags (issue #44). QAPage is Google's type for community pages with user-submitted answers; using it for site-authored FAQ content was invalid. Existing pages are auto-converted on update (or run `wp swps migrate-qapage`); then use Search Console's "Validate fix" on the Q&A report.
+* Fix: The schema validator now requires every FAQ question to carry a real answer (acceptedAnswer text) before the JSON-LD is emitted, so incomplete markup can no longer reach Search Console.
+* Note: Google retired FAQ rich results (the expandable Q&A in search) for most sites in 2023, so FAQPage markup no longer shows that rich snippet — but it is valid, error-free, and still helps AI answer engines parse your content.
 
 = 4.9.0 — 2026-05-29 =
 * Feature: AI model lists are now fully dynamic — fetched live from each provider's API and refreshed daily, so new models appear automatically without a plugin update.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.9.0
+ * Version: 4.9.1
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.9.0' );
+define( 'SWPS_VERSION', '4.9.1' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -103,6 +103,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/aeo/class-authority-scorer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/aeo/class-coverage-scorer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-scorer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-schema-generator.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-schema-migrator.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-optimizer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-editor-panel.php';
 
@@ -243,6 +244,7 @@ final class StrataWP_SEO {
 
 	private function __construct() {
 		$this->maybe_migrate_legacy_options();
+		$this->maybe_migrate_qapage_to_faqpage();
 
 		// Initialize foundation subsystems.
 		$this->cache_manager     = new SWPS_Cache_Manager();
@@ -433,6 +435,29 @@ final class StrataWP_SEO {
 		}
 
 		update_option( 'swps_provider_migrated', 1 );
+	}
+
+	/**
+	 * One-time migration: rewrite legacy QAPage AEO schema as FAQPage (issue #44).
+	 *
+	 * QAPage emitted for site-authored Q&A content trips Google Search Console.
+	 * The generator now emits FAQPage; this fixes pages optimized before the
+	 * change, whose QAPage is frozen into post meta. Idempotent and gated on a
+	 * flag so it runs once after the update. Can be re-run manually via
+	 * `wp swps migrate-qapage`.
+	 */
+	private function maybe_migrate_qapage_to_faqpage(): void {
+		if ( get_option( 'swps_qapage_faqpage_migrated' ) ) {
+			return;
+		}
+		// Frontend page loads shouldn't pay for a full-table scan; defer to
+		// admin/CLI where the update is actually triggered.
+		if ( ! is_admin() && ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+			return;
+		}
+
+		SWPS_AEO_Schema_Migrator::migrate_all();
+		update_option( 'swps_qapage_faqpage_migrated', 1 );
 	}
 
 	/**

--- a/tests/aeo/AeoSchemaGeneratorTest.php
+++ b/tests/aeo/AeoSchemaGeneratorTest.php
@@ -97,26 +97,28 @@ final class AeoSchemaGeneratorTest extends TestCase {
 		$this->assertStringContainsString( 'AI provider error', (string) $r['error'] );
 	}
 
-	public function test_qapage_prompt_includes_main_entity_shape_guidance(): void {
+	public function test_faqpage_prompt_includes_array_shape_guidance(): void {
 		$provider = new FakeAIProvider();
 		$provider->next_response = array(
 			'@context'   => 'https://schema.org',
-			'@type'      => 'QAPage',
+			'@type'      => 'FAQPage',
 			'mainEntity' => array(
-				'@type'          => 'Question',
-				'name'           => 'How long does sourdough need to ferment?',
-				'text'           => 'How long does sourdough need to ferment?',
-				'acceptedAnswer' => array(
-					'@type' => 'Answer',
-					'text'  => '4-6 hours at room temperature.',
+				array(
+					'@type'          => 'Question',
+					'name'           => 'How long does sourdough need to ferment?',
+					'acceptedAnswer' => array(
+						'@type' => 'Answer',
+						'text'  => '4-6 hours at room temperature.',
+					),
 				),
 			),
 		);
 		$gen = new SWPS_AEO_Schema_Generator( $provider, $this->fields_path() );
-		$r   = $gen->generate( 'qapage', 'How long does sourdough ferment?', '<p>4-6 hours.</p>' );
+		$r   = $gen->generate( 'faqpage', 'How long does sourdough ferment?', '<p>4-6 hours.</p>' );
 
-		// The prompt must teach the AI the Question shape so mainEntity isn't empty.
-		$this->assertStringContainsString( 'mainEntity should be a Question object', $provider->last_user );
+		// The prompt must teach the AI that mainEntity is an ARRAY of Questions
+		// (issue #44: site-authored Q&A is FAQPage, not QAPage).
+		$this->assertStringContainsString( 'mainEntity should be an ARRAY of Question objects', $provider->last_user );
 		$this->assertStringContainsString( 'acceptedAnswer', $provider->last_user );
 
 		// Required-vs-recommended distinction must be explicit (regression for the
@@ -125,25 +127,76 @@ final class AeoSchemaGeneratorTest extends TestCase {
 		$this->assertStringContainsString( 'REQUIRED fields', $provider->last_user );
 		$this->assertStringContainsString( 'never empty', $provider->last_user );
 
-		// And a well-formed QAPage passes validation end-to-end.
-		$this->assertSame( 'QAPage', $r['json']['@type'] );
+		// And a well-formed FAQPage passes validation end-to-end.
+		$this->assertSame( 'FAQPage', $r['json']['@type'] );
 		$this->assertNull( $r['error'] );
 	}
 
-	public function test_qapage_with_empty_main_entity_still_rejected(): void {
-		// Regression for the live bug: AI returned mainEntity:[] for a QAPage,
-		// the validator (correctly) flagged it as "empty required field: mainEntity".
-		// The prompt fix reduces the likelihood; the validator still has the final say.
+	public function test_faqpage_wraps_single_question_into_array(): void {
+		// The AI sometimes returns mainEntity as a single Question object for a
+		// one-question post. Google's FAQPage shape is a list; the generator
+		// must normalize before output.
 		$provider = new FakeAIProvider();
 		$provider->next_response = array(
 			'@context'   => 'https://schema.org',
-			'@type'      => 'QAPage',
+			'@type'      => 'FAQPage',
+			'mainEntity' => array(
+				'@type'          => 'Question',
+				'name'           => 'Is it vegan?',
+				'acceptedAnswer' => array( '@type' => 'Answer', 'text' => 'Yes.' ),
+			),
+		);
+		$gen = new SWPS_AEO_Schema_Generator( $provider, $this->fields_path() );
+		$r   = $gen->generate( 'faqpage', 'FAQ', '<p>...</p>' );
+
+		$this->assertNull( $r['error'] );
+		$this->assertArrayHasKey( 0, $r['json']['mainEntity'] );
+		$this->assertSame( 'Question', $r['json']['mainEntity'][0]['@type'] );
+	}
+
+	public function test_faqpage_with_empty_main_entity_rejected(): void {
+		$provider = new FakeAIProvider();
+		$provider->next_response = array(
+			'@context'   => 'https://schema.org',
+			'@type'      => 'FAQPage',
 			'mainEntity' => array(),
 		);
 		$gen = new SWPS_AEO_Schema_Generator( $provider, $this->fields_path() );
-		$r   = $gen->generate( 'qapage', 'X', '<p>Y</p>' );
+		$r   = $gen->generate( 'faqpage', 'X', '<p>Y</p>' );
 
 		$this->assertNull( $r['json'] );
 		$this->assertStringContainsString( 'mainEntity', (string) $r['error'] );
+	}
+
+	public function test_faqpage_question_missing_answer_rejected(): void {
+		// The pre-fix validator only checked mainEntity was non-empty, so a
+		// Question with no acceptedAnswer.text slipped through and tripped
+		// Search Console (issue #44). It must now be rejected.
+		$provider = new FakeAIProvider();
+		$provider->next_response = array(
+			'@context'   => 'https://schema.org',
+			'@type'      => 'FAQPage',
+			'mainEntity' => array(
+				array(
+					'@type' => 'Question',
+					'name'  => 'What time does it open?',
+					// No acceptedAnswer.
+				),
+			),
+		);
+		$gen = new SWPS_AEO_Schema_Generator( $provider, $this->fields_path() );
+		$r   = $gen->generate( 'faqpage', 'X', '<p>Y</p>' );
+
+		$this->assertNull( $r['json'] );
+		$this->assertStringContainsString( 'acceptedAnswer', (string) $r['error'] );
+	}
+
+	public function test_qapage_is_no_longer_a_supported_type(): void {
+		$provider = new FakeAIProvider();
+		$gen      = new SWPS_AEO_Schema_Generator( $provider, $this->fields_path() );
+		$r        = $gen->generate( 'qapage', 'X', '<p>Y</p>' );
+
+		$this->assertNull( $r['json'] );
+		$this->assertSame( 'unsupported_type', $r['error'] );
 	}
 }

--- a/tests/aeo/AeoSchemaMigratorTest.php
+++ b/tests/aeo/AeoSchemaMigratorTest.php
@@ -1,0 +1,158 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-aeo-schema-migrator.php';
+
+/**
+ * Covers the pure QAPage→FAQPage conversion (issue #44). The WP-dependent
+ * bulk runner migrate_all() is exercised via manual WP-CLI smoke.
+ */
+final class AeoSchemaMigratorTest extends TestCase {
+
+	public function test_converts_single_question_qapage_to_faqpage(): void {
+		$qa = array(
+			'@context'   => 'https://schema.org',
+			'@type'      => 'QAPage',
+			'mainEntity' => array(
+				'@type'          => 'Question',
+				'name'           => 'How long does sourdough ferment?',
+				'answerCount'    => 1,
+				'upvoteCount'    => 0,
+				'acceptedAnswer' => array(
+					'@type'       => 'Answer',
+					'text'        => '4-6 hours at room temperature.',
+					'upvoteCount' => 0,
+				),
+			),
+		);
+
+		$faq = SWPS_AEO_Schema_Migrator::convert_schema( $qa );
+
+		$this->assertSame( 'FAQPage', $faq['@type'] );
+		$this->assertSame( 'https://schema.org', $faq['@context'] );
+		$this->assertCount( 1, $faq['mainEntity'] );
+
+		$q = $faq['mainEntity'][0];
+		$this->assertSame( 'Question', $q['@type'] );
+		$this->assertSame( 'How long does sourdough ferment?', $q['name'] );
+		$this->assertSame( '4-6 hours at room temperature.', $q['acceptedAnswer']['text'] );
+
+		// QAPage-only fields are stripped.
+		$this->assertArrayNotHasKey( 'answerCount', $q );
+		$this->assertArrayNotHasKey( 'upvoteCount', $q );
+		$this->assertArrayNotHasKey( 'upvoteCount', $q['acceptedAnswer'] );
+	}
+
+	public function test_converts_array_of_questions(): void {
+		$qa = array(
+			'@type'      => 'QAPage',
+			'mainEntity' => array(
+				array(
+					'@type'          => 'Question',
+					'name'           => 'Q1?',
+					'acceptedAnswer' => array( '@type' => 'Answer', 'text' => 'A1.' ),
+				),
+				array(
+					'@type'          => 'Question',
+					'name'           => 'Q2?',
+					'acceptedAnswer' => array( '@type' => 'Answer', 'text' => 'A2.' ),
+				),
+			),
+		);
+
+		$faq = SWPS_AEO_Schema_Migrator::convert_schema( $qa );
+
+		$this->assertCount( 2, $faq['mainEntity'] );
+		$this->assertSame( 'Q2?', $faq['mainEntity'][1]['name'] );
+	}
+
+	public function test_promotes_suggested_answer_when_no_accepted_answer(): void {
+		$qa = array(
+			'@type'      => 'QAPage',
+			'mainEntity' => array(
+				'@type'           => 'Question',
+				'name'            => 'Which flour?',
+				'suggestedAnswer' => array(
+					array( '@type' => 'Answer', 'text' => 'Bread flour works best.' ),
+				),
+			),
+		);
+
+		$faq = SWPS_AEO_Schema_Migrator::convert_schema( $qa );
+
+		$this->assertSame( 'Bread flour works best.', $faq['mainEntity'][0]['acceptedAnswer']['text'] );
+	}
+
+	public function test_falls_back_to_question_text_when_name_missing(): void {
+		$qa = array(
+			'@type'      => 'QAPage',
+			'mainEntity' => array(
+				'@type'          => 'Question',
+				'text'           => 'Is it gluten free?',
+				'acceptedAnswer' => array( '@type' => 'Answer', 'text' => 'No.' ),
+			),
+		);
+
+		$faq = SWPS_AEO_Schema_Migrator::convert_schema( $qa );
+
+		$this->assertSame( 'Is it gluten free?', $faq['mainEntity'][0]['name'] );
+	}
+
+	public function test_drops_questions_with_no_usable_answer(): void {
+		$qa = array(
+			'@type'      => 'QAPage',
+			'mainEntity' => array(
+				array(
+					'@type'          => 'Question',
+					'name'           => 'Has answer?',
+					'acceptedAnswer' => array( '@type' => 'Answer', 'text' => 'Yes.' ),
+				),
+				array(
+					'@type' => 'Question',
+					'name'  => 'No answer here',
+				),
+			),
+		);
+
+		$faq = SWPS_AEO_Schema_Migrator::convert_schema( $qa );
+
+		$this->assertCount( 1, $faq['mainEntity'] );
+		$this->assertSame( 'Has answer?', $faq['mainEntity'][0]['name'] );
+	}
+
+	public function test_returns_null_when_nothing_convertible(): void {
+		$this->assertNull( SWPS_AEO_Schema_Migrator::convert_schema( array( '@type' => 'QAPage' ) ) );
+		$this->assertNull( SWPS_AEO_Schema_Migrator::convert_schema( array(
+			'@type'      => 'QAPage',
+			'mainEntity' => array( '@type' => 'Question', 'name' => 'No answer' ),
+		) ) );
+	}
+
+	public function test_converted_output_passes_generator_faqpage_validation(): void {
+		// The conversion must produce markup the (now strict) FAQPage validator
+		// accepts — otherwise we'd swap one invalid type for another.
+		require_once __DIR__ . '/../../includes/class-aeo-schema-generator.php';
+		require_once __DIR__ . '/FakeAIProvider.php';
+
+		$qa = array(
+			'@type'      => 'QAPage',
+			'mainEntity' => array(
+				'@type'          => 'Question',
+				'name'           => 'Q?',
+				'acceptedAnswer' => array( '@type' => 'Answer', 'text' => 'A.' ),
+			),
+		);
+		$faq = SWPS_AEO_Schema_Migrator::convert_schema( $qa );
+
+		$provider                = new FakeAIProvider();
+		$provider->next_response = $faq;
+		$gen                     = new SWPS_AEO_Schema_Generator(
+			$provider,
+			__DIR__ . '/../../includes/data/aeo-schema-fields.json'
+		);
+		$r = $gen->generate( 'faqpage', 'X', '<p>Y</p>' );
+
+		$this->assertNull( $r['error'] );
+		$this->assertSame( 'FAQPage', $r['json']['@type'] );
+	}
+}


### PR DESCRIPTION
Fixes #44.

## Problem
The AEO optimizer emitted **`QAPage`** structured data for site-authored Q&A sections. `QAPage` is Google's type for community pages with *user-submitted* answers (Stack Overflow / forum threads); FAQ-style content the site authors itself must use **`FAQPage`**. The mismatch made Search Console flag the data ("Q&A structured data issues"), and the validator was too loose — it let questions through without a complete answer.

## Changes
- **`qapage` → `faqpage`** across the field manifest, schema generator, markup scorer (`infer_schema_type`), optimizer prompt enum, renderer defaults, and settings labels.
- **Stricter FAQPage validation:** `mainEntity` must be a non-empty list of `Question` objects, each with a non-empty `name` and an `acceptedAnswer.text`; a single `Question` is normalized into a list on output. Incomplete markup can no longer be emitted.
- **`SWPS_AEO_Schema_Migrator`** (new): pure `convert_schema()` (QAPage JSON → FAQPage) + `migrate_all()` bulk runner that rewrites the frozen `_swps_aeo_schema_json` / `_swps_aeo_schema_type` post meta on already-optimized pages. Wired as an idempotent one-time **auto-migration on update** (admin/CLI only, gated by `swps_qapage_faqpage_migrated`) and exposed as **`wp swps migrate-qapage`**.
- Version bump to **4.9.1** + changelog entries (`README.md`, `readme.txt`).

## Tests
- Added FAQPage validation cases (array shape, single-Question wrapping, missing-answer rejection, `qapage` now unsupported) and 8 migrator conversion tests (single/array questions, `suggestedAnswer` promotion, `name`/`text` fallback, dropping answerless questions, and asserting converted output passes the strict validator).
- Full suite green: **83 tests, 167 assertions**. PHPStan clean on changed files; new file passes PHPCS.

## Note on expectations
Google retired FAQ rich results for most sites in 2023, so `FAQPage` won't restore a rich snippet in regular search — but it's **valid and error-free** (clears the GSC errors) and still helps AI answer engines parse the content, which is the AEO feature's purpose.

## Base branch
Targets `feature/dynamic-model-catalog` (not `main`) because this fix builds on the 4.9.0 release commit that lives on that branch, so the diff here is scoped to just the issue-44 change.
