### PR TITLE
feat: white-label email digest with needs-attention alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.11.0-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.12.0-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1446,6 +1446,10 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.12.0 — June 2026
+- **New — White-label email digest:** weekly/daily/monthly report of generations, failures, keyword movers, backlinks, competitors, AI-bot trends, and AI spend, led by a needs-attention triage section; agency branding (logo, accent color, footer), multiple recipients, test-send button, and an optional AI executive summary.
+- **New:** generation failures are now persistently recorded and surfaced in the digest.
 
 ### v4.11.0 — June 2026
 - **New — Autopilot Guardian:** monthly AI budget cap with 80 % warning notice, automatic retry with exponential backoff for transient API errors, failed-topic requeue (max 3 attempts per topic), and a dashboard autopilot status tile showing enabled state, last-run health, and budget spend vs cap. A single failed generation no longer abandons the rest of a scheduled batch.

--- a/docs/superpowers/plans/2026-06-10-weekly-digest.md
+++ b/docs/superpowers/plans/2026-06-10-weekly-digest.md
@@ -1,0 +1,224 @@
+# White-Label Weekly Digest Email Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A scheduled HTML digest email aggregating everything the plugin already measures — posts generated, generation failures, keyword winners/losers, backlink changes, competitor changes, AI-bot crawl trends, monthly AI spend, AEO score movers — led by a "needs your attention" triage section, with agency branding, multiple recipients, a test-send button, and an optional AI executive summary.
+
+**Architecture:** One new class `SWPS_Digest` (data assembly, cron, settings, send + failure-listener) plus an email template `templates/email/digest.php` (inline-CSS table layout). Pure computation helpers (movers, keyword deltas, recipient parsing) are static and unit-tested without WordPress. Every data section uses fail-soft getters (try/catch → null) and the template suppresses empty sections. Structured generation failures get their first persistent store (a rolling option written by a `swps_generation_failed` listener). AEO movers come from a per-send postmeta snapshot diff.
+
+**Tech Stack:** PHP 8.0, WP options/cron/Settings API/wp_mail, PHPUnit pure-PHP tests, PHPCS/PHPStan.
+
+**Branch:** `feature/weekly-digest` STACKED on `feature/autopilot-guardian` (PR base = that branch; version bumps 4.11.0 → 4.12.0). The guardian's `SWPS_Autopilot_Guardian::get_status()` is available and used for budget info.
+
+**Project conventions:** no autoloader (require_once in stratawp-seo.php), files < 500 lines, tabs/WPCS in includes/, no Co-Authored-By, version bump + README/readme.txt changelog at the end, release workflow builds the zip on merge to main.
+
+---
+
+## Verified code facts (branch feature/autopilot-guardian @ 7242c65)
+
+- `SWPS_Backlinks::get_stats(): array` — includes/class-backlinks.php:584 (read it to learn exact keys: new/lost/broken counts).
+- `SWPS_Competitors::get_dashboard_summary( int $limit = 3 ): array` — includes/class-competitors.php:310.
+- `SWPS_Bot_Analytics_Tracker::get_bot_summary( int $days = 30 ): array` — includes/class-bot-analytics-tracker.php:324; also has `get_totals` patterns with period deltas (read the class).
+- `SWPS_Cost_Tracker::get_monthly_stats(): array` (total_cost, generation_count, tokens).
+- `SWPS_Autopilot_Guardian::get_status(): array` (last_run, spent, budget, budget_state).
+- Keyword history table `wp_swps_keyword_tracking`: columns include keyword, position (FLOAT NULL), date; UNIQUE (keyword, date). One row per keyword per sync. Winners/losers = compare each keyword's latest position vs its position ~7 days prior.
+- Generation log: option `swps_generation_log` (rolling array, see `SWPS_Generator::append_log` line 698) — lossy strings; NOT sufficient for failures, hence the new listener.
+- `SWPS_Hooks::do_generation_failed( WP_Error $error, string $topic, string $template )` fires the action `swps_generation_failed` with 3 args (verify arg order with `grep -n "swps_generation_failed" includes/class-hooks.php` — read the do_action call).
+- Settings tabs: `SWPS_Settings::get_settings_tabs()` (class-settings.php:1597) maps tab keys → section id arrays; template renders via `render_sections_for_tab`. To show a NEW section, its id must be appended to a tab's `sections` array AND the section/fields registered on page `'stratawp-seo'`, group `'stratawp-seo'`.
+- Recent generations: `SWPS_Dashboard::safe_get_recent_generations()` (class-dashboard.php:208) — read it and reuse its query shape (it queries posts with `_swps_cost`/generation meta; copy the approach, not the method).
+- Cron schedule pattern: `SWPS_Keyword_Tracker::schedule_cron()` (reads a frequency option, wp_schedule_event); custom intervals `swps_monthly` etc. registered by SWPS_Cron::add_custom_schedules. 'daily'/'weekly' are WP core schedules.
+- AEO score meta key: `_swps_aeo_score` (int per post).
+- Email: there is currently ZERO `wp_mail` usage in the plugin.
+- Activation defaults: `swps_activate()` in stratawp-seo.php uses a defaults array whose keys get prefixed `swps_`.
+
+---
+
+### Task 0: Branch
+
+- [ ] `git checkout -b feature/weekly-digest feature/autopilot-guardian` (HEAD must be 7242c65 or later)
+- [ ] `vendor/bin/phpunit` → 105 passing baseline.
+
+---
+
+### Task 1: Pure computation helpers (TDD)
+
+**Files:** Create `includes/class-digest.php`; Test `tests/unit/DigestTest.php`
+
+Static methods to build first, test-first (tab indentation in BOTH files):
+
+```php
+	/**
+	 * Split a comma/space-separated recipients string into valid emails.
+	 *
+	 * @param string $raw Raw setting value.
+	 * @return string[] Deduplicated valid emails (may be empty).
+	 */
+	public static function parse_recipients( string $raw ): array {
+		$parts  = preg_split( '/[\s,;]+/', $raw, -1, PREG_SPLIT_NO_EMPTY );
+		$emails = array();
+		foreach ( $parts as $part ) {
+			$email = filter_var( $part, FILTER_VALIDATE_EMAIL );
+			if ( false !== $email ) {
+				$emails[ strtolower( $email ) ] = $email;
+			}
+		}
+		return array_values( $emails );
+	}
+
+	/**
+	 * Diff two post_id => score maps into top movers.
+	 *
+	 * @param array $previous post_id => int score at last send.
+	 * @param array $current  post_id => int score now.
+	 * @param int   $limit    Max movers per direction.
+	 * @return array{risers: array<int, int>, fallers: array<int, int>} post_id => delta.
+	 */
+	public static function compute_movers( array $previous, array $current, int $limit = 5 ): array {
+		$deltas = array();
+		foreach ( $current as $post_id => $score ) {
+			if ( isset( $previous[ $post_id ] ) && (int) $previous[ $post_id ] !== (int) $score ) {
+				$deltas[ $post_id ] = (int) $score - (int) $previous[ $post_id ];
+			}
+		}
+		arsort( $deltas );
+		$risers = array_slice( array_filter( $deltas, static fn( $d ) => $d > 0 ), 0, $limit, true );
+		asort( $deltas );
+		$fallers = array_slice( array_filter( $deltas, static fn( $d ) => $d < 0 ), 0, $limit, true );
+		return array(
+			'risers'  => $risers,
+			'fallers' => $fallers,
+		);
+	}
+
+	/**
+	 * Compute keyword winners/losers from (keyword => [old_position, new_position]) pairs.
+	 * Lower position = better. Null positions are skipped.
+	 *
+	 * @param array $pairs keyword => array{0: float|null, 1: float|null}.
+	 * @param int   $limit Max per direction.
+	 * @return array{winners: array<string, float>, losers: array<string, float>} keyword => signed delta (negative = improved).
+	 */
+	public static function keyword_deltas( array $pairs, int $limit = 5 ): array {
+		$deltas = array();
+		foreach ( $pairs as $keyword => $pair ) {
+			if ( ! isset( $pair[0], $pair[1] ) ) {
+				continue;
+			}
+			$delta = (float) $pair[1] - (float) $pair[0];
+			if ( 0.0 !== $delta ) {
+				$deltas[ $keyword ] = $delta;
+			}
+		}
+		asort( $deltas ); // Most negative (biggest improvement) first.
+		$winners = array_slice( array_filter( $deltas, static fn( $d ) => $d < 0 ), 0, $limit, true );
+		arsort( $deltas );
+		$losers = array_slice( array_filter( $deltas, static fn( $d ) => $d > 0 ), 0, $limit, true );
+		return array(
+			'winners' => $winners,
+			'losers'  => $losers,
+		);
+	}
+```
+
+Tests (write FIRST, watch fail, then implement — the test file `require_once`s includes/class-digest.php; class skeleton has ABSPATH guard + constants + these statics only at this stage):
+- parse_recipients: mixed separators (`"a@b.com, c@d.com;e@f.com\ng@h.io"` → 4), invalid entries dropped, case-dedup (`A@B.com a@b.com` → 1), empty string → empty array.
+- compute_movers: rising/falling split, limit respected, posts absent from previous skipped, unchanged scores skipped.
+- keyword_deltas: improvement = negative delta in winners, null old or new skipped, zero delta skipped, limit respected.
+
+Run suite (expect ~118+), commit `feat: digest pure helpers — recipients, movers, keyword deltas`.
+
+---
+
+### Task 2: Failure listener + data assembly
+
+**Files:** Modify `includes/class-digest.php`
+
+Constants on the class:
+
+```php
+	public const OPTION_ENABLED    = 'swps_digest_enabled';
+	public const OPTION_FREQUENCY  = 'swps_digest_frequency'; // daily|weekly|monthly
+	public const OPTION_RECIPIENTS = 'swps_digest_recipients';
+	public const OPTION_LOGO       = 'swps_digest_logo';
+	public const OPTION_ACCENT     = 'swps_digest_accent';
+	public const OPTION_FOOTER     = 'swps_digest_footer';
+	public const OPTION_AI_SUMMARY = 'swps_digest_ai_summary';
+	public const OPTION_FAILURES   = 'swps_generation_failures';
+	public const OPTION_AEO_SNAP   = 'swps_digest_aeo_snapshot';
+	public const OPTION_LAST_SENT  = 'swps_digest_last_sent';
+	public const CRON_HOOK         = 'swps_send_digest';
+	private const MAX_FAILURES     = 20;
+```
+
+Constructor hooks: `add_action( 'swps_generation_failed', array( $this, 'record_failure' ), 10, 3 )`; `add_action( self::CRON_HOOK, array( $this, 'send' ) )`; settings + test-send hooks come in Task 3. VERIFY the action arg order in class-hooks.php before writing record_failure; signature `record_failure( WP_Error $error, string $topic, string $template ): void` — prepend `array( 'time' => time(), 'code' => ..., 'message' => ..., 'topic' => ..., 'template' => ... )` to the OPTION_FAILURES rolling array, trim to MAX_FAILURES, update_option autoload false.
+
+`collect_data( int $since ): array` — assembles sections, each via a private fail-soft getter wrapped in try/catch (Throwable) returning null; null sections are dropped:
+- `generated`: posts since $since with `_swps_tokens` meta (mirror safe_get_recent_generations query), each: title, edit link, `_swps_seo_score`/`_swps_aeo_score` meta if present, `_swps_cost`.
+- `failures`: entries from OPTION_FAILURES newer than $since (then prune older ones).
+- `keywords`: query wp_swps_keyword_tracking — for each tracked keyword, latest position and the closest row <= ($since): build pairs, run `keyword_deltas()`.
+- `backlinks`: `SWPS_Backlinks::get_stats()` — read the class first; how to construct it (constructor args?) — if it needs dependencies, get the instance off `stratawp_seo()` (check the property name in stratawp-seo.php). Same for competitors/bot tracker below.
+- `competitors`: `get_dashboard_summary( 3 )`.
+- `bots`: `get_bot_summary( $days )` where $days matches the frequency window.
+- `spend`: `SWPS_Cost_Tracker::get_monthly_stats()` + `SWPS_Autopilot_Guardian::get_status()` (budget + state).
+- `aeo_movers`: read current `_swps_aeo_score` map (one `$wpdb` query over postmeta, LIMIT 500), `compute_movers()` vs OPTION_AEO_SNAP, then write the new snapshot.
+- `attention`: built last — failures count, broken backlinks (key from get_stats — read it), budget_state warning/exceeded, autopilot last_run failed count. Empty array = "all good" line in the email.
+
+No commit yet if you prefer one commit with Task 3, but preferred: commit `feat: digest failure listener and data assembly`.
+
+---
+
+### Task 3: Settings section, cron scheduling, test-send
+
+**Files:** Modify `includes/class-digest.php`, `includes/class-settings.php` (ONE line: add section id to the analytics tab), `stratawp-seo.php` (activation defaults)
+
+- Register section `swps_digest_section` titled "Email Digest" on page 'stratawp-seo' from the digest class (admin_init priority 20), with fields: enabled checkbox; frequency select (daily/weekly/monthly); recipients text (sanitize: `sanitize_textarea_field`, validated on use via parse_recipients — show a description that invalid addresses are ignored); logo URL (esc_url_raw sanitize); accent color (sanitize_hex_color); footer text (sanitize_text_field); AI summary checkbox. Group 'stratawp-seo' so it saves with the main form.
+- Add `'swps_digest_section'` to the `'analytics'` tab's sections array in `get_settings_tabs()` (class-settings.php:1631-1636).
+- Scheduling: on `update_option_swps_digest_enabled` and `update_option_swps_digest_frequency` (use `add_action( 'update_option_{option}', ..., 10, 2 )`), call a `reschedule()` method: clear CRON_HOOK (wp_unschedule_hook) and, if enabled, `wp_schedule_event( time() + HOUR_IN_SECONDS, $schedule, self::CRON_HOOK )` where $schedule maps daily→'daily', weekly→'weekly', monthly→'swps_monthly' (registered by SWPS_Cron). Also handle first-save (add_option_… actions fire instead of update when option didn't exist — register both or seed activation defaults so update always fires; defaults below).
+- Activation defaults in stratawp-seo.php: `digest_enabled => 0`, `digest_frequency => 'weekly'`, `digest_recipients => ''`, `digest_ai_summary => 0` (keys get swps_ prefix via the loop).
+- Test-send: `add_action( 'admin_post_swps_digest_test', array( $this, 'handle_test_send' ) )` — manage_options + check_admin_referer( 'swps_digest_test' ); sends the digest (window = last 7 days) to the CURRENT USER's email only; redirect back with `&swps_digest_test=sent|failed` and show an admin notice. Render the button inside the section description callback as a small form posting to admin-post.php (a nested form inside the settings form is invalid HTML — use a LINK styled as button: `wp_nonce_url( admin_url( 'admin-post.php?action=swps_digest_test' ), 'swps_digest_test' )` and make handle_test_send accept GET).
+- Uninstall/cron hygiene: add `wp_unschedule_hook( 'swps_send_digest' )` wherever the plugin clears its other cron hooks on deactivation (grep `register_deactivation_hook` / the deactivate function in stratawp-seo.php and match the pattern), and add the new options to uninstall.php following its existing option-deletion pattern (it was recently overhauled — read it).
+
+Commit: `feat: digest settings, scheduling, and test-send`
+
+---
+
+### Task 4: Email template + send()
+
+**Files:** Create `templates/email/digest.php`; modify `includes/class-digest.php`
+
+`send( bool $test = false, ?string $override_recipient = null ): bool`:
+- Window: since OPTION_LAST_SENT (fallback: frequency span); collect_data; bail (return false, no email) if EVERY section is null/empty AND attention is empty — except never bail on test sends.
+- Optional AI executive summary: if OPTION_AI_SUMMARY, build a compact stats JSON and ask the provider for 2 sentences via `SWPS_Provider_Factory::create_ai_provider()->chat(...)` (check the factory method name with grep first); wrap fully in try/catch + is_wp_error → skip section. If the provider exposes a public usage accessor (grep for `last_usage` public method), track cost via SWPS_Cost_Tracker; if not, skip tracking with a brief comment.
+- Render: `ob_start(); include ...templates/email/digest.php; $html = ob_get_clean();` passing data via local vars. Template: 600px-wide table layout, ALL CSS inline (no <style> reliance for layout; a minimal <style> block for dark-mode meta is fine), accent color applied to header bar + links, logo at top when set, footer text + "Prepared by" line, every item linking to wp-admin pages with absolute URLs (admin_url). Sections render ONLY when their data key is non-empty. The attention section renders first with a colored left border; when empty render the one-liner "Nothing needs your attention this week. 🎉".
+- Headers: `array( 'Content-Type: text/html; charset=UTF-8' )`. Recipients: parse_recipients(OPTION_RECIPIENTS); fallback to `get_option( 'admin_email' )` when empty. `wp_mail( $recipients, $subject, $html, $headers )`. Subject: `sprintf( '[%s] SEO digest — %s', get_bloginfo( 'name' ), wp_date( get_option( 'date_format' ) ) )`.
+- On real (non-test) success: update OPTION_LAST_SENT = time().
+- Catch-up guard: the cron callback `send()` should no-op (and NOT update last_sent) if last_sent is more recent than half the frequency window (double-fire protection).
+
+Templates dir note: `templates/email/` is new — creating a subdirectory is fine (templates/ already exists).
+
+Commit: `feat: digest email template and send pipeline`
+
+---
+
+### Task 5: Wire-up, verification, release
+
+- require_once `includes/class-digest.php` in stratawp-seo.php (with the other requires) + public typed property + `$this->digest = new SWPS_Digest();` near the guardian instantiation.
+- `php -l` everything touched; `vendor/bin/phpunit`; `vendor/bin/phpstan analyse --memory-limit=2G` (no new errors); `vendor/bin/phpcs --standard=phpcs.xml.dist includes/class-digest.php templates/email/digest.php` (clean — new files).
+- Version 4.11.0 → 4.12.0 (stratawp-seo.php header + SWPS_VERSION, readme.txt stable tag + changelog, README.md badge + changelog):
+
+```
+= 4.12.0 =
+* New: White-label email digest — weekly/daily/monthly report of generations, failures, keyword movers, backlinks, competitors, AI-bot trends, and AI spend, led by a needs-attention triage section; agency branding, multiple recipients, test-send, optional AI executive summary.
+* New: generation failures are now persistently recorded (swps_generation_failed listener) and surfaced in the digest.
+```
+
+- Commit `chore: release 4.12.0 — email digest`, commit the plan doc too, push, PR with base `feature/autopilot-guardian`:
+  `gh pr create --base feature/autopilot-guardian --title "feat: white-label email digest with needs-attention alerts" --body ...` (summary + test plan + note that wp_mail deliverability depends on the site's mailer and a deliverability note was added to the field description). End body with the Claude Code attribution line.
+
+## Self-review checklist
+1. Digest class < 500 lines? (If over, move the AI-summary + rendering glue into the template/a trait — report rather than improvise a new file.)
+2. Every section fail-soft? A fatal in one getter must not kill the email.
+3. No section renders empty headings?
+4. Cron cleared on deactivation; options removed in uninstall.php?
+5. parse_recipients used everywhere recipients are read (never raw)?
+6. Test-send works via GET admin-post link with nonce + capability?

--- a/includes/class-digest-settings.php
+++ b/includes/class-digest-settings.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Digest settings — section/fields registration, cron scheduling, test-send.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers the Email Digest settings section, handles (re)scheduling the
+ * digest cron when options change, and processes the test-send action.
+ */
+class SWPS_Digest_Settings {
+
+	/**
+	 * The digest instance used for test sends.
+	 *
+	 * @var SWPS_Digest
+	 */
+	private SWPS_Digest $digest;
+
+	/**
+	 * Wire up settings, scheduling, and test-send hooks.
+	 *
+	 * @param SWPS_Digest $digest Digest instance (DI for test sends).
+	 */
+	public function __construct( SWPS_Digest $digest ) {
+		$this->digest = $digest;
+
+		add_action( 'admin_init', array( $this, 'register_settings' ), 20 );
+
+		// Reschedule when enable/frequency change (both add_ and update_ in case
+		// activation defaults were never seeded).
+		foreach ( array( SWPS_Digest::OPTION_ENABLED, SWPS_Digest::OPTION_FREQUENCY ) as $option ) {
+			add_action( "update_option_{$option}", array( $this, 'reschedule' ), 10, 0 );
+			add_action( "add_option_{$option}", array( $this, 'reschedule' ), 10, 0 );
+		}
+
+		add_action( 'admin_post_swps_digest_test', array( $this, 'handle_test_send' ) );
+		add_action( 'admin_notices', array( $this, 'maybe_show_test_notice' ) );
+	}
+
+	/**
+	 * Register the Email Digest section and its fields on the main settings page.
+	 *
+	 * @return void
+	 */
+	public function register_settings(): void {
+		add_settings_section(
+			'swps_digest_section',
+			__( 'Email Digest', 'stratawp-seo' ),
+			array( $this, 'render_section_description' ),
+			'stratawp-seo'
+		);
+
+		$fields = array(
+			SWPS_Digest::OPTION_ENABLED    => array(
+				'title'    => __( 'Enable Digest', 'stratawp-seo' ),
+				'render'   => 'render_enabled_field',
+				'sanitize' => 'absint',
+			),
+			SWPS_Digest::OPTION_FREQUENCY  => array(
+				'title'    => __( 'Frequency', 'stratawp-seo' ),
+				'render'   => 'render_frequency_field',
+				'sanitize' => array( $this, 'sanitize_frequency' ),
+			),
+			SWPS_Digest::OPTION_RECIPIENTS => array(
+				'title'    => __( 'Recipients', 'stratawp-seo' ),
+				'render'   => 'render_recipients_field',
+				'sanitize' => 'sanitize_textarea_field',
+			),
+			SWPS_Digest::OPTION_LOGO       => array(
+				'title'    => __( 'Logo URL', 'stratawp-seo' ),
+				'render'   => 'render_logo_field',
+				'sanitize' => 'esc_url_raw',
+			),
+			SWPS_Digest::OPTION_ACCENT     => array(
+				'title'    => __( 'Accent Color', 'stratawp-seo' ),
+				'render'   => 'render_accent_field',
+				'sanitize' => 'sanitize_hex_color',
+			),
+			SWPS_Digest::OPTION_FOOTER     => array(
+				'title'    => __( 'Footer Text', 'stratawp-seo' ),
+				'render'   => 'render_footer_field',
+				'sanitize' => 'sanitize_text_field',
+			),
+			SWPS_Digest::OPTION_AI_SUMMARY => array(
+				'title'    => __( 'AI Executive Summary', 'stratawp-seo' ),
+				'render'   => 'render_ai_summary_field',
+				'sanitize' => 'absint',
+			),
+		);
+
+		foreach ( $fields as $option => $field ) {
+			register_setting( 'stratawp-seo', $option, array( 'sanitize_callback' => $field['sanitize'] ) );
+			add_settings_field(
+				$option,
+				$field['title'],
+				array( $this, $field['render'] ),
+				'stratawp-seo',
+				'swps_digest_section'
+			);
+		}
+	}
+
+	/**
+	 * Section description with the test-send button (nonce-protected GET link;
+	 * a nested form inside the settings form would be invalid HTML).
+	 *
+	 * @return void
+	 */
+	public function render_section_description(): void {
+		echo '<p>' . esc_html__( 'Scheduled HTML email summarizing generations, failures, keyword movers, backlinks, competitors, AI-bot trends, and AI spend. Delivery depends on your site\'s mailer — use the test send to verify.', 'stratawp-seo' ) . '</p>';
+		$url = wp_nonce_url( admin_url( 'admin-post.php?action=swps_digest_test' ), 'swps_digest_test' );
+		echo '<p><a href="' . esc_url( $url ) . '" class="button button-secondary">' . esc_html__( 'Send test digest to my email', 'stratawp-seo' ) . '</a></p>';
+	}
+
+	/**
+	 * Render the enabled checkbox.
+	 *
+	 * @return void
+	 */
+	public function render_enabled_field(): void {
+		printf(
+			'<label><input type="checkbox" name="%s" value="1" %s /> %s</label>',
+			esc_attr( SWPS_Digest::OPTION_ENABLED ),
+			checked( 1, (int) get_option( SWPS_Digest::OPTION_ENABLED, 0 ), false ),
+			esc_html__( 'Send the digest email on a schedule', 'stratawp-seo' )
+		);
+	}
+
+	/**
+	 * Render the frequency select.
+	 *
+	 * @return void
+	 */
+	public function render_frequency_field(): void {
+		$current = get_option( SWPS_Digest::OPTION_FREQUENCY, 'weekly' );
+		$options = array(
+			'daily'   => __( 'Daily', 'stratawp-seo' ),
+			'weekly'  => __( 'Weekly', 'stratawp-seo' ),
+			'monthly' => __( 'Monthly', 'stratawp-seo' ),
+		);
+		echo '<select name="' . esc_attr( SWPS_Digest::OPTION_FREQUENCY ) . '">';
+		foreach ( $options as $value => $label ) {
+			printf( '<option value="%s" %s>%s</option>', esc_attr( $value ), selected( $current, $value, false ), esc_html( $label ) );
+		}
+		echo '</select>';
+	}
+
+	/**
+	 * Render the recipients textarea.
+	 *
+	 * @return void
+	 */
+	public function render_recipients_field(): void {
+		printf(
+			'<textarea name="%s" rows="3" class="large-text" placeholder="client@example.com, manager@example.com">%s</textarea><p class="description">%s</p>',
+			esc_attr( SWPS_Digest::OPTION_RECIPIENTS ),
+			esc_textarea( get_option( SWPS_Digest::OPTION_RECIPIENTS, '' ) ),
+			esc_html__( 'Separate addresses with commas, spaces, or new lines. Invalid addresses are ignored. Falls back to the site admin email when empty.', 'stratawp-seo' )
+		);
+	}
+
+	/**
+	 * Render the logo URL field.
+	 *
+	 * @return void
+	 */
+	public function render_logo_field(): void {
+		printf(
+			'<input type="url" name="%s" value="%s" class="regular-text" placeholder="https://" /><p class="description">%s</p>',
+			esc_attr( SWPS_Digest::OPTION_LOGO ),
+			esc_attr( get_option( SWPS_Digest::OPTION_LOGO, '' ) ),
+			esc_html__( 'Shown at the top of the email. Leave empty for no logo.', 'stratawp-seo' )
+		);
+	}
+
+	/**
+	 * Render the accent color field.
+	 *
+	 * @return void
+	 */
+	public function render_accent_field(): void {
+		printf(
+			'<input type="text" name="%s" value="%s" class="small-text" placeholder="#2271b1" /><p class="description">%s</p>',
+			esc_attr( SWPS_Digest::OPTION_ACCENT ),
+			esc_attr( get_option( SWPS_Digest::OPTION_ACCENT, '' ) ),
+			esc_html__( 'Hex color for the header bar and links.', 'stratawp-seo' )
+		);
+	}
+
+	/**
+	 * Render the footer text field.
+	 *
+	 * @return void
+	 */
+	public function render_footer_field(): void {
+		printf(
+			'<input type="text" name="%s" value="%s" class="regular-text" /><p class="description">%s</p>',
+			esc_attr( SWPS_Digest::OPTION_FOOTER ),
+			esc_attr( get_option( SWPS_Digest::OPTION_FOOTER, '' ) ),
+			esc_html__( 'Custom footer line, e.g. your agency name and contact.', 'stratawp-seo' )
+		);
+	}
+
+	/**
+	 * Render the AI summary checkbox.
+	 *
+	 * @return void
+	 */
+	public function render_ai_summary_field(): void {
+		printf(
+			'<label><input type="checkbox" name="%s" value="1" %s /> %s</label>',
+			esc_attr( SWPS_Digest::OPTION_AI_SUMMARY ),
+			checked( 1, (int) get_option( SWPS_Digest::OPTION_AI_SUMMARY, 0 ), false ),
+			esc_html__( 'Open each digest with a short AI-written executive summary (uses your configured provider; small per-send cost)', 'stratawp-seo' )
+		);
+	}
+
+	/**
+	 * Whitelist sanitizer for the frequency option.
+	 *
+	 * @param mixed $value Submitted value.
+	 * @return string One of daily|weekly|monthly.
+	 */
+	public function sanitize_frequency( $value ): string {
+		return in_array( $value, array( 'daily', 'weekly', 'monthly' ), true ) ? $value : 'weekly';
+	}
+
+	/**
+	 * Clear and (when enabled) re-create the digest cron event.
+	 *
+	 * First run lands one hour after saving, then recurs on the chosen schedule.
+	 *
+	 * @return void
+	 */
+	public function reschedule(): void {
+		wp_unschedule_hook( SWPS_Digest::CRON_HOOK );
+
+		if ( ! get_option( SWPS_Digest::OPTION_ENABLED ) ) {
+			return;
+		}
+
+		$map      = array(
+			'daily'   => 'daily',
+			'weekly'  => 'weekly',
+			'monthly' => 'swps_monthly',
+		);
+		$freq     = get_option( SWPS_Digest::OPTION_FREQUENCY, 'weekly' );
+		$schedule = $map[ $freq ] ?? 'weekly';
+
+		wp_schedule_event( time() + HOUR_IN_SECONDS, $schedule, SWPS_Digest::CRON_HOOK );
+	}
+
+	/**
+	 * Handle the test-send GET action: send a 7-day digest to the current user only.
+	 *
+	 * @return void
+	 */
+	public function handle_test_send(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You are not allowed to do that.', 'stratawp-seo' ) );
+		}
+		check_admin_referer( 'swps_digest_test' );
+
+		$sent = $this->digest->send( true, wp_get_current_user()->user_email );
+
+		$redirect = add_query_arg(
+			'swps_digest_test',
+			$sent ? 'sent' : 'failed',
+			admin_url( 'admin.php?page=swps-settings' )
+		) . '#analytics';
+		wp_safe_redirect( $redirect );
+		exit;
+	}
+
+	/**
+	 * Show an admin notice after a test send.
+	 *
+	 * @return void
+	 */
+	public function maybe_show_test_notice(): void {
+		if ( ! isset( $_GET['swps_digest_test'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+		$result = sanitize_key( wp_unslash( $_GET['swps_digest_test'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( 'sent' === $result ) {
+			echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__( 'Test digest sent — check your inbox (and spam folder).', 'stratawp-seo' ) . '</p></div>';
+		} elseif ( 'failed' === $result ) {
+			echo '<div class="notice notice-error is-dismissible"><p>' . esc_html__( 'Test digest could not be sent. Check your site\'s mail configuration.', 'stratawp-seo' ) . '</p></div>';
+		}
+	}
+}

--- a/includes/class-digest.php
+++ b/includes/class-digest.php
@@ -37,11 +37,20 @@ class SWPS_Digest {
 
 	/**
 	 * Register action hooks: generation-failure listener and cron send.
-	 * Settings and test-send hooks are added in Task 3.
+	 * Settings and test-send hooks live in SWPS_Digest_Settings.
 	 */
 	public function __construct() {
 		add_action( 'swps_generation_failed', array( $this, 'record_failure' ), 10, 3 );
-		add_action( self::CRON_HOOK, array( $this, 'send' ) );
+		add_action( self::CRON_HOOK, array( $this, 'cron_send' ) );
+	}
+
+	/**
+	 * Void cron callback wrapper around send().
+	 *
+	 * @return void
+	 */
+	public function cron_send(): void {
+		$this->send();
 	}
 
 	// ---- Failure listener ----
@@ -272,7 +281,7 @@ class SWPS_Digest {
 	 * AI-bot summary from the singleton.
 	 *
 	 * @param int $days Number of days to include.
-	 * @return array<string, mixed>|null
+	 * @return array<int, array<string, mixed>>|null
 	 */
 	private function get_bots( int $days ): ?array {
 		try {

--- a/includes/class-digest.php
+++ b/includes/class-digest.php
@@ -9,10 +9,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once __DIR__ . '/trait-digest-send.php';
+
 /**
  * Handles the weekly digest email: failure tracking, data assembly, send pipeline.
  */
 class SWPS_Digest {
+
+	use SWPS_Digest_Send;
 
 	// ---- Option / hook name constants ----
 

--- a/includes/class-digest.php
+++ b/includes/class-digest.php
@@ -33,6 +33,13 @@ class SWPS_Digest {
 	public const CRON_HOOK         = 'swps_send_digest';
 	private const MAX_FAILURES     = 20;
 
+	/**
+	 * AEO snapshot staged by get_aeo_movers(); persisted by send() on success.
+	 *
+	 * @var array<int, int>|null
+	 */
+	private ?array $pending_aeo_snapshot = null;
+
 	// ---- Constructor ----
 
 	/**
@@ -213,15 +220,17 @@ class SWPS_Digest {
 			global $wpdb;
 			$table      = $wpdb->prefix . 'swps_keyword_tracking';
 			$since_date = gmdate( 'Y-m-d', $since );
+			// new_pos is the latest reading regardless of window — keyword syncs may be
+			// less frequent than the digest, so constraining it to the period would
+			// silently drop every keyword on daily digests.
 			// Table name is built from $wpdb->prefix + a fixed literal — safe to interpolate.
 			// phpcs:disable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$rows = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT t.keyword,
-					(SELECT position FROM {$table} WHERE keyword = t.keyword AND date > %s ORDER BY date DESC LIMIT 1) AS new_pos,
+					(SELECT position FROM {$table} WHERE keyword = t.keyword ORDER BY date DESC LIMIT 1) AS new_pos,
 					(SELECT position FROM {$table} WHERE keyword = t.keyword AND date <= %s ORDER BY date DESC LIMIT 1) AS old_pos
 					FROM (SELECT DISTINCT keyword FROM {$table}) t",
-					$since_date,
 					$since_date
 				),
 				ARRAY_A
@@ -333,7 +342,9 @@ class SWPS_Digest {
 			if ( ! is_array( $previous ) ) {
 				$previous = array();
 			}
-			update_option( self::OPTION_AEO_SNAP, $current, false );
+			// Written by send() only after a successful real send, so a bailed or
+			// failed send doesn't silently swallow this period's movers.
+			$this->pending_aeo_snapshot = $current;
 			if ( empty( $previous ) ) {
 				return null;
 			}

--- a/includes/class-digest.php
+++ b/includes/class-digest.php
@@ -1,0 +1,475 @@
+<?php
+/**
+ * Weekly digest email — data assembly, cron scheduling, failure listener.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles the weekly digest email: failure tracking, data assembly, send pipeline.
+ */
+class SWPS_Digest {
+
+	// ---- Option / hook name constants ----
+
+	public const OPTION_ENABLED    = 'swps_digest_enabled';
+	public const OPTION_FREQUENCY  = 'swps_digest_frequency'; // Values: daily, weekly, monthly.
+	public const OPTION_RECIPIENTS = 'swps_digest_recipients';
+	public const OPTION_LOGO       = 'swps_digest_logo';
+	public const OPTION_ACCENT     = 'swps_digest_accent';
+	public const OPTION_FOOTER     = 'swps_digest_footer';
+	public const OPTION_AI_SUMMARY = 'swps_digest_ai_summary';
+	public const OPTION_FAILURES   = 'swps_generation_failures';
+	public const OPTION_AEO_SNAP   = 'swps_digest_aeo_snapshot';
+	public const OPTION_LAST_SENT  = 'swps_digest_last_sent';
+	public const CRON_HOOK         = 'swps_send_digest';
+	private const MAX_FAILURES     = 20;
+
+	// ---- Constructor ----
+
+	/**
+	 * Register action hooks: generation-failure listener and cron send.
+	 * Settings and test-send hooks are added in Task 3.
+	 */
+	public function __construct() {
+		add_action( 'swps_generation_failed', array( $this, 'record_failure' ), 10, 3 );
+		add_action( self::CRON_HOOK, array( $this, 'send' ) );
+	}
+
+	// ---- Failure listener ----
+
+	/**
+	 * Persist a generation failure to the rolling option store.
+	 *
+	 * Fires on `swps_generation_failed` with args (WP_Error $error, string $topic, string $template).
+	 *
+	 * @param WP_Error $error    The error object from the failed generation.
+	 * @param string   $topic    The topic/title being generated.
+	 * @param string   $template The template slug used.
+	 * @return void
+	 */
+	public function record_failure( WP_Error $error, string $topic, string $template ): void {
+		$entry = array(
+			'time'     => time(),
+			'code'     => $error->get_error_code(),
+			'message'  => $error->get_error_message(),
+			'topic'    => $topic,
+			'template' => $template,
+		);
+
+		$failures = get_option( self::OPTION_FAILURES, array() );
+		if ( ! is_array( $failures ) ) {
+			$failures = array();
+		}
+		array_unshift( $failures, $entry );
+		$failures = array_slice( $failures, 0, self::MAX_FAILURES );
+		update_option( self::OPTION_FAILURES, $failures, false );
+	}
+
+	// ---- Data assembly ----
+
+	/**
+	 * Assemble all digest sections for the given time window.
+	 *
+	 * Each section uses a fail-soft private getter; null sections are omitted from
+	 * the returned array. Callers should treat a missing key as "no data".
+	 *
+	 * @param int $since Unix timestamp — only include data generated after this time.
+	 * @return array<string, mixed> Keyed sections with non-null data.
+	 */
+	public function collect_data( int $since ): array {
+		$frequency = get_option( self::OPTION_FREQUENCY, 'weekly' );
+		$days      = 'daily' === $frequency ? 1 : ( 'monthly' === $frequency ? 30 : 7 );
+
+		$data = array();
+
+		$generated = $this->get_generated( $since );
+		if ( null !== $generated ) {
+			$data['generated'] = $generated;
+		}
+
+		$failures = $this->get_failures( $since );
+		if ( null !== $failures ) {
+			$data['failures'] = $failures;
+		}
+
+		$keywords = $this->get_keywords( $since );
+		if ( null !== $keywords ) {
+			$data['keywords'] = $keywords;
+		}
+
+		$backlinks = $this->get_backlinks();
+		if ( null !== $backlinks ) {
+			$data['backlinks'] = $backlinks;
+		}
+
+		$competitors = $this->get_competitors();
+		if ( null !== $competitors ) {
+			$data['competitors'] = $competitors;
+		}
+
+		$bots = $this->get_bots( $days );
+		if ( null !== $bots ) {
+			$data['bots'] = $bots;
+		}
+
+		$spend = $this->get_spend();
+		if ( null !== $spend ) {
+			$data['spend'] = $spend;
+		}
+
+		$aeo_movers = $this->get_aeo_movers();
+		if ( null !== $aeo_movers ) {
+			$data['aeo_movers'] = $aeo_movers;
+		}
+
+		// Attention section is built last from assembled data.
+		$data['attention'] = $this->build_attention( $data );
+
+		return $data;
+	}
+
+	// ---- Private fail-soft getters ----
+
+	/**
+	 * Posts generated since $since with _swps_tokens meta.
+	 *
+	 * @param int $since Unix timestamp.
+	 * @return array<int, array<string, mixed>>|null
+	 */
+	private function get_generated( int $since ): ?array {
+		try {
+			global $wpdb;
+			$since_date = gmdate( 'Y-m-d H:i:s', $since );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT p.ID, p.post_title
+					FROM {$wpdb->posts} p
+					INNER JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID AND pm.meta_key = '_swps_tokens'
+					WHERE p.post_status IN ('publish','draft')
+					AND p.post_modified_gmt >= %s
+					ORDER BY p.post_modified_gmt DESC
+					LIMIT 50",
+					$since_date
+				),
+				ARRAY_A
+			);
+			if ( empty( $rows ) ) {
+				return null;
+			}
+			$generated = array();
+			foreach ( $rows as $row ) {
+				$post_id     = (int) $row['ID'];
+				$seo_score   = get_post_meta( $post_id, '_swps_seo_score', true );
+				$aeo_score   = get_post_meta( $post_id, '_swps_aeo_score', true );
+				$cost        = get_post_meta( $post_id, '_swps_cost', true );
+				$generated[] = array(
+					'post_id'   => $post_id,
+					'title'     => $row['post_title'],
+					'edit_link' => get_edit_post_link( $post_id, 'raw' ),
+					'seo_score' => $seo_score ? $seo_score : null,
+					'aeo_score' => $aeo_score ? $aeo_score : null,
+					'cost'      => $cost ? $cost : null,
+				);
+			}
+			return $generated;
+		} catch ( Throwable $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Generation failures newer than $since (also prunes old ones).
+	 *
+	 * @param int $since Unix timestamp.
+	 * @return array<int, array<string, mixed>>|null
+	 */
+	private function get_failures( int $since ): ?array {
+		try {
+			$failures = get_option( self::OPTION_FAILURES, array() );
+			if ( ! is_array( $failures ) ) {
+				return null;
+			}
+			$recent = array_values(
+				array_filter(
+					$failures,
+					static fn( $f ) => isset( $f['time'] ) && (int) $f['time'] >= $since
+				)
+			);
+			$pruned = array_values(
+				array_filter(
+					$failures,
+					static fn( $f ) => isset( $f['time'] ) && (int) $f['time'] >= ( $since - WEEK_IN_SECONDS * 4 )
+				)
+			);
+			if ( count( $pruned ) < count( $failures ) ) {
+				update_option( self::OPTION_FAILURES, $pruned, false );
+			}
+			return empty( $recent ) ? null : $recent;
+		} catch ( Throwable $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Keyword winners and losers for the period.
+	 *
+	 * Queries wp_swps_keyword_tracking directly: for each keyword, compares the
+	 * latest position to the position closest to $since (7 days prior for weekly).
+	 *
+	 * @param int $since Unix timestamp.
+	 * @return array{winners: array<string, float>, losers: array<string, float>}|null
+	 */
+	private function get_keywords( int $since ): ?array {
+		try {
+			global $wpdb;
+			$table      = $wpdb->prefix . 'swps_keyword_tracking';
+			$since_date = gmdate( 'Y-m-d', $since );
+			// Table name is built from $wpdb->prefix + a fixed literal — safe to interpolate.
+			// phpcs:disable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$rows = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT keyword,
+					MAX(CASE WHEN date > %s THEN position END) AS new_pos,
+					MAX(CASE WHEN date <= %s THEN position END) AS old_pos
+					FROM {$table}
+					GROUP BY keyword
+					HAVING new_pos IS NOT NULL OR old_pos IS NOT NULL",
+					$since_date,
+					$since_date
+				),
+				ARRAY_A
+			);
+			// phpcs:enable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			if ( empty( $rows ) ) {
+				return null;
+			}
+			$pairs = array();
+			foreach ( $rows as $row ) {
+				$pairs[ $row['keyword'] ] = array(
+					null !== $row['old_pos'] ? (float) $row['old_pos'] : null,
+					null !== $row['new_pos'] ? (float) $row['new_pos'] : null,
+				);
+			}
+			$result = self::keyword_deltas( $pairs );
+			if ( empty( $result['winners'] ) && empty( $result['losers'] ) ) {
+				return null;
+			}
+			return $result;
+		} catch ( Throwable $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Backlink stats from the singleton.
+	 *
+	 * Keys: total, live, lost, broken, pending, new_30d, lost_30d, unique_domains.
+	 *
+	 * @return array<string, int>|null
+	 */
+	private function get_backlinks(): ?array {
+		try {
+			$stats = stratawp_seo()->backlinks->get_stats();
+			return ! empty( $stats ) ? $stats : null;
+		} catch ( Throwable $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Competitor dashboard summary from the singleton.
+	 *
+	 * @return array<int, mixed>|null
+	 */
+	private function get_competitors(): ?array {
+		try {
+			$summary = stratawp_seo()->competitors->get_dashboard_summary( 3 );
+			return ! empty( $summary ) ? $summary : null;
+		} catch ( Throwable $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * AI-bot summary from the singleton.
+	 *
+	 * @param int $days Number of days to include.
+	 * @return array<string, mixed>|null
+	 */
+	private function get_bots( int $days ): ?array {
+		try {
+			$summary = stratawp_seo()->bot_analytics_tracker->get_bot_summary( $days );
+			return ! empty( $summary ) ? $summary : null;
+		} catch ( Throwable $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Cost tracker stats + guardian budget status.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	private function get_spend(): ?array {
+		try {
+			$monthly  = stratawp_seo()->cost_tracker->get_monthly_stats();
+			$guardian = SWPS_Autopilot_Guardian::get_status();
+			return array_merge( $monthly, array( 'guardian' => $guardian ) );
+		} catch ( Throwable $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * AEO score movers since last snapshot.
+	 *
+	 * Reads current _swps_aeo_score postmeta, diffs against OPTION_AEO_SNAP,
+	 * then writes the new snapshot for next time.
+	 *
+	 * @return array{risers: array<int, int>, fallers: array<int, int>}|null
+	 */
+	private function get_aeo_movers(): ?array {
+		try {
+			global $wpdb;
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$rows    = $wpdb->get_results(
+				"SELECT post_id, meta_value FROM {$wpdb->postmeta}
+				WHERE meta_key = '_swps_aeo_score'
+				LIMIT 500",
+				ARRAY_A
+			);
+			$current = array();
+			foreach ( $rows as $row ) {
+				$current[ (int) $row['post_id'] ] = (int) $row['meta_value'];
+			}
+			$previous = get_option( self::OPTION_AEO_SNAP, array() );
+			if ( ! is_array( $previous ) ) {
+				$previous = array();
+			}
+			update_option( self::OPTION_AEO_SNAP, $current, false );
+			if ( empty( $previous ) ) {
+				return null;
+			}
+			$movers = self::compute_movers( $previous, $current );
+			if ( empty( $movers['risers'] ) && empty( $movers['fallers'] ) ) {
+				return null;
+			}
+			return $movers;
+		} catch ( Throwable $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Build the attention/triage section from already-assembled data.
+	 *
+	 * @param array<string, mixed> $data Assembled sections.
+	 * @return array<int, string> Items needing attention (empty = all good).
+	 */
+	private function build_attention( array $data ): array {
+		$items = array();
+
+		// Recent generation failures.
+		if ( ! empty( $data['failures'] ) ) {
+			$count   = count( $data['failures'] );
+			$items[] = sprintf( '%d generation failure%s since last digest', $count, 1 === $count ? '' : 's' );
+		}
+
+		// Broken backlinks.
+		if ( isset( $data['backlinks']['broken'] ) && $data['backlinks']['broken'] > 0 ) {
+			$items[] = sprintf( '%d broken backlink%s', $data['backlinks']['broken'], 1 === $data['backlinks']['broken'] ? '' : 's' );
+		}
+
+		// Budget warnings from autopilot guardian.
+		if ( isset( $data['spend']['guardian']['budget_state'] ) ) {
+			$state = $data['spend']['guardian']['budget_state'];
+			if ( 'warning' === $state ) {
+				$items[] = 'AI spend approaching budget limit';
+			} elseif ( 'exceeded' === $state ) {
+				$items[] = 'AI spend has exceeded the configured budget';
+			}
+		}
+
+		return $items;
+	}
+
+	// ---- Static pure helpers ----
+
+	/**
+	 * Split a comma/space-separated recipients string into valid emails.
+	 *
+	 * @param string $raw Raw setting value.
+	 * @return string[] Deduplicated valid emails (may be empty).
+	 */
+	public static function parse_recipients( string $raw ): array {
+		$parts  = preg_split( '/[\s,;]+/', $raw, -1, PREG_SPLIT_NO_EMPTY );
+		$emails = array();
+		foreach ( $parts as $part ) {
+			$email = filter_var( $part, FILTER_VALIDATE_EMAIL );
+			if ( false !== $email ) {
+				$emails[ strtolower( $email ) ] = $email;
+			}
+		}
+		return array_values( $emails );
+	}
+
+	/**
+	 * Diff two post_id => score maps into top movers.
+	 *
+	 * @param array $previous post_id => int score at last send.
+	 * @param array $current  post_id => int score now.
+	 * @param int   $limit    Max movers per direction.
+	 * @return array{risers: array<int, int>, fallers: array<int, int>} post_id => delta.
+	 */
+	public static function compute_movers( array $previous, array $current, int $limit = 5 ): array {
+		$deltas = array();
+		foreach ( $current as $post_id => $score ) {
+			if ( isset( $previous[ $post_id ] ) && (int) $previous[ $post_id ] !== (int) $score ) {
+				$deltas[ $post_id ] = (int) $score - (int) $previous[ $post_id ];
+			}
+		}
+		arsort( $deltas );
+		$risers = array_slice( array_filter( $deltas, static fn( $d ) => $d > 0 ), 0, $limit, true );
+		asort( $deltas );
+		$fallers = array_slice( array_filter( $deltas, static fn( $d ) => $d < 0 ), 0, $limit, true );
+		return array(
+			'risers'  => $risers,
+			'fallers' => $fallers,
+		);
+	}
+
+	/**
+	 * Compute keyword winners/losers from (keyword => [old_position, new_position]) pairs.
+	 * Lower position = better. Null positions are skipped.
+	 *
+	 * @param array $pairs keyword => array{0: float|null, 1: float|null}.
+	 * @param int   $limit Max per direction.
+	 * @return array{winners: array<string, float>, losers: array<string, float>} keyword => signed delta (negative = improved).
+	 */
+	public static function keyword_deltas( array $pairs, int $limit = 5 ): array {
+		$deltas = array();
+		foreach ( $pairs as $keyword => $pair ) {
+			if ( ! isset( $pair[0], $pair[1] ) ) {
+				continue;
+			}
+			$delta = (float) $pair[1] - (float) $pair[0];
+			if ( 0.0 !== $delta ) {
+				$deltas[ $keyword ] = $delta;
+			}
+		}
+		asort( $deltas ); // Most negative (biggest improvement) first.
+		$winners = array_slice( array_filter( $deltas, static fn( $d ) => $d < 0 ), 0, $limit, true );
+		arsort( $deltas );
+		$losers = array_slice( array_filter( $deltas, static fn( $d ) => $d > 0 ), 0, $limit, true );
+		return array(
+			'winners' => $winners,
+			'losers'  => $losers,
+		);
+	}
+}

--- a/includes/class-digest.php
+++ b/includes/class-digest.php
@@ -356,6 +356,13 @@ class SWPS_Digest {
 			$items[] = sprintf( '%d broken backlink%s', $data['backlinks']['broken'], 1 === $data['backlinks']['broken'] ? '' : 's' );
 		}
 
+		// Autopilot last-run failures.
+		if ( isset( $data['spend']['guardian']['last_run']['failed'] ) && (int) $data['spend']['guardian']['last_run']['failed'] > 0 ) {
+			$count = (int) $data['spend']['guardian']['last_run']['failed'];
+			/* translators: %d: failed count */
+			$items[] = sprintf( _n( 'Autopilot: %d post failed to generate in the last run', 'Autopilot: %d posts failed to generate in the last run', $count, 'stratawp-seo' ), $count );
+		}
+
 		// Budget warnings from autopilot guardian.
 		if ( isset( $data['spend']['guardian']['budget_state'] ) ) {
 			$state = $data['spend']['guardian']['budget_state'];

--- a/includes/class-digest.php
+++ b/includes/class-digest.php
@@ -208,12 +208,10 @@ class SWPS_Digest {
 			// phpcs:disable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$rows = $wpdb->get_results(
 				$wpdb->prepare(
-					"SELECT keyword,
-					MAX(CASE WHEN date > %s THEN position END) AS new_pos,
-					MAX(CASE WHEN date <= %s THEN position END) AS old_pos
-					FROM {$table}
-					GROUP BY keyword
-					HAVING new_pos IS NOT NULL OR old_pos IS NOT NULL",
+					"SELECT t.keyword,
+					(SELECT position FROM {$table} WHERE keyword = t.keyword AND date > %s ORDER BY date DESC LIMIT 1) AS new_pos,
+					(SELECT position FROM {$table} WHERE keyword = t.keyword AND date <= %s ORDER BY date DESC LIMIT 1) AS old_pos
+					FROM (SELECT DISTINCT keyword FROM {$table}) t",
 					$since_date,
 					$since_date
 				),
@@ -351,13 +349,16 @@ class SWPS_Digest {
 
 		// Recent generation failures.
 		if ( ! empty( $data['failures'] ) ) {
-			$count   = count( $data['failures'] );
-			$items[] = sprintf( '%d generation failure%s since last digest', $count, 1 === $count ? '' : 's' );
+			$count = count( $data['failures'] );
+			/* translators: %d: failure count */
+			$items[] = sprintf( _n( '%d generation failure since last digest', '%d generation failures since last digest', $count, 'stratawp-seo' ), $count );
 		}
 
 		// Broken backlinks.
 		if ( isset( $data['backlinks']['broken'] ) && $data['backlinks']['broken'] > 0 ) {
-			$items[] = sprintf( '%d broken backlink%s', $data['backlinks']['broken'], 1 === $data['backlinks']['broken'] ? '' : 's' );
+			$count = (int) $data['backlinks']['broken'];
+			/* translators: %d: broken backlink count */
+			$items[] = sprintf( _n( '%d broken backlink', '%d broken backlinks', $count, 'stratawp-seo' ), $count );
 		}
 
 		// Autopilot last-run failures.

--- a/includes/class-digest.php
+++ b/includes/class-digest.php
@@ -85,49 +85,19 @@ class SWPS_Digest {
 		$frequency = get_option( self::OPTION_FREQUENCY, 'weekly' );
 		$days      = 'daily' === $frequency ? 1 : ( 'monthly' === $frequency ? 30 : 7 );
 
-		$data = array();
+		$sections = array(
+			'generated'   => $this->get_generated( $since ),
+			'failures'    => $this->get_failures( $since ),
+			'keywords'    => $this->get_keywords( $since ),
+			'backlinks'   => $this->get_backlinks(),
+			'competitors' => $this->get_competitors(),
+			'bots'        => $this->get_bots( $days ),
+			'spend'       => $this->get_spend(),
+			'aeo_movers'  => $this->get_aeo_movers(),
+		);
 
-		$generated = $this->get_generated( $since );
-		if ( null !== $generated ) {
-			$data['generated'] = $generated;
-		}
-
-		$failures = $this->get_failures( $since );
-		if ( null !== $failures ) {
-			$data['failures'] = $failures;
-		}
-
-		$keywords = $this->get_keywords( $since );
-		if ( null !== $keywords ) {
-			$data['keywords'] = $keywords;
-		}
-
-		$backlinks = $this->get_backlinks();
-		if ( null !== $backlinks ) {
-			$data['backlinks'] = $backlinks;
-		}
-
-		$competitors = $this->get_competitors();
-		if ( null !== $competitors ) {
-			$data['competitors'] = $competitors;
-		}
-
-		$bots = $this->get_bots( $days );
-		if ( null !== $bots ) {
-			$data['bots'] = $bots;
-		}
-
-		$spend = $this->get_spend();
-		if ( null !== $spend ) {
-			$data['spend'] = $spend;
-		}
-
-		$aeo_movers = $this->get_aeo_movers();
-		if ( null !== $aeo_movers ) {
-			$data['aeo_movers'] = $aeo_movers;
-		}
-
-		// Attention section is built last from assembled data.
+		// Drop null sections; build attention last from what survived.
+		$data              = array_filter( $sections, static fn( $v ) => null !== $v );
 		$data['attention'] = $this->build_attention( $data );
 
 		return $data;

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1632,6 +1632,7 @@ class SWPS_Settings {
 				'label'    => __( 'Analytics', 'stratawp-seo' ),
 				'sections' => array(
 					'swps_analytics_section',
+					'swps_digest_section',
 				),
 			),
 			'aeo'             => array(

--- a/includes/trait-digest-send.php
+++ b/includes/trait-digest-send.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Digest send pipeline — rendering glue and optional AI executive summary.
+ *
+ * Split out of SWPS_Digest as a trait to keep class-digest.php under the
+ * project's 500-line file limit.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Send pipeline for SWPS_Digest: send() plus the AI-summary helper.
+ */
+trait SWPS_Digest_Send {
+
+	/**
+	 * Build and send the digest email.
+	 *
+	 * @param bool        $test               True for a manual test send (never bails on empty data,
+	 *                                        never updates last-sent).
+	 * @param string|null $override_recipient Send to this address only (used by test sends).
+	 * @return bool Whether wp_mail reported success.
+	 */
+	public function send( bool $test = false, ?string $override_recipient = null ): bool {
+		$frequency = get_option( self::OPTION_FREQUENCY, 'weekly' );
+		$span      = 'daily' === $frequency ? DAY_IN_SECONDS : ( 'monthly' === $frequency ? 30 * DAY_IN_SECONDS : WEEK_IN_SECONDS );
+		$last_sent = (int) get_option( self::OPTION_LAST_SENT, 0 );
+
+		// Double-fire guard: skip cron runs landing inside half the frequency window.
+		if ( ! $test && $last_sent > ( time() - (int) ( $span / 2 ) ) ) {
+			return false;
+		}
+
+		$since = ( $test || $last_sent <= 0 ) ? time() - ( $test ? WEEK_IN_SECONDS : $span ) : $last_sent;
+		$data  = $this->collect_data( $since );
+
+		// Bail when there is literally nothing to report — except on test sends.
+		$sections = array_diff_key( $data, array( 'attention' => true ) );
+		if ( ! $test && empty( $sections ) && empty( $data['attention'] ) ) {
+			return false;
+		}
+
+		if ( get_option( self::OPTION_AI_SUMMARY ) ) {
+			$summary = $this->get_ai_summary( $data );
+			if ( null !== $summary ) {
+				$data['ai_summary'] = $summary;
+			}
+		}
+
+		$accent = get_option( self::OPTION_ACCENT, '' );
+		$accent = $accent ? $accent : '#2271b1';
+		$logo   = (string) get_option( self::OPTION_LOGO, '' );
+		$footer = (string) get_option( self::OPTION_FOOTER, '' );
+
+		ob_start();
+		include SWPS_PLUGIN_DIR . 'templates/email/digest.php';
+		$html = ob_get_clean();
+
+		if ( $test && $override_recipient ) {
+			$recipients = array( $override_recipient );
+		} else {
+			$recipients = self::parse_recipients( (string) get_option( self::OPTION_RECIPIENTS, '' ) );
+		}
+		if ( empty( $recipients ) ) {
+			$recipients = array( get_option( 'admin_email' ) );
+		}
+
+		$subject = sprintf( '[%s] SEO digest — %s', get_bloginfo( 'name' ), wp_date( get_option( 'date_format' ) ) );
+		$sent    = wp_mail( $recipients, $subject, $html, array( 'Content-Type: text/html; charset=UTF-8' ) );
+
+		if ( $sent && ! $test ) {
+			update_option( self::OPTION_LAST_SENT, time(), false );
+		}
+
+		return (bool) $sent;
+	}
+
+	/**
+	 * Optional AI executive summary (2 sentences) from compact section stats.
+	 *
+	 * Fail-soft: any provider error returns null and the section is skipped.
+	 * Note: SWPS_AI_Provider keeps last_usage protected with no public accessor,
+	 * so per-send cost tracking is skipped here.
+	 *
+	 * @param array<string, mixed> $data Assembled digest data.
+	 * @return string|null Plain-text summary or null on any failure.
+	 */
+	private function get_ai_summary( array $data ): ?string {
+		try {
+			$stats = array(
+				'posts_generated'     => isset( $data['generated'] ) ? count( $data['generated'] ) : 0,
+				'generation_failures' => isset( $data['failures'] ) ? count( $data['failures'] ) : 0,
+				'keyword_winners'     => isset( $data['keywords']['winners'] ) ? count( $data['keywords']['winners'] ) : 0,
+				'keyword_losers'      => isset( $data['keywords']['losers'] ) ? count( $data['keywords']['losers'] ) : 0,
+				'backlinks'           => $data['backlinks'] ?? null,
+				'monthly_spend'       => $data['spend']['total_cost'] ?? null,
+				'attention_items'     => $data['attention'],
+			);
+
+			$response = SWPS_Provider_Factory::create_ai_provider()->chat(
+				'You are an SEO consultant writing a friendly executive summary for a client email digest. Reply with exactly two short sentences of plain text, no markdown.',
+				'Summarize this week for the client: ' . wp_json_encode( $stats ),
+				200
+			);
+
+			if ( is_wp_error( $response ) || ! is_string( $response ) || '' === trim( $response ) ) {
+				return null;
+			}
+			return trim( $response );
+		} catch ( Throwable $e ) {
+			return null;
+		}
+	}
+}

--- a/includes/trait-digest-send.php
+++ b/includes/trait-digest-send.php
@@ -79,6 +79,9 @@ trait SWPS_Digest_Send {
 
 		if ( $sent && ! $test ) {
 			update_option( self::OPTION_LAST_SENT, time(), false );
+			if ( null !== $this->pending_aeo_snapshot ) {
+				update_option( self::OPTION_AEO_SNAP, $this->pending_aeo_snapshot, false );
+			}
 		}
 
 		return (bool) $sent;

--- a/includes/trait-digest-send.php
+++ b/includes/trait-digest-send.php
@@ -58,7 +58,7 @@ trait SWPS_Digest_Send {
 
 		ob_start();
 		include SWPS_PLUGIN_DIR . 'templates/email/digest.php';
-		$html = ob_get_clean();
+		$html = (string) ob_get_clean();
 
 		if ( $test && $override_recipient ) {
 			$recipients = array( $override_recipient );
@@ -70,7 +70,12 @@ trait SWPS_Digest_Send {
 		}
 
 		$subject = sprintf( '[%s] SEO digest — %s', get_bloginfo( 'name' ), wp_date( get_option( 'date_format' ) ) );
-		$sent    = wp_mail( $recipients, $subject, $html, array( 'Content-Type: text/html; charset=UTF-8' ) );
+
+		try {
+			$sent = wp_mail( $recipients, $subject, $html, array( 'Content-Type: text/html; charset=UTF-8' ) );
+		} catch ( Throwable $e ) {
+			$sent = false;
+		}
 
 		if ( $sent && ! $test ) {
 			update_option( self::OPTION_LAST_SENT, time(), false );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.11.0
+Stable tag: 4.12.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -293,6 +293,10 @@ No. GSC integration is optional. The on-site analytics works entirely without an
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.12.0 =
+* New: White-label email digest — weekly/daily/monthly report of generations, failures, keyword movers, backlinks, competitors, AI-bot trends, and AI spend, led by a needs-attention triage section; agency branding, multiple recipients, test-send, optional AI executive summary.
+* New: generation failures are now persistently recorded and surfaced in the digest.
 
 = 4.11.0 =
 * New: Autopilot Guardian — monthly AI budget cap with 80% warning, automatic retry with backoff for transient API errors, failed-topic requeue (max 3 attempts), and a dashboard autopilot status tile.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.11.0
+ * Version: 4.12.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.11.0' );
+define( 'SWPS_VERSION', '4.12.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -63,6 +63,8 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-duplicate-checker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-rate-limiter.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-cost-tracker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-autopilot-guardian.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-digest.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-digest-settings.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-topic-queue.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-content-scorer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-voice-profile.php';
@@ -223,6 +225,8 @@ final class StrataWP_SEO {
 	public SWPS_Crawl_Files $crawl_files;
 	public SWPS_Backlinks $backlinks;
 	public SWPS_Autopilot_Guardian $autopilot_guardian;
+	public SWPS_Digest $digest;
+	public SWPS_Digest_Settings $digest_settings;
 
 	// AEO Optimize (v4.6).
 	public SWPS_AEO_Scorer            $aeo_scorer;
@@ -324,6 +328,8 @@ final class StrataWP_SEO {
 		);
 		$this->cron                 = new SWPS_Cron( $this->generator, $this->topic_queue );
 		$this->autopilot_guardian   = new SWPS_Autopilot_Guardian();
+		$this->digest               = new SWPS_Digest();
+		$this->digest_settings      = new SWPS_Digest_Settings( $this->digest );
 
 		// Initialize v2.0 subsystems.
 		$this->calendar             = new SWPS_Calendar( $this->topic_queue );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -1277,6 +1277,11 @@ function swps_activate(): void {
 		'breadcrumbs_home_label'      => 'Home',
 		// Redirect defaults.
 		'auto_redirect_slug_change'   => 1,
+		// Email digest defaults.
+		'digest_enabled'              => 0,
+		'digest_frequency'            => 'weekly',
+		'digest_recipients'           => '',
+		'digest_ai_summary'           => 0,
 	);
 
 	foreach ( $defaults as $key => $value ) {
@@ -1331,6 +1336,7 @@ function swps_deactivate(): void {
 	SWPS_Competitors::unschedule_cron();
 	SWPS_Backlinks::unschedule_cron();
 	wp_clear_scheduled_hook( 'swps_aeo_sweep_proposals' );
+	wp_unschedule_hook( 'swps_send_digest' );
 	flush_rewrite_rules();
 }
 register_deactivation_hook( __FILE__, 'swps_deactivate' );

--- a/templates/email/digest.php
+++ b/templates/email/digest.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * HTML digest email template — 600px inline-CSS table layout.
+ *
+ * Expects local vars from SWPS_Digest::send(): $data (array of sections),
+ * $accent (hex color), $logo (URL or ''), $footer (string or '').
+ * Sections render only when their key is present and non-empty.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$swps_site = get_bloginfo( 'name' );
+?>
+<!DOCTYPE html>
+<html lang="<?php echo esc_attr( get_locale() ); ?>">
+<head>
+<meta charset="UTF-8">
+<meta name="color-scheme" content="light dark">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin:0;padding:0;background-color:#f0f0f1;font-family:Helvetica,Arial,sans-serif;color:#1d2327;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f0f0f1;">
+<tr><td align="center" style="padding:24px 12px;">
+<table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background-color:#ffffff;border-radius:8px;overflow:hidden;">
+
+	<?php /* Header bar with optional logo. */ ?>
+	<tr><td style="background-color:<?php echo esc_attr( $accent ); ?>;padding:20px 32px;">
+		<?php if ( ! empty( $logo ) ) : ?>
+			<img src="<?php echo esc_url( $logo ); ?>" alt="<?php echo esc_attr( $swps_site ); ?>" height="40" style="display:block;max-height:40px;width:auto;margin-bottom:8px;">
+		<?php endif; ?>
+		<h1 style="margin:0;font-size:20px;line-height:1.3;color:#ffffff;"><?php echo esc_html( $swps_site ); ?> — <?php esc_html_e( 'SEO Digest', 'stratawp-seo' ); ?></h1>
+		<p style="margin:4px 0 0;font-size:13px;color:#ffffff;opacity:0.85;"><?php echo esc_html( wp_date( get_option( 'date_format' ) ) ); ?></p>
+	</td></tr>
+
+	<?php /* Attention section — always first. */ ?>
+	<tr><td style="padding:24px 32px 8px;">
+		<?php if ( ! empty( $data['attention'] ) ) : ?>
+			<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-left:4px solid #d63638;background-color:#fcf0f1;">
+			<tr><td style="padding:14px 18px;">
+				<h2 style="margin:0 0 8px;font-size:15px;color:#d63638;"><?php esc_html_e( 'Needs your attention', 'stratawp-seo' ); ?></h2>
+				<?php foreach ( $data['attention'] as $swps_item ) : ?>
+					<p style="margin:0 0 4px;font-size:14px;line-height:1.5;">&bull; <?php echo esc_html( $swps_item ); ?></p>
+				<?php endforeach; ?>
+			</td></tr>
+			</table>
+		<?php else : ?>
+			<p style="margin:0;font-size:14px;line-height:1.6;"><?php esc_html_e( 'Nothing needs your attention this week. 🎉', 'stratawp-seo' ); ?></p>
+		<?php endif; ?>
+	</td></tr>
+
+	<?php /* AI executive summary. */ ?>
+	<?php if ( ! empty( $data['ai_summary'] ) ) : ?>
+	<tr><td style="padding:16px 32px 0;">
+		<p style="margin:0;font-size:14px;line-height:1.6;font-style:italic;color:#50575e;"><?php echo esc_html( $data['ai_summary'] ); ?></p>
+	</td></tr>
+	<?php endif; ?>
+
+	<?php /* Generated posts. */ ?>
+	<?php if ( ! empty( $data['generated'] ) ) : ?>
+	<tr><td style="padding:24px 32px 0;">
+		<h2 style="margin:0 0 10px;font-size:16px;color:<?php echo esc_attr( $accent ); ?>;"><?php esc_html_e( 'Posts generated', 'stratawp-seo' ); ?></h2>
+		<?php foreach ( $data['generated'] as $swps_post ) : ?>
+			<p style="margin:0 0 6px;font-size:14px;line-height:1.5;">
+				<a href="<?php echo esc_url( (string) $swps_post['edit_link'] ); ?>" style="color:<?php echo esc_attr( $accent ); ?>;text-decoration:none;"><?php echo esc_html( $swps_post['title'] ); ?></a>
+				<?php if ( null !== $swps_post['seo_score'] ) : ?>
+					<span style="color:#50575e;font-size:12px;"> · SEO <?php echo esc_html( (string) $swps_post['seo_score'] ); ?></span>
+				<?php endif; ?>
+				<?php if ( null !== $swps_post['aeo_score'] ) : ?>
+					<span style="color:#50575e;font-size:12px;"> · AEO <?php echo esc_html( (string) $swps_post['aeo_score'] ); ?></span>
+				<?php endif; ?>
+				<?php if ( null !== $swps_post['cost'] ) : ?>
+					<span style="color:#50575e;font-size:12px;"> · $<?php echo esc_html( number_format( (float) $swps_post['cost'], 4 ) ); ?></span>
+				<?php endif; ?>
+			</p>
+		<?php endforeach; ?>
+	</td></tr>
+	<?php endif; ?>
+
+	<?php /* Generation failures. */ ?>
+	<?php if ( ! empty( $data['failures'] ) ) : ?>
+	<tr><td style="padding:24px 32px 0;">
+		<h2 style="margin:0 0 10px;font-size:16px;color:#d63638;"><?php esc_html_e( 'Generation failures', 'stratawp-seo' ); ?></h2>
+		<?php foreach ( $data['failures'] as $swps_failure ) : ?>
+			<p style="margin:0 0 6px;font-size:13px;line-height:1.5;color:#50575e;">
+				<strong style="color:#1d2327;"><?php echo esc_html( $swps_failure['topic'] ?? '' ); ?></strong>
+				— <?php echo esc_html( $swps_failure['message'] ?? '' ); ?>
+				<span style="font-size:12px;">(<?php echo esc_html( wp_date( get_option( 'date_format' ), (int) ( $swps_failure['time'] ?? 0 ) ) ); ?>)</span>
+			</p>
+		<?php endforeach; ?>
+		<p style="margin:6px 0 0;font-size:13px;"><a href="<?php echo esc_url( admin_url( 'edit.php?post_type=swps_topic' ) ); ?>" style="color:<?php echo esc_attr( $accent ); ?>;"><?php esc_html_e( 'Review the topic queue', 'stratawp-seo' ); ?></a></p>
+	</td></tr>
+	<?php endif; ?>
+
+	<?php /* Keyword winners / losers. */ ?>
+	<?php if ( ! empty( $data['keywords'] ) ) : ?>
+	<tr><td style="padding:24px 32px 0;">
+		<h2 style="margin:0 0 10px;font-size:16px;color:<?php echo esc_attr( $accent ); ?>;"><?php esc_html_e( 'Keyword movers', 'stratawp-seo' ); ?></h2>
+		<?php if ( ! empty( $data['keywords']['winners'] ) ) : ?>
+			<?php foreach ( $data['keywords']['winners'] as $swps_kw => $swps_delta ) : ?>
+				<p style="margin:0 0 4px;font-size:14px;">▲ <?php echo esc_html( $swps_kw ); ?> <span style="color:#00a32a;font-size:13px;">(<?php echo esc_html( number_format( abs( $swps_delta ), 1 ) ); ?> <?php esc_html_e( 'positions up', 'stratawp-seo' ); ?>)</span></p>
+			<?php endforeach; ?>
+		<?php endif; ?>
+		<?php if ( ! empty( $data['keywords']['losers'] ) ) : ?>
+			<?php foreach ( $data['keywords']['losers'] as $swps_kw => $swps_delta ) : ?>
+				<p style="margin:0 0 4px;font-size:14px;">▼ <?php echo esc_html( $swps_kw ); ?> <span style="color:#d63638;font-size:13px;">(<?php echo esc_html( number_format( abs( $swps_delta ), 1 ) ); ?> <?php esc_html_e( 'positions down', 'stratawp-seo' ); ?>)</span></p>
+			<?php endforeach; ?>
+		<?php endif; ?>
+		<p style="margin:6px 0 0;font-size:13px;"><a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-keywords' ) ); ?>" style="color:<?php echo esc_attr( $accent ); ?>;"><?php esc_html_e( 'View keyword tracking', 'stratawp-seo' ); ?></a></p>
+	</td></tr>
+	<?php endif; ?>
+
+	<?php /* Backlinks. */ ?>
+	<?php if ( ! empty( $data['backlinks'] ) ) : ?>
+	<tr><td style="padding:24px 32px 0;">
+		<h2 style="margin:0 0 10px;font-size:16px;color:<?php echo esc_attr( $accent ); ?>;"><?php esc_html_e( 'Backlinks', 'stratawp-seo' ); ?></h2>
+		<p style="margin:0;font-size:14px;line-height:1.6;">
+			<?php
+			printf(
+				/* translators: 1: total, 2: live, 3: new, 4: lost, 5: broken */
+				esc_html__( '%1$d total (%2$d live) · %3$d new and %4$d lost in the last 30 days · %5$d broken', 'stratawp-seo' ),
+				(int) ( $data['backlinks']['total'] ?? 0 ),
+				(int) ( $data['backlinks']['live'] ?? 0 ),
+				(int) ( $data['backlinks']['new_30d'] ?? 0 ),
+				(int) ( $data['backlinks']['lost_30d'] ?? 0 ),
+				(int) ( $data['backlinks']['broken'] ?? 0 )
+			);
+			?>
+		</p>
+		<p style="margin:6px 0 0;font-size:13px;"><a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-backlinks' ) ); ?>" style="color:<?php echo esc_attr( $accent ); ?>;"><?php esc_html_e( 'View backlinks', 'stratawp-seo' ); ?></a></p>
+	</td></tr>
+	<?php endif; ?>
+
+	<?php /* Competitors. */ ?>
+	<?php if ( ! empty( $data['competitors'] ) ) : ?>
+	<tr><td style="padding:24px 32px 0;">
+		<h2 style="margin:0 0 10px;font-size:16px;color:<?php echo esc_attr( $accent ); ?>;"><?php esc_html_e( 'Competitor activity', 'stratawp-seo' ); ?></h2>
+		<?php foreach ( $data['competitors'] as $swps_comp ) : ?>
+			<p style="margin:0 0 6px;font-size:14px;line-height:1.5;">
+				<strong><?php echo esc_html( $swps_comp['label'] ?? '' ); ?></strong>
+				<?php if ( ! empty( $swps_comp['summary'] ) ) : ?>
+					— <?php echo esc_html( $swps_comp['summary'] ); ?>
+				<?php endif; ?>
+			</p>
+		<?php endforeach; ?>
+		<p style="margin:6px 0 0;font-size:13px;"><a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-competitors' ) ); ?>" style="color:<?php echo esc_attr( $accent ); ?>;"><?php esc_html_e( 'View competitors', 'stratawp-seo' ); ?></a></p>
+	</td></tr>
+	<?php endif; ?>
+
+	<?php /* AI-bot crawl trends. */ ?>
+	<?php if ( ! empty( $data['bots'] ) ) : ?>
+	<tr><td style="padding:24px 32px 0;">
+		<h2 style="margin:0 0 10px;font-size:16px;color:<?php echo esc_attr( $accent ); ?>;"><?php esc_html_e( 'AI bot crawls', 'stratawp-seo' ); ?></h2>
+		<?php foreach ( array_slice( $data['bots'], 0, 5 ) as $swps_bot ) : ?>
+			<p style="margin:0 0 4px;font-size:14px;">
+				<?php echo esc_html( $swps_bot['label'] ?? ( $swps_bot['bot_key'] ?? '' ) ); ?>:
+				<strong><?php echo esc_html( number_format( (int) ( $swps_bot['hits'] ?? 0 ) ) ); ?></strong> <?php esc_html_e( 'hits', 'stratawp-seo' ); ?>
+			</p>
+		<?php endforeach; ?>
+		<p style="margin:6px 0 0;font-size:13px;"><a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-analytics' ) ); ?>" style="color:<?php echo esc_attr( $accent ); ?>;"><?php esc_html_e( 'View bot analytics', 'stratawp-seo' ); ?></a></p>
+	</td></tr>
+	<?php endif; ?>
+
+	<?php /* AI spend. */ ?>
+	<?php if ( ! empty( $data['spend'] ) ) : ?>
+	<tr><td style="padding:24px 32px 0;">
+		<h2 style="margin:0 0 10px;font-size:16px;color:<?php echo esc_attr( $accent ); ?>;"><?php esc_html_e( 'AI spend this month', 'stratawp-seo' ); ?></h2>
+		<p style="margin:0;font-size:14px;line-height:1.6;">
+			<strong>$<?php echo esc_html( number_format( (float) ( $data['spend']['total_cost'] ?? 0 ), 2 ) ); ?></strong>
+			<?php if ( isset( $data['spend']['generation_count'] ) ) : ?>
+				· <?php echo esc_html( number_format( (int) $data['spend']['generation_count'] ) ); ?> <?php esc_html_e( 'generations', 'stratawp-seo' ); ?>
+			<?php endif; ?>
+			<?php if ( ! empty( $data['spend']['guardian']['budget'] ) ) : ?>
+				· <?php esc_html_e( 'budget', 'stratawp-seo' ); ?> $<?php echo esc_html( number_format( (float) $data['spend']['guardian']['budget'], 2 ) ); ?>
+			<?php endif; ?>
+		</p>
+	</td></tr>
+	<?php endif; ?>
+
+	<?php /* AEO movers. */ ?>
+	<?php if ( ! empty( $data['aeo_movers'] ) ) : ?>
+	<tr><td style="padding:24px 32px 0;">
+		<h2 style="margin:0 0 10px;font-size:16px;color:<?php echo esc_attr( $accent ); ?>;"><?php esc_html_e( 'AEO score movers', 'stratawp-seo' ); ?></h2>
+		<?php foreach ( $data['aeo_movers']['risers'] as $swps_pid => $swps_delta ) : ?>
+			<p style="margin:0 0 4px;font-size:14px;">▲ <a href="<?php echo esc_url( (string) get_edit_post_link( $swps_pid, 'raw' ) ); ?>" style="color:<?php echo esc_attr( $accent ); ?>;text-decoration:none;"><?php echo esc_html( get_the_title( $swps_pid ) ); ?></a> <span style="color:#00a32a;font-size:13px;">(+<?php echo esc_html( (string) $swps_delta ); ?>)</span></p>
+		<?php endforeach; ?>
+		<?php foreach ( $data['aeo_movers']['fallers'] as $swps_pid => $swps_delta ) : ?>
+			<p style="margin:0 0 4px;font-size:14px;">▼ <a href="<?php echo esc_url( (string) get_edit_post_link( $swps_pid, 'raw' ) ); ?>" style="color:<?php echo esc_attr( $accent ); ?>;text-decoration:none;"><?php echo esc_html( get_the_title( $swps_pid ) ); ?></a> <span style="color:#d63638;font-size:13px;">(<?php echo esc_html( (string) $swps_delta ); ?>)</span></p>
+		<?php endforeach; ?>
+	</td></tr>
+	<?php endif; ?>
+
+	<?php /* Footer. */ ?>
+	<tr><td style="padding:28px 32px 24px;">
+		<hr style="border:none;border-top:1px solid #dcdcde;margin:0 0 16px;">
+		<?php if ( ! empty( $footer ) ) : ?>
+			<p style="margin:0 0 6px;font-size:13px;color:#50575e;"><?php echo esc_html( $footer ); ?></p>
+		<?php endif; ?>
+		<p style="margin:0;font-size:12px;color:#787c82;">
+			<?php
+			printf(
+				/* translators: %s: site name */
+				esc_html__( 'Prepared by StrataWP SEO for %s.', 'stratawp-seo' ),
+				esc_html( $swps_site )
+			);
+			?>
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=swps-settings' ) ); ?>" style="color:<?php echo esc_attr( $accent ); ?>;"><?php esc_html_e( 'Digest settings', 'stratawp-seo' ); ?></a>
+		</p>
+	</td></tr>
+
+</table>
+</td></tr>
+</table>
+</body>
+</html>

--- a/tests/unit/DigestTest.php
+++ b/tests/unit/DigestTest.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Unit tests for SWPS_Digest pure computation helpers.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-digest.php';
+
+/**
+ * Tests for SWPS_Digest static helpers (no WordPress required).
+ */
+class DigestTest extends TestCase {
+
+	// ---- parse_recipients() ----
+
+	/**
+	 * Mixed separators (comma, space, semicolon, newline) all split correctly.
+	 */
+	public function test_parse_recipients_mixed_separators(): void {
+		$result = SWPS_Digest::parse_recipients( "a@b.com, c@d.com;e@f.com\ng@h.io" );
+		$this->assertCount( 4, $result );
+		$this->assertContains( 'a@b.com', $result );
+		$this->assertContains( 'c@d.com', $result );
+		$this->assertContains( 'e@f.com', $result );
+		$this->assertContains( 'g@h.io', $result );
+	}
+
+	/**
+	 * Invalid entries (bare words, malformed addresses) are dropped.
+	 */
+	public function test_parse_recipients_invalid_dropped(): void {
+		$result = SWPS_Digest::parse_recipients( 'good@test.com notanemail bad@ @nope.com' );
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'good@test.com', $result[0] );
+	}
+
+	/**
+	 * Case-insensitive deduplication: A@B.com and a@b.com are the same address.
+	 */
+	public function test_parse_recipients_case_dedup(): void {
+		$result = SWPS_Digest::parse_recipients( 'A@B.com a@b.com' );
+		$this->assertCount( 1, $result );
+	}
+
+	/**
+	 * Empty string returns empty array.
+	 */
+	public function test_parse_recipients_empty_string(): void {
+		$this->assertSame( array(), SWPS_Digest::parse_recipients( '' ) );
+	}
+
+	// ---- compute_movers() ----
+
+	/**
+	 * Posts with positive delta end up in risers, negative in fallers.
+	 */
+	public function test_compute_movers_rising_falling_split(): void {
+		$previous = array(
+			1 => 40,
+			2 => 60,
+			3 => 50,
+		);
+		$current  = array(
+			1 => 50,
+			2 => 45,
+			3 => 50,
+		);
+		$result   = SWPS_Digest::compute_movers( $previous, $current );
+		$this->assertArrayHasKey( 1, $result['risers'] );
+		$this->assertSame( 10, $result['risers'][1] );
+		$this->assertArrayHasKey( 2, $result['fallers'] );
+		$this->assertSame( -15, $result['fallers'][2] );
+		$this->assertArrayNotHasKey( 3, $result['risers'] );
+		$this->assertArrayNotHasKey( 3, $result['fallers'] );
+	}
+
+	/**
+	 * Limit parameter caps the number of risers and fallers returned.
+	 */
+	public function test_compute_movers_limit_respected(): void {
+		$previous = array();
+		$current  = array();
+		for ( $i = 1; $i <= 10; $i++ ) {
+			$previous[ $i ] = 10;
+			$current[ $i ]  = 10 + $i;
+		}
+		$result = SWPS_Digest::compute_movers( $previous, $current, 3 );
+		$this->assertCount( 3, $result['risers'] );
+		$this->assertCount( 0, $result['fallers'] );
+	}
+
+	/**
+	 * Posts absent from previous are skipped (not treated as 0).
+	 */
+	public function test_compute_movers_absent_from_previous_skipped(): void {
+		$previous = array( 1 => 50 );
+		$current  = array(
+			1 => 60,
+			2 => 80,
+		);
+		$result   = SWPS_Digest::compute_movers( $previous, $current );
+		$this->assertArrayNotHasKey( 2, $result['risers'] );
+		$this->assertArrayNotHasKey( 2, $result['fallers'] );
+		$this->assertArrayHasKey( 1, $result['risers'] );
+	}
+
+	/**
+	 * Posts with unchanged scores are excluded entirely.
+	 */
+	public function test_compute_movers_unchanged_skipped(): void {
+		$previous = array(
+			1 => 50,
+			2 => 70,
+		);
+		$current  = array(
+			1 => 50,
+			2 => 70,
+		);
+		$result   = SWPS_Digest::compute_movers( $previous, $current );
+		$this->assertEmpty( $result['risers'] );
+		$this->assertEmpty( $result['fallers'] );
+	}
+
+	// ---- keyword_deltas() ----
+
+	/**
+	 * Improvement (lower position) produces a negative delta in winners.
+	 */
+	public function test_keyword_deltas_improvement_in_winners(): void {
+		$pairs  = array( 'seo tips' => array( 10.0, 5.0 ) );
+		$result = SWPS_Digest::keyword_deltas( $pairs );
+		$this->assertArrayHasKey( 'seo tips', $result['winners'] );
+		$this->assertSame( -5.0, $result['winners']['seo tips'] );
+		$this->assertEmpty( $result['losers'] );
+	}
+
+	/**
+	 * Null old or new position causes keyword to be skipped.
+	 */
+	public function test_keyword_deltas_null_skipped(): void {
+		$pairs  = array(
+			'kw_null_old' => array( null, 5.0 ),
+			'kw_null_new' => array( 5.0, null ),
+			'kw_good'     => array( 8.0, 3.0 ),
+		);
+		$result = SWPS_Digest::keyword_deltas( $pairs );
+		$this->assertCount( 1, $result['winners'] );
+		$this->assertArrayHasKey( 'kw_good', $result['winners'] );
+	}
+
+	/**
+	 * Zero delta is excluded from both winners and losers.
+	 */
+	public function test_keyword_deltas_zero_skipped(): void {
+		$pairs  = array( 'same kw' => array( 5.0, 5.0 ) );
+		$result = SWPS_Digest::keyword_deltas( $pairs );
+		$this->assertEmpty( $result['winners'] );
+		$this->assertEmpty( $result['losers'] );
+	}
+
+	/**
+	 * Limit parameter caps movers per direction.
+	 */
+	public function test_keyword_deltas_limit_respected(): void {
+		$pairs = array();
+		for ( $i = 1; $i <= 10; $i++ ) {
+			$pairs[ "kw_{$i}" ] = array( (float) ( 10 + $i ), (float) $i ); // all improve.
+		}
+		$result = SWPS_Digest::keyword_deltas( $pairs, 3 );
+		$this->assertCount( 3, $result['winners'] );
+		$this->assertEmpty( $result['losers'] );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -35,6 +35,7 @@ $swps_cron_hooks = array(
 	'swps_competitors_daily_scan',
 	'swps_refresh_models',
 	'swps_aeo_sweep_proposals',
+	'swps_send_digest',
 );
 
 foreach ( $swps_cron_hooks as $swps_cron_hook ) {


### PR DESCRIPTION
## Summary
- **New `SWPS_Digest`**: assembles a periodic report from data the plugin already collects — posts generated (scores + cost), generation failures, keyword winners/losers (latest GSC-synced position vs period start), backlink stats, competitor changes, AI-bot crawl trends, monthly AI spend + budget state, and AEO score movers (per-send snapshot diff, persisted only after a successful send)
- **Needs-attention triage first**: failures, broken backlinks, budget warnings, autopilot failures — or a one-line "all good"
- **Generation failures now persistently recorded**: first listener for `swps_generation_failed` (rolling 20-entry option), surfaced in the digest
- **`SWPS_Digest_Settings`**: Email Digest section in Settings → Analytics — enable, frequency (daily/weekly/monthly), recipients, logo/accent/footer branding, optional AI executive summary (fail-soft, 2 sentences), nonce-protected test-send link
- **Send pipeline**: cron with reschedule-on-save, double-fire guard, bail-when-empty, guarded `wp_mail` (throwing SMTP plugins can't kill cron), 600px inline-CSS email template
- Cron/option hygiene on deactivation + uninstall; version bump to 4.12.0

## Test plan
- [x] 117 unit tests green (12 new: recipient parsing, AEO movers, keyword deltas)
- [x] PHPStan clean, PHPCS clean on all new files
- [ ] Manual: enable digest + test-send button delivers to current user; weekly cron schedules on save

## Review trail
Per-task spec + quality reviews, plus a final whole-branch review; final-review fixes: keyword `new_pos` no longer window-constrained (daily digests on weekly keyword syncs would have reported nothing), AEO snapshot advance deferred to successful real sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
