### PR TITLE
feat: AI referral attribution — crawl-to-click funnel reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.13.0-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.14.0-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1446,6 +1446,9 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.14.0 — June 2026
+- **New — AI referral attribution:** visits from ChatGPT, Perplexity, Claude, Gemini, Copilot and others are classified at capture, with an AI Referrals analytics tab (engine trends, landing posts, engagement vs organic), a per-post crawl-to-visit funnel joined to AI-bot crawl data, and a dashboard KPI tile.
 
 ### v4.13.0 — June 2026
 - **New — 5-minute onboarding wizard:** a guided first-run flow — migrate from Yoast/Rank Math, validate your AI key with a live test, AI-suggest your site description, run the audit, and generate a preview post — with a persistent setup checklist on the dashboard until complete.

--- a/admin/js/analytics.js
+++ b/admin/js/analytics.js
@@ -105,6 +105,121 @@
         });
     }
 
+    function loadAiReferrals() {
+        if (!$('#swps-ai-ref-engines-table').length) return;
+
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_analytics_ai_referrals',
+            nonce: swpsAdmin.nonce,
+            days: currentDays
+        }, function (res) {
+            if (!res.success) return;
+            var d = res.data;
+
+            // Summary tiles.
+            $('#swps-ai-ref-views').text(d.summary.total_views.toLocaleString());
+
+            var changeEl = $('#swps-ai-ref-change');
+            if (d.summary.delta_pct !== null) {
+                var up = d.summary.delta_pct >= 0;
+                changeEl.html('<span class="' + (up ? 'swps-change-up' : 'swps-change-down') + '">' +
+                    (up ? '↑' : '↓') + ' ' + Math.abs(d.summary.delta_pct) + '% vs prev period</span>');
+            } else {
+                changeEl.html('');
+            }
+
+            var engines = Object.keys(d.summary.by_source);
+            $('#swps-ai-ref-top-engine').text(engines.length ? engines[0] : '—');
+
+            // Views by engine.
+            var engineBody = $('#swps-ai-ref-engines-table tbody');
+            engineBody.empty();
+            if (!engines.length) {
+                engineBody.html('<tr><td colspan="2">No AI-referred views yet.</td></tr>');
+            } else {
+                engines.forEach(function (engine) {
+                    engineBody.append('<tr><td><code>' + escHtml(engine) + '</code></td>' +
+                        '<td style="text-align:right">' + d.summary.by_source[engine].toLocaleString() + '</td></tr>');
+                });
+            }
+
+            // Landing posts.
+            var landingBody = $('#swps-ai-ref-landing-table tbody');
+            landingBody.empty();
+            if (!d.landing_posts.length) {
+                landingBody.html('<tr><td colspan="6">No AI-referred visits yet.</td></tr>');
+            } else {
+                d.landing_posts.forEach(function (p) {
+                    var title = p.url
+                        ? '<a href="' + p.url + '" target="_blank">' + escHtml(p.title) + '</a>'
+                        : escHtml(p.title);
+                    landingBody.append('<tr><td>' + title + '</td>' +
+                        '<td style="text-align:right">' + p.views.toLocaleString() + '</td>' +
+                        '<td style="text-align:right">' + formatSeconds(p.avg_time) + '</td>' +
+                        '<td style="text-align:right">' + p.avg_scroll + '%</td>' +
+                        '<td style="text-align:right">' + p.bounce_rate + '%</td>' +
+                        '<td><code>' + escHtml(p.ai_sources || '') + '</code></td></tr>');
+                });
+            }
+
+            // Engagement panel.
+            var engEl = $('#swps-ai-ref-engagement');
+            if (!d.engagement) {
+                engEl.html('<p style="margin:0;color:var(--swps-text-muted)">Not enough data yet — engagement comparison needs at least 30 AI-referred views and 30 organic views in this period.</p>');
+            } else {
+                var e = d.engagement;
+                var html = '<table class="widefat striped" style="margin-top:4px"><thead><tr>' +
+                    '<th></th><th style="text-align:right">AI-referred</th><th style="text-align:right">Organic</th><th style="text-align:right">Ratio</th></tr></thead><tbody>';
+                html += '<tr><td>Avg time on page</td><td style="text-align:right">' + formatSeconds(e.ai.avg_time) + '</td>' +
+                    '<td style="text-align:right">' + formatSeconds(e.organic.avg_time) + '</td>' +
+                    '<td style="text-align:right">' + e.time_ratio.toFixed(2) + '×</td></tr>';
+                html += '<tr><td>Avg scroll depth</td><td style="text-align:right">' + e.ai.avg_scroll + '%</td>' +
+                    '<td style="text-align:right">' + e.organic.avg_scroll + '%</td>' +
+                    '<td style="text-align:right">' + e.scroll_ratio.toFixed(2) + '×</td></tr>';
+                html += '<tr><td>Bounce rate</td><td style="text-align:right">' + e.ai.bounce_rate + '%</td>' +
+                    '<td style="text-align:right">' + e.organic.bounce_rate + '%</td>' +
+                    '<td style="text-align:right">' + e.bounce_ratio.toFixed(2) + '×</td></tr>';
+                html += '</tbody></table>';
+                html += '<p style="color:var(--swps-text-muted);font-size:11px;margin:8px 0 0">Based on ' +
+                    e.ai_n.toLocaleString() + ' AI-referred views and ' + e.organic_n.toLocaleString() + ' organic views.</p>';
+                engEl.html(html);
+            }
+
+            // Funnel.
+            var funnelBody = $('#swps-ai-ref-funnel-table tbody');
+            funnelBody.empty();
+            if (!d.funnel.rows.length) {
+                funnelBody.html('<tr><td colspan="4">No AI crawl data for this period.</td></tr>');
+            } else {
+                d.funnel.rows.forEach(function (r) {
+                    var title = r.edit_link
+                        ? '<a href="' + r.edit_link + '">' + escHtml(r.title) + '</a>'
+                        : escHtml(r.title);
+                    funnelBody.append('<tr><td>' + title + '</td>' +
+                        '<td><code>' + escHtml(r.ai_source) + '</code></td>' +
+                        '<td style="text-align:right">' + r.crawls.toLocaleString() + '</td>' +
+                        '<td style="text-align:right">' + r.visits.toLocaleString() + '</td></tr>');
+                });
+            }
+
+            // Crawled but no AI visits.
+            var noVisitsBody = $('#swps-ai-ref-novisits-table tbody');
+            noVisitsBody.empty();
+            if (!d.funnel.crawled_no_visits.length) {
+                noVisitsBody.html('<tr><td colspan="3">None — every crawled post has AI-referred visits.</td></tr>');
+            } else {
+                d.funnel.crawled_no_visits.forEach(function (r) {
+                    var title = r.edit_link
+                        ? '<a href="' + r.edit_link + '">' + escHtml(r.title) + '</a>'
+                        : escHtml(r.title);
+                    noVisitsBody.append('<tr><td>' + title + '</td>' +
+                        '<td><code>' + escHtml(r.ai_source) + '</code></td>' +
+                        '<td style="text-align:right">' + r.crawls.toLocaleString() + '</td></tr>');
+                });
+            }
+        });
+    }
+
     // --- Chart.js Chart ---
 
     var chartInstance = null;
@@ -259,6 +374,7 @@
         if ($('.swps-analytics-wrap').length) {
             loadOverview();
             loadTopPages();
+            loadAiReferrals();
 
             if ($('#swps-top-queries-table').length) {
                 loadTopQueries();
@@ -271,6 +387,7 @@
                 currentDays = parseInt($(this).data('days'));
                 loadOverview();
                 loadTopPages();
+                loadAiReferrals();
                 if ($('#swps-top-queries-table').length) loadTopQueries();
             });
 

--- a/docs/superpowers/plans/2026-06-10-ai-referral-attribution.md
+++ b/docs/superpowers/plans/2026-06-10-ai-referral-attribution.md
@@ -1,0 +1,102 @@
+# AI Referral Attribution (Crawl-to-Click Funnel) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Classify visit referrers into AI sources at insert time (the tracker already captures referrers and never reads them), persist per-source daily rollups, and report: AI-referred views by engine over time, landing posts, engagement vs organic (low-sample suppressed), a per-post crawl→visit funnel joining `swps_bot_hits_daily`, a dashboard KPI tile, and a crawled-but-no-AI-visits list.
+
+**Architecture:** New class `SWPS_AI_Referrals` owns the classifier (pure static core for TDD + filterable domain map), the bot_key→ai_source map, the daily-rollup SQL (called from the tracker's existing aggregation cron), and all reporting queries. `SWPS_Analytics_Tracker` gets two surgical touches: an `ai_source VARCHAR(32)` column (dbDelta handles column adds on activation; also add a one-time `maybe_upgrade_schema` for existing installs) and one classify call in `ajax_track()`. The new rollup table stores SUMS (total_time, total_scroll) not averages — averages computed at read time — deliberately avoiding the daily table's `(avg+new)/2` compounding bug. UI: new "AI Referrals" tab in the analytics dashboard + dashboard KPI tile.
+
+**Branch:** `feature/ai-referral-attribution`, stacked on `feature/onboarding-wizard`. Version → 4.14.0. PR base: previous branch (or main if its PR merged).
+
+**Conventions:** as previous plans (no autoloader, <500 lines, tabs/WPCS, nonce+cap on new AJAX, no Co-Authored-By, version bump + changelogs last, never push/PR — controller does).
+
+---
+
+## Verified facts (HEAD 21a339c)
+
+- Raw table `swps_analytics` (class-analytics-tracker.php:43): id, post_id, page_url, referrer VARCHAR(500), time_on_page, scroll_depth, is_bounce, created_at; `ajax_track()` (:138) inserts with `'referrer' => esc_url_raw( $_POST['referrer'] ?? '' )`.
+- Daily table `swps_analytics_daily` UNIQUE (post_id, date) — DO NOT TOUCH its key. Its ON DUPLICATE averaging `(avg + VALUES(avg)) / 2` is a known bug — do not replicate.
+- `aggregate_and_prune()` (:195): rolls raw → daily for rows `created_at < -7 days`, then DELETES those raw rows, then prunes daily past `swps_analytics_retention` (90d). The AI rollup MUST run inside this method BEFORE the raw delete.
+- Tracker JS nonce action `swps_track`; tracker disabled for admins by default.
+- Bot rollup `swps_bot_hits_daily` UNIQUE (bot_key, post_id, date) with a `hits` count (verify the count column name by reading the CREATE TABLE at class-bot-analytics-tracker.php:63-73). Bot keys from `SWPS_AI_Bots::get_bots()` (class-ai-bots.php:19+) — read the full list; relevant: gptbot, oai_searchbot?, chatgpt_user?, claudebot, claude_web?, anthropic_ai?, perplexitybot, perplexity_user?, google_extended, copilot? (use EXACT keys found).
+- Analytics dashboard AJAX pattern: `wp_ajax_swps_analytics_overview/top_pages/top_queries/post_stats` in class-analytics-dashboard.php (:25-28); read one handler fully (nonce action, response shape) + templates/analytics-page.php tab markup + admin/js JS file driving it before adding the tab.
+- Dashboard tiles: `safe_get_*` in class-dashboard.php + `$data[...]` in templates/dashboard-page.php.
+- `SWPS_Hooks` has a `filter_analytics_track`/`swps_analytics_track` filter applied in the insert path (verify name/signature at class-hooks.php:~263) — classification happens directly in ajax_track, not via the filter (simpler, always-on), but keep the filter untouched.
+- Activation table creation: `SWPS_Analytics_Tracker::create_tables()` is static, called from activation (verify where).
+
+---
+
+### Task 0: Branch check + baseline
+`git branch --show-current` → feature/ai-referral-attribution; `vendor/bin/phpunit` → 131.
+
+### Task 1: Classifier (TDD)
+Create `includes/class-ai-referrals.php` + `tests/unit/AiReferralsTest.php`. Pure static core:
+
+```php
+	/**
+	 * Default referrer-host → AI source map. Subdomains match via suffix.
+	 *
+	 * @var array<string, string>
+	 */
+	private const SOURCE_MAP = array(
+		'chatgpt.com'           => 'chatgpt',
+		'chat.openai.com'       => 'chatgpt',
+		'perplexity.ai'         => 'perplexity',
+		'claude.ai'             => 'claude',
+		'gemini.google.com'     => 'gemini',
+		'copilot.microsoft.com' => 'copilot',
+		'you.com'               => 'you',
+		'chat.deepseek.com'     => 'deepseek',
+		'grok.com'              => 'grok',
+		'meta.ai'               => 'meta',
+	);
+
+	/**
+	 * Classify a visit into an AI source.
+	 *
+	 * @param string $referrer Full referrer URL ('' when none).
+	 * @param string $page_url Landing URL (utm_source fallback).
+	 * @param array<string, string>|null $map Override map (null = default).
+	 * @return string Source key or '' when not AI-referred.
+	 */
+	public static function classify( string $referrer, string $page_url = '', ?array $map = null ): string
+```
+
+Rules (write tests FIRST): host match exact or `.host` suffix (www.chatgpt.com → chatgpt; notchatgpt.com → ''); case-insensitive; invalid/empty referrer → check page_url `utm_source` (chatgpt.com→chatgpt, perplexity.ai→perplexity, plus bare values matching a map host or source value); neither → ''. Runtime wrapper `classify_visit()` applies `apply_filters( 'swps_ai_referral_sources', self::SOURCE_MAP )` then calls classify (filter only in the wrapper so the core stays WP-free).
+Also pure + tested: `bot_source_map()` returning bot_key→ai_source for the EXACT keys in SWPS_AI_Bots (gptbot→chatgpt etc.; google_extended→gemini; bots with no visit-side counterpart omitted), and `engagement_comparison( array $ai, array $organic, int $min_n = 30 ): ?array` returning null when either sample < min_n else ratio metrics (time, scroll, bounce) — pure math, tested.
+Commit: `feat: AI referral classifier and maps`
+
+### Task 2: Capture + rollup
+- Tracker schema: add `ai_source VARCHAR(32) NOT NULL DEFAULT ''` + `KEY idx_ai_source (ai_source)` to the raw CREATE TABLE (dbDelta adds columns/keys); ALSO call `create_tables()` (or a slim `maybe_upgrade()`) from an `upgrader_process_complete`/version-check path — find how the plugin handles schema upgrades on plugin update (`grep -n "dbDelta\|db_version\|maybe_upgrade" stratawp-seo.php includes/*.php | head`); follow precedent; if none exists, add a `swps_db_version` option check on admin_init that re-runs create_tables once.
+- New rollup table (in SWPS_AI_Referrals::create_table, called alongside the tracker's): `swps_ai_referrals_daily`: id, ai_source VARCHAR(32), post_id, date, views INT, total_time INT UNSIGNED, total_scroll INT UNSIGNED, bounces INT, UNIQUE KEY idx_source_post_date (ai_source, post_id, date). SUMS not averages.
+- ajax_track: `$ai_source = SWPS_AI_Referrals::classify_visit( $referrer, $page_url );` added to the insert columns.
+- Rollup inside aggregate_and_prune BEFORE the raw delete (delegate: `SWPS_AI_Referrals::aggregate( $cutoff )`): INSERT…SELECT from raw WHERE ai_source <> '' AND created_at < cutoff GROUP BY ai_source, post_id, DATE; ON DUPLICATE: views=views+VALUES, total_time=total_time+VALUES, total_scroll=total_scroll+VALUES, bounces=bounces+VALUES (additive — correct, unlike the daily table). Prune with the same retention option.
+- Uninstall: add the new table to uninstall.php's table list (read its pattern).
+Commit: `feat: capture and roll up AI referral sources`
+
+### Task 3: Reporting queries + AJAX + UI
+In SWPS_AI_Referrals (reporting methods combine raw last-7-days + rollup, mirroring how the tracker's existing readers combine raw+daily — read get_post_views/:254 area first):
+- `get_summary( int $days )`: views by ai_source by date (chartable), totals + previous-period delta.
+- `get_landing_posts( int $days, int $limit = 10 )`: per post: views, avg time (total_time/views), avg scroll, bounce rate, ai_sources.
+- `get_engagement_vs_organic( int $days )`: AI aggregate vs non-AI aggregate from the same tables → engagement_comparison() (null ⇒ UI shows "not enough data yet").
+- `get_funnel( int $days, int $limit = 20 )`: join bot crawls to visits per post: from swps_bot_hits_daily sum hits per (post_id, mapped ai_source) via bot_source_map(), LEFT JOIN rollup sums; output rows: post, source, crawls, visits — plus `crawled_no_visits` list (crawls>0, visits=0, ordered by crawls desc). Batched single queries, no N+1.
+- AJAX `wp_ajax_swps_analytics_ai_referrals` in class-analytics-dashboard.php following its siblings exactly (same nonce/cap pattern), delegating to these methods. Wording everywhere: views/visits, never sessions; the funnel labeled "correlation, not causation" in the UI copy.
+- templates/analytics-page.php + its JS: new "AI Referrals" tab matching the existing tabs (read the markup/JS pattern first): summary chart or table, landing posts table, engagement panel (or the low-sample message), funnel table + crawled-but-no-visits list with edit links.
+- Dashboard tile: `safe_get_ai_referrals()` (30d views + prev-period delta from get_summary) + tile after the autopilot tile in dashboard-page.php (trend arrow pattern like posts_30d).
+Commit: `feat: AI referrals analytics tab, funnel, and dashboard tile`
+
+### Task 4: Wiring + release
+require_once class-ai-referrals.php; instantiate if it has hooks (create_table call wired wherever tracker's create_tables runs — activation + upgrade path); phpunit/phpstan(2G)/phpcs gates; version 4.14.0 + changelogs:
+```
+= 4.14.0 =
+* New: AI referral attribution — visits from ChatGPT, Perplexity, Claude, Gemini, Copilot and others are classified at capture, with an AI Referrals analytics tab (engine trends, landing posts, engagement vs organic), a per-post crawl-to-visit funnel joined to AI-bot crawl data, and a dashboard KPI tile.
+```
+Commits: `chore: release 4.14.0 — AI referral attribution` + `docs: implementation plan for AI referral attribution`. No push/PR.
+
+## Self-review
+1. Raw insert always sets ai_source (default '' for non-AI)?
+2. Rollup additive sums only; runs BEFORE raw delete; pruned by retention?
+3. Existing installs get the new column + table without re-activation?
+4. Low-sample suppression actually reachable (n<30 → message, not bogus ratios)?
+5. No N+1 in funnel/landing queries?
+6. Copy: views/visits; funnel labeled correlation.

--- a/includes/class-ai-referrals-report.php
+++ b/includes/class-ai-referrals-report.php
@@ -59,6 +59,7 @@ class SWPS_AI_Referrals_Report {
 			),
 			ARRAY_A
 		);
+		$rows = $rows ? $rows : array();
         // phpcs:enable
 
 		$daily       = array();
@@ -143,6 +144,7 @@ class SWPS_AI_Referrals_Report {
 			),
 			ARRAY_A
 		);
+		$rows = $rows ? $rows : array();
         // phpcs:enable
 
 		$out = array();
@@ -329,7 +331,7 @@ class SWPS_AI_Referrals_Report {
 
 		// Map crawls to (source, post_id), skipping bots with no visit-side counterpart.
 		$crawls = array();
-		foreach ( $crawl_rows as $row ) {
+		foreach ( $crawl_rows ? $crawl_rows : array() as $row ) {
 			$source = $bot_map[ $row['bot_key'] ] ?? '';
 			if ( '' === $source ) {
 				continue;
@@ -340,7 +342,7 @@ class SWPS_AI_Referrals_Report {
 		}
 
 		$visits = array();
-		foreach ( $visit_rows as $row ) {
+		foreach ( $visit_rows ? $visit_rows : array() as $row ) {
 			$visits[ $row['ai_source'] . '|' . $row['post_id'] ] = (int) $row['views'];
 		}
 

--- a/includes/class-ai-referrals-report.php
+++ b/includes/class-ai-referrals-report.php
@@ -1,0 +1,380 @@
+<?php
+/**
+ * AI Referral Attribution — reporting queries.
+ *
+ * Read-side companion to SWPS_AI_Referrals. Every reader combines the raw
+ * analytics table's last-7-days rows (not yet rolled up) with the
+ * swps_ai_referrals_daily rollup via UNION ALL, mirroring how
+ * SWPS_Analytics_Tracker::get_daily_stats() combines raw + daily.
+ *
+ * Averages are always computed at read time from summed totals
+ * (total_time / views), never stored — avoiding the daily table's
+ * compounding-average bug.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Reporting queries for AI referral attribution: per-engine summary,
+ * landing posts, engagement vs organic, and the crawl-to-visit funnel.
+ */
+class SWPS_AI_Referrals_Report {
+
+	/**
+	 * Per-source daily views over a period, with totals and a
+	 * previous-period delta.
+	 *
+	 * @param int $days Number of days to look back.
+	 * @return array{daily: array, by_source: array, total_views: int, prev_views: int, delta_pct: float|null}
+	 */
+	public static function get_summary( int $days ): array {
+		global $wpdb;
+
+		$raw        = $wpdb->prefix . 'swps_analytics';
+		$rollup     = $wpdb->prefix . 'swps_ai_referrals_daily';
+		$since      = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+		$prev_since = gmdate( 'Y-m-d', strtotime( '-' . ( $days * 2 ) . ' days' ) );
+
+		// One query covers both periods; split in PHP.
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT date, ai_source, SUM(views) AS views FROM (
+                     SELECT DATE(created_at) AS date, ai_source, 1 AS views
+                     FROM {$raw}
+                     WHERE ai_source <> '' AND DATE(created_at) >= %s
+                     UNION ALL
+                     SELECT date, ai_source, views
+                     FROM {$rollup}
+                     WHERE date >= %s
+                 ) c
+                 GROUP BY date, ai_source
+                 ORDER BY date ASC",
+				$prev_since,
+				$prev_since
+			),
+			ARRAY_A
+		);
+        // phpcs:enable
+
+		$daily       = array();
+		$by_source   = array();
+		$total_views = 0;
+		$prev_views  = 0;
+
+		foreach ( $rows as $row ) {
+			$views = (int) $row['views'];
+
+			if ( $row['date'] >= $since ) {
+				$daily[]      = array(
+					'date'      => $row['date'],
+					'ai_source' => $row['ai_source'],
+					'views'     => $views,
+				);
+				$total_views += $views;
+
+				if ( ! isset( $by_source[ $row['ai_source'] ] ) ) {
+					$by_source[ $row['ai_source'] ] = 0;
+				}
+				$by_source[ $row['ai_source'] ] += $views;
+			} else {
+				$prev_views += $views;
+			}
+		}
+
+		arsort( $by_source );
+
+		return array(
+			'daily'       => $daily,
+			'by_source'   => $by_source,
+			'total_views' => $total_views,
+			'prev_views'  => $prev_views,
+			'delta_pct'   => $prev_views > 0
+				? round( ( ( $total_views - $prev_views ) / $prev_views ) * 100, 1 )
+				: null,
+		);
+	}
+
+	/**
+	 * Top landing posts for AI-referred visits.
+	 *
+	 * Averages computed at read time from summed totals.
+	 *
+	 * @param int $days  Number of days to look back.
+	 * @param int $limit Max posts.
+	 * @return array<int, array> Rows: post_id, views, avg_time, avg_scroll, bounce_rate, ai_sources.
+	 */
+	public static function get_landing_posts( int $days, int $limit = 10 ): array {
+		global $wpdb;
+
+		$raw    = $wpdb->prefix . 'swps_analytics';
+		$rollup = $wpdb->prefix . 'swps_ai_referrals_daily';
+		$since  = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_id,
+                        SUM(views) AS views,
+                        SUM(total_time) AS total_time,
+                        SUM(total_scroll) AS total_scroll,
+                        SUM(bounces) AS bounces,
+                        GROUP_CONCAT(DISTINCT ai_source ORDER BY ai_source) AS ai_sources
+                 FROM (
+                     SELECT post_id, ai_source, 1 AS views, time_on_page AS total_time,
+                            scroll_depth AS total_scroll, is_bounce AS bounces
+                     FROM {$raw}
+                     WHERE ai_source <> '' AND DATE(created_at) >= %s AND post_id > 0
+                     UNION ALL
+                     SELECT post_id, ai_source, views, total_time, total_scroll, bounces
+                     FROM {$rollup}
+                     WHERE date >= %s AND post_id > 0
+                 ) c
+                 GROUP BY post_id
+                 ORDER BY views DESC
+                 LIMIT %d",
+				$since,
+				$since,
+				$limit
+			),
+			ARRAY_A
+		);
+        // phpcs:enable
+
+		$out = array();
+
+		foreach ( $rows as $row ) {
+			$views = (int) $row['views'];
+			$out[] = array(
+				'post_id'     => (int) $row['post_id'],
+				'views'       => $views,
+				'avg_time'    => $views > 0 ? (int) round( $row['total_time'] / $views ) : 0,
+				'avg_scroll'  => $views > 0 ? (int) round( $row['total_scroll'] / $views ) : 0,
+				'bounce_rate' => $views > 0 ? (int) round( ( $row['bounces'] / $views ) * 100 ) : 0,
+				'ai_sources'  => $row['ai_sources'],
+			);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * AI vs organic engagement comparison over a period.
+	 *
+	 * AI aggregate comes from raw + the AI rollup (exact sums). The all-traffic
+	 * aggregate comes from raw + the analytics daily table (daily stores
+	 * per-day averages, so its time/scroll contributions are weighted by views
+	 * — an approximation). Organic = all − AI.
+	 *
+	 * @param int $days  Number of days to look back.
+	 * @param int $min_n Minimum sample size per group.
+	 * @return array|null Ratio metrics, or null when either sample is too small.
+	 */
+	public static function get_engagement_vs_organic( int $days, int $min_n = 30 ): ?array {
+		global $wpdb;
+
+		$raw    = $wpdb->prefix . 'swps_analytics';
+		$rollup = $wpdb->prefix . 'swps_ai_referrals_daily';
+		$daily  = $wpdb->prefix . 'swps_analytics_daily';
+		$since  = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$ai = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT SUM(views) AS views, SUM(total_time) AS total_time,
+                        SUM(total_scroll) AS total_scroll, SUM(bounces) AS bounces
+                 FROM (
+                     SELECT 1 AS views, time_on_page AS total_time,
+                            scroll_depth AS total_scroll, is_bounce AS bounces
+                     FROM {$raw}
+                     WHERE ai_source <> '' AND DATE(created_at) >= %s
+                     UNION ALL
+                     SELECT views, total_time, total_scroll, bounces
+                     FROM {$rollup}
+                     WHERE date >= %s
+                 ) c",
+				$since,
+				$since
+			),
+			ARRAY_A
+		);
+
+		$all = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT SUM(views) AS views, SUM(total_time) AS total_time,
+                        SUM(total_scroll) AS total_scroll, SUM(bounces) AS bounces
+                 FROM (
+                     SELECT 1 AS views, time_on_page AS total_time,
+                            scroll_depth AS total_scroll, is_bounce AS bounces
+                     FROM {$raw}
+                     WHERE DATE(created_at) >= %s
+                     UNION ALL
+                     SELECT views, views * avg_time_on_page AS total_time,
+                            views * avg_scroll_depth AS total_scroll, bounces
+                     FROM {$daily}
+                     WHERE date >= %s
+                 ) c",
+				$since,
+				$since
+			),
+			ARRAY_A
+		);
+        // phpcs:enable
+
+		$ai_views  = (int) ( $ai['views'] ?? 0 );
+		$all_views = (int) ( $all['views'] ?? 0 );
+		$org_views = max( 0, $all_views - $ai_views );
+
+		$org_time   = max( 0, (int) ( $all['total_time'] ?? 0 ) - (int) ( $ai['total_time'] ?? 0 ) );
+		$org_scroll = max( 0, (int) ( $all['total_scroll'] ?? 0 ) - (int) ( $ai['total_scroll'] ?? 0 ) );
+		$org_bounce = max( 0, (int) ( $all['bounces'] ?? 0 ) - (int) ( $ai['bounces'] ?? 0 ) );
+
+		$ai_agg = array(
+			'views'       => $ai_views,
+			'avg_time'    => $ai_views > 0 ? $ai['total_time'] / $ai_views : 0,
+			'avg_scroll'  => $ai_views > 0 ? $ai['total_scroll'] / $ai_views : 0,
+			'bounce_rate' => $ai_views > 0 ? $ai['bounces'] / $ai_views : 0,
+		);
+
+		$org_agg = array(
+			'views'       => $org_views,
+			'avg_time'    => $org_views > 0 ? $org_time / $org_views : 0,
+			'avg_scroll'  => $org_views > 0 ? $org_scroll / $org_views : 0,
+			'bounce_rate' => $org_views > 0 ? $org_bounce / $org_views : 0,
+		);
+
+		$comparison = SWPS_AI_Referrals::engagement_comparison( $ai_agg, $org_agg, $min_n );
+
+		if ( null === $comparison ) {
+			return null;
+		}
+
+		// Add display-friendly absolutes alongside the ratios.
+		$comparison['ai']      = array(
+			'avg_time'    => (int) round( $ai_agg['avg_time'] ),
+			'avg_scroll'  => (int) round( $ai_agg['avg_scroll'] ),
+			'bounce_rate' => (int) round( $ai_agg['bounce_rate'] * 100 ),
+		);
+		$comparison['organic'] = array(
+			'avg_time'    => (int) round( $org_agg['avg_time'] ),
+			'avg_scroll'  => (int) round( $org_agg['avg_scroll'] ),
+			'bounce_rate' => (int) round( $org_agg['bounce_rate'] * 100 ),
+		);
+
+		return $comparison;
+	}
+
+	/**
+	 * Crawl-to-visit funnel: AI bot crawls joined to AI-referred visits per
+	 * post and source. Two batched queries joined in PHP — no N+1.
+	 *
+	 * @param int $days  Number of days to look back.
+	 * @param int $limit Max funnel rows.
+	 * @return array{rows: array, crawled_no_visits: array}
+	 */
+	public static function get_funnel( int $days, int $limit = 20 ): array {
+		global $wpdb;
+
+		$bot_raw   = $wpdb->prefix . 'swps_bot_hits';
+		$bot_daily = $wpdb->prefix . 'swps_bot_hits_daily';
+		$raw       = $wpdb->prefix . 'swps_analytics';
+		$rollup    = $wpdb->prefix . 'swps_ai_referrals_daily';
+		$since     = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+		$bot_map = SWPS_AI_Referrals::bot_source_map();
+
+		// Query 1: crawls per (bot_key, post_id) — raw + daily, like the bot tracker readers.
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$crawl_rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT bot_key, post_id, SUM(hits) AS hits FROM (
+                     SELECT bot_key, post_id, 1 AS hits
+                     FROM {$bot_raw}
+                     WHERE DATE(created_at) >= %s AND post_id > 0
+                     UNION ALL
+                     SELECT bot_key, post_id, hits
+                     FROM {$bot_daily}
+                     WHERE date >= %s AND post_id > 0
+                 ) c
+                 GROUP BY bot_key, post_id",
+				$since,
+				$since
+			),
+			ARRAY_A
+		);
+
+		// Query 2: AI-referred visits per (ai_source, post_id) — raw + rollup.
+		$visit_rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ai_source, post_id, SUM(views) AS views FROM (
+                     SELECT ai_source, post_id, 1 AS views
+                     FROM {$raw}
+                     WHERE ai_source <> '' AND DATE(created_at) >= %s AND post_id > 0
+                     UNION ALL
+                     SELECT ai_source, post_id, views
+                     FROM {$rollup}
+                     WHERE date >= %s AND post_id > 0
+                 ) c
+                 GROUP BY ai_source, post_id",
+				$since,
+				$since
+			),
+			ARRAY_A
+		);
+        // phpcs:enable
+
+		// Map crawls to (source, post_id), skipping bots with no visit-side counterpart.
+		$crawls = array();
+		foreach ( $crawl_rows as $row ) {
+			$source = $bot_map[ $row['bot_key'] ] ?? '';
+			if ( '' === $source ) {
+				continue;
+			}
+			$key = $source . '|' . $row['post_id'];
+
+			$crawls[ $key ] = ( $crawls[ $key ] ?? 0 ) + (int) $row['hits'];
+		}
+
+		$visits = array();
+		foreach ( $visit_rows as $row ) {
+			$visits[ $row['ai_source'] . '|' . $row['post_id'] ] = (int) $row['views'];
+		}
+
+		$rows = array();
+		foreach ( $crawls as $key => $crawl_count ) {
+			list( $source, $post_id ) = explode( '|', $key, 2 );
+
+			$rows[] = array(
+				'post_id'   => (int) $post_id,
+				'ai_source' => $source,
+				'crawls'    => $crawl_count,
+				'visits'    => $visits[ $key ] ?? 0,
+			);
+		}
+
+		usort(
+			$rows,
+			static function ( array $a, array $b ): int {
+				return $b['crawls'] <=> $a['crawls'];
+			}
+		);
+
+		$crawled_no_visits = array_values(
+			array_filter(
+				$rows,
+				static function ( array $row ): bool {
+					return 0 === $row['visits'];
+				}
+			)
+		);
+
+		return array(
+			'rows'              => array_slice( $rows, 0, $limit ),
+			'crawled_no_visits' => array_slice( $crawled_no_visits, 0, $limit ),
+		);
+	}
+}

--- a/includes/class-ai-referrals.php
+++ b/includes/class-ai-referrals.php
@@ -1,0 +1,371 @@
+<?php
+/**
+ * AI Referral Attribution — classifier, bot-source map, engagement comparison,
+ * daily rollup table, and aggregation.
+ *
+ * Pure static core (classify, bot_source_map, engagement_comparison) is
+ * WordPress-free so it can be unit-tested without a WP bootstrap.
+ *
+ * The runtime wrapper classify_visit() applies the swps_ai_referral_sources
+ * filter so site owners can extend the default source map.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * AI Referral Attribution — classifier, bot-source map, engagement comparison,
+ * daily rollup table, and aggregation methods.
+ */
+class SWPS_AI_Referrals {
+
+	// -------------------------------------------------------------------------
+	// Constants
+	// -------------------------------------------------------------------------
+
+	/** Schema version — bump when the rollup table DDL changes. */
+	public const DB_VERSION = '1';
+
+	/** Option key used to gate the schema upgrade. */
+	public const OPT_DB_VER = 'swps_ai_referrals_db_version';
+
+	/** Rollup table (without $wpdb->prefix). */
+	private const ROLLUP_TABLE = 'swps_ai_referrals_daily';
+
+	// -------------------------------------------------------------------------
+	// Classifier core — WP-free
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Default referrer-host → AI source map. Subdomains match via suffix.
+	 *
+	 * @var array<string, string>
+	 */
+	private const SOURCE_MAP = array(
+		'chatgpt.com'           => 'chatgpt',
+		'chat.openai.com'       => 'chatgpt',
+		'perplexity.ai'         => 'perplexity',
+		'claude.ai'             => 'claude',
+		'gemini.google.com'     => 'gemini',
+		'copilot.microsoft.com' => 'copilot',
+		'you.com'               => 'you',
+		'chat.deepseek.com'     => 'deepseek',
+		'grok.com'              => 'grok',
+		'meta.ai'               => 'meta',
+	);
+
+	/**
+	 * Classify a visit into an AI source.
+	 *
+	 * Matching rules (in priority order):
+	 * 1. referrer host exact-match or `.host` suffix match (case-insensitive).
+	 * 2. page_url utm_source fallback: value matches a map key (host) or a map
+	 *    value (source slug), case-insensitive.
+	 * 3. Returns '' when neither matches.
+	 *
+	 * @param string                     $referrer  Full referrer URL ('' when none).
+	 * @param string                     $page_url  Landing URL (utm_source fallback).
+	 * @param array<string, string>|null $map       Override map (null = default).
+	 * @return string Source key, or '' when not AI-referred.
+	 */
+	public static function classify( string $referrer, string $page_url = '', ?array $map = null ): string {
+		$map = $map ?? self::SOURCE_MAP;
+
+		// 1. Referrer host match.
+		if ( '' !== $referrer ) {
+			$host = self::parse_host( $referrer );
+
+			if ( '' !== $host ) {
+				$source = self::match_host( $host, $map );
+
+				if ( '' !== $source ) {
+					return $source;
+				}
+			}
+		}
+
+		// 2. utm_source fallback from page_url.
+		if ( '' !== $page_url ) {
+			$utm = self::extract_utm_source( $page_url );
+
+			if ( '' !== $utm ) {
+				return self::match_utm( $utm, $map );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Runtime wrapper: applies the swps_ai_referral_sources filter before classifying.
+	 *
+	 * @param string $referrer Full referrer URL.
+	 * @param string $page_url Landing page URL.
+	 * @return string Source key, or '' when not AI-referred.
+	 */
+	public static function classify_visit( string $referrer, string $page_url = '' ): string {
+		$map = (array) apply_filters( 'swps_ai_referral_sources', self::SOURCE_MAP );
+
+		return self::classify( $referrer, $page_url, $map );
+	}
+
+	// -------------------------------------------------------------------------
+	// Bot → AI source map
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Return a map of bot_key → ai_source for bot keys from SWPS_AI_Bots that
+	 * have a visit-side counterpart in the source map.
+	 *
+	 * Bots with no visit-side counterpart (applebot_extended, ccbot, bytespider,
+	 * amazonbot, duckassistbot) are omitted intentionally.
+	 *
+	 * @return array<string, string> bot_key → ai_source.
+	 */
+	public static function bot_source_map(): array {
+		return array(
+			'gptbot'             => 'chatgpt',
+			'oai_searchbot'      => 'chatgpt',
+			'chatgpt_user'       => 'chatgpt',
+			'claudebot'          => 'claude',
+			'claude_web'         => 'claude',
+			'anthropic_ai'       => 'claude',
+			'perplexitybot'      => 'perplexity',
+			'perplexity_user'    => 'perplexity',
+			'google_extended'    => 'gemini',
+			'meta_externalagent' => 'meta',
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Engagement comparison — pure math, WP-free
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Compare AI-referred engagement against organic.
+	 *
+	 * Returns null when either sample is below the minimum threshold to prevent
+	 * misleading ratios from sparse data.
+	 *
+	 * @param array{views: int, avg_time: float, avg_scroll: float, bounce_rate: float} $ai      AI aggregate metrics.
+	 * @param array{views: int, avg_time: float, avg_scroll: float, bounce_rate: float} $organic Organic aggregate metrics.
+	 * @param int                                                                       $min_n   Minimum sample size per group.
+	 * @return array{time_ratio: float, scroll_ratio: float, bounce_ratio: float, ai_n: int, organic_n: int}|null
+	 */
+	public static function engagement_comparison( array $ai, array $organic, int $min_n = 30 ): ?array {
+		if ( ( $ai['views'] ?? 0 ) < $min_n || ( $organic['views'] ?? 0 ) < $min_n ) {
+			return null;
+		}
+
+		$organic_time   = (float) ( $organic['avg_time'] ?? 1 );
+		$organic_scroll = (float) ( $organic['avg_scroll'] ?? 1 );
+		$organic_bounce = (float) ( $organic['bounce_rate'] ?? 1 );
+
+		return array(
+			'time_ratio'   => $organic_time > 0 ? round( (float) $ai['avg_time'] / $organic_time, 4 ) : 0.0,
+			'scroll_ratio' => $organic_scroll > 0 ? round( (float) $ai['avg_scroll'] / $organic_scroll, 4 ) : 0.0,
+			'bounce_ratio' => $organic_bounce > 0 ? round( (float) $ai['bounce_rate'] / $organic_bounce, 4 ) : 0.0,
+			'ai_n'         => (int) $ai['views'],
+			'organic_n'    => (int) $organic['views'],
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Schema — rollup table
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Create the AI referrals daily rollup table.
+	 * Called on activation (from stratawp-seo.php) and via maybe_upgrade().
+	 */
+	public static function create_table(): void {
+		global $wpdb;
+
+		$charset = $wpdb->get_charset_collate();
+		$table   = $wpdb->prefix . self::ROLLUP_TABLE;
+
+		$sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            ai_source VARCHAR(32) NOT NULL DEFAULT '',
+            post_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
+            date DATE NOT NULL,
+            views INT UNSIGNED NOT NULL DEFAULT 0,
+            total_time INT UNSIGNED NOT NULL DEFAULT 0,
+            total_scroll INT UNSIGNED NOT NULL DEFAULT 0,
+            bounces INT UNSIGNED NOT NULL DEFAULT 0,
+            PRIMARY KEY (id),
+            UNIQUE KEY idx_source_post_date (ai_source, post_id, date),
+            KEY idx_ai_source (ai_source),
+            KEY idx_date (date)
+        ) {$charset};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Drop the rollup table. Called on uninstall.
+	 */
+	public static function drop_table(): void {
+		global $wpdb;
+		$table = $wpdb->prefix . self::ROLLUP_TABLE;
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
+		$wpdb->query( "DROP TABLE IF EXISTS {$table}" );
+	}
+
+	/**
+	 * Ensure the rollup table exists for existing installs that did not
+	 * re-run the activation hook (i.e. plugin was updated, not reactivated).
+	 *
+	 * Mirrors the SWPS_Backlinks::__construct() upgrade pattern.
+	 */
+	public static function maybe_upgrade(): void {
+		if ( self::DB_VERSION !== get_option( self::OPT_DB_VER ) ) {
+			self::create_table();
+			update_option( self::OPT_DB_VER, self::DB_VERSION );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Aggregation — called from SWPS_Analytics_Tracker::aggregate_and_prune()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Roll up raw analytics rows (where ai_source is set) into the daily
+	 * rollup table. Uses additive SUMS — no averaging bug.
+	 *
+	 * Must be called BEFORE the raw delete in aggregate_and_prune().
+	 *
+	 * @param string $cutoff MySQL datetime string — rows older than this are rolled up.
+	 */
+	public static function aggregate( string $cutoff ): void {
+		global $wpdb;
+
+		$raw    = $wpdb->prefix . 'swps_analytics';
+		$rollup = $wpdb->prefix . self::ROLLUP_TABLE;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$rollup} (ai_source, post_id, date, views, total_time, total_scroll, bounces)
+                 SELECT ai_source, post_id, DATE(created_at),
+                        COUNT(*), SUM(time_on_page), SUM(scroll_depth), SUM(is_bounce)
+                 FROM {$raw}
+                 WHERE ai_source <> '' AND created_at < %s
+                 GROUP BY ai_source, post_id, DATE(created_at)
+                 ON DUPLICATE KEY UPDATE
+                    views        = views        + VALUES(views),
+                    total_time   = total_time   + VALUES(total_time),
+                    total_scroll = total_scroll + VALUES(total_scroll),
+                    bounces      = bounces      + VALUES(bounces)",
+				$cutoff
+			)
+		);
+		// phpcs:enable
+
+		// Prune rollup beyond retention (same option as the analytics table).
+		$retention_days = (int) get_option( 'swps_analytics_retention', 90 );
+		$prune_date     = gmdate( 'Y-m-d', strtotime( "-{$retention_days} days" ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$rollup} WHERE date < %s",
+				$prune_date
+			)
+		);
+		// phpcs:enable
+	}
+
+	// -------------------------------------------------------------------------
+	// Internal helpers — WP-free
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Extract lowercased hostname from a URL string.
+	 * Returns '' on parse failure.
+	 *
+	 * @param string $url URL string.
+	 * @return string Lowercase hostname, or ''.
+	 */
+	private static function parse_host( string $url ): string {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+
+		if ( ! is_string( $host ) || '' === $host ) {
+			return '';
+		}
+
+		return strtolower( $host );
+	}
+
+	/**
+	 * Match a hostname (already lowercased) against the source map.
+	 * Supports exact match and dot-prefixed suffix match (subdomains).
+	 *
+	 * @param string                $host Lowercased hostname.
+	 * @param array<string, string> $map  Source map.
+	 * @return string Source key, or ''.
+	 */
+	private static function match_host( string $host, array $map ): string {
+		foreach ( $map as $entry => $source ) {
+			$entry_lower = strtolower( $entry );
+
+			if ( $host === $entry_lower || str_ends_with( $host, '.' . $entry_lower ) ) {
+				return $source;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extract the utm_source query parameter from a URL.
+	 * Returns '' when absent or unparseable.
+	 *
+	 * @param string $url URL string.
+	 * @return string utm_source value (raw, lowercased), or ''.
+	 */
+	private static function extract_utm_source( string $url ): string {
+		$query = wp_parse_url( $url, PHP_URL_QUERY );
+
+		if ( ! is_string( $query ) || '' === $query ) {
+			return '';
+		}
+
+		parse_str( $query, $params );
+
+		return strtolower( (string) ( $params['utm_source'] ?? '' ) );
+	}
+
+	/**
+	 * Resolve a utm_source value to an AI source slug.
+	 *
+	 * Checks two strategies:
+	 * 1. utm_source is a hostname — match via host-match rules (e.g. chatgpt.com).
+	 * 2. utm_source is a bare slug — match against map source values (e.g. chatgpt).
+	 *
+	 * @param string                $utm_source Lowercased utm_source value.
+	 * @param array<string, string> $map         Source map.
+	 * @return string Source key, or ''.
+	 */
+	private static function match_utm( string $utm_source, array $map ): string {
+		// Strategy 1: utm_source looks like a hostname (contains a dot).
+		if ( str_contains( $utm_source, '.' ) ) {
+			$matched = self::match_host( $utm_source, $map );
+
+			if ( '' !== $matched ) {
+				return $matched;
+			}
+		}
+
+		// Strategy 2: bare slug — check if the value is in the source values.
+		if ( in_array( $utm_source, $map, true ) ) {
+			return $utm_source;
+		}
+
+		return '';
+	}
+}

--- a/includes/class-ai-referrals.php
+++ b/includes/class-ai-referrals.php
@@ -150,9 +150,9 @@ class SWPS_AI_Referrals {
 	 * Returns null when either sample is below the minimum threshold to prevent
 	 * misleading ratios from sparse data.
 	 *
-	 * @param array{views: int, avg_time: float, avg_scroll: float, bounce_rate: float} $ai      AI aggregate metrics.
-	 * @param array{views: int, avg_time: float, avg_scroll: float, bounce_rate: float} $organic Organic aggregate metrics.
-	 * @param int                                                                       $min_n   Minimum sample size per group.
+	 * @param array{views?: int, avg_time?: float, avg_scroll?: float, bounce_rate?: float} $ai      AI aggregate metrics.
+	 * @param array{views?: int, avg_time?: float, avg_scroll?: float, bounce_rate?: float} $organic Organic aggregate metrics.
+	 * @param int                                                                           $min_n   Minimum sample size per group.
 	 * @return array{time_ratio: float, scroll_ratio: float, bounce_ratio: float, ai_n: int, organic_n: int}|null
 	 */
 	public static function engagement_comparison( array $ai, array $organic, int $min_n = 30 ): ?array {
@@ -165,11 +165,11 @@ class SWPS_AI_Referrals {
 		$organic_bounce = (float) ( $organic['bounce_rate'] ?? 1 );
 
 		return array(
-			'time_ratio'   => $organic_time > 0 ? round( (float) $ai['avg_time'] / $organic_time, 4 ) : 0.0,
-			'scroll_ratio' => $organic_scroll > 0 ? round( (float) $ai['avg_scroll'] / $organic_scroll, 4 ) : 0.0,
-			'bounce_ratio' => $organic_bounce > 0 ? round( (float) $ai['bounce_rate'] / $organic_bounce, 4 ) : 0.0,
-			'ai_n'         => (int) $ai['views'],
-			'organic_n'    => (int) $organic['views'],
+			'time_ratio'   => $organic_time > 0 ? round( (float) ( $ai['avg_time'] ?? 0 ) / $organic_time, 4 ) : 0.0,
+			'scroll_ratio' => $organic_scroll > 0 ? round( (float) ( $ai['avg_scroll'] ?? 0 ) / $organic_scroll, 4 ) : 0.0,
+			'bounce_ratio' => $organic_bounce > 0 ? round( (float) ( $ai['bounce_rate'] ?? 0 ) / $organic_bounce, 4 ) : 0.0,
+			'ai_n'         => (int) ( $ai['views'] ?? 0 ),
+			'organic_n'    => (int) ( $organic['views'] ?? 0 ),
 		);
 	}
 

--- a/includes/class-analytics-dashboard.php
+++ b/includes/class-analytics-dashboard.php
@@ -26,6 +26,7 @@ class SWPS_Analytics_Dashboard {
 		add_action( 'wp_ajax_swps_analytics_top_pages', array( $this, 'ajax_top_pages' ) );
 		add_action( 'wp_ajax_swps_analytics_top_queries', array( $this, 'ajax_top_queries' ) );
 		add_action( 'wp_ajax_swps_analytics_post_stats', array( $this, 'ajax_post_stats' ) );
+		add_action( 'wp_ajax_swps_analytics_ai_referrals', array( $this, 'ajax_ai_referrals' ) );
 		add_action( 'wp_ajax_swps_gsc_disconnect', array( $this, 'ajax_disconnect_gsc' ) );
 		add_action( 'wp_ajax_swps_gsc_refresh', array( $this, 'ajax_refresh_gsc' ) );
 		add_action( 'wp_ajax_swps_gsc_save_property', array( $this, 'ajax_save_property' ) );
@@ -281,6 +282,58 @@ class SWPS_Analytics_Dashboard {
 		}
 
 		wp_send_json_success( $result );
+	}
+
+	/**
+	 * AJAX: AI referral attribution data (summary, landing posts,
+	 * engagement vs organic, crawl-to-visit funnel).
+	 */
+	public function ajax_ai_referrals(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$days = absint( $_POST['days'] ?? 30 );
+		$days = in_array( $days, array( 7, 30, 90 ), true ) ? $days : 30;
+
+		$summary       = SWPS_AI_Referrals_Report::get_summary( $days );
+		$landing_posts = SWPS_AI_Referrals_Report::get_landing_posts( $days );
+		$engagement    = SWPS_AI_Referrals_Report::get_engagement_vs_organic( $days );
+		$funnel        = SWPS_AI_Referrals_Report::get_funnel( $days );
+
+		// Enrich post rows with titles and links (same pattern as ajax_top_pages).
+		foreach ( $landing_posts as &$row ) {
+			$post             = get_post( $row['post_id'] );
+			$row['title']     = $post ? $post->post_title : __( '(Unknown)', 'stratawp-seo' );
+			$row['url']       = $post ? get_permalink( $post ) : '';
+			$row['edit_link'] = get_edit_post_link( $row['post_id'], 'raw' ) ?? '';
+		}
+		unset( $row );
+
+		foreach ( $funnel['rows'] as &$row ) {
+			$post             = get_post( $row['post_id'] );
+			$row['title']     = $post ? $post->post_title : __( '(Unknown)', 'stratawp-seo' );
+			$row['edit_link'] = get_edit_post_link( $row['post_id'], 'raw' ) ?? '';
+		}
+		unset( $row );
+
+		foreach ( $funnel['crawled_no_visits'] as &$row ) {
+			$post             = get_post( $row['post_id'] );
+			$row['title']     = $post ? $post->post_title : __( '(Unknown)', 'stratawp-seo' );
+			$row['edit_link'] = get_edit_post_link( $row['post_id'], 'raw' ) ?? '';
+		}
+		unset( $row );
+
+		wp_send_json_success(
+			array(
+				'summary'       => $summary,
+				'landing_posts' => $landing_posts,
+				'engagement'    => $engagement,
+				'funnel'        => $funnel,
+			)
+		);
 	}
 
 	/**

--- a/includes/class-analytics-tracker.php
+++ b/includes/class-analytics-tracker.php
@@ -48,10 +48,12 @@ class SWPS_Analytics_Tracker {
             time_on_page SMALLINT UNSIGNED NOT NULL DEFAULT 0,
             scroll_depth TINYINT UNSIGNED NOT NULL DEFAULT 0,
             is_bounce TINYINT(1) UNSIGNED NOT NULL DEFAULT 1,
+            ai_source VARCHAR(32) NOT NULL DEFAULT '',
             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (id),
             KEY idx_created_at (created_at),
-            KEY idx_post_id (post_id)
+            KEY idx_post_id (post_id),
+            KEY idx_ai_source (ai_source)
         ) {$charset};";
 
 		$sql_daily = "CREATE TABLE {$daily} (
@@ -146,6 +148,7 @@ class SWPS_Analytics_Tracker {
 		$time_on_page = min( absint( $_POST['time_on_page'] ?? 0 ), 3600 );
 		$scroll_depth = min( absint( $_POST['scroll_depth'] ?? 0 ), 100 );
 		$is_bounce    = absint( $_POST['is_bounce'] ?? 1 ) ? 1 : 0;
+		$ai_source    = SWPS_AI_Referrals::classify_visit( $referrer, $page_url );
 
 		$data = array(
 			'post_id'      => $post_id,
@@ -154,6 +157,7 @@ class SWPS_Analytics_Tracker {
 			'time_on_page' => $time_on_page,
 			'scroll_depth' => $scroll_depth,
 			'is_bounce'    => $is_bounce,
+			'ai_source'    => $ai_source,
 		);
 
 		/**
@@ -183,6 +187,7 @@ class SWPS_Analytics_Tracker {
 				'%d',
 				'%d',
 				'%d',
+				'%s',
 			)
 		);
 
@@ -217,6 +222,9 @@ class SWPS_Analytics_Tracker {
 				$cutoff
 			)
 		);
+
+		// Roll up AI referral data BEFORE deleting raw rows.
+		SWPS_AI_Referrals::aggregate( $cutoff );
 
 		// Delete aggregated raw rows.
 		$wpdb->query(

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -99,6 +99,7 @@ class SWPS_Dashboard {
 			'ai_cost_30d'         => $this->safe_get_ai_cost(),
 			'autopilot'           => $this->safe_get_autopilot(),
 			'posts_30d'           => $this->safe_get_post_views(),
+			'ai_referrals'        => $this->safe_get_ai_referrals(),
 			'top_issues'          => $this->safe_get_top_issues(),
 			'top_queries'         => $this->safe_get_top_gsc_queries(),
 			'auto_optimize_queue' => array(), // Phase 7 fills in.
@@ -290,6 +291,27 @@ class SWPS_Dashboard {
 			return array(
 				'views'     => $views_30,
 				'delta_pct' => $delta,
+			);
+		} catch ( \Throwable $e ) {
+			return array(
+				'views'     => 0,
+				'delta_pct' => null,
+			);
+		}
+	}
+
+	/**
+	 * AI-referred views over the last 30 days with a previous-period delta.
+	 *
+	 * @return array{views: int, delta_pct: float|null}
+	 */
+	private function safe_get_ai_referrals(): array {
+		try {
+			$summary = SWPS_AI_Referrals_Report::get_summary( 30 );
+
+			return array(
+				'views'     => (int) $summary['total_views'],
+				'delta_pct' => $summary['delta_pct'],
 			);
 		} catch ( \Throwable $e ) {
 			return array(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.13.0
+Stable tag: 4.14.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -293,6 +293,9 @@ No. GSC integration is optional. The on-site analytics works entirely without an
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.14.0 =
+* New: AI referral attribution — visits from ChatGPT, Perplexity, Claude, Gemini, Copilot and others are classified at capture, with an AI Referrals analytics tab (engine trends, landing posts, engagement vs organic), a per-post crawl-to-visit funnel joined to AI-bot crawl data, and a dashboard KPI tile.
 
 = 4.13.0 =
 * New: 5-minute onboarding wizard — migrate from Yoast/Rank Math, validate your AI key, AI-suggest your site description, run the audit, and generate a preview post; setup checklist on the dashboard until complete.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -88,6 +88,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-schema.php';
 
 // Analytics.
 require_once SWPS_PLUGIN_DIR . 'includes/class-ai-referrals.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-ai-referrals-report.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-analytics-tracker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-search-console.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-bot-analytics-tracker.php';

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.13.0
+ * Version: 4.14.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.13.0' );
+define( 'SWPS_VERSION', '4.14.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -87,6 +87,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/audit/class-pagespeed-module.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-schema.php';
 
 // Analytics.
+require_once SWPS_PLUGIN_DIR . 'includes/class-ai-referrals.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-analytics-tracker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-search-console.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-bot-analytics-tracker.php';
@@ -269,6 +270,7 @@ final class StrataWP_SEO {
 		$this->image_inserter        = new SWPS_Image_Inserter( $this->images );
 		$this->seo_audit             = new SWPS_SEO_Audit();
 		$this->schema                = new SWPS_Schema();
+		SWPS_AI_Referrals::maybe_upgrade();
 		$this->analytics_tracker     = new SWPS_Analytics_Tracker();
 		$this->bot_analytics_tracker = new SWPS_Bot_Analytics_Tracker();
 		$this->search_console        = new SWPS_Search_Console();
@@ -1314,6 +1316,8 @@ function swps_activate(): void {
 	SWPS_Analytics_Tracker::schedule_cron();
 	SWPS_Bot_Analytics_Tracker::create_tables();
 	SWPS_Bot_Analytics_Tracker::schedule_cron();
+	SWPS_AI_Referrals::create_table();
+	update_option( SWPS_AI_Referrals::OPT_DB_VER, SWPS_AI_Referrals::DB_VERSION );
 	SWPS_Search_Console::schedule_cron();
 	SWPS_Keyword_Tracker::create_tables();
 	SWPS_Keyword_Tracker::schedule_cron();

--- a/templates/analytics-page.php
+++ b/templates/analytics-page.php
@@ -146,6 +146,108 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</table>
 	<?php endif; ?>
 
+	<div class="swps-section-h" style="margin-top:40px">
+		<h3><?php esc_html_e( 'AI Referrals', 'stratawp-seo' ); ?></h3>
+		<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+			<?php esc_html_e( 'Visits referred from AI assistants (ChatGPT, Perplexity, Claude, Gemini, Copilot, and others), classified at capture time.', 'stratawp-seo' ); ?>
+		</p>
+	</div>
+
+	<div class="swps-summary-tiles" style="margin-bottom:16px">
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'AI-Referred Views', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad" id="swps-ai-ref-views">—</div>
+			<div class="swps-summary-tile-foot" id="swps-ai-ref-change"></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Top Engine', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad" id="swps-ai-ref-top-engine">—</div>
+		</div>
+	</div>
+
+	<div class="swps-tile" style="margin-bottom:16px">
+		<div class="swps-tile-h"><?php esc_html_e( 'Views by Engine', 'stratawp-seo' ); ?></div>
+		<table class="widefat striped" id="swps-ai-ref-engines-table" style="margin-top:8px">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Engine', 'stratawp-seo' ); ?></th>
+					<th style="text-align:right"><?php esc_html_e( 'Views', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr><td colspan="2" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+			</tbody>
+		</table>
+	</div>
+
+	<div class="swps-section-h" style="margin-top:24px">
+		<h3><?php esc_html_e( 'AI Landing Posts', 'stratawp-seo' ); ?></h3>
+		<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+			<?php esc_html_e( 'Posts receiving the most AI-referred visits.', 'stratawp-seo' ); ?>
+		</p>
+	</div>
+	<table class="widefat striped" id="swps-ai-ref-landing-table">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Post', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Views', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Avg Time', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Scroll', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Bounce', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Engines', 'stratawp-seo' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td colspan="6" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+		</tbody>
+	</table>
+
+	<div class="swps-section-h" style="margin-top:24px">
+		<h3><?php esc_html_e( 'Engagement: AI vs Organic', 'stratawp-seo' ); ?></h3>
+	</div>
+	<div class="swps-tile" id="swps-ai-ref-engagement">
+		<p class="swps-loading" style="margin:0;color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></p>
+	</div>
+
+	<div class="swps-section-h" style="margin-top:24px">
+		<h3><?php esc_html_e( 'Crawl-to-Visit Funnel', 'stratawp-seo' ); ?></h3>
+		<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+			<?php esc_html_e( 'AI bot crawls of a post next to AI-referred visits to it. Crawls vs visits are correlational, not causal.', 'stratawp-seo' ); ?>
+		</p>
+	</div>
+	<table class="widefat striped" id="swps-ai-ref-funnel-table">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Post', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Engine', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Crawls', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Visits', 'stratawp-seo' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td colspan="4" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+		</tbody>
+	</table>
+
+	<div class="swps-section-h" style="margin-top:24px">
+		<h3><?php esc_html_e( 'Crawled but No AI Visits', 'stratawp-seo' ); ?></h3>
+		<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+			<?php esc_html_e( 'Posts AI bots crawl that have not yet received AI-referred visits — candidates for AEO optimization.', 'stratawp-seo' ); ?>
+		</p>
+	</div>
+	<table class="widefat striped" id="swps-ai-ref-novisits-table">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Post', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Engine', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Crawls', 'stratawp-seo' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td colspan="3" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+		</tbody>
+	</table>
+
 	<?php
 	if ( ! empty( $bot_data ) ) :
 		$totals    = $bot_data['totals'];

--- a/templates/dashboard-page.php
+++ b/templates/dashboard-page.php
@@ -276,6 +276,28 @@ $welcome_msg = sprintf(
 			</div>
 		<?php endif; ?>
 
+		<?php $ai_referrals = $data['ai_referrals'] ?? array(); ?>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'AI referrals (30d)', 'stratawp-seo' ); ?></div>
+			<div class="swps-tile-stat"><?php echo number_format( (int) ( $ai_referrals['views'] ?? 0 ) ); ?></div>
+			<?php
+			if ( null !== ( $ai_referrals['delta_pct'] ?? null ) ) :
+				$ai_ref_delta = (float) $ai_referrals['delta_pct'];
+				$ai_ref_cls   = $ai_ref_delta >= 0 ? '' : ' is-down';
+				$ai_ref_arrow = $ai_ref_delta >= 0 ? '↑' : '↓';
+				?>
+				<div class="swps-tile-trend<?php echo esc_attr( $ai_ref_cls ); ?>">
+					<?php echo esc_html( $ai_ref_arrow ); ?>
+					<?php echo esc_html( number_format( abs( $ai_ref_delta ), 1 ) ); ?>%
+					<?php esc_html_e( 'vs prev 30d', 'stratawp-seo' ); ?>
+				</div>
+			<?php else : ?>
+				<div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+					<?php esc_html_e( 'Views from AI assistants — no data yet', 'stratawp-seo' ); ?>
+				</div>
+			<?php endif; ?>
+		</div>
+
 		<a class="swps-tile swps-tile-aeo" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-aeo-optimize' ) ); ?>" style="text-decoration:none;color:inherit;display:block">
 			<div class="swps-tile-h"><?php esc_html_e( 'AEO health (avg)', 'stratawp-seo' ); ?></div>
 			<div class="swps-tile-stat">

--- a/tests/unit/AiReferralsTest.php
+++ b/tests/unit/AiReferralsTest.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * Tests for SWPS_AI_Referrals — classifier, bot source map, engagement comparison.
+ *
+ * Pure-static core: no WordPress functions required. The runtime wrapper
+ * classify_visit() uses apply_filters(), so we stub it here; the core
+ * classify() method is WP-free and tested directly.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+// Stub WordPress functions used only in the runtime wrapper, not in the core.
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $tag, $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	/**
+	 * Thin wrapper around parse_url() that mirrors the WP function signature.
+	 *
+	 * @param string $url       URL to parse.
+	 * @param int    $component PHP_URL_* constant, or -1 for the full array.
+	 * @return mixed
+	 */
+	function wp_parse_url( string $url, int $component = -1 ) {
+		return parse_url( $url, $component );
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-ai-referrals.php';
+
+/**
+ * @covers SWPS_AI_Referrals
+ */
+class AiReferralsTest extends TestCase {
+
+	// -------------------------------------------------------------------------
+	// classify() — referrer matching
+	// -------------------------------------------------------------------------
+
+	public function test_exact_host_match_returns_source(): void {
+		$this->assertSame( 'chatgpt', SWPS_AI_Referrals::classify( 'https://chatgpt.com/c/abc' ) );
+	}
+
+	public function test_subdomain_suffix_match(): void {
+		$this->assertSame( 'chatgpt', SWPS_AI_Referrals::classify( 'https://www.chatgpt.com/share/xyz' ) );
+	}
+
+	public function test_case_insensitive_host(): void {
+		$this->assertSame( 'chatgpt', SWPS_AI_Referrals::classify( 'https://ChatGPT.COM/c/abc' ) );
+	}
+
+	public function test_perplexity_referrer(): void {
+		$this->assertSame( 'perplexity', SWPS_AI_Referrals::classify( 'https://perplexity.ai/search/foo' ) );
+	}
+
+	public function test_claude_referrer(): void {
+		$this->assertSame( 'claude', SWPS_AI_Referrals::classify( 'https://claude.ai/chat/abc' ) );
+	}
+
+	public function test_gemini_referrer(): void {
+		$this->assertSame( 'gemini', SWPS_AI_Referrals::classify( 'https://gemini.google.com/app' ) );
+	}
+
+	public function test_copilot_referrer(): void {
+		$this->assertSame( 'copilot', SWPS_AI_Referrals::classify( 'https://copilot.microsoft.com/' ) );
+	}
+
+	public function test_you_referrer(): void {
+		$this->assertSame( 'you', SWPS_AI_Referrals::classify( 'https://you.com/search?q=test' ) );
+	}
+
+	public function test_deepseek_referrer(): void {
+		$this->assertSame( 'deepseek', SWPS_AI_Referrals::classify( 'https://chat.deepseek.com/' ) );
+	}
+
+	public function test_grok_referrer(): void {
+		$this->assertSame( 'grok', SWPS_AI_Referrals::classify( 'https://grok.com/chat' ) );
+	}
+
+	public function test_meta_ai_referrer(): void {
+		$this->assertSame( 'meta', SWPS_AI_Referrals::classify( 'https://meta.ai/chat' ) );
+	}
+
+	public function test_chat_openai_maps_to_chatgpt(): void {
+		$this->assertSame( 'chatgpt', SWPS_AI_Referrals::classify( 'https://chat.openai.com/share/abc' ) );
+	}
+
+	public function test_non_ai_referrer_returns_empty(): void {
+		$this->assertSame( '', SWPS_AI_Referrals::classify( 'https://google.com/search?q=foo' ) );
+	}
+
+	public function test_partial_host_match_not_accepted(): void {
+		// notchatgpt.com must NOT match chatgpt.com.
+		$this->assertSame( '', SWPS_AI_Referrals::classify( 'https://notchatgpt.com/' ) );
+	}
+
+	public function test_empty_referrer_no_page_url_returns_empty(): void {
+		$this->assertSame( '', SWPS_AI_Referrals::classify( '' ) );
+	}
+
+	public function test_invalid_referrer_url_returns_empty(): void {
+		$this->assertSame( '', SWPS_AI_Referrals::classify( 'not a url' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// classify() — page_url utm_source fallback
+	// -------------------------------------------------------------------------
+
+	public function test_utm_source_chatgpt_dot_com_maps_to_chatgpt(): void {
+		$this->assertSame(
+			'chatgpt',
+			SWPS_AI_Referrals::classify( '', 'https://example.com/post/?utm_source=chatgpt.com' )
+		);
+	}
+
+	public function test_utm_source_perplexity_ai_maps_to_perplexity(): void {
+		$this->assertSame(
+			'perplexity',
+			SWPS_AI_Referrals::classify( '', 'https://example.com/post/?utm_source=perplexity.ai' )
+		);
+	}
+
+	public function test_utm_source_bare_source_value_maps(): void {
+		// utm_source=chatgpt (bare source value, not a host) should resolve.
+		$this->assertSame(
+			'chatgpt',
+			SWPS_AI_Referrals::classify( '', 'https://example.com/post/?utm_source=chatgpt' )
+		);
+	}
+
+	public function test_utm_source_takes_precedence_when_referrer_empty(): void {
+		$this->assertSame(
+			'claude',
+			SWPS_AI_Referrals::classify( '', 'https://example.com/?utm_source=claude.ai' )
+		);
+	}
+
+	public function test_referrer_wins_over_utm_source(): void {
+		// If referrer is set and matches, it takes priority (utm_source irrelevant).
+		$this->assertSame(
+			'perplexity',
+			SWPS_AI_Referrals::classify(
+				'https://perplexity.ai/search',
+				'https://example.com/?utm_source=chatgpt.com'
+			)
+		);
+	}
+
+	public function test_utm_source_unknown_value_returns_empty(): void {
+		$this->assertSame(
+			'',
+			SWPS_AI_Referrals::classify( '', 'https://example.com/?utm_source=unknownbot' )
+		);
+	}
+
+	public function test_no_utm_source_in_page_url_returns_empty(): void {
+		$this->assertSame( '', SWPS_AI_Referrals::classify( '', 'https://example.com/post/' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// classify() — custom map override
+	// -------------------------------------------------------------------------
+
+	public function test_custom_map_overrides_default(): void {
+		$map = array( 'custom-ai.example' => 'custom_ai' );
+		$this->assertSame( 'custom_ai', SWPS_AI_Referrals::classify( 'https://custom-ai.example/chat', '', $map ) );
+	}
+
+	public function test_custom_map_ignores_default_entries(): void {
+		$map = array( 'custom-ai.example' => 'custom_ai' );
+		// chatgpt.com is NOT in the custom map, so it should return ''.
+		$this->assertSame( '', SWPS_AI_Referrals::classify( 'https://chatgpt.com/', '', $map ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// bot_source_map()
+	// -------------------------------------------------------------------------
+
+	public function test_bot_source_map_returns_array(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertIsArray( $map );
+	}
+
+	public function test_gptbot_maps_to_chatgpt(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'chatgpt', $map['gptbot'] );
+	}
+
+	public function test_oai_searchbot_maps_to_chatgpt(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'chatgpt', $map['oai_searchbot'] );
+	}
+
+	public function test_chatgpt_user_maps_to_chatgpt(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'chatgpt', $map['chatgpt_user'] );
+	}
+
+	public function test_claudebot_maps_to_claude(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'claude', $map['claudebot'] );
+	}
+
+	public function test_claude_web_maps_to_claude(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'claude', $map['claude_web'] );
+	}
+
+	public function test_anthropic_ai_maps_to_claude(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'claude', $map['anthropic_ai'] );
+	}
+
+	public function test_perplexitybot_maps_to_perplexity(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'perplexity', $map['perplexitybot'] );
+	}
+
+	public function test_perplexity_user_maps_to_perplexity(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'perplexity', $map['perplexity_user'] );
+	}
+
+	public function test_google_extended_maps_to_gemini(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'gemini', $map['google_extended'] );
+	}
+
+	public function test_bots_without_visit_counterpart_omitted(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		// applebot_extended, ccbot, bytespider, amazonbot, duckassistbot
+		// have no visit-side counterpart and should not be in the map.
+		$this->assertArrayNotHasKey( 'applebot_extended', $map );
+		$this->assertArrayNotHasKey( 'ccbot', $map );
+		$this->assertArrayNotHasKey( 'bytespider', $map );
+		$this->assertArrayNotHasKey( 'amazonbot', $map );
+		$this->assertArrayNotHasKey( 'duckassistbot', $map );
+	}
+
+	public function test_meta_externalagent_maps_to_meta(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'meta', $map['meta_externalagent'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// engagement_comparison()
+	// -------------------------------------------------------------------------
+
+	public function test_returns_null_when_ai_sample_below_min(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 10, 'avg_time' => 120, 'avg_scroll' => 50, 'bounce_rate' => 0.4 ),
+			array( 'views' => 500, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+		$this->assertNull( $result );
+	}
+
+	public function test_returns_null_when_organic_sample_below_min(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 500, 'avg_time' => 120, 'avg_scroll' => 50, 'bounce_rate' => 0.4 ),
+			array( 'views' => 5, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+		$this->assertNull( $result );
+	}
+
+	public function test_returns_null_when_both_samples_below_min(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 10, 'avg_time' => 120, 'avg_scroll' => 50, 'bounce_rate' => 0.4 ),
+			array( 'views' => 10, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+		$this->assertNull( $result );
+	}
+
+	public function test_returns_ratio_metrics_when_sufficient_sample(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 100, 'avg_time' => 120, 'avg_scroll' => 60, 'bounce_rate' => 0.3 ),
+			array( 'views' => 500, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'time_ratio', $result );
+		$this->assertArrayHasKey( 'scroll_ratio', $result );
+		$this->assertArrayHasKey( 'bounce_ratio', $result );
+	}
+
+	public function test_time_ratio_calculated_correctly(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 100, 'avg_time' => 120, 'avg_scroll' => 60, 'bounce_rate' => 0.3 ),
+			array( 'views' => 100, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+
+		// 120/80 = 1.5.
+		$this->assertEqualsWithDelta( 1.5, $result['time_ratio'], 0.001 );
+	}
+
+	public function test_scroll_ratio_calculated_correctly(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 100, 'avg_time' => 120, 'avg_scroll' => 60, 'bounce_rate' => 0.3 ),
+			array( 'views' => 100, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+
+		// 60/40 = 1.5.
+		$this->assertEqualsWithDelta( 1.5, $result['scroll_ratio'], 0.001 );
+	}
+
+	public function test_bounce_ratio_calculated_correctly(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 100, 'avg_time' => 120, 'avg_scroll' => 60, 'bounce_rate' => 0.3 ),
+			array( 'views' => 100, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+
+		// 0.3/0.6 = 0.5.
+		$this->assertEqualsWithDelta( 0.5, $result['bounce_ratio'], 0.001 );
+	}
+
+	public function test_exact_min_n_threshold_is_sufficient(): void {
+		// Exactly 30 should not return null.
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 30, 'avg_time' => 120, 'avg_scroll' => 60, 'bounce_rate' => 0.3 ),
+			array( 'views' => 30, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+		$this->assertNotNull( $result );
+	}
+
+	public function test_result_includes_ai_and_organic_counts(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 100, 'avg_time' => 120, 'avg_scroll' => 60, 'bounce_rate' => 0.3 ),
+			array( 'views' => 500, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+
+		$this->assertArrayHasKey( 'ai_n', $result );
+		$this->assertArrayHasKey( 'organic_n', $result );
+		$this->assertSame( 100, $result['ai_n'] );
+		$this->assertSame( 500, $result['organic_n'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// classify_visit() — runtime wrapper applies filter
+	// -------------------------------------------------------------------------
+
+	public function test_classify_visit_returns_source_via_default_map(): void {
+		// apply_filters is stubbed to return the value unchanged above.
+		$this->assertSame( 'chatgpt', SWPS_AI_Referrals::classify_visit( 'https://chatgpt.com/c/abc' ) );
+	}
+
+	public function test_classify_visit_returns_empty_for_non_ai(): void {
+		$this->assertSame( '', SWPS_AI_Referrals::classify_visit( 'https://example.com/' ) );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -88,6 +88,7 @@ $swps_tables = array(
 	'swps_404_log',
 	'swps_analytics',
 	'swps_analytics_daily',
+	'swps_ai_referrals_daily',
 	'swps_bot_hits',
 	'swps_bot_hits_daily',
 	'swps_keyword_tracking',


### PR DESCRIPTION
## Summary
- **Classifier**: visit referrers classified into AI sources at capture time (ChatGPT, Perplexity, Claude, Gemini, Copilot, You, DeepSeek, Grok, Meta — filterable via `swps_ai_referral_sources`), with `utm_source` fallback; the tracker has stored referrers since day one and never read them — now it does
- **Storage**: `ai_source` column on `swps_analytics` (DB-version upgrade path for existing installs) + new `swps_ai_referrals_daily` rollup keyed (ai_source, post_id, date) storing additive SUMS — read-time averages, deliberately avoiding the legacy daily table's compounding-average bug; rolled up in the existing aggregation cron before raw pruning
- **AI Referrals analytics section**: views by engine over time with period delta, landing posts with engagement, AI-vs-organic engagement comparison (suppressed below 30-view samples), and a per-post **crawl→visit funnel** joining `swps_bot_hits_daily` via a bot→source map — labeled correlational — plus a crawled-but-no-AI-visits list
- **Dashboard tile**: AI referrals (30d) with trend
- 48 new unit tests (classifier, maps, engagement math); suite at 179; PHPStan/PHPCS clean; version 4.14.0

## Stacked on
feature/onboarding-wizard (#53) — merge that first; this retargets to main automatically.

## Review trail
Per-task spec + quality reviews and a final whole-branch review (hot-path cost, upgrade ordering, SQL prepare sweep, raw/rollup double-count boundary, JS escaping); final fix: null-safe iteration over `$wpdb->get_results`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)