### PR TITLE
fix: robots.txt → canonical /sitemap_index.xml, + remove dead sitemap code (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.9.1-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.9.3-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1274,6 +1274,9 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.9.3 — June 2026
+- **Fix — robots.txt points at the real sitemap:** the virtual robots.txt now advertises the canonical sitemap index at `/sitemap_index.xml` instead of the legacy `/swps-sitemap.xml` URL (issue #48). When the sitemap engine was upgraded to a full index, `/swps-sitemap.xml` became a 301 redirect, but the robots.txt `Sitemap:` directive was never updated — so crawlers such as Ubersuggest reported the sitemap as not found. The advertised URL is now a single source of truth shared with the `/llms.txt` generator and stays correct when Yoast, Rank Math, or All in One SEO is handling sitemaps.
 
 ### v4.9.2 — June 2026
 - **Improvement — discoverable theme toggle:** the dark/light mode toggle in the admin top bar is now a labeled accent pill (sun/moon icon plus a "Light"/"Dark" label naming the mode it switches to) instead of a muted icon button that was visually identical to the Help button beside it. Several users reported being unable to find the toggle; it now reads clearly as an interactive control and stands out from the surrounding icons.

--- a/README.md
+++ b/README.md
@@ -1277,6 +1277,7 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 
 ### v4.9.3 — June 2026
 - **Fix — robots.txt points at the real sitemap:** the virtual robots.txt now advertises the canonical sitemap index at `/sitemap_index.xml` instead of the legacy `/swps-sitemap.xml` URL (issue #48). When the sitemap engine was upgraded to a full index, `/swps-sitemap.xml` became a 301 redirect, but the robots.txt `Sitemap:` directive was never updated — so crawlers such as Ubersuggest reported the sitemap as not found. The advertised URL is now a single source of truth shared with the `/llms.txt` generator and stays correct when Yoast, Rank Math, or All in One SEO is handling sitemaps.
+- **Maintenance — removed dead sitemap code:** deleted ~130 lines of superseded sitemap serving/rewrite/ping code from the audit module (now handled entirely by `SWPS_Sitemap_Manager`) and fixed the audit panel's "sitemap enabled" message to name the canonical `/sitemap_index.xml` URL.
 
 ### v4.9.2 — June 2026
 - **Improvement — discoverable theme toggle:** the dark/light mode toggle in the admin top bar is now a labeled accent pill (sun/moon icon plus a "Light"/"Dark" label naming the mode it switches to) instead of a muted icon button that was visually identical to the Help button beside it. Several users reported being unable to find the toggle; it now reads clearly as an interactive control and stands out from the surrounding icons.

--- a/includes/audit/class-robots-module.php
+++ b/includes/audit/class-robots-module.php
@@ -89,16 +89,11 @@ class SWPS_Robots_Module extends SWPS_Audit_Module {
 			return $output;
 		}
 
-		// Add sitemap URL if not already present.
+		// Add sitemap URL if not already present. Use the manager's canonical,
+		// provider-aware URL so robots.txt always points at the sitemap we
+		// actually serve (/sitemap_index.xml), not the legacy redirect (#48).
 		if ( false === stripos( $output, 'sitemap:' ) ) {
-			// Prefer our sitemap if active, otherwise WP core.
-			if ( get_option( 'swps_audit_auto_sitemap', 1 ) ) {
-				$sitemap_url = home_url( '/swps-sitemap.xml' );
-			} else {
-				$sitemap_url = home_url( '/wp-sitemap.xml' );
-			}
-
-			$output .= "\nSitemap: " . esc_url( $sitemap_url ) . "\n";
+			$output .= "\nSitemap: " . esc_url( SWPS_Sitemap_Manager::get_sitemap_url() ) . "\n";
 		}
 
 		return $output;

--- a/includes/audit/class-sitemap-module.php
+++ b/includes/audit/class-sitemap-module.php
@@ -2,9 +2,10 @@
 /**
  * XML Sitemap audit module.
  *
- * Checks if a sitemap exists and covers all public posts.
- * Auto-fix: Generates /swps-sitemap.xml via rewrite rule.
- * Skips generation if Yoast, RankMath, or WordPress core sitemaps are active.
+ * Checks if a sitemap exists and covers all public posts. The sitemap itself is
+ * generated and served by SWPS_Sitemap_Manager (at /sitemap_index.xml); this
+ * module only audits coverage and toggles the swps_audit_auto_sitemap option.
+ * Reports a pass when Yoast, RankMath, or WordPress core sitemaps are active.
  *
  * @package StrataWP_SEO
  */
@@ -87,7 +88,13 @@ class SWPS_Sitemap_Module extends SWPS_Audit_Module {
 
 		return array(
 			'fixed'    => 1,
-			'messages' => array( __( 'SWPS sitemap generation enabled at /swps-sitemap.xml.', 'stratawp-seo' ) ),
+			'messages' => array(
+				sprintf(
+					/* translators: %s: the canonical sitemap URL. */
+					__( 'SWPS sitemap generation enabled at %s.', 'stratawp-seo' ),
+					SWPS_Sitemap_Manager::get_sitemap_url()
+				),
+			),
 		);
 	}
 
@@ -114,138 +121,5 @@ class SWPS_Sitemap_Module extends SWPS_Audit_Module {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Register sitemap rewrite rules.
-	 * Called from main plugin on init.
-	 */
-	public static function register_rewrite_rules(): void {
-		if ( ! get_option( 'swps_audit_auto_sitemap', 1 ) ) {
-			return;
-		}
-
-		add_rewrite_rule( 'swps-sitemap\.xml$', 'index.php?swps_sitemap=1', 'top' );
-		add_filter(
-			'query_vars',
-			function ( array $vars ): array {
-				$vars[] = 'swps_sitemap';
-				return $vars;
-			}
-		);
-	}
-
-	/**
-	 * Handle the sitemap request.
-	 * Hooked to template_redirect from the main plugin class.
-	 */
-	public static function serve_sitemap(): void {
-		if ( ! get_query_var( 'swps_sitemap' ) ) {
-			return;
-		}
-
-		// Skip if another provider is active.
-		$module = new self();
-		if ( $module->detect_other_sitemap() ) {
-			return;
-		}
-
-		if ( ! get_option( 'swps_audit_auto_sitemap', 1 ) ) {
-			return;
-		}
-
-		header( 'Content-Type: application/xml; charset=UTF-8' );
-		header( 'X-Robots-Tag: noindex' );
-
-		echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
-		echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"' . "\n";
-		echo '        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">' . "\n";
-
-		// Homepage.
-		printf(
-			"<url>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n  <priority>1.0</priority>\n</url>\n",
-			esc_url( home_url( '/' ) ),
-			gmdate( 'Y-m-d\TH:i:s+00:00' )
-		);
-
-		$posts = get_posts(
-			array(
-				'post_type'      => get_post_types( array( 'public' => true ) ),
-				'post_status'    => 'publish',
-				'posts_per_page' => 2000,
-				'orderby'        => 'modified',
-				'order'          => 'DESC',
-				'no_found_rows'  => true,
-			)
-		);
-
-		$now = time();
-
-		foreach ( $posts as $post ) {
-			// Skip noindex posts.
-			$noindex   = get_post_meta( $post->ID, '_yoast_wpseo_meta-robots-noindex', true );
-			$rm_robots = get_post_meta( $post->ID, 'rank_math_robots', true );
-			if ( '1' === $noindex || ( is_array( $rm_robots ) && in_array( 'noindex', $rm_robots, true ) ) ) {
-				continue;
-			}
-
-			$modified = get_post_modified_time( 'U', true, $post );
-			$age_days = ( $now - $modified ) / DAY_IN_SECONDS;
-			$priority = $age_days < 30 ? '0.8' : '0.6';
-
-			echo "<url>\n";
-			printf( "  <loc>%s</loc>\n", esc_url( get_permalink( $post ) ) );
-			printf( "  <lastmod>%s</lastmod>\n", gmdate( 'Y-m-d\TH:i:s+00:00', $modified ) );
-			printf( "  <priority>%s</priority>\n", $priority );
-
-			// Image entry for featured image.
-			$thumb_id = get_post_thumbnail_id( $post->ID );
-			if ( $thumb_id ) {
-				$img_url = wp_get_attachment_url( $thumb_id );
-				if ( $img_url ) {
-					echo "  <image:image>\n";
-					printf( "    <image:loc>%s</image:loc>\n", esc_url( $img_url ) );
-					$alt = get_post_meta( $thumb_id, '_wp_attachment_image_alt', true );
-					if ( $alt ) {
-						printf( "    <image:title>%s</image:title>\n", esc_xml( $alt ) );
-					}
-					echo "  </image:image>\n";
-				}
-			}
-
-			echo "</url>\n";
-		}
-
-		echo '</urlset>';
-		exit;
-	}
-
-	/**
-	 * Ping search engines after a post is published.
-	 */
-	public static function ping_search_engines(): void {
-		if ( ! get_option( 'swps_audit_auto_sitemap', 1 ) ) {
-			return;
-		}
-
-		$sitemap_url = home_url( '/swps-sitemap.xml' );
-
-		wp_remote_get(
-			'https://www.google.com/ping?sitemap=' . urlencode( $sitemap_url ),
-			array(
-				'timeout'   => 5,
-				'blocking'  => false,
-				'sslverify' => false,
-			)
-		);
-
-		wp_remote_get(
-			'https://www.bing.com/ping?sitemap=' . urlencode( $sitemap_url ),
-			array(
-				'timeout'   => 5,
-				'blocking'  => false,
-				'sslverify' => false,
-			)
-		);
 	}
 }

--- a/includes/class-ai-bots.php
+++ b/includes/class-ai-bots.php
@@ -292,20 +292,10 @@ class SWPS_AI_Bots {
 	}
 
 	/**
-	 * Detect the canonical sitemap URL from common providers.
+	 * The canonical, provider-aware sitemap URL. Delegates to
+	 * SWPS_Sitemap_Manager so robots.txt and llms.txt stay in lock-step (#48).
 	 */
 	private function detect_sitemap_url(): ?string {
-		if ( defined( 'WPSEO_VERSION' ) ) {
-			return home_url( '/sitemap_index.xml' );
-		}
-		if ( class_exists( 'RankMath' ) ) {
-			return home_url( '/sitemap_index.xml' );
-		}
-		if ( defined( 'AIOSEO_VERSION' ) ) {
-			return home_url( '/sitemap.xml' );
-		}
-
-		// StrataWP SEO disables the WP core sitemap and serves its own index.
-		return home_url( '/sitemap_index.xml' );
+		return SWPS_Sitemap_Manager::get_sitemap_url();
 	}
 }

--- a/includes/class-sitemap-manager.php
+++ b/includes/class-sitemap-manager.php
@@ -29,6 +29,28 @@ class SWPS_Sitemap_Manager {
 			|| (bool) get_option( "swps_noindex_{$taxonomy}", 0 );
 	}
 
+	/**
+	 * The canonical, provider-aware sitemap URL to advertise in robots.txt and
+	 * llms.txt. Single source of truth so the advertised location can never
+	 * drift from what is actually served (see issue #48).
+	 *
+	 * StrataWP SEO serves its own index at /sitemap_index.xml (see
+	 * register_rewrite_rules() and serve_sitemap()). When a major third-party
+	 * SEO plugin is active we defer to its well-known sitemap location instead.
+	 */
+	public static function get_sitemap_url(): string {
+		// Yoast SEO and Rank Math both serve their index at /sitemap_index.xml.
+		if ( defined( 'WPSEO_VERSION' ) || class_exists( 'RankMath' ) ) {
+			return home_url( '/sitemap_index.xml' );
+		}
+		// All in One SEO serves its index at /sitemap.xml.
+		if ( defined( 'AIOSEO_VERSION' ) ) {
+			return home_url( '/sitemap.xml' );
+		}
+		// StrataWP SEO disables WP core sitemaps and serves its own index.
+		return home_url( '/sitemap_index.xml' );
+	}
+
 	public function __construct() {
 		// Disable WP core sitemaps to prevent conflict detection from blocking us.
 		add_filter( 'wp_sitemaps_enabled', '__return_false' );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.9.2
+Stable tag: 4.9.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -252,6 +252,9 @@ Yes. The built-in analytics tracker is cookie-free and does not use any external
 No. GSC integration is optional. The on-site analytics works entirely without any external services. Add Google OAuth credentials only if you want search clicks, impressions, and ranking data.
 
 == Changelog ==
+
+= 4.9.3 — 2026-06-03 =
+* Fix: robots.txt now advertises the canonical sitemap at /sitemap_index.xml instead of the legacy /swps-sitemap.xml redirect (issue #48). The sitemap engine was upgraded to a full index in 4.7, but the robots.txt Sitemap directive still pointed at the old single-file URL — which is now only a 301 redirect — so crawlers such as Ubersuggest reported the sitemap as missing. The advertised URL is now a single source of truth shared with the llms.txt generator, and stays correct when Yoast, Rank Math, or All in One SEO is handling sitemaps.
 
 = 4.9.2 — 2026-06-02 =
 * Improvement: The dark/light mode toggle in the admin top bar is now a labeled accent pill (showing "Light" or "Dark" next to the sun/moon icon) instead of a plain icon button that looked identical to the Help button beside it. Users reported being unable to find the toggle; it now reads clearly as an interactive control.

--- a/readme.txt
+++ b/readme.txt
@@ -255,6 +255,7 @@ No. GSC integration is optional. The on-site analytics works entirely without an
 
 = 4.9.3 — 2026-06-03 =
 * Fix: robots.txt now advertises the canonical sitemap at /sitemap_index.xml instead of the legacy /swps-sitemap.xml redirect (issue #48). The sitemap engine was upgraded to a full index in 4.7, but the robots.txt Sitemap directive still pointed at the old single-file URL — which is now only a 301 redirect — so crawlers such as Ubersuggest reported the sitemap as missing. The advertised URL is now a single source of truth shared with the llms.txt generator, and stays correct when Yoast, Rank Math, or All in One SEO is handling sitemaps.
+* Maintenance: Removed ~130 lines of superseded sitemap-serving code from the audit module (generation is handled entirely by the sitemap engine now) and corrected the audit panel's "sitemap enabled" message to name the canonical /sitemap_index.xml URL.
 
 = 4.9.2 — 2026-06-02 =
 * Improvement: The dark/light mode toggle in the admin top bar is now a labeled accent pill (showing "Light" or "Dark" next to the sun/moon icon) instead of a plain icon button that looked identical to the Help button beside it. Users reported being unable to find the toggle; it now reads clearly as an interactive control.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -390,10 +390,7 @@ final class StrataWP_SEO {
 		if ( get_option( 'swps_meta_editor_enabled', 1 ) && ! defined( 'WPSEO_VERSION' ) && ! defined( 'RANK_MATH_VERSION' ) && ! defined( 'AIOSEO_VERSION' ) ) {
 			remove_action( 'wp_head', array( SWPS_OpenGraph_Module::class, 'output_meta_tags' ), 5 );
 		}
-		// Sitemap generation/serving/pinging now handled by SWPS_Sitemap_Manager.
-		// add_action( 'init', [ SWPS_Sitemap_Module::class, 'register_rewrite_rules' ] );
-		// add_action( 'template_redirect', [ SWPS_Sitemap_Module::class, 'serve_sitemap' ] );
-		// add_action( 'publish_post', [ SWPS_Sitemap_Module::class, 'ping_search_engines' ] );
+		// Sitemap generation, serving, and pinging are handled by SWPS_Sitemap_Manager.
 		add_filter( 'robots_txt', array( SWPS_Robots_Module::class, 'filter_robots_txt' ), 10, 2 );
 
 		// SEO Audit AJAX handlers.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.9.2
+ * Version: 4.9.3
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.9.2' );
+define( 'SWPS_VERSION', '4.9.3' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/tests/unit/SitemapUrlTest.php
+++ b/tests/unit/SitemapUrlTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Regression tests for the canonical sitemap URL advertised in robots.txt
+ * and llms.txt.
+ *
+ * Issue #48: robots.txt advertised the legacy /swps-sitemap.xml redirect
+ * instead of the canonical /sitemap_index.xml that SWPS_Sitemap_Manager
+ * actually serves, so crawlers reported the sitemap as missing.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+// Minimal stub: the URL builder only needs home_url().
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return 'https://example.com' . $path;
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-sitemap-manager.php';
+
+class SitemapUrlTest extends TestCase {
+
+	/**
+	 * The reported scenario: no third-party SEO plugin active, so StrataWP SEO
+	 * serves the sitemap itself. robots.txt must advertise the canonical
+	 * /sitemap_index.xml, never the legacy /swps-sitemap.xml redirect.
+	 */
+	public function test_default_advertises_canonical_sitemap_index(): void {
+		$url = SWPS_Sitemap_Manager::get_sitemap_url();
+
+		$this->assertSame( 'https://example.com/sitemap_index.xml', $url );
+		$this->assertStringNotContainsString( 'swps-sitemap.xml', $url );
+	}
+
+	/**
+	 * Yoast SEO serves its index at /sitemap_index.xml — defer to it.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_yoast_uses_sitemap_index(): void {
+		define( 'WPSEO_VERSION', '99.0' );
+
+		$this->assertSame(
+			'https://example.com/sitemap_index.xml',
+			SWPS_Sitemap_Manager::get_sitemap_url()
+		);
+	}
+
+	/**
+	 * All in One SEO serves its index at /sitemap.xml — defer to it.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_aioseo_uses_its_own_sitemap(): void {
+		define( 'AIOSEO_VERSION', '4.0' );
+
+		$this->assertSame(
+			'https://example.com/sitemap.xml',
+			SWPS_Sitemap_Manager::get_sitemap_url()
+		);
+	}
+}


### PR DESCRIPTION
Fixes #48

## Problem

A user's crawl (Ubersuggest) reported their sitemap as missing. Their `robots.txt` advertised `…/swps-sitemap.xml`, but the live sitemap is at `…/sitemap_index.xml`.

## Root cause

The sitemap engine was upgraded to a full **sitemap index** served at `/sitemap_index.xml` (`SWPS_Sitemap_Manager`), and `/swps-sitemap.xml` was kept only as a **301 redirect**. But the robots.txt generator (`SWPS_Robots_Module::filter_robots_txt()`) still hard-coded the legacy `/swps-sitemap.xml`. Crawlers read the `Sitemap:` line directly and expect a fetchable sitemap, not a redirect, so they flagged it as not found. The real defect was **two divergent copies** of "what's the sitemap URL" (the `llms.txt` generator already had it right).

## Fix (commit 1)

- Add `SWPS_Sitemap_Manager::get_sitemap_url()` as the single source of truth — provider-aware (Yoast / Rank Math → `/sitemap_index.xml`, All in One SEO → `/sitemap.xml`, otherwise our own `/sitemap_index.xml`).
- Point both the **robots.txt** and **llms.txt** generators at it, so they can never drift again.

```
Sitemap: https://example.com/sitemap_index.xml   ← was /swps-sitemap.xml
```

## Cleanup (commit 2)

While tracing the bug I found the old `SWPS_Sitemap_Module` still carried ~130 lines of **dead** serving code that `SWPS_Sitemap_Manager` superseded:

- Removed `register_rewrite_rules()`, `serve_sitemap()`, `ping_search_engines()` — none were hooked (their `add_action`s had been commented out in the bootstrap).
- Fixed the audit panel's auto-fix message (it named the retired `/swps-sitemap.xml`) to use `get_sitemap_url()`.
- Refreshed the class docblock and dropped the obsolete commented-out hook lines from `stratawp-seo.php`.

The audit module's live behaviour (`run()` / `auto_fix()` coverage checks) is unchanged; only dead code was removed. The module shrank 257 → 125 lines.

## Testing

- New `tests/unit/SitemapUrlTest.php` regression test (default + Yoast + AIOSEO).
- End-to-end harnesses confirm robots.txt emits `Sitemap: …/sitemap_index.xml` and the audit message names the canonical URL — neither references `swps-sitemap.xml`.
- Full suite green (**86 tests**), PHPStan clean, and phpcs violations on the touched files went **down**, none added.

## Release

Bumps **4.9.2 → 4.9.3** and updates `readme.txt` + `README.md` changelogs. Merging to `main` triggers the release workflow to build and publish the v4.9.3 zip, which reaches the issue author via the in-plugin GitHub updater.