### PR TITLE
feat: 5-minute onboarding wizard with guaranteed first win

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.12.0-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.13.0-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1446,6 +1446,10 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.13.0 — June 2026
+- **New — 5-minute onboarding wizard:** a guided first-run flow — migrate from Yoast/Rank Math, validate your AI key with a live test, AI-suggest your site description, run the audit, and generate a preview post — with a persistent setup checklist on the dashboard until complete.
+- **New:** AI provider keys can now be validated from the UI (Test & Save).
 
 ### v4.12.0 — June 2026
 - **New — White-label email digest:** weekly/daily/monthly report of generations, failures, keyword movers, backlinks, competitors, AI-bot trends, and AI spend, led by a needs-attention triage section; agency branding (logo, accent color, footer), multiple recipients, test-send button, and an optional AI executive summary.

--- a/admin/css/onboarding.css
+++ b/admin/css/onboarding.css
@@ -1,0 +1,215 @@
+/* Onboarding wizard page. */
+
+.swps-onboarding-wrap {
+    max-width: 860px;
+}
+
+/* Vertical stepper. */
+.swps-ob-stepper {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 16px;
+}
+
+.swps-ob-step {
+    position: relative;
+    background: var(--swps-surface, #fff);
+    border: 1px solid var(--swps-border, #e2e4e9);
+    border-radius: var(--swps-radius-lg, 12px);
+    padding: 20px 24px;
+    transition: var(--swps-transition, all .15s ease);
+}
+
+.swps-ob-step.is-done {
+    border-color: var(--swps-success, #00a32a);
+    opacity: 0.75;
+}
+
+.swps-ob-step-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.swps-ob-step-head h2 {
+    margin: 0;
+    font-size: 16px;
+    flex: 1;
+}
+
+.swps-ob-step-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    flex: none;
+    border-radius: 50%;
+    background: var(--swps-accent-grad, var(--swps-accent, #6c5ce7));
+    color: var(--swps-text-on-grad, #fff);
+    font-weight: 600;
+    font-size: 13px;
+}
+
+.swps-ob-step.is-done .swps-ob-step-num {
+    background: var(--swps-success, #00a32a);
+}
+
+.swps-ob-step-check {
+    display: none;
+    color: var(--swps-success, #00a32a);
+    font-size: 18px;
+    font-weight: 700;
+}
+
+.swps-ob-step.is-done .swps-ob-step-check {
+    display: inline;
+}
+
+.swps-ob-step-body {
+    margin-top: 10px;
+    color: var(--swps-text-body, var(--swps-text, #1f2933));
+}
+
+/* Inline field rows. */
+.swps-ob-field-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.swps-ob-field-row select,
+.swps-ob-field-row input[type="text"],
+.swps-ob-field-row input[type="password"] {
+    background: var(--swps-bg-input, #fff);
+    border: 1px solid var(--swps-border, #e2e4e9);
+    border-radius: var(--swps-radius-sm, 6px);
+    color: var(--swps-text-primary, #1f2933);
+    padding: 6px 10px;
+    min-height: 36px;
+}
+
+.swps-ob-field-row input[type="text"],
+.swps-ob-field-row input[type="password"] {
+    flex: 1;
+    min-width: 220px;
+}
+
+#swps-ob-description {
+    width: 100%;
+    background: var(--swps-bg-input, #fff);
+    border: 1px solid var(--swps-border, #e2e4e9);
+    border-radius: var(--swps-radius-sm, 6px);
+    color: var(--swps-text-primary, #1f2933);
+    padding: 8px 10px;
+}
+
+/* Sources list. */
+.swps-ob-sources {
+    margin: 8px 0 12px;
+    padding-left: 18px;
+    list-style: disc;
+}
+
+/* Status messages. */
+.swps-ob-msg {
+    min-height: 1.4em;
+    margin: 8px 0 0;
+    font-size: 13px;
+}
+
+.swps-ob-msg.is-ok {
+    color: var(--swps-success, #00a32a);
+}
+
+.swps-ob-msg.is-err {
+    color: var(--swps-crit, #d63638);
+}
+
+.swps-ob-note.is-ok {
+    color: var(--swps-success, #00a32a);
+}
+
+.swps-ob-cost-note {
+    font-size: 12px;
+    color: var(--swps-text-muted, #6b7280);
+    margin: 6px 0 0;
+}
+
+/* Skip link. */
+.swps-ob-skip {
+    position: absolute;
+    top: 22px;
+    right: 24px;
+    font-size: 12px;
+    color: var(--swps-text-muted, #6b7280);
+    text-decoration: none;
+}
+
+.swps-ob-skip:hover {
+    color: var(--swps-text-primary, #1f2933);
+    text-decoration: underline;
+}
+
+.swps-ob-step.is-done .swps-ob-skip {
+    display: none;
+}
+
+/* Spinner. */
+.swps-ob-spinner {
+    display: none;
+    width: 16px;
+    height: 16px;
+    border: 2px solid var(--swps-border, #e2e4e9);
+    border-top-color: var(--swps-accent, #6c5ce7);
+    border-radius: 50%;
+    animation: swps-ob-spin .7s linear infinite;
+}
+
+.swps-ob-spinner.is-active {
+    display: inline-block;
+}
+
+@keyframes swps-ob-spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Preview result card. */
+.swps-ob-preview-card {
+    margin-top: 14px;
+    border: 1px solid var(--swps-border, #e2e4e9);
+    border-radius: var(--swps-radius, 8px);
+    padding: 16px 18px;
+    background: var(--swps-bg-surface, #fafbfc);
+}
+
+.swps-ob-preview-card h3 {
+    margin: 0 0 6px;
+}
+
+.swps-ob-preview-meta {
+    color: var(--swps-text-muted, #6b7280);
+    font-size: 13px;
+    margin: 0 0 10px;
+}
+
+/* Win panel. */
+.swps-ob-win {
+    background: var(--swps-surface, #fff);
+    border: 1px solid var(--swps-success, #00a32a);
+    border-radius: var(--swps-radius-lg, 12px);
+    padding: 24px 28px;
+    margin-top: 16px;
+}
+
+.swps-ob-win h2 {
+    margin-top: 0;
+}
+
+.swps-ob-win-pointers {
+    margin-top: 16px;
+    font-size: 13px;
+    color: var(--swps-text-muted, #6b7280);
+}

--- a/admin/css/pages/dashboard.css
+++ b/admin/css/pages/dashboard.css
@@ -379,3 +379,61 @@
     top: 12px;
     right: 12px;
 }
+
+/* ------------------------------------------------------------------
+ * Onboarding setup checklist card (shown until complete or dismissed)
+ * ------------------------------------------------------------------ */
+.swps-ob-checklist {
+    margin-bottom: 16px;
+}
+
+.swps-ob-checklist-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.swps-ob-checklist-dismiss {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 18px;
+    line-height: 1;
+    color: var(--swps-text-muted);
+    padding: 2px 6px;
+}
+.swps-ob-checklist-dismiss:hover {
+    color: var(--swps-text-primary);
+}
+
+.swps-ob-checklist-steps {
+    margin: 10px 0 14px;
+    padding: 0;
+    list-style: none;
+}
+.swps-ob-checklist-steps li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 3px 0;
+}
+.swps-ob-checklist-steps li.is-done a {
+    text-decoration: line-through;
+    color: var(--swps-text-muted);
+}
+.swps-ob-checklist-steps a {
+    text-decoration: none;
+    color: var(--swps-text-primary);
+}
+.swps-ob-checklist-steps a:hover {
+    color: var(--swps-accent-1);
+}
+
+.swps-ob-checklist-mark {
+    color: var(--swps-success);
+    width: 16px;
+    text-align: center;
+}
+.swps-ob-checklist-steps li:not(.is-done) .swps-ob-checklist-mark {
+    color: var(--swps-text-muted);
+}

--- a/admin/js/dashboard.js
+++ b/admin/js/dashboard.js
@@ -122,9 +122,46 @@
         });
     }
 
+    /* ------------------------------------------------------------------
+     * Onboarding checklist dismiss — POST swps_onboarding_dismiss
+     * ------------------------------------------------------------------ */
+    function bindOnboardingDismiss() {
+        var card = document.getElementById('swps-ob-checklist');
+        if (!card) return;
+        var btn = card.querySelector('.swps-ob-checklist-dismiss');
+        if (!btn) return;
+        btn.addEventListener('click', function () {
+            btn.disabled = true;
+            var body = new URLSearchParams({
+                action: 'swps_onboarding_dismiss',
+                nonce: card.getAttribute('data-nonce') || ''
+            });
+            fetch(window.ajaxurl || '/wp-admin/admin-ajax.php', {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body
+            })
+                .then(function (r) { return r.json(); })
+                .then(function (data) {
+                    if (data && data.success) {
+                        card.remove();
+                    } else {
+                        btn.disabled = false;
+                        showFlash('Could not dismiss the checklist.', 'err');
+                    }
+                })
+                .catch(function () {
+                    btn.disabled = false;
+                    showFlash('Could not dismiss the checklist.', 'err');
+                });
+        });
+    }
+
     function init() {
         bindRunAudit();
         bindModuleToggles();
+        bindOnboardingDismiss();
     }
 
     if (document.readyState === 'loading') {

--- a/admin/js/onboarding.js
+++ b/admin/js/onboarding.js
@@ -1,0 +1,240 @@
+/**
+ * StrataWP SEO — Onboarding wizard interactions.
+ *
+ * Vanilla JS (matches dashboard.js / sitemaps.js style). All endpoints share
+ * the swps_onboarding nonce localized via the swpsOnboarding object.
+ */
+(function () {
+    'use strict';
+
+    var cfg = window.swpsOnboarding || {};
+    var ajaxUrl = cfg.ajaxUrl || (typeof ajaxurl !== 'undefined' ? ajaxurl : '/wp-admin/admin-ajax.php');
+    var nonce = cfg.nonce || '';
+    var i18n = cfg.i18n || {};
+
+    function post(action, data) {
+        var body = new URLSearchParams(data || {});
+        body.set('action', action);
+        body.set('nonce', nonce);
+        return fetch(ajaxUrl, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body,
+        }).then(function (r) { return r.json(); });
+    }
+
+    function setMsg(id, text, ok) {
+        var el = document.getElementById(id);
+        if (!el) return;
+        el.textContent = text || '';
+        el.classList.toggle('is-ok', !!ok);
+        el.classList.toggle('is-err', !ok && !!text);
+    }
+
+    function spinner(id, on) {
+        var el = document.getElementById(id);
+        if (el) el.classList.toggle('is-active', !!on);
+    }
+
+    function stepCard(step) {
+        return document.querySelector('.swps-ob-step[data-step="' + step + '"]');
+    }
+
+    function markDone(step) {
+        var card = stepCard(step);
+        if (card) card.classList.add('is-done');
+        // All five done? Reload so the server renders the win panel.
+        var total = document.querySelectorAll('.swps-ob-step').length;
+        var done = document.querySelectorAll('.swps-ob-step.is-done').length;
+        if (total > 0 && done >= total) {
+            window.setTimeout(function () { window.location.reload(); }, 900);
+        }
+    }
+
+    function completeStep(step) {
+        return post('swps_onboarding_step_done', { step: step }).then(function (res) {
+            if (res && res.success) markDone(step);
+            return res;
+        });
+    }
+
+    /* Skip links + explicit "I'm done" buttons. */
+    document.querySelectorAll('.swps-ob-skip, .swps-ob-step-complete').forEach(function (el) {
+        el.addEventListener('click', function (e) {
+            e.preventDefault();
+            completeStep(el.getAttribute('data-step'));
+        });
+    });
+
+    /* Step 1: auto-skip when nothing was detected. */
+    var autoSkip = document.querySelector('.swps-ob-step[data-auto-skip="1"]');
+    if (autoSkip) {
+        completeStep(autoSkip.getAttribute('data-step'));
+    }
+
+    /* Step 1: refresh detection counts on demand. */
+    var refreshBtn = document.querySelector('.swps-ob-refresh-detect');
+    if (refreshBtn) {
+        refreshBtn.addEventListener('click', function () {
+            refreshBtn.disabled = true;
+            post('swps_onboarding_status', {}).then(function (res) {
+                refreshBtn.disabled = false;
+                if (res && res.success) {
+                    // Counts are server-rendered — a reload is the simplest sync.
+                    window.location.reload();
+                }
+            }).catch(function () { refreshBtn.disabled = false; });
+        });
+    }
+
+    /* Step 2: Test & Save the API key. */
+    var testBtn = document.getElementById('swps-ob-test-key');
+    if (testBtn) {
+        testBtn.addEventListener('click', function () {
+            var provider = document.getElementById('swps-ob-provider').value;
+            var key = document.getElementById('swps-ob-api-key').value.trim();
+            if (!key) {
+                setMsg('swps-ob-key-msg', i18n.keyRequired || 'Please paste an API key first.', false);
+                return;
+            }
+            testBtn.disabled = true;
+            setMsg('swps-ob-key-msg', i18n.testing || 'Testing key…', true);
+            post('swps_onboarding_test_key', { provider: provider, api_key: key })
+                .then(function (res) {
+                    testBtn.disabled = false;
+                    if (res && res.success) {
+                        setMsg('swps-ob-key-msg', res.data.message, true);
+                        markDone('api_key');
+                    } else {
+                        setMsg('swps-ob-key-msg', (res && res.data && res.data.message) || i18n.failed || 'Request failed.', false);
+                    }
+                })
+                .catch(function () {
+                    testBtn.disabled = false;
+                    setMsg('swps-ob-key-msg', i18n.failed || 'Request failed.', false);
+                });
+        });
+    }
+
+    /* Step 3: Suggest with AI. */
+    var suggestBtn = document.getElementById('swps-ob-suggest');
+    if (suggestBtn) {
+        suggestBtn.addEventListener('click', function () {
+            suggestBtn.disabled = true;
+            setMsg('swps-ob-info-msg', i18n.suggesting || 'Asking the AI…', true);
+            post('swps_onboarding_suggest_site_info', {})
+                .then(function (res) {
+                    suggestBtn.disabled = false;
+                    if (res && res.success && res.data.suggestion) {
+                        document.getElementById('swps-ob-description').value = res.data.suggestion;
+                        setMsg('swps-ob-info-msg', i18n.suggested || 'Suggestion ready — edit it, then save.', true);
+                    } else if (res && res.success) {
+                        setMsg('swps-ob-info-msg', i18n.noSuggestion || 'No suggestion available — add a key in step 2 or write your own.', false);
+                    } else {
+                        setMsg('swps-ob-info-msg', (res && res.data && res.data.message) || i18n.failed || 'Request failed.', false);
+                    }
+                })
+                .catch(function () {
+                    suggestBtn.disabled = false;
+                    setMsg('swps-ob-info-msg', i18n.failed || 'Request failed.', false);
+                });
+        });
+    }
+
+    /* Step 3: Save description. */
+    var saveInfoBtn = document.getElementById('swps-ob-save-info');
+    if (saveInfoBtn) {
+        saveInfoBtn.addEventListener('click', function () {
+            var desc = document.getElementById('swps-ob-description').value.trim();
+            if (!desc) {
+                setMsg('swps-ob-info-msg', i18n.descRequired || 'Please enter a description first.', false);
+                return;
+            }
+            saveInfoBtn.disabled = true;
+            post('swps_onboarding_save_site_info', { description: desc })
+                .then(function (res) {
+                    saveInfoBtn.disabled = false;
+                    if (res && res.success) {
+                        setMsg('swps-ob-info-msg', res.data.message, true);
+                        markDone('site_info');
+                    } else {
+                        setMsg('swps-ob-info-msg', (res && res.data && res.data.message) || i18n.failed || 'Request failed.', false);
+                    }
+                })
+                .catch(function () {
+                    saveInfoBtn.disabled = false;
+                    setMsg('swps-ob-info-msg', i18n.failed || 'Request failed.', false);
+                });
+        });
+    }
+
+    /* Step 4: Run audit. */
+    var auditBtn = document.getElementById('swps-ob-run-audit');
+    if (auditBtn) {
+        auditBtn.addEventListener('click', function () {
+            auditBtn.disabled = true;
+            spinner('swps-ob-audit-spinner', true);
+            setMsg('swps-ob-audit-msg', i18n.auditing || 'Running the audit — this can take a minute…', true);
+            post('swps_onboarding_run_audit', {})
+                .then(function (res) {
+                    auditBtn.disabled = false;
+                    spinner('swps-ob-audit-spinner', false);
+                    if (res && res.success) {
+                        var d = res.data;
+                        var summary = (i18n.auditDone || '%1$s passed / %2$s issues.')
+                            .replace('%1$s', d.pass)
+                            .replace('%2$s', d.issues);
+                        var msgEl = document.getElementById('swps-ob-audit-msg');
+                        msgEl.textContent = summary + ' ';
+                        var link = document.createElement('a');
+                        link.href = d.audit_url;
+                        link.textContent = i18n.openAudit || 'Open the audit';
+                        msgEl.appendChild(link);
+                        msgEl.classList.add('is-ok');
+                        msgEl.classList.remove('is-err');
+                        markDone('audit');
+                    } else {
+                        setMsg('swps-ob-audit-msg', (res && res.data && res.data.message) || i18n.failed || 'Request failed.', false);
+                    }
+                })
+                .catch(function () {
+                    auditBtn.disabled = false;
+                    spinner('swps-ob-audit-spinner', false);
+                    setMsg('swps-ob-audit-msg', i18n.failed || 'Request failed.', false);
+                });
+        });
+    }
+
+    /* Step 5: Generate preview. */
+    var previewBtn = document.getElementById('swps-ob-preview');
+    if (previewBtn) {
+        previewBtn.addEventListener('click', function () {
+            previewBtn.disabled = true;
+            spinner('swps-ob-preview-spinner', true);
+            setMsg('swps-ob-preview-msg', i18n.generating || 'Generating — usually 30–60 seconds…', true);
+            post('swps_onboarding_preview', { topic: document.getElementById('swps-ob-topic').value })
+                .then(function (res) {
+                    previewBtn.disabled = false;
+                    spinner('swps-ob-preview-spinner', false);
+                    if (res && res.success) {
+                        setMsg('swps-ob-preview-msg', '', true);
+                        var card = document.getElementById('swps-ob-preview-card');
+                        document.getElementById('swps-ob-preview-title').textContent = res.data.title;
+                        document.getElementById('swps-ob-preview-meta').textContent = res.data.meta_description;
+                        // content_html is wp_kses_post-sanitized server-side.
+                        document.getElementById('swps-ob-preview-content').innerHTML = res.data.content_html;
+                        card.hidden = false;
+                        markDone('preview');
+                    } else {
+                        setMsg('swps-ob-preview-msg', (res && res.data && res.data.message) || i18n.failed || 'Request failed.', false);
+                    }
+                })
+                .catch(function () {
+                    previewBtn.disabled = false;
+                    spinner('swps-ob-preview-spinner', false);
+                    setMsg('swps-ob-preview-msg', i18n.failed || 'Request failed.', false);
+                });
+        });
+    }
+})();

--- a/admin/js/onboarding.js
+++ b/admin/js/onboarding.js
@@ -222,8 +222,8 @@
                         var card = document.getElementById('swps-ob-preview-card');
                         document.getElementById('swps-ob-preview-title').textContent = res.data.title;
                         document.getElementById('swps-ob-preview-meta').textContent = res.data.meta_description;
-                        // content_html is wp_kses_post-sanitized server-side.
-                        document.getElementById('swps-ob-preview-content').innerHTML = res.data.content_html;
+                        // Plain-text excerpt — textContent keeps AI output out of the DOM as markup.
+                        document.getElementById('swps-ob-preview-content').textContent = res.data.content_excerpt;
                         card.hidden = false;
                         markDone('preview');
                     } else {

--- a/docs/superpowers/plans/2026-06-10-onboarding-wizard.md
+++ b/docs/superpowers/plans/2026-06-10-onboarding-wizard.md
@@ -1,0 +1,124 @@
+# 5-Minute Onboarding Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A guided first-run flow — detect & preview Yoast/RankMath migration, validate an AI API key (wiring the existing-but-unused `test_key()`), AI-suggest the site niche/description, run the audit, generate a preview post — ending on a concrete win, with a persistent dashboard setup checklist until complete.
+
+**Architecture:** One new class `SWPS_Onboarding` (hidden admin page, activation redirect, AJAX endpoints, state option `swps_onboarding_state`, pure static step helpers) + `templates/onboarding-page.php` + `admin/js/onboarding.js` + `admin/css/onboarding.css`. The wizard *sequences existing backends*; the only new logic is state tracking and the key-test/niche-suggest endpoints. The migration RUN is deep-linked to the existing Migration page (avoids wizard-embedded timeouts); the wizard shows detection + preview counts only. Dashboard checklist renders from the state option.
+
+**Branch:** `feature/onboarding-wizard`, stacked on `feature/weekly-digest` (HEAD adfb31e). Version 4.12.0 → 4.13.0 at the end. PR base: `main` if PR #52 has merged by then, else `feature/weekly-digest`.
+
+**Conventions:** no autoloader (require_once), files <500 lines, tabs/WPCS, no Co-Authored-By, all new AJAX = `manage_options` + nonce, version bump + changelogs at the end.
+
+---
+
+## Verified backends (HEAD adfb31e)
+
+- `SWPS_Migration::detect_sources(): array` (:102), `preview( string $source, string $conflict_policy, array $phases ): array` (:138) — read the class header + these methods to learn the source ids, policies, and phases arrays and the preview return shape before use. Migration page slug: find via `grep -n "swps-migration\|add_submenu_page" includes/class-migration.php includes/class-admin-shell.php`.
+- `SWPS_AI_Provider::test_key( string $api_key ): bool|WP_Error` — abstract, implemented by all four providers (:171 in anthropic). Provider construction: read `SWPS_Provider_Factory` for how a provider is created and how API keys are stored/read (check for an encryption layer — `grep -n "encrypt\|swps_api_key" includes/class-provider-factory.php includes/class-encryption.php includes/class-settings.php | head -20`). The wizard must SAVE the key through the same path settings uses (sanitize callback may encrypt!).
+- `SWPS_Analyzer::get_site_summary( int $max_posts = 50 ): array` (:29), `get_site_info()`, `get_categories()`. Instance available at `stratawp_seo()->analyzer` (verify property name).
+- `SWPS_SEO_Audit::run_all(): array` (:86), `fix_module( string $id )` (:139). Audit page slug + existing fix-all AJAX: `grep -n "swps_fix_all\|swps-audit" admin/js/admin.js includes/class-seo-audit.php | head`.
+- `SWPS_Generator::preview_content( string $topic = '', string $template = 'auto' )` — rate-limited, returns array|WP_Error. Note: generation is gated on the budget (guardian) — surface a clear error message if blocked.
+- Dashboard: `SWPS_Dashboard::get_summary_data()` + `templates/dashboard-page.php` tile/`$data` pattern; menu parent slug `stratawp-seo` (add_menu_page in class-dashboard.php:52).
+- Activation: `swps_activate()` at stratawp-seo.php:1196 (defaults array with swps_ prefix loop).
+- Admin shell chrome: see how other pages render inside the shell — read `templates/audit-page.php` top lines + how its assets enqueue (`grep -n "audit" includes/class-admin-shell.php includes/class-seo-audit.php | grep -i enqueue`); match that pattern for the wizard page + its JS/CSS.
+
+---
+
+### Task 0: Branch check
+`git branch --show-current` must print feature/onboarding-wizard (already created). `vendor/bin/phpunit` baseline: 117 passing.
+
+### Task 1: State helpers (TDD)
+Create `includes/class-onboarding.php` with ABSPATH guard, constants, and pure statics; test-first in `tests/unit/OnboardingTest.php` (tabs, full docblocks):
+
+```php
+	public const OPTION_STATE = 'swps_onboarding_state';
+	public const STEPS        = array( 'migrate', 'api_key', 'site_info', 'audit', 'preview' );
+
+	/**
+	 * Normalize a stored state array: unknown keys dropped, known steps cast to bool,
+	 * 'dismissed' preserved.
+	 *
+	 * @param mixed $raw Raw option value.
+	 * @return array{steps: array<string, bool>, dismissed: bool}
+	 */
+	public static function normalize_state( $raw ): array {
+		$steps = array();
+		$raw   = is_array( $raw ) ? $raw : array();
+		$saved = isset( $raw['steps'] ) && is_array( $raw['steps'] ) ? $raw['steps'] : array();
+		foreach ( self::STEPS as $step ) {
+			$steps[ $step ] = ! empty( $saved[ $step ] );
+		}
+		return array(
+			'steps'     => $steps,
+			'dismissed' => ! empty( $raw['dismissed'] ),
+		);
+	}
+
+	/**
+	 * @param array{steps: array<string, bool>} $state Normalized state.
+	 * @return array{done: int, total: int, complete: bool, next: string|null}
+	 */
+	public static function progress( array $state ): array {
+		$done = count( array_filter( $state['steps'] ) );
+		$next = null;
+		foreach ( self::STEPS as $step ) {
+			if ( empty( $state['steps'][ $step ] ) ) {
+				$next = $step;
+				break;
+			}
+		}
+		return array(
+			'done'     => $done,
+			'total'    => count( self::STEPS ),
+			'complete' => count( self::STEPS ) === $done,
+			'next'     => $next,
+		);
+	}
+```
+
+Tests: normalize drops junk keys/casts/missing→false/dismissed; progress counts, next = first incomplete in STEPS order, complete when all done, next null when complete. Commit `feat: onboarding state helpers`.
+
+### Task 2: Class behavior — page, redirect, AJAX
+Add to SWPS_Onboarding (constructor hooks):
+- `admin_menu` (priority 70): hidden page — `add_submenu_page( '', ... )` is deprecated-ish; use parent slug `'stratawp-seo'` then REMOVE it from the menu via `remove_submenu_page` on a later hook, OR follow however the plugin registers any hidden page already (grep `remove_submenu_page|add_submenu_page( ''` first; match precedent; if none, register under 'stratawp-seo' visible as "Setup Wizard" — visible is acceptable and simpler; decide and report). Page slug `swps-onboarding`, cap `manage_options`, renders `templates/onboarding-page.php` inside the same chrome other pages use.
+- Activation redirect: in `swps_activate()` add `set_transient( 'swps_onboarding_redirect', 1, 60 );` ONLY when `get_option( self::OPTION_STATE ) === false` (fresh install, not upgrade/re-activation). In the class, on `admin_init`: if transient present → delete it; bail on: `wp_doing_ajax()`, `is_network_admin()`, `isset( $_GET['activate-multi'] )`, `defined('WP_CLI') && WP_CLI`, `! current_user_can('manage_options')`; else `wp_safe_redirect( admin_url( 'admin.php?page=swps-onboarding' ) ); exit;`
+- AJAX endpoints (ALL: `check_ajax_referer( 'swps_onboarding', 'nonce' )` + manage_options; wp_send_json_success/error):
+  - `swps_onboarding_status`: returns normalize_state + progress + detection info (`SWPS_Migration::detect_sources()`).
+  - `swps_onboarding_test_key`: POST provider + api_key; create that provider via the factory (or directly construct with the key — read how factory injects keys; you may need a small factory method accepting an explicit key — check for one first), call `test_key`; on success SAVE provider choice + key through the SAME option names + sanitization settings uses (encryption-aware), mark step api_key done.
+  - `swps_onboarding_suggest_site_info`: uses analyzer summary + provider chat() for a 1-2 sentence site description suggestion (fail-soft); does NOT save.
+  - `swps_onboarding_save_site_info`: POST description (sanitize_textarea_field) → save to the same option the settings Site Details section uses (find the option name), mark site_info done.
+  - `swps_onboarding_run_audit`: calls run_all(), stores nothing new (audit stores its own results), marks audit done, returns issue counts + audit page URL.
+  - `swps_onboarding_preview`: POST optional topic → `preview_content()`; returns title + meta_description + first ~600 chars of content_html (wp_kses_post'd); marks preview done. Budget/rate-limit WP_Errors → clean error message.
+  - `swps_onboarding_step_done`: POST step (whitelisted vs STEPS) — used for migrate (deep-linked) and skip buttons; sets the step true.
+  - `swps_onboarding_dismiss`: sets dismissed (used by dashboard checklist).
+- `mark_step( string $step ): void` private helper (normalize → set → update_option autoload false).
+Commit `feat: onboarding wizard page, redirect, and AJAX backends`.
+
+### Task 3: Template + JS + CSS
+- `templates/onboarding-page.php`: five-step vertical stepper. Each step card: title, body, primary action, "Skip" link. Step 1 (migrate): server-rendered detection (sources found or "nothing to migrate" auto-skip state), preview counts via JS on demand, link to the real Migration page + "I'm done / skip" → step_done. Step 2 (api key): provider select (anthropic/openai/google/xai), password input, Test & Save button, success/error inline. Step 3: textarea pre-filled by "Suggest with AI" button, Save. Step 4: Run audit button + spinner + results summary (X passed / Y issues) + "Open audit" link. Step 5: topic input (optional) + Generate preview + rendered preview card + cost note ("uses your API key; one generation"). Final state (all done): win panel — audit issues count with "Fix now" link if >0, else the preview-post panel, else schema/llms.txt pointers. Escape everything.
+- `admin/js/onboarding.js`: vanilla JS (match the plugin's existing JS style — check admin/js/admin.js), `fetch`/jQuery.post to ajaxurl with the nonce (localized via wp_localize_script as other pages do — find the enqueue pattern), step transitions, button spinners, error rendering.
+- `admin/css/onboarding.css`: stepper styles consistent with the swps admin look (reuse CSS vars like var(--swps-*) seen in dashboard CSS).
+- Enqueue both only on the wizard page (hook check like other pages).
+Commit `feat: onboarding wizard UI`.
+
+### Task 4: Dashboard checklist + wiring + release
+- class-dashboard.php: `'onboarding' => $this->safe_get_onboarding()` → normalize_state + progress; templates/dashboard-page.php: when NOT complete and NOT dismissed, render a checklist card at the TOP of the dashboard: "Setup X/5 complete" + per-step links into the wizard + dismiss control (calls swps_onboarding_dismiss; simple inline JS or reuse dashboard JS file if one exists).
+- stratawp-seo.php: require_once class-onboarding.php; public property + instantiate; activation: the set_transient line + (no state default — absence of the option IS the fresh-install signal; do NOT seed swps_onboarding_state in defaults).
+- uninstall: confirm swps_% wildcard covers swps_onboarding_state (it does — note only).
+- Verification gate: phpunit (117 + new Onboarding tests), phpstan --memory-limit=2G no new errors, phpcs clean on all NEW files.
+- Version 4.12.0 → 4.13.0 everywhere + changelog:
+```
+= 4.13.0 =
+* New: 5-minute onboarding wizard — migrate from Yoast/Rank Math, validate your AI key, AI-suggest your site description, run the audit, and generate a preview post; setup checklist on the dashboard until complete.
+* New: AI provider keys can now be validated from the UI (Test & Save).
+```
+- Commit `chore: release 4.13.0 — onboarding wizard`, commit the plan doc, do NOT push/PR (controller does after final review).
+
+## Self-review checklist
+1. Every AJAX endpoint: nonce + manage_options + sanitized inputs?
+2. Key saved via the settings-equivalent path (encrypted if settings encrypt)?
+3. Redirect guards: ajax/network/bulk/WP-CLI/capability + fresh-install-only transient?
+4. class-onboarding.php < 500 lines (template/JS carry the UI)?
+5. No step can wedge: every step skippable; wizard reachable anytime via URL?
+6. Dashboard checklist disappears when complete or dismissed?

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -104,6 +104,7 @@ class SWPS_Dashboard {
 			'auto_optimize_queue' => array(), // Phase 7 fills in.
 			'competitors'         => $this->safe_get_competitor_summary(),
 			'backlinks'           => $this->safe_get_backlinks_summary(),
+			'onboarding'          => $this->safe_get_onboarding(),
 			'modules'             => $this->get_modules_for_grid(),
 		);
 	}
@@ -368,6 +369,34 @@ class SWPS_Dashboard {
 					'unique_domains' => 0,
 				),
 				'recent' => array(),
+			);
+		}
+	}
+
+	/**
+	 * Onboarding wizard state + progress for the setup checklist card.
+	 *
+	 * @return array{state: array, progress: array}
+	 */
+	private function safe_get_onboarding(): array {
+		try {
+			$state = SWPS_Onboarding::normalize_state( get_option( SWPS_Onboarding::OPTION_STATE ) );
+			return array(
+				'state'    => $state,
+				'progress' => SWPS_Onboarding::progress( $state ),
+			);
+		} catch ( \Throwable $e ) {
+			return array(
+				'state'    => array(
+					'steps'     => array(),
+					'dismissed' => true,
+				),
+				'progress' => array(
+					'done'     => 0,
+					'total'    => 0,
+					'complete' => true,
+					'next'     => null,
+				),
 			);
 		}
 	}

--- a/includes/class-onboarding.php
+++ b/includes/class-onboarding.php
@@ -1,0 +1,525 @@
+<?php
+/**
+ * Onboarding wizard: state helpers, admin page, activation redirect, AJAX endpoints.
+ *
+ * Registers a "Setup Wizard" submenu page under the StrataWP SEO top-level menu,
+ * sets an activation-redirect transient on fresh installs, and handles all eight
+ * AJAX endpoints that drive the onboarding flow.
+ *
+ * Constructor hooks fire only when the class is instantiated — see Task 4 in the
+ * plan for the require_once + instantiation in stratawp-seo.php.
+ *
+ * @package StrataWP_SEO
+ * @since   4.13.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Onboarding wizard controller.
+ *
+ * Pure-static helpers (normalize_state, progress) carry no WordPress
+ * dependencies and are unit-testable in isolation.
+ */
+class SWPS_Onboarding {
+
+	/**
+	 * WordPress option that persists wizard progress.
+	 *
+	 * @var string
+	 */
+	public const OPTION_STATE = 'swps_onboarding_state';
+
+	/**
+	 * Canonical wizard step order.
+	 *
+	 * @var array<int, string>
+	 */
+	public const STEPS = array( 'migrate', 'api_key', 'site_info', 'audit', 'preview' );
+
+	/**
+	 * Nonce action used for all wizard AJAX endpoints.
+	 *
+	 * @var string
+	 */
+	private const NONCE_ACTION = 'swps_onboarding';
+
+	/**
+	 * Wizard admin page slug.
+	 *
+	 * @var string
+	 */
+	private const PAGE_SLUG = 'swps-onboarding';
+
+	/**
+	 * Activation-redirect transient key.
+	 *
+	 * @var string
+	 */
+	private const REDIRECT_TRANSIENT = 'swps_onboarding_redirect';
+
+	/**
+	 * Register WordPress hooks.
+	 *
+	 * Called in the constructor so hooks are wired at instantiation time,
+	 * not at require_once time (keeps things testable).
+	 */
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'register_page' ), 70 );
+		add_action( 'admin_init', array( $this, 'maybe_redirect' ) );
+
+		// AJAX endpoints — both logged-in (wp_ajax_) and nopriv omitted (all require manage_options).
+		$endpoints = array(
+			'swps_onboarding_status',
+			'swps_onboarding_test_key',
+			'swps_onboarding_suggest_site_info',
+			'swps_onboarding_save_site_info',
+			'swps_onboarding_run_audit',
+			'swps_onboarding_preview',
+			'swps_onboarding_step_done',
+			'swps_onboarding_dismiss',
+		);
+		foreach ( $endpoints as $action ) {
+			add_action( "wp_ajax_{$action}", array( $this, "ajax_{$action}" ) );
+		}
+	}
+
+	// =========================================================================
+	// Pure static helpers (no WordPress required — unit-testable)
+	// =========================================================================
+
+	/**
+	 * Normalise a raw option value into a well-typed state array.
+	 *
+	 * Unknown keys are silently dropped; known step keys are cast to bool;
+	 * missing step keys default to false; 'dismissed' is cast to bool.
+	 *
+	 * @param mixed $raw Raw value from get_option() or any source.
+	 * @return array{steps: array<string, bool>, dismissed: bool}
+	 */
+	public static function normalize_state( $raw ): array {
+		$steps = array();
+		$raw   = is_array( $raw ) ? $raw : array();
+		$saved = isset( $raw['steps'] ) && is_array( $raw['steps'] ) ? $raw['steps'] : array();
+
+		foreach ( self::STEPS as $step ) {
+			$steps[ $step ] = ! empty( $saved[ $step ] );
+		}
+
+		return array(
+			'steps'     => $steps,
+			'dismissed' => ! empty( $raw['dismissed'] ),
+		);
+	}
+
+	/**
+	 * Compute progress metrics from a normalised state array.
+	 *
+	 * @param array{steps: array<string, bool>} $state Normalised state (from normalize_state()).
+	 * @return array{done: int, total: int, complete: bool, next: string|null}
+	 */
+	public static function progress( array $state ): array {
+		$done = count( array_filter( $state['steps'] ) );
+		$next = null;
+
+		foreach ( self::STEPS as $step ) {
+			if ( empty( $state['steps'][ $step ] ) ) {
+				$next = $step;
+				break;
+			}
+		}
+
+		return array(
+			'done'     => $done,
+			'total'    => count( self::STEPS ),
+			'complete' => count( self::STEPS ) === $done,
+			'next'     => $next,
+		);
+	}
+
+	// =========================================================================
+	// Admin page registration
+	// =========================================================================
+
+	/**
+	 * Register the Setup Wizard submenu page under the StrataWP SEO parent menu.
+	 *
+	 * Visible as "Setup Wizard" — no hidden-page pattern exists in the plugin,
+	 * so a visible entry is simpler and matches existing conventions.
+	 *
+	 * @since 4.13.0
+	 */
+	public function register_page(): void {
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Setup Wizard', 'stratawp-seo' ),
+			__( 'Setup Wizard', 'stratawp-seo' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Render the wizard page.
+	 *
+	 * Includes the template if it exists; outputs a placeholder during Task 2
+	 * (before the template is built in Task 3).
+	 *
+	 * @since 4.13.0
+	 */
+	public function render_page(): void {
+		$template = SWPS_PLUGIN_DIR . 'templates/onboarding-page.php';
+
+		if ( file_exists( $template ) ) {
+			include $template;
+		} else {
+			echo '<div class="wrap"><h1>';
+			echo esc_html__( 'StrataWP SEO — Setup Wizard', 'stratawp-seo' );
+			echo '</h1><p>';
+			echo esc_html__( 'Onboarding wizard template coming soon.', 'stratawp-seo' );
+			echo '</p></div>';
+		}
+	}
+
+	// =========================================================================
+	// Activation redirect
+	// =========================================================================
+
+	/**
+	 * Redirect to the wizard on first activation if the transient is present.
+	 *
+	 * Bails early when called from an AJAX request, the network admin,
+	 * a bulk-activate action, WP-CLI, or by a user without manage_options.
+	 *
+	 * @since 4.13.0
+	 */
+	public function maybe_redirect(): void {
+		if ( ! get_transient( self::REDIRECT_TRANSIENT ) ) {
+			return;
+		}
+
+		delete_transient( self::REDIRECT_TRANSIENT );
+
+		// Bail conditions that make a redirect inappropriate.
+		if ( wp_doing_ajax() ) {
+			return;
+		}
+		if ( is_network_admin() ) {
+			return;
+		}
+		if ( isset( $_GET['activate-multi'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return;
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		wp_safe_redirect( admin_url( 'admin.php?page=' . self::PAGE_SLUG ) );
+		exit;
+	}
+
+	// =========================================================================
+	// AJAX — shared security guard
+	// =========================================================================
+
+	/**
+	 * Verify the request nonce and capability; die on failure.
+	 *
+	 * Call at the top of every AJAX handler.
+	 *
+	 * @since 4.13.0
+	 */
+	private function check_ajax(): void {
+		check_ajax_referer( self::NONCE_ACTION, 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ), 403 );
+		}
+	}
+
+	// =========================================================================
+	// AJAX — private state helper
+	// =========================================================================
+
+	/**
+	 * Mark a single wizard step as complete and persist the state option.
+	 *
+	 * @param string $step One of the STEPS values.
+	 * @since 4.13.0
+	 */
+	private function mark_step( string $step ): void {
+		$state                   = self::normalize_state( get_option( self::OPTION_STATE ) );
+		$state['steps'][ $step ] = true;
+		update_option( self::OPTION_STATE, $state, false );
+	}
+
+	// =========================================================================
+	// AJAX handlers
+	// =========================================================================
+
+	/**
+	 * Return current wizard status: normalised state, progress, and migration detection.
+	 *
+	 * @since 4.13.0
+	 */
+	public function ajax_swps_onboarding_status(): void {
+		$this->check_ajax();
+
+		$state    = self::normalize_state( get_option( self::OPTION_STATE ) );
+		$progress = self::progress( $state );
+
+		$migration = stratawp_seo()->migration ?? null;
+		$sources   = $migration ? $migration->detect_sources() : array();
+
+		wp_send_json_success(
+			array(
+				'state'    => $state,
+				'progress' => $progress,
+				'sources'  => $sources,
+			)
+		);
+	}
+
+	/**
+	 * Test an API key for the specified provider and, on success, save both
+	 * the provider choice and key through the same paths that Settings uses.
+	 *
+	 * POST: provider (string), api_key (string).
+	 *
+	 * @since 4.13.0
+	 */
+	public function ajax_swps_onboarding_test_key(): void {
+		$this->check_ajax();
+
+		// Nonce already verified inside check_ajax() via check_ajax_referer().
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		$provider_slug = isset( $_POST['provider'] ) ? sanitize_key( wp_unslash( $_POST['provider'] ) ) : '';
+		$api_key       = isset( $_POST['api_key'] ) ? sanitize_text_field( wp_unslash( $_POST['api_key'] ) ) : '';
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+
+		if ( empty( $provider_slug ) || empty( $api_key ) ) {
+			wp_send_json_error( array( 'message' => __( 'Provider and API key are required.', 'stratawp-seo' ) ) );
+		}
+
+		// Build a temporary provider instance using the factory's slug map.
+		// Keys are NOT encrypted — settings stores them via sanitize_text_field.
+		$provider_classes = array(
+			'anthropic' => 'SWPS_Anthropic_Provider',
+			'openai'    => 'SWPS_OpenAI_Provider',
+			'google'    => 'SWPS_Google_Provider',
+			'xai'       => 'SWPS_XAI_Provider',
+		);
+
+		if ( ! isset( $provider_classes[ $provider_slug ] ) ) {
+			wp_send_json_error( array( 'message' => __( 'Unknown provider.', 'stratawp-seo' ) ) );
+		}
+
+		$class    = $provider_classes[ $provider_slug ];
+		$provider = new $class();
+
+		$result = $provider->test_key( $api_key );
+
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+		}
+
+		if ( ! $result ) {
+			wp_send_json_error( array( 'message' => __( 'API key test failed. Please check the key and try again.', 'stratawp-seo' ) ) );
+		}
+
+		// Key is valid — save through the same option names Settings uses:
+		// swps_ai_provider  and  swps_{slug}_api_key  (plain sanitize_text_field, not encrypted).
+		update_option( 'swps_ai_provider', $provider_slug );
+		update_option( $provider->get_api_key_option(), $api_key );
+
+		$this->mark_step( 'api_key' );
+
+		wp_send_json_success( array( 'message' => __( 'API key validated and saved.', 'stratawp-seo' ) ) );
+	}
+
+	/**
+	 * Use the active AI provider to suggest a 1-2 sentence site description.
+	 *
+	 * Fails soft: returns an empty suggestion rather than a hard error so the
+	 * wizard step remains completable without a working key.
+	 *
+	 * @since 4.13.0
+	 */
+	public function ajax_swps_onboarding_suggest_site_info(): void {
+		$this->check_ajax();
+
+		$analyzer = stratawp_seo()->analyzer;
+		$summary  = $analyzer->get_site_summary( 50 );
+		$provider = SWPS_Provider_Factory::create_ai_provider();
+
+		if ( empty( $provider->get_api_key() ) ) {
+			wp_send_json_success( array( 'suggestion' => '' ) );
+		}
+
+		$system = 'You are an SEO assistant. Respond only with a 1-2 sentence plain-text site description — no markdown, no lists.';
+		$user   = sprintf(
+			/* translators: %s: JSON-encoded site summary data */
+			'Based on this WordPress site data, write a concise 1-2 sentence description of the site for SEO purposes: %s',
+			wp_json_encode( $summary )
+		);
+
+		$response = $provider->chat( $system, $user, 200 );
+
+		$suggestion = is_wp_error( $response ) ? '' : trim( $response );
+
+		wp_send_json_success( array( 'suggestion' => $suggestion ) );
+	}
+
+	/**
+	 * Save the site description entered (or confirmed) by the user.
+	 *
+	 * POST: description (string).
+	 *
+	 * @since 4.13.0
+	 */
+	public function ajax_swps_onboarding_save_site_info(): void {
+		$this->check_ajax();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- verified inside check_ajax().
+		$description = isset( $_POST['description'] ) ? sanitize_textarea_field( wp_unslash( $_POST['description'] ) ) : '';
+
+		if ( empty( $description ) ) {
+			wp_send_json_error( array( 'message' => __( 'Description cannot be empty.', 'stratawp-seo' ) ) );
+		}
+
+		// Save through the same option the Settings "Site Details" section uses.
+		update_option( 'swps_site_description', $description );
+
+		$this->mark_step( 'site_info' );
+
+		wp_send_json_success( array( 'message' => __( 'Site description saved.', 'stratawp-seo' ) ) );
+	}
+
+	/**
+	 * Run the full SEO audit, mark the step done, and return a summary.
+	 *
+	 * @since 4.13.0
+	 */
+	public function ajax_swps_onboarding_run_audit(): void {
+		$this->check_ajax();
+
+		$audit   = stratawp_seo()->seo_audit;
+		$results = $audit->run_all();
+
+		$pass    = 0;
+		$issues  = 0;
+		$modules = $results['modules'] ?? array();
+
+		foreach ( $modules as $mod ) {
+			$status = $mod['status'] ?? 'fail';
+			if ( 'pass' === $status ) {
+				++$pass;
+			} else {
+				++$issues;
+			}
+		}
+
+		$this->mark_step( 'audit' );
+
+		wp_send_json_success(
+			array(
+				'pass'      => $pass,
+				'issues'    => $issues,
+				'audit_url' => admin_url( 'admin.php?page=swps-seo-audit' ),
+			)
+		);
+	}
+
+	/**
+	 * Generate a preview post (rate-limited, uses budget guardian).
+	 *
+	 * POST: topic (string, optional).
+	 *
+	 * @since 4.13.0
+	 */
+	public function ajax_swps_onboarding_preview(): void {
+		$this->check_ajax();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- verified inside check_ajax().
+		$topic  = isset( $_POST['topic'] ) ? sanitize_text_field( wp_unslash( $_POST['topic'] ) ) : '';
+		$result = stratawp_seo()->generator->preview_content( $topic );
+
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+		}
+
+		// Return title, meta description, and first ~600 chars of sanitised content.
+		$content_html = isset( $result['content_html'] ) ? wp_kses_post( $result['content_html'] ) : '';
+		if ( mb_strlen( $content_html ) > 600 ) {
+			// Truncate at a space boundary to avoid mid-tag splits.
+			$content_html = mb_substr( $content_html, 0, 600 );
+			$last_space   = mb_strrpos( $content_html, ' ' );
+			if ( false !== $last_space ) {
+				$content_html = mb_substr( $content_html, 0, $last_space );
+			}
+			$content_html .= '&hellip;';
+		}
+
+		$this->mark_step( 'preview' );
+
+		wp_send_json_success(
+			array(
+				'title'            => isset( $result['title'] ) ? sanitize_text_field( $result['title'] ) : '',
+				'meta_description' => isset( $result['meta_description'] ) ? sanitize_text_field( $result['meta_description'] ) : '',
+				'content_html'     => $content_html,
+			)
+		);
+	}
+
+	/**
+	 * Mark a whitelisted step as done — used by the migration "I'm done" button
+	 * and per-step skip controls.
+	 *
+	 * POST: step (string — must be a member of STEPS).
+	 *
+	 * @since 4.13.0
+	 */
+	public function ajax_swps_onboarding_step_done(): void {
+		$this->check_ajax();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- verified inside check_ajax().
+		$step = isset( $_POST['step'] ) ? sanitize_key( wp_unslash( $_POST['step'] ) ) : '';
+
+		if ( ! in_array( $step, self::STEPS, true ) ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid step.', 'stratawp-seo' ) ) );
+		}
+
+		$this->mark_step( $step );
+
+		$state    = self::normalize_state( get_option( self::OPTION_STATE ) );
+		$progress = self::progress( $state );
+
+		wp_send_json_success(
+			array(
+				'step'     => $step,
+				'progress' => $progress,
+			)
+		);
+	}
+
+	/**
+	 * Set the wizard as dismissed — hides the dashboard checklist.
+	 *
+	 * @since 4.13.0
+	 */
+	public function ajax_swps_onboarding_dismiss(): void {
+		$this->check_ajax();
+
+		$state              = self::normalize_state( get_option( self::OPTION_STATE ) );
+		$state['dismissed'] = true;
+		update_option( self::OPTION_STATE, $state, false );
+
+		wp_send_json_success( array( 'dismissed' => true ) );
+	}
+}

--- a/includes/class-onboarding.php
+++ b/includes/class-onboarding.php
@@ -2,13 +2,6 @@
 /**
  * Onboarding wizard: state helpers, admin page, activation redirect, AJAX endpoints.
  *
- * Registers a "Setup Wizard" submenu page under the StrataWP SEO top-level menu,
- * sets an activation-redirect transient on fresh installs, and handles all eight
- * AJAX endpoints that drive the onboarding flow.
- *
- * Constructor hooks fire only when the class is instantiated — see Task 4 in the
- * plan for the require_once + instantiation in stratawp-seo.php.
- *
  * @package StrataWP_SEO
  * @since   4.13.0
  */
@@ -86,9 +79,7 @@ class SWPS_Onboarding {
 		}
 	}
 
-	// =========================================================================
-	// Pure static helpers (no WordPress required — unit-testable)
-	// =========================================================================
+	// -- Pure static helpers (no WordPress required — unit-testable) --
 
 	/**
 	 * Normalise a raw option value into a well-typed state array.
@@ -139,15 +130,10 @@ class SWPS_Onboarding {
 		);
 	}
 
-	// =========================================================================
-	// Admin page registration
-	// =========================================================================
+	// -- Admin page registration --
 
 	/**
-	 * Register the Setup Wizard submenu page under the StrataWP SEO parent menu.
-	 *
-	 * Visible as "Setup Wizard" — no hidden-page pattern exists in the plugin,
-	 * so a visible entry is simpler and matches existing conventions.
+	 * Register the Setup Wizard submenu page (visible — no hidden-page pattern exists).
 	 *
 	 * @since 4.13.0
 	 */
@@ -163,10 +149,7 @@ class SWPS_Onboarding {
 	}
 
 	/**
-	 * Render the wizard page.
-	 *
-	 * Includes the template if it exists; outputs a placeholder during Task 2
-	 * (before the template is built in Task 3).
+	 * Render the wizard page (includes template or shows placeholder).
 	 *
 	 * @since 4.13.0
 	 */
@@ -184,15 +167,10 @@ class SWPS_Onboarding {
 		}
 	}
 
-	// =========================================================================
-	// Activation redirect
-	// =========================================================================
+	// -- Activation redirect --
 
 	/**
-	 * Redirect to the wizard on first activation if the transient is present.
-	 *
-	 * Bails early when called from an AJAX request, the network admin,
-	 * a bulk-activate action, WP-CLI, or by a user without manage_options.
+	 * Redirect to the wizard on first activation (bails on AJAX/network/CLI/bulk).
 	 *
 	 * @since 4.13.0
 	 */
@@ -224,14 +202,10 @@ class SWPS_Onboarding {
 		exit;
 	}
 
-	// =========================================================================
-	// AJAX — shared security guard
-	// =========================================================================
+	// -- AJAX shared security guard --
 
 	/**
-	 * Verify the request nonce and capability; die on failure.
-	 *
-	 * Call at the top of every AJAX handler.
+	 * Verify nonce and manage_options capability; die on failure.
 	 *
 	 * @since 4.13.0
 	 */
@@ -243,9 +217,7 @@ class SWPS_Onboarding {
 		}
 	}
 
-	// =========================================================================
-	// AJAX — private state helper
-	// =========================================================================
+	// -- AJAX private state helper --
 
 	/**
 	 * Mark a single wizard step as complete and persist the state option.
@@ -259,9 +231,7 @@ class SWPS_Onboarding {
 		update_option( self::OPTION_STATE, $state, false );
 	}
 
-	// =========================================================================
-	// AJAX handlers
-	// =========================================================================
+	// -- AJAX handlers --
 
 	/**
 	 * Return current wizard status: normalised state, progress, and migration detection.
@@ -287,8 +257,7 @@ class SWPS_Onboarding {
 	}
 
 	/**
-	 * Test an API key for the specified provider and, on success, save both
-	 * the provider choice and key through the same paths that Settings uses.
+	 * Test an API key then save provider + key through the same Settings path.
 	 *
 	 * POST: provider (string), api_key (string).
 	 *
@@ -344,10 +313,7 @@ class SWPS_Onboarding {
 	}
 
 	/**
-	 * Use the active AI provider to suggest a 1-2 sentence site description.
-	 *
-	 * Fails soft: returns an empty suggestion rather than a hard error so the
-	 * wizard step remains completable without a working key.
+	 * AI-suggest a 1-2 sentence site description (fails soft — returns '' on error).
 	 *
 	 * @since 4.13.0
 	 */
@@ -478,10 +444,9 @@ class SWPS_Onboarding {
 	}
 
 	/**
-	 * Mark a whitelisted step as done — used by the migration "I'm done" button
-	 * and per-step skip controls.
+	 * Mark a step done — used by the migration "I'm done" and skip buttons.
 	 *
-	 * POST: step (string — must be a member of STEPS).
+	 * POST: step (string — must be in STEPS).
 	 *
 	 * @since 4.13.0
 	 */

--- a/includes/class-onboarding.php
+++ b/includes/class-onboarding.php
@@ -429,17 +429,11 @@ class SWPS_Onboarding {
 			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
 		}
 
-		// Return title, meta description, and first ~600 chars of sanitised content.
-		$content_html = isset( $result['content_html'] ) ? wp_kses_post( $result['content_html'] ) : '';
-		if ( mb_strlen( $content_html ) > 600 ) {
-			// Truncate at a space boundary to avoid mid-tag splits.
-			$content_html = mb_substr( $content_html, 0, 600 );
-			$last_space   = mb_strrpos( $content_html, ' ' );
-			if ( false !== $last_space ) {
-				$content_html = mb_substr( $content_html, 0, $last_space );
-			}
-			$content_html .= '&hellip;';
-		}
+		// Return title, meta description, and a plain-text excerpt. Plain text
+		// (rendered via textContent in JS) keeps AI-generated markup out of the
+		// admin DOM entirely and can't be broken by truncation.
+		$excerpt = isset( $result['content_html'] ) ? wp_strip_all_tags( $result['content_html'] ) : '';
+		$excerpt = wp_trim_words( $excerpt, 100, '…' );
 
 		$this->mark_step( 'preview' );
 
@@ -447,7 +441,7 @@ class SWPS_Onboarding {
 			array(
 				'title'            => isset( $result['title'] ) ? sanitize_text_field( $result['title'] ) : '',
 				'meta_description' => isset( $result['meta_description'] ) ? sanitize_text_field( $result['meta_description'] ) : '',
-				'content_html'     => $content_html,
+				'content_excerpt'  => $excerpt,
 			)
 		);
 	}

--- a/includes/class-onboarding.php
+++ b/includes/class-onboarding.php
@@ -18,50 +18,28 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class SWPS_Onboarding {
 
-	/**
-	 * WordPress option that persists wizard progress.
-	 *
-	 * @var string
-	 */
+	/** WordPress option that persists wizard progress. */
 	public const OPTION_STATE = 'swps_onboarding_state';
 
-	/**
-	 * Canonical wizard step order.
-	 *
-	 * @var array<int, string>
-	 */
+	/** Canonical wizard step order. */
 	public const STEPS = array( 'migrate', 'api_key', 'site_info', 'audit', 'preview' );
 
-	/**
-	 * Nonce action used for all wizard AJAX endpoints.
-	 *
-	 * @var string
-	 */
+	/** Nonce action used for all wizard AJAX endpoints. */
 	private const NONCE_ACTION = 'swps_onboarding';
 
-	/**
-	 * Wizard admin page slug.
-	 *
-	 * @var string
-	 */
+	/** Wizard admin page slug. */
 	private const PAGE_SLUG = 'swps-onboarding';
 
-	/**
-	 * Activation-redirect transient key.
-	 *
-	 * @var string
-	 */
+	/** Activation-redirect transient key. */
 	private const REDIRECT_TRANSIENT = 'swps_onboarding_redirect';
 
 	/**
-	 * Register WordPress hooks.
-	 *
-	 * Called in the constructor so hooks are wired at instantiation time,
-	 * not at require_once time (keeps things testable).
+	 * Register WordPress hooks (wired at instantiation, not require time).
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', array( $this, 'register_page' ), 70 );
 		add_action( 'admin_init', array( $this, 'maybe_redirect' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
 		// AJAX endpoints — both logged-in (wp_ajax_) and nopriv omitted (all require manage_options).
 		$endpoints = array(
@@ -78,8 +56,6 @@ class SWPS_Onboarding {
 			add_action( "wp_ajax_{$action}", array( $this, "ajax_{$action}" ) );
 		}
 	}
-
-	// -- Pure static helpers (no WordPress required — unit-testable) --
 
 	/**
 	 * Normalise a raw option value into a well-typed state array.
@@ -130,8 +106,6 @@ class SWPS_Onboarding {
 		);
 	}
 
-	// -- Admin page registration --
-
 	/**
 	 * Register the Setup Wizard submenu page (visible — no hidden-page pattern exists).
 	 *
@@ -167,7 +141,52 @@ class SWPS_Onboarding {
 		}
 	}
 
-	// -- Activation redirect --
+	/**
+	 * Enqueue wizard CSS/JS only on the wizard page.
+	 *
+	 * @param string $hook Current admin page hook suffix.
+	 * @since 4.13.0
+	 */
+	public function enqueue_assets( string $hook ): void {
+		if ( 'stratawp-seo_page_swps-onboarding' !== $hook ) {
+			return;
+		}
+		wp_enqueue_style(
+			'swps-onboarding',
+			SWPS_PLUGIN_URL . 'admin/css/onboarding.css',
+			array( 'swps-tokens', 'swps-components', 'swps-templates' ),
+			SWPS_VERSION
+		);
+		wp_enqueue_script(
+			'swps-onboarding',
+			SWPS_PLUGIN_URL . 'admin/js/onboarding.js',
+			array(),
+			SWPS_VERSION,
+			true
+		);
+		wp_localize_script(
+			'swps-onboarding',
+			'swpsOnboarding',
+			array(
+				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'nonce'   => wp_create_nonce( self::NONCE_ACTION ),
+				'i18n'    => array(
+					'testing'      => __( 'Testing key…', 'stratawp-seo' ),
+					'keyRequired'  => __( 'Please paste an API key first.', 'stratawp-seo' ),
+					'suggesting'   => __( 'Asking the AI…', 'stratawp-seo' ),
+					'suggested'    => __( 'Suggestion ready — edit it, then save.', 'stratawp-seo' ),
+					'noSuggestion' => __( 'No suggestion available — add a key in step 2 or write your own.', 'stratawp-seo' ),
+					'descRequired' => __( 'Please enter a description first.', 'stratawp-seo' ),
+					'auditing'     => __( 'Running the audit — this can take a minute…', 'stratawp-seo' ),
+					/* translators: 1: passed module count, 2: issue count */
+					'auditDone'    => __( '%1$s passed / %2$s issues.', 'stratawp-seo' ),
+					'openAudit'    => __( 'Open the audit', 'stratawp-seo' ),
+					'generating'   => __( 'Generating — usually 30–60 seconds…', 'stratawp-seo' ),
+					'failed'       => __( 'Request failed.', 'stratawp-seo' ),
+				),
+			)
+		);
+	}
 
 	/**
 	 * Redirect to the wizard on first activation (bails on AJAX/network/CLI/bulk).
@@ -182,27 +201,17 @@ class SWPS_Onboarding {
 		delete_transient( self::REDIRECT_TRANSIENT );
 
 		// Bail conditions that make a redirect inappropriate.
-		if ( wp_doing_ajax() ) {
+		if ( wp_doing_ajax() || is_network_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 			return;
 		}
-		if ( is_network_admin() ) {
-			return;
-		}
-		if ( isset( $_GET['activate-multi'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			return;
-		}
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			return;
-		}
-		if ( ! current_user_can( 'manage_options' ) ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only bulk-activation check.
+		if ( isset( $_GET['activate-multi'] ) || ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
 
 		wp_safe_redirect( admin_url( 'admin.php?page=' . self::PAGE_SLUG ) );
 		exit;
 	}
-
-	// -- AJAX shared security guard --
 
 	/**
 	 * Verify nonce and manage_options capability; die on failure.
@@ -217,8 +226,6 @@ class SWPS_Onboarding {
 		}
 	}
 
-	// -- AJAX private state helper --
-
 	/**
 	 * Mark a single wizard step as complete and persist the state option.
 	 *
@@ -230,8 +237,6 @@ class SWPS_Onboarding {
 		$state['steps'][ $step ] = true;
 		update_option( self::OPTION_STATE, $state, false );
 	}
-
-	// -- AJAX handlers --
 
 	/**
 	 * Return current wizard status: normalised state, progress, and migration detection.
@@ -320,26 +325,30 @@ class SWPS_Onboarding {
 	public function ajax_swps_onboarding_suggest_site_info(): void {
 		$this->check_ajax();
 
-		$analyzer = stratawp_seo()->analyzer;
-		$summary  = $analyzer->get_site_summary( 50 );
-		$provider = SWPS_Provider_Factory::create_ai_provider();
+		try {
+			$analyzer = stratawp_seo()->analyzer;
+			$summary  = $analyzer->get_site_summary( 50 );
+			$provider = SWPS_Provider_Factory::create_ai_provider();
 
-		if ( empty( $provider->get_api_key() ) ) {
-			wp_send_json_success( array( 'suggestion' => '' ) );
+			if ( empty( $provider->get_api_key() ) ) {
+				wp_send_json_success( array( 'suggestion' => '' ) );
+			}
+
+			$system = 'You are an SEO assistant. Respond only with a 1-2 sentence plain-text site description — no markdown, no lists.';
+			$user   = sprintf(
+				/* translators: %s: JSON-encoded site summary data */
+				'Based on this WordPress site data, write a concise 1-2 sentence description of the site for SEO purposes: %s',
+				wp_json_encode( $summary )
+			);
+
+			$response = $provider->chat( $system, $user, 200 );
+
+			$suggestion = is_wp_error( $response ) ? '' : trim( $response );
+
+			wp_send_json_success( array( 'suggestion' => $suggestion ) );
+		} catch ( Throwable $e ) {
+			wp_send_json_error( array( 'message' => __( 'Suggestion unavailable right now.', 'stratawp-seo' ) ) );
 		}
-
-		$system = 'You are an SEO assistant. Respond only with a 1-2 sentence plain-text site description — no markdown, no lists.';
-		$user   = sprintf(
-			/* translators: %s: JSON-encoded site summary data */
-			'Based on this WordPress site data, write a concise 1-2 sentence description of the site for SEO purposes: %s',
-			wp_json_encode( $summary )
-		);
-
-		$response = $provider->chat( $system, $user, 200 );
-
-		$suggestion = is_wp_error( $response ) ? '' : trim( $response );
-
-		wp_send_json_success( array( 'suggestion' => $suggestion ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.12.0
+Stable tag: 4.13.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -293,6 +293,10 @@ No. GSC integration is optional. The on-site analytics works entirely without an
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.13.0 =
+* New: 5-minute onboarding wizard — migrate from Yoast/Rank Math, validate your AI key, AI-suggest your site description, run the audit, and generate a preview post; setup checklist on the dashboard until complete.
+* New: AI provider keys can now be validated from the UI (Test & Save).
 
 = 4.12.0 =
 * New: White-label email digest — weekly/daily/monthly report of generations, failures, keyword movers, backlinks, competitors, AI-bot trends, and AI spend, led by a needs-attention triage section; agency branding, multiple recipients, test-send, optional AI executive summary.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -65,6 +65,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-cost-tracker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-autopilot-guardian.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-digest.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-digest-settings.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-onboarding.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-topic-queue.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-content-scorer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-voice-profile.php';
@@ -227,6 +228,7 @@ final class StrataWP_SEO {
 	public SWPS_Autopilot_Guardian $autopilot_guardian;
 	public SWPS_Digest $digest;
 	public SWPS_Digest_Settings $digest_settings;
+	public SWPS_Onboarding $onboarding;
 
 	// AEO Optimize (v4.6).
 	public SWPS_AEO_Scorer            $aeo_scorer;
@@ -330,6 +332,7 @@ final class StrataWP_SEO {
 		$this->autopilot_guardian   = new SWPS_Autopilot_Guardian();
 		$this->digest               = new SWPS_Digest();
 		$this->digest_settings      = new SWPS_Digest_Settings( $this->digest );
+		$this->onboarding           = new SWPS_Onboarding();
 
 		// Initialize v2.0 subsystems.
 		$this->calendar             = new SWPS_Calendar( $this->topic_queue );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.12.0
+ * Version: 4.13.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.12.0' );
+define( 'SWPS_VERSION', '4.13.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -1296,6 +1296,11 @@ function swps_activate(): void {
 		}
 	}
 
+	// On a fresh install (option absent = never activated before), trigger the onboarding wizard.
+	if ( false === get_option( 'swps_onboarding_state' ) ) {
+		set_transient( 'swps_onboarding_redirect', 1, 60 );
+	}
+
 	// Register CPTs for flush_rewrite_rules.
 	SWPS_Topic_Queue::register_post_type();
 	SWPS_Voice_Profile::register_post_type();

--- a/templates/dashboard-page.php
+++ b/templates/dashboard-page.php
@@ -81,6 +81,56 @@ $welcome_msg = sprintf(
 	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
 	?>
 
+	<?php
+	// Setup checklist — shown until the onboarding wizard is complete or dismissed.
+	$swps_ob          = $data['onboarding'] ?? array();
+	$swps_ob_state    = $swps_ob['state'] ?? array(
+		'steps'     => array(),
+		'dismissed' => true,
+	);
+	$swps_ob_progress = $swps_ob['progress'] ?? array(
+		'done'     => 0,
+		'total'    => 0,
+		'complete' => true,
+		'next'     => null,
+	);
+	$swps_ob_labels   = array(
+		'migrate'   => __( 'Migrate from your old SEO plugin', 'stratawp-seo' ),
+		'api_key'   => __( 'Connect your AI provider', 'stratawp-seo' ),
+		'site_info' => __( 'Describe your site', 'stratawp-seo' ),
+		'audit'     => __( 'Run your first SEO audit', 'stratawp-seo' ),
+		'preview'   => __( 'Generate a preview post', 'stratawp-seo' ),
+	);
+	$swps_ob_url      = admin_url( 'admin.php?page=swps-onboarding' );
+	if ( ! $swps_ob_progress['complete'] && empty( $swps_ob_state['dismissed'] ) ) :
+		?>
+	<div class="swps-tile swps-ob-checklist" id="swps-ob-checklist"
+		data-nonce="<?php echo esc_attr( wp_create_nonce( 'swps_onboarding' ) ); ?>">
+		<div class="swps-ob-checklist-head">
+			<div class="swps-tile-h">
+				<?php
+				printf(
+					/* translators: 1: completed steps, 2: total steps */
+					esc_html__( 'Setup %1$d/%2$d complete', 'stratawp-seo' ),
+					(int) $swps_ob_progress['done'],
+					(int) $swps_ob_progress['total']
+				);
+				?>
+			</div>
+			<button type="button" class="swps-ob-checklist-dismiss" aria-label="<?php esc_attr_e( 'Dismiss setup checklist', 'stratawp-seo' ); ?>">&times;</button>
+		</div>
+		<ul class="swps-ob-checklist-steps">
+			<?php foreach ( $swps_ob_labels as $swps_ob_step => $swps_ob_label ) : ?>
+				<li class="<?php echo ! empty( $swps_ob_state['steps'][ $swps_ob_step ] ) ? 'is-done' : ''; ?>">
+					<span class="swps-ob-checklist-mark" aria-hidden="true"><?php echo ! empty( $swps_ob_state['steps'][ $swps_ob_step ] ) ? '&#10003;' : '&#9675;'; ?></span>
+					<a href="<?php echo esc_url( $swps_ob_url ); ?>"><?php echo esc_html( $swps_ob_label ); ?></a>
+				</li>
+			<?php endforeach; ?>
+		</ul>
+		<a class="swps-btn swps-btn-grad" href="<?php echo esc_url( $swps_ob_url ); ?>"><?php esc_html_e( 'Continue setup', 'stratawp-seo' ); ?></a>
+	</div>
+	<?php endif; ?>
+
 	<!-- Row 1 — KPI tiles -->
 	<div class="swps-dash-row swps-dash-row-1">
 

--- a/templates/onboarding-page.php
+++ b/templates/onboarding-page.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Onboarding wizard page — five-step vertical stepper.
+ *
+ * Wrapped by SWPS_Admin_Shell. Uses the page-header partial like other pages.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$swps_state    = SWPS_Onboarding::normalize_state( get_option( SWPS_Onboarding::OPTION_STATE ) );
+$swps_progress = SWPS_Onboarding::progress( $swps_state );
+$swps_steps    = $swps_state['steps'];
+
+$swps_sources       = stratawp_seo()->migration->detect_sources();
+$swps_providers     = SWPS_Provider_Factory::get_ai_provider_options();
+$swps_provider_now  = get_option( 'swps_ai_provider', 'anthropic' );
+$swps_has_key       = '' !== SWPS_Provider_Factory::create_ai_provider()->get_api_key();
+$swps_description   = (string) get_option( 'swps_site_description', '' );
+$swps_audit_results = stratawp_seo()->seo_audit->get_cached_results();
+
+$swps_issue_count = 0;
+foreach ( ( $swps_audit_results['modules'] ?? array() ) as $swps_mod ) {
+	if ( 'pass' !== ( $swps_mod['status'] ?? 'fail' ) ) {
+		++$swps_issue_count;
+	}
+}
+
+$swps_migration_url = admin_url( 'admin.php?page=swps-migration' );
+$swps_audit_url     = admin_url( 'admin.php?page=swps-seo-audit' );
+$swps_generate_url  = admin_url( 'admin.php?page=swps-generate' );
+$swps_schema_url    = admin_url( 'admin.php?page=swps-search-appearance' );
+$swps_crawl_url     = admin_url( 'admin.php?page=swps-crawl-files' );
+?>
+<div class="wrap swps-onboarding-wrap">
+
+	<?php
+	// The page-header partial expects these exact variable names.
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$title = __( 'Setup Wizard', 'stratawp-seo' );
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+	$subtitle = sprintf(
+		/* translators: 1: completed steps, 2: total steps */
+		esc_html__( 'Five minutes to a fully configured site — %1$d of %2$d steps done.', 'stratawp-seo' ),
+		(int) $swps_progress['done'],
+		(int) $swps_progress['total']
+	);
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	?>
+
+	<?php if ( $swps_progress['complete'] ) : ?>
+		<!-- Win panel — all steps complete. -->
+		<div class="swps-ob-win swps-card">
+			<h2><?php esc_html_e( 'Setup complete — nice work!', 'stratawp-seo' ); ?></h2>
+			<?php if ( $swps_issue_count > 0 ) : ?>
+				<p>
+					<?php
+					printf(
+						/* translators: %d: number of audit issues */
+						esc_html( _n( 'Your audit found %d issue you can fix right now.', 'Your audit found %d issues you can fix right now.', $swps_issue_count, 'stratawp-seo' ) ),
+						(int) $swps_issue_count
+					);
+					?>
+				</p>
+				<a class="swps-btn swps-btn-grad" href="<?php echo esc_url( $swps_audit_url ); ?>"><?php esc_html_e( 'Fix now', 'stratawp-seo' ); ?></a>
+			<?php else : ?>
+				<p><?php esc_html_e( 'Your audit is clean. Generate your first AI post to put the setup to work.', 'stratawp-seo' ); ?></p>
+				<a class="swps-btn swps-btn-grad" href="<?php echo esc_url( $swps_generate_url ); ?>"><?php esc_html_e( 'Generate a post', 'stratawp-seo' ); ?></a>
+			<?php endif; ?>
+			<p class="swps-ob-win-pointers">
+				<?php esc_html_e( 'Go deeper:', 'stratawp-seo' ); ?>
+				<a href="<?php echo esc_url( $swps_schema_url ); ?>"><?php esc_html_e( 'Schema & search appearance', 'stratawp-seo' ); ?></a>
+				&middot;
+				<a href="<?php echo esc_url( $swps_crawl_url ); ?>"><?php esc_html_e( 'llms.txt & robots.txt', 'stratawp-seo' ); ?></a>
+			</p>
+		</div>
+	<?php endif; ?>
+
+	<div class="swps-ob-stepper" id="swps-ob-stepper">
+
+		<!-- Step 1: Migrate -->
+		<div class="swps-ob-step swps-card<?php echo $swps_steps['migrate'] ? ' is-done' : ''; ?>"
+			data-step="migrate"
+			<?php echo ( empty( $swps_sources ) && ! $swps_steps['migrate'] ) ? 'data-auto-skip="1"' : ''; ?>>
+			<div class="swps-ob-step-head">
+				<span class="swps-ob-step-num">1</span>
+				<h2><?php esc_html_e( 'Migrate from your old SEO plugin', 'stratawp-seo' ); ?></h2>
+				<span class="swps-ob-step-check" aria-hidden="true">&#10003;</span>
+			</div>
+			<div class="swps-ob-step-body">
+				<?php if ( empty( $swps_sources ) ) : ?>
+					<p><?php esc_html_e( 'Nothing to migrate — no Yoast or Rank Math data was detected. This step completes itself.', 'stratawp-seo' ); ?></p>
+				<?php else : ?>
+					<p><?php esc_html_e( 'We detected SEO data you can import:', 'stratawp-seo' ); ?></p>
+					<ul class="swps-ob-sources">
+						<?php foreach ( $swps_sources as $swps_slug => $swps_src ) : ?>
+							<li>
+								<strong><?php echo esc_html( $swps_src['label'] ); ?></strong>
+								&mdash;
+								<?php
+								printf(
+									/* translators: %d: number of posts with importable SEO data */
+									esc_html( _n( '%d post with SEO data', '%d posts with SEO data', (int) $swps_src['post_count'], 'stratawp-seo' ) ),
+									(int) $swps_src['post_count']
+								);
+								?>
+							</li>
+						<?php endforeach; ?>
+					</ul>
+					<p>
+						<a class="swps-btn swps-btn-grad" href="<?php echo esc_url( $swps_migration_url ); ?>"><?php esc_html_e( 'Open the Migration tool', 'stratawp-seo' ); ?></a>
+						<button type="button" class="swps-btn swps-btn-secondary swps-ob-refresh-detect"><?php esc_html_e( 'Refresh detection', 'stratawp-seo' ); ?></button>
+						<button type="button" class="swps-btn swps-btn-secondary swps-ob-step-complete" data-step="migrate"><?php esc_html_e( "I'm done migrating", 'stratawp-seo' ); ?></button>
+					</p>
+				<?php endif; ?>
+			</div>
+			<a href="#" class="swps-ob-skip" data-step="migrate"><?php esc_html_e( 'Skip this step', 'stratawp-seo' ); ?></a>
+		</div>
+
+		<!-- Step 2: API key -->
+		<div class="swps-ob-step swps-card<?php echo $swps_steps['api_key'] ? ' is-done' : ''; ?>" data-step="api_key">
+			<div class="swps-ob-step-head">
+				<span class="swps-ob-step-num">2</span>
+				<h2><?php esc_html_e( 'Connect your AI provider', 'stratawp-seo' ); ?></h2>
+				<span class="swps-ob-step-check" aria-hidden="true">&#10003;</span>
+			</div>
+			<div class="swps-ob-step-body">
+				<?php if ( $swps_has_key ) : ?>
+					<p class="swps-ob-note is-ok"><?php esc_html_e( 'An API key is already saved — test a new one below to replace it, or skip ahead.', 'stratawp-seo' ); ?></p>
+				<?php else : ?>
+					<p><?php esc_html_e( 'Paste an API key and we will validate it with a live request before saving.', 'stratawp-seo' ); ?></p>
+				<?php endif; ?>
+				<div class="swps-ob-field-row">
+					<select id="swps-ob-provider">
+						<?php foreach ( $swps_providers as $swps_slug => $swps_label ) : ?>
+							<option value="<?php echo esc_attr( $swps_slug ); ?>" <?php selected( $swps_provider_now, $swps_slug ); ?>><?php echo esc_html( $swps_label ); ?></option>
+						<?php endforeach; ?>
+					</select>
+					<input type="password" id="swps-ob-api-key" autocomplete="off"
+						placeholder="<?php esc_attr_e( 'Paste your API key', 'stratawp-seo' ); ?>" />
+					<button type="button" class="swps-btn swps-btn-grad" id="swps-ob-test-key"><?php esc_html_e( 'Test & Save', 'stratawp-seo' ); ?></button>
+				</div>
+				<p class="swps-ob-msg" id="swps-ob-key-msg" role="status"></p>
+			</div>
+			<a href="#" class="swps-ob-skip" data-step="api_key"><?php esc_html_e( 'Skip this step', 'stratawp-seo' ); ?></a>
+		</div>
+
+		<!-- Step 3: Site info -->
+		<div class="swps-ob-step swps-card<?php echo $swps_steps['site_info'] ? ' is-done' : ''; ?>" data-step="site_info">
+			<div class="swps-ob-step-head">
+				<span class="swps-ob-step-num">3</span>
+				<h2><?php esc_html_e( 'Describe your site', 'stratawp-seo' ); ?></h2>
+				<span class="swps-ob-step-check" aria-hidden="true">&#10003;</span>
+			</div>
+			<div class="swps-ob-step-body">
+				<p><?php esc_html_e( 'A short description helps the AI write content that fits your site. Let AI draft one from your existing posts, then edit and save.', 'stratawp-seo' ); ?></p>
+				<textarea id="swps-ob-description" rows="3"
+					placeholder="<?php esc_attr_e( 'e.g. A blog about home coffee roasting for hobbyists.', 'stratawp-seo' ); ?>"><?php echo esc_textarea( $swps_description ); ?></textarea>
+				<p>
+					<button type="button" class="swps-btn swps-btn-secondary" id="swps-ob-suggest"><?php esc_html_e( 'Suggest with AI', 'stratawp-seo' ); ?></button>
+					<button type="button" class="swps-btn swps-btn-grad" id="swps-ob-save-info"><?php esc_html_e( 'Save description', 'stratawp-seo' ); ?></button>
+				</p>
+				<p class="swps-ob-msg" id="swps-ob-info-msg" role="status"></p>
+			</div>
+			<a href="#" class="swps-ob-skip" data-step="site_info"><?php esc_html_e( 'Skip this step', 'stratawp-seo' ); ?></a>
+		</div>
+
+		<!-- Step 4: Audit -->
+		<div class="swps-ob-step swps-card<?php echo $swps_steps['audit'] ? ' is-done' : ''; ?>" data-step="audit">
+			<div class="swps-ob-step-head">
+				<span class="swps-ob-step-num">4</span>
+				<h2><?php esc_html_e( 'Run your first SEO audit', 'stratawp-seo' ); ?></h2>
+				<span class="swps-ob-step-check" aria-hidden="true">&#10003;</span>
+			</div>
+			<div class="swps-ob-step-body">
+				<p><?php esc_html_e( 'A full technical check of your site — titles, sitemaps, schema, performance signals, and more.', 'stratawp-seo' ); ?></p>
+				<p>
+					<button type="button" class="swps-btn swps-btn-grad" id="swps-ob-run-audit"><?php esc_html_e( 'Run audit', 'stratawp-seo' ); ?></button>
+					<span class="swps-ob-spinner" id="swps-ob-audit-spinner" aria-hidden="true"></span>
+				</p>
+				<p class="swps-ob-msg" id="swps-ob-audit-msg" role="status"></p>
+			</div>
+			<a href="#" class="swps-ob-skip" data-step="audit"><?php esc_html_e( 'Skip this step', 'stratawp-seo' ); ?></a>
+		</div>
+
+		<!-- Step 5: Preview post -->
+		<div class="swps-ob-step swps-card<?php echo $swps_steps['preview'] ? ' is-done' : ''; ?>" data-step="preview">
+			<div class="swps-ob-step-head">
+				<span class="swps-ob-step-num">5</span>
+				<h2><?php esc_html_e( 'Generate a preview post', 'stratawp-seo' ); ?></h2>
+				<span class="swps-ob-step-check" aria-hidden="true">&#10003;</span>
+			</div>
+			<div class="swps-ob-step-body">
+				<p><?php esc_html_e( 'See what the generator produces for your site. Leave the topic blank to let the AI pick one.', 'stratawp-seo' ); ?></p>
+				<div class="swps-ob-field-row">
+					<input type="text" id="swps-ob-topic" placeholder="<?php esc_attr_e( 'Optional topic', 'stratawp-seo' ); ?>" />
+					<button type="button" class="swps-btn swps-btn-grad" id="swps-ob-preview"><?php esc_html_e( 'Generate preview', 'stratawp-seo' ); ?></button>
+					<span class="swps-ob-spinner" id="swps-ob-preview-spinner" aria-hidden="true"></span>
+				</div>
+				<p class="swps-ob-cost-note"><?php esc_html_e( 'Uses your API key — one generation.', 'stratawp-seo' ); ?></p>
+				<p class="swps-ob-msg" id="swps-ob-preview-msg" role="status"></p>
+				<div class="swps-ob-preview-card" id="swps-ob-preview-card" hidden>
+					<h3 id="swps-ob-preview-title"></h3>
+					<p class="swps-ob-preview-meta" id="swps-ob-preview-meta"></p>
+					<div class="swps-ob-preview-content" id="swps-ob-preview-content"></div>
+				</div>
+			</div>
+			<a href="#" class="swps-ob-skip" data-step="preview"><?php esc_html_e( 'Skip this step', 'stratawp-seo' ); ?></a>
+		</div>
+
+	</div>
+</div>

--- a/tests/unit/OnboardingTest.php
+++ b/tests/unit/OnboardingTest.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Unit tests for SWPS_Onboarding pure static helpers.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-onboarding.php';
+
+/**
+ * Tests for SWPS_Onboarding::normalize_state() and SWPS_Onboarding::progress().
+ */
+class OnboardingTest extends TestCase {
+
+	// ---- normalize_state() ----
+
+	/**
+	 * Null / non-array raw value normalises to all-false steps, dismissed false.
+	 */
+	public function test_normalize_null_raw(): void {
+		$state = SWPS_Onboarding::normalize_state( null );
+
+		$this->assertSame( array( 'migrate', 'api_key', 'site_info', 'audit', 'preview' ), array_keys( $state['steps'] ) );
+		foreach ( $state['steps'] as $v ) {
+			$this->assertFalse( $v );
+		}
+		$this->assertFalse( $state['dismissed'] );
+	}
+
+	/**
+	 * Scalar raw value normalises cleanly (not an array).
+	 */
+	public function test_normalize_scalar_raw(): void {
+		$state = SWPS_Onboarding::normalize_state( 'garbage' );
+
+		foreach ( $state['steps'] as $v ) {
+			$this->assertFalse( $v );
+		}
+		$this->assertFalse( $state['dismissed'] );
+	}
+
+	/**
+	 * Unknown/extra keys inside the 'steps' sub-array are dropped silently.
+	 */
+	public function test_normalize_drops_unknown_step_keys(): void {
+		$raw = array(
+			'steps' => array(
+				'migrate'  => true,
+				'unknown'  => true,
+				'junk_key' => 1,
+			),
+		);
+
+		$state = SWPS_Onboarding::normalize_state( $raw );
+
+		$this->assertArrayNotHasKey( 'unknown', $state['steps'] );
+		$this->assertArrayNotHasKey( 'junk_key', $state['steps'] );
+	}
+
+	/**
+	 * Known step keys are preserved; missing ones default to false.
+	 */
+	public function test_normalize_known_steps_present_missing_false(): void {
+		$raw = array(
+			'steps' => array(
+				'migrate' => true,
+				'api_key' => 1,
+				// site_info, audit, preview absent.
+			),
+		);
+
+		$state = SWPS_Onboarding::normalize_state( $raw );
+
+		$this->assertTrue( $state['steps']['migrate'] );
+		$this->assertTrue( $state['steps']['api_key'] );
+		$this->assertFalse( $state['steps']['site_info'] );
+		$this->assertFalse( $state['steps']['audit'] );
+		$this->assertFalse( $state['steps']['preview'] );
+	}
+
+	/**
+	 * Truthy values (1, "yes", non-empty array) are cast to true.
+	 */
+	public function test_normalize_truthy_values_cast_to_bool_true(): void {
+		$raw = array(
+			'steps' => array(
+				'migrate'   => 1,
+				'api_key'   => 'yes',
+				'site_info' => array( 'x' ),
+			),
+		);
+
+		$state = SWPS_Onboarding::normalize_state( $raw );
+
+		$this->assertTrue( $state['steps']['migrate'] );
+		$this->assertTrue( $state['steps']['api_key'] );
+		$this->assertTrue( $state['steps']['site_info'] );
+	}
+
+	/**
+	 * Falsy values (0, '', null, false) remain false.
+	 */
+	public function test_normalize_falsy_values_cast_to_bool_false(): void {
+		$raw = array(
+			'steps' => array(
+				'migrate'   => 0,
+				'api_key'   => '',
+				'site_info' => null,
+				'audit'     => false,
+			),
+		);
+
+		$state = SWPS_Onboarding::normalize_state( $raw );
+
+		$this->assertFalse( $state['steps']['migrate'] );
+		$this->assertFalse( $state['steps']['api_key'] );
+		$this->assertFalse( $state['steps']['site_info'] );
+		$this->assertFalse( $state['steps']['audit'] );
+	}
+
+	/**
+	 * The 'dismissed' flag is cast from truthy input.
+	 */
+	public function test_normalize_dismissed_truthy(): void {
+		$state = SWPS_Onboarding::normalize_state( array( 'dismissed' => 1 ) );
+
+		$this->assertTrue( $state['dismissed'] );
+	}
+
+	/**
+	 * The 'dismissed' flag is false when absent.
+	 */
+	public function test_normalize_dismissed_absent(): void {
+		$state = SWPS_Onboarding::normalize_state( array() );
+
+		$this->assertFalse( $state['dismissed'] );
+	}
+
+	/**
+	 * Returned array always has exactly the two keys 'steps' and 'dismissed'.
+	 */
+	public function test_normalize_returns_expected_shape(): void {
+		$state = SWPS_Onboarding::normalize_state( array() );
+
+		$this->assertArrayHasKey( 'steps', $state );
+		$this->assertArrayHasKey( 'dismissed', $state );
+		$this->assertCount( 2, $state );
+	}
+
+	// ---- progress() ----
+
+	/**
+	 * All steps false → done = 0, next = 'migrate', complete = false.
+	 */
+	public function test_progress_all_false(): void {
+		$state = SWPS_Onboarding::normalize_state( array() );
+		$p     = SWPS_Onboarding::progress( $state );
+
+		$this->assertSame( 0, $p['done'] );
+		$this->assertSame( 5, $p['total'] );
+		$this->assertFalse( $p['complete'] );
+		$this->assertSame( 'migrate', $p['next'] );
+	}
+
+	/**
+	 * First step done → done = 1, next = 'api_key'.
+	 */
+	public function test_progress_first_step_done(): void {
+		$state = SWPS_Onboarding::normalize_state( array( 'steps' => array( 'migrate' => true ) ) );
+		$p     = SWPS_Onboarding::progress( $state );
+
+		$this->assertSame( 1, $p['done'] );
+		$this->assertSame( 'api_key', $p['next'] );
+		$this->assertFalse( $p['complete'] );
+	}
+
+	/**
+	 * Middle gap: migrate + audit done but api_key pending → next = 'api_key'.
+	 */
+	public function test_progress_next_is_first_incomplete_in_order(): void {
+		$state = SWPS_Onboarding::normalize_state(
+			array(
+				'steps' => array(
+					'migrate' => true,
+					'audit'   => true,
+					// api_key, site_info, preview pending.
+				),
+			)
+		);
+		$p = SWPS_Onboarding::progress( $state );
+
+		$this->assertSame( 2, $p['done'] );
+		$this->assertSame( 'api_key', $p['next'] );
+	}
+
+	/**
+	 * All steps true → complete = true, done = 5, next = null.
+	 */
+	public function test_progress_all_done(): void {
+		$steps = array_fill_keys( SWPS_Onboarding::STEPS, true );
+		$state = SWPS_Onboarding::normalize_state( array( 'steps' => $steps ) );
+		$p     = SWPS_Onboarding::progress( $state );
+
+		$this->assertSame( 5, $p['done'] );
+		$this->assertSame( 5, $p['total'] );
+		$this->assertTrue( $p['complete'] );
+		$this->assertNull( $p['next'] );
+	}
+
+	/**
+	 * Total is always the count of SWPS_Onboarding::STEPS.
+	 */
+	public function test_progress_total_matches_steps_constant(): void {
+		$state = SWPS_Onboarding::normalize_state( array() );
+		$p     = SWPS_Onboarding::progress( $state );
+
+		$this->assertSame( count( SWPS_Onboarding::STEPS ), $p['total'] );
+	}
+}


### PR DESCRIPTION
## Summary
- **Setup Wizard** page (StrataWP SEO → Setup Wizard) sequencing five steps, all skippable: (1) Yoast/Rank Math detection with per-source counts + deep link to the Migration page, (2) AI key validation — finally wires the existing-but-unused `test_key()` on every provider — saving provider + key exactly as Settings does, (3) AI-suggested site description from the site analyzer, (4) one-click audit run with results summary, (5) preview-post generation (rate-limit + budget aware, plain-text excerpt)
- **Activation redirect** on fresh installs only (`swps_onboarding_state` absence), guarded against AJAX/network-admin/bulk-activation/WP-CLI/capability
- **Dashboard setup checklist** ("Setup X/5 complete") until completed or dismissed; fails closed
- Final **win panel**: fixable audit issues → "Fix now", else generate-a-post, plus schema/llms.txt pointers
- All 8 AJAX endpoints nonce + `manage_options` guarded; state helpers unit-tested (14 new tests, suite at 131)
- Version 4.13.0

## Stacked on
feature/weekly-digest (#52) — merge that first; GitHub will retarget this PR to main.

## Review trail
Per-task spec + quality reviews and a final whole-branch security review; final fixes: preview excerpt is now plain text rendered via `textContent` (no AI-generated markup reaches the admin DOM, no mid-tag truncation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)