### PR TITLE
ci: run PHPUnit suite in the quality workflow

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,8 +1,9 @@
 name: Code quality
 
-# Lint, coding standards, and static analysis. PRs are gated via the
-# pull_request trigger; main is checked post-merge. (No feature/chore
-# push triggers — combined with pull_request they ran CI twice per PR.)
+# Lint, coding standards, static analysis, and unit tests. PRs are
+# gated via the pull_request trigger; main is checked post-merge. (No
+# feature/chore push triggers — combined with pull_request they ran CI
+# twice per PR.)
 
 on:
   push:
@@ -70,3 +71,20 @@ jobs:
       - uses: ramsey/composer-install@v3
       - name: Run PHPStan
         run: composer analyze -- --no-progress --error-format=github
+
+  unit-tests:
+    name: PHPUnit (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+      - uses: ramsey/composer-install@v3
+      - name: Run PHPUnit
+        run: composer test

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
             "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "optimize-autoloader": true,
+        "platform": {
+            "php": "8.0.30"
+        },
         "sort-packages": true
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d672a5e2b12332a86cfe8aa41786786",
+    "content-hash": "457e3a5290d9cce185d4b2c9525a3beb",
     "packages": [],
     "packages-dev": [
         {
@@ -105,30 +105,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.0.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -155,7 +155,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -171,7 +171,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:23:10+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2691,5 +2691,8 @@
         "php": ">=8.0"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.0.30"
+    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary
- The quality workflow ran PHP syntax checks, PHPCS, and PHPStan but never executed the PHPUnit suite (`composer test`), so a failing test could merge silently.
- Adds a `unit-tests` job on the same PHP 8.0–8.4 matrix as the syntax job (`fail-fast: false`), installing dev dependencies via `ramsey/composer-install@v3` and running `composer test` as a hard merge gate (no `continue-on-error`).
- Pins `config.platform.php` to `8.0.30` (the plugin's declared minimum) and downgrades `doctrine/instantiator` 2.0.0 → 1.5.0. The lock file had been generated on a newer PHP without a pin, so it contained a transitive PHPUnit dependency requiring PHP ^8.1 — the first CI run on this PR caught exactly that: the PHP 8.0 leg failed at `composer install`. The pin keeps every future lock resolution installable on all supported PHP versions.
- Updates the workflow header comment to mention tests.

## Test plan
- [x] `composer test` locally — OK (86 tests, 171 assertions)
- [x] `composer validate --strict` passes with the platform pin
- [x] All five PHPUnit matrix legs (8.0–8.4) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)