### PR TITLE
feat: AI citation tracker — BYO-key share-of-voice monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.14.0-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.15.0-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1446,6 +1446,9 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.15.0 — June 2026
+- **New — AI visibility funnel:** AEO-score sorting on the crawl-gap report (sort by high-score-but-uncrawled first), crawl recency and AI-visit columns on the AEO queue, a per-post funnel line in the AEO editor panel, and a dashboard funnel tile showing posts crawled → posts receiving AI visits (30d, with stage conversion rates).
 
 ### v4.14.0 — June 2026
 - **New — AI referral attribution:** visits from ChatGPT, Perplexity, Claude, Gemini, Copilot and others are classified at capture, with an AI Referrals analytics tab (engine trends, landing posts, engagement vs organic), a per-post crawl-to-visit funnel joined to AI-bot crawl data, and a dashboard KPI tile.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.15.0-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.16.0-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1446,6 +1446,9 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.16.0 — June 2026
+- **New — AI citation tracker:** monitor whether ChatGPT, Claude, Gemini, and Grok cite your site for your tracked prompts (BYO keys, search-grounded), with per-engine cited/lost/never/mixed state badges, share-of-voice bars vs competitors, a cited-domains breakdown, seed-from-keywords/GSC prompt suggestions, monthly call caps, a dashboard tile, and lost-citation context surfaced in the AEO editor panel and proposals.
 
 ### v4.15.0 — June 2026
 - **New — AI visibility funnel:** AEO-score sorting on the crawl-gap report (sort by high-score-but-uncrawled first), crawl recency and AI-visit columns on the AEO queue, a per-post funnel line in the AEO editor panel, and a dashboard funnel tile showing posts crawled → posts receiving AI visits (30d, with stage conversion rates).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.13.0-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.14.0-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1446,6 +1446,9 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.14.0 — June 2026
+- **New — AI referral attribution:** visits from ChatGPT, Perplexity, Claude, Gemini, Copilot and others are classified at capture, with an AI Referrals analytics tab (engine trends, landing posts, engagement vs organic), a per-post crawl-to-visit funnel joined to AI-bot crawl data, and a dashboard KPI tile.
 
 ### v4.13.0 — June 2026
 - **New — 5-minute onboarding wizard:** a guided first-run flow — migrate from Yoast/Rank Math, validate your AI key with a live test, AI-suggest your site description, run the audit, and generate a preview post — with a persistent setup checklist on the dashboard until complete.

--- a/admin/js/aeo-optimizer.js
+++ b/admin/js/aeo-optimizer.js
@@ -87,6 +87,12 @@
             var actionBtn = r.has_proposal
                 ? '<button class="button swps-aeo-review"  data-id="' + r.post_id + '">' + escapeHtml(swpsAeo.i18n.review) + '</button>'
                 : '<button class="button swps-aeo-propose" data-id="' + r.post_id + '">' + escapeHtml(swpsAeo.i18n.generate) + '</button>';
+            var crawlCell = r.last_crawl_ago
+                ? escapeHtml(r.last_crawl_ago) + (r.last_bot ? '<br><small style="color:#999">' + escapeHtml(r.last_bot) + '</small>' : '')
+                : '<span style="color:#bbb">—</span>';
+            var visitsCell = r.ai_visits_30d > 0
+                ? String(r.ai_visits_30d)
+                : '<span style="color:#bbb">0</span>';
             return '<tr data-post-id="' + r.post_id + '">' +
                 '<td><span class="swps-aeo-score-cell ' + scoreClass(r.score) + '">' + r.score + '</span></td>' +
                 '<td>' +
@@ -99,6 +105,8 @@
                     chip('authority',      sub.authority) +
                     chip('coverage',       sub.coverage) +
                 '</td>' +
+                '<td style="font-size:12px">' + crawlCell + '</td>' +
+                '<td style="text-align:right">' + visitsCell + '</td>' +
                 '<td>' +
                     actionBtn + ' ' +
                     '<button class="button-link swps-aeo-dismiss" data-id="' + r.post_id + '">' + escapeHtml(swpsAeo.i18n.dismiss) + '</button>' +

--- a/admin/js/analytics.js
+++ b/admin/js/analytics.js
@@ -105,6 +105,121 @@
         });
     }
 
+    function loadAiReferrals() {
+        if (!$('#swps-ai-ref-engines-table').length) return;
+
+        $.post(swpsAdmin.ajax_url, {
+            action: 'swps_analytics_ai_referrals',
+            nonce: swpsAdmin.nonce,
+            days: currentDays
+        }, function (res) {
+            if (!res.success) return;
+            var d = res.data;
+
+            // Summary tiles.
+            $('#swps-ai-ref-views').text(d.summary.total_views.toLocaleString());
+
+            var changeEl = $('#swps-ai-ref-change');
+            if (d.summary.delta_pct !== null) {
+                var up = d.summary.delta_pct >= 0;
+                changeEl.html('<span class="' + (up ? 'swps-change-up' : 'swps-change-down') + '">' +
+                    (up ? '↑' : '↓') + ' ' + Math.abs(d.summary.delta_pct) + '% vs prev period</span>');
+            } else {
+                changeEl.html('');
+            }
+
+            var engines = Object.keys(d.summary.by_source);
+            $('#swps-ai-ref-top-engine').text(engines.length ? engines[0] : '—');
+
+            // Views by engine.
+            var engineBody = $('#swps-ai-ref-engines-table tbody');
+            engineBody.empty();
+            if (!engines.length) {
+                engineBody.html('<tr><td colspan="2">No AI-referred views yet.</td></tr>');
+            } else {
+                engines.forEach(function (engine) {
+                    engineBody.append('<tr><td><code>' + escHtml(engine) + '</code></td>' +
+                        '<td style="text-align:right">' + d.summary.by_source[engine].toLocaleString() + '</td></tr>');
+                });
+            }
+
+            // Landing posts.
+            var landingBody = $('#swps-ai-ref-landing-table tbody');
+            landingBody.empty();
+            if (!d.landing_posts.length) {
+                landingBody.html('<tr><td colspan="6">No AI-referred visits yet.</td></tr>');
+            } else {
+                d.landing_posts.forEach(function (p) {
+                    var title = p.url
+                        ? '<a href="' + p.url + '" target="_blank">' + escHtml(p.title) + '</a>'
+                        : escHtml(p.title);
+                    landingBody.append('<tr><td>' + title + '</td>' +
+                        '<td style="text-align:right">' + p.views.toLocaleString() + '</td>' +
+                        '<td style="text-align:right">' + formatSeconds(p.avg_time) + '</td>' +
+                        '<td style="text-align:right">' + p.avg_scroll + '%</td>' +
+                        '<td style="text-align:right">' + p.bounce_rate + '%</td>' +
+                        '<td><code>' + escHtml(p.ai_sources || '') + '</code></td></tr>');
+                });
+            }
+
+            // Engagement panel.
+            var engEl = $('#swps-ai-ref-engagement');
+            if (!d.engagement) {
+                engEl.html('<p style="margin:0;color:var(--swps-text-muted)">Not enough data yet — engagement comparison needs at least 30 AI-referred views and 30 organic views in this period.</p>');
+            } else {
+                var e = d.engagement;
+                var html = '<table class="widefat striped" style="margin-top:4px"><thead><tr>' +
+                    '<th></th><th style="text-align:right">AI-referred</th><th style="text-align:right">Organic</th><th style="text-align:right">Ratio</th></tr></thead><tbody>';
+                html += '<tr><td>Avg time on page</td><td style="text-align:right">' + formatSeconds(e.ai.avg_time) + '</td>' +
+                    '<td style="text-align:right">' + formatSeconds(e.organic.avg_time) + '</td>' +
+                    '<td style="text-align:right">' + e.time_ratio.toFixed(2) + '×</td></tr>';
+                html += '<tr><td>Avg scroll depth</td><td style="text-align:right">' + e.ai.avg_scroll + '%</td>' +
+                    '<td style="text-align:right">' + e.organic.avg_scroll + '%</td>' +
+                    '<td style="text-align:right">' + e.scroll_ratio.toFixed(2) + '×</td></tr>';
+                html += '<tr><td>Bounce rate</td><td style="text-align:right">' + e.ai.bounce_rate + '%</td>' +
+                    '<td style="text-align:right">' + e.organic.bounce_rate + '%</td>' +
+                    '<td style="text-align:right">' + e.bounce_ratio.toFixed(2) + '×</td></tr>';
+                html += '</tbody></table>';
+                html += '<p style="color:var(--swps-text-muted);font-size:11px;margin:8px 0 0">Based on ' +
+                    e.ai_n.toLocaleString() + ' AI-referred views and ' + e.organic_n.toLocaleString() + ' organic views.</p>';
+                engEl.html(html);
+            }
+
+            // Funnel.
+            var funnelBody = $('#swps-ai-ref-funnel-table tbody');
+            funnelBody.empty();
+            if (!d.funnel.rows.length) {
+                funnelBody.html('<tr><td colspan="4">No AI crawl data for this period.</td></tr>');
+            } else {
+                d.funnel.rows.forEach(function (r) {
+                    var title = r.edit_link
+                        ? '<a href="' + r.edit_link + '">' + escHtml(r.title) + '</a>'
+                        : escHtml(r.title);
+                    funnelBody.append('<tr><td>' + title + '</td>' +
+                        '<td><code>' + escHtml(r.ai_source) + '</code></td>' +
+                        '<td style="text-align:right">' + r.crawls.toLocaleString() + '</td>' +
+                        '<td style="text-align:right">' + r.visits.toLocaleString() + '</td></tr>');
+                });
+            }
+
+            // Crawled but no AI visits.
+            var noVisitsBody = $('#swps-ai-ref-novisits-table tbody');
+            noVisitsBody.empty();
+            if (!d.funnel.crawled_no_visits.length) {
+                noVisitsBody.html('<tr><td colspan="3">None — every crawled post has AI-referred visits.</td></tr>');
+            } else {
+                d.funnel.crawled_no_visits.forEach(function (r) {
+                    var title = r.edit_link
+                        ? '<a href="' + r.edit_link + '">' + escHtml(r.title) + '</a>'
+                        : escHtml(r.title);
+                    noVisitsBody.append('<tr><td>' + title + '</td>' +
+                        '<td><code>' + escHtml(r.ai_source) + '</code></td>' +
+                        '<td style="text-align:right">' + r.crawls.toLocaleString() + '</td></tr>');
+                });
+            }
+        });
+    }
+
     // --- Chart.js Chart ---
 
     var chartInstance = null;
@@ -259,6 +374,7 @@
         if ($('.swps-analytics-wrap').length) {
             loadOverview();
             loadTopPages();
+            loadAiReferrals();
 
             if ($('#swps-top-queries-table').length) {
                 loadTopQueries();
@@ -271,6 +387,7 @@
                 currentDays = parseInt($(this).data('days'));
                 loadOverview();
                 loadTopPages();
+                loadAiReferrals();
                 if ($('#swps-top-queries-table').length) loadTopQueries();
             });
 

--- a/admin/js/citations.js
+++ b/admin/js/citations.js
@@ -1,0 +1,293 @@
+/**
+ * StrataWP SEO — AI Citations card (Keywords page)
+ */
+(function ($) {
+    'use strict';
+
+    if (typeof swpsCitations === 'undefined') return;
+    if (!$('#swps-citations-card').length) return;
+
+    var STATE_COLORS = {
+        cited: '#16a34a',
+        lost: '#dc2626',
+        never: '#9ca3af',
+        mixed: '#d97706'
+    };
+
+    var lastState = null;
+
+    function escHtml(str) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(str || ''));
+        return div.innerHTML;
+    }
+
+    function escAttr(str) {
+        return (str || '').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    function badge(state) {
+        var color = STATE_COLORS[state] || '#9ca3af';
+        return '<span style="display:inline-block;padding:1px 8px;border-radius:10px;font-size:11px;color:#fff;background:' + color + '">' + escHtml(state) + '</span>';
+    }
+
+    function engineLabel(slug) {
+        return swpsCitations.engines[slug] || slug;
+    }
+
+    // --- Load + render card state ---
+    function loadState() {
+        $.post(swpsCitations.ajax_url, {
+            action: 'swps_citations_state',
+            nonce: swpsCitations.nonce
+        }, function (res) {
+            if (!res.success) return;
+            lastState = res.data;
+            renderPrompts(res.data);
+            renderSov(res.data.share_of_voice);
+            renderBreakdown(res.data.breakdown);
+            renderCap(res.data.cap);
+        });
+    }
+
+    function renderPrompts(data) {
+        var tbody = $('#swps-citations-table tbody');
+        tbody.empty();
+
+        if (!data.prompt_states.length) {
+            tbody.html('<tr><td colspan="4">No tracked prompts yet. Add one above or seed from your keywords.</td></tr>');
+            return;
+        }
+
+        data.prompt_states.forEach(function (row) {
+            var badges = [];
+            var lastDate = '';
+            data.engines.forEach(function (engine) {
+                var info = row.states[engine];
+                if (!info) return;
+                badges.push('<span title="' + escAttr(engineLabel(engine)) + '" style="margin-right:6px;white-space:nowrap">' +
+                    escHtml(engineLabel(engine).split(' ')[0]) + ' ' + badge(info.state) + '</span>');
+                if (info.last_date && info.last_date > lastDate) lastDate = info.last_date;
+            });
+
+            var tr = '<tr>';
+            tr += '<td>' + escHtml(row.prompt) + '</td>';
+            tr += '<td>' + (badges.length ? badges.join('') : '<em>No engines enabled</em>') + '</td>';
+            tr += '<td>' + (lastDate ? escHtml(lastDate) : '—') + '</td>';
+            tr += '<td><button class="button button-small swps-citation-remove" data-prompt="' + escAttr(row.prompt) + '">Remove</button></td>';
+            tr += '</tr>';
+            tbody.append(tr);
+        });
+    }
+
+    function renderSov(sov) {
+        var box = $('#swps-citation-sov');
+        if (!sov || !sov.total_prompts) {
+            box.html('<span style="color:var(--swps-text-muted);font-size:12px">No checks in the last 30 days.</span>');
+            return;
+        }
+        var html = '';
+        Object.keys(sov.pct).forEach(function (domain) {
+            var pct = sov.pct[domain];
+            var isUs = domain === sov.us;
+            var color = isUs ? '#2271b1' : '#9ca3af';
+            html += '<div style="margin-bottom:6px;font-size:12px">';
+            html += '<div style="display:flex;justify-content:space-between">' +
+                '<span>' + escHtml(domain) + (isUs ? ' <strong>(you)</strong>' : '') + '</span>' +
+                '<span>' + pct + '%</span></div>';
+            html += '<div style="background:#f0f0f1;border-radius:3px;height:8px;overflow:hidden">' +
+                '<div style="width:' + Math.min(100, pct) + '%;height:8px;background:' + color + '"></div></div>';
+            html += '</div>';
+        });
+        box.html(html);
+    }
+
+    function renderBreakdown(breakdown) {
+        var list = $('#swps-citation-breakdown');
+        list.empty();
+        var domains = Object.keys(breakdown || {});
+        if (!domains.length) {
+            list.html('<li style="list-style:none;margin-left:-18px;color:var(--swps-text-muted)">No citation data yet.</li>');
+            return;
+        }
+        domains.forEach(function (domain) {
+            list.append('<li>' + escHtml(domain) + ' <span style="color:var(--swps-text-muted)">(' + parseInt(breakdown[domain], 10) + ')</span></li>');
+        });
+    }
+
+    function renderCap(cap) {
+        $('#swps-citation-cap-line').text(cap.used + ' of ' + cap.limit + ' checks this month');
+    }
+
+    // --- Add prompt ---
+    $('#swps-citation-add-btn').on('click', function () {
+        var input = $('#swps-citation-prompt-input');
+        var prompt = input.val().trim();
+        if (!prompt) return;
+
+        $.post(swpsCitations.ajax_url, {
+            action: 'swps_citations_add_prompt',
+            nonce: swpsCitations.nonce,
+            prompt: prompt
+        }, function (res) {
+            if (!res.success) {
+                alert(res.data.message || 'Failed to add prompt.');
+                return;
+            }
+            input.val('');
+            loadState();
+        });
+    });
+
+    // --- Remove prompt ---
+    $(document).on('click', '.swps-citation-remove', function () {
+        var prompt = $(this).data('prompt');
+        if (!confirm('Stop tracking this prompt?')) return;
+
+        $.post(swpsCitations.ajax_url, {
+            action: 'swps_citations_remove_prompt',
+            nonce: swpsCitations.nonce,
+            prompt: prompt
+        }, function () { loadState(); });
+    });
+
+    // --- Seed candidates ---
+    $('#swps-citation-seed-btn').on('click', function () {
+        var btn = $(this);
+        var panel = $('#swps-citation-seed-panel');
+        btn.prop('disabled', true);
+        $('#swps-citation-spinner').addClass('is-active');
+
+        $.post(swpsCitations.ajax_url, {
+            action: 'swps_citations_seed',
+            nonce: swpsCitations.nonce
+        }, function (res) {
+            btn.prop('disabled', false);
+            $('#swps-citation-spinner').removeClass('is-active');
+            if (!res.success) {
+                alert((res.data && res.data.message) || 'Failed to load candidates.');
+                return;
+            }
+            if (!res.data.length) {
+                panel.html('<em>No new candidates found from tracked keywords or GSC question queries.</em>').show();
+                return;
+            }
+            var html = '<strong style="display:block;margin-bottom:6px">Select prompts to track:</strong>';
+            res.data.forEach(function (c) {
+                html += '<label style="display:block;margin-bottom:3px;font-size:12px">' +
+                    '<input type="checkbox" class="swps-citation-candidate" value="' + escAttr(c.prompt) + '" data-post-id="' + parseInt(c.post_id, 10) + '" /> ' +
+                    escHtml(c.prompt) + ' <span style="color:var(--swps-text-muted)">(' + escHtml(c.source) + ')</span></label>';
+            });
+            html += '<button class="button button-primary" id="swps-citation-add-selected" style="margin-top:6px">Add selected</button> ';
+            html += '<button class="button" id="swps-citation-seed-cancel" style="margin-top:6px">Cancel</button>';
+            panel.html(html).show();
+        });
+    });
+
+    $(document).on('click', '#swps-citation-seed-cancel', function () {
+        $('#swps-citation-seed-panel').hide().empty();
+    });
+
+    $(document).on('click', '#swps-citation-add-selected', function () {
+        var checked = $('.swps-citation-candidate:checked');
+        if (!checked.length) return;
+        var queue = checked.map(function () {
+            return { prompt: $(this).val(), post_id: $(this).data('post-id') || 0 };
+        }).get();
+
+        var addNext = function () {
+            if (!queue.length) {
+                $('#swps-citation-seed-panel').hide().empty();
+                loadState();
+                return;
+            }
+            var item = queue.shift();
+            $.post(swpsCitations.ajax_url, {
+                action: 'swps_citations_add_prompt',
+                nonce: swpsCitations.nonce,
+                prompt: item.prompt,
+                post_id: item.post_id
+            }, function (res) {
+                if (!res.success && res.data && res.data.message) {
+                    alert(res.data.message);
+                    queue = [];
+                }
+                addNext();
+            });
+        };
+        addNext();
+    });
+
+    // --- Run checks now (sequential chunked AJAX) ---
+    $('#swps-citation-run-btn').on('click', function () {
+        if (!lastState || !lastState.prompt_states.length) {
+            alert('Add at least one prompt first.');
+            return;
+        }
+        if (!lastState.engines.length) {
+            alert('No engines enabled. Select engines (with saved API keys) in Settings → AI Crawlers.');
+            return;
+        }
+
+        var queue = [];
+        lastState.prompt_states.forEach(function (row) {
+            lastState.engines.forEach(function (engine) {
+                queue.push({ prompt: row.prompt, engine: engine });
+            });
+        });
+
+        var btn = $(this);
+        var progress = $('#swps-citation-progress');
+        var total = queue.length;
+        var done = 0;
+        var failed = 0;
+        btn.prop('disabled', true);
+        progress.show();
+
+        var runNext = function () {
+            if (!queue.length) {
+                btn.prop('disabled', false);
+                progress.text('Done — ' + done + ' of ' + total + ' checks completed' + (failed ? ' (' + failed + ' failed)' : '') + '.');
+                loadState();
+                return;
+            }
+            var item = queue.shift();
+            progress.text('Checking ' + (done + failed + 1) + ' of ' + total + ': "' + item.prompt + '" on ' + engineLabel(item.engine) + '…');
+
+            $.ajax({
+                url: swpsCitations.ajax_url,
+                method: 'POST',
+                timeout: 180000,
+                data: {
+                    action: 'swps_citations_run_one',
+                    nonce: swpsCitations.nonce,
+                    prompt: item.prompt,
+                    engine: item.engine
+                },
+                success: function (res) {
+                    if (res.success) {
+                        done++;
+                    } else {
+                        failed++;
+                        if (res.data && res.data.code === 'cap') {
+                            btn.prop('disabled', false);
+                            progress.text('Stopped: ' + res.data.message);
+                            loadState();
+                            return;
+                        }
+                    }
+                    runNext();
+                },
+                error: function () {
+                    failed++;
+                    runNext();
+                }
+            });
+        };
+        runNext();
+    });
+
+    // --- Init ---
+    $(document).ready(loadState);
+
+})(jQuery);

--- a/docs/superpowers/plans/2026-06-10-ai-citation-tracker.md
+++ b/docs/superpowers/plans/2026-06-10-ai-citation-tracker.md
@@ -1,0 +1,82 @@
+# AI Citation Tracker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** BYO-key share-of-voice monitoring: user-managed tracked prompts are run on a schedule through the user's own AI providers in search-grounded mode; responses are parsed for citations of the site's domain vs competitor domains; results power a Citations section on the Keywords page (per-prompt per-engine cited status with smoothing, share-of-voice vs competitors, cited-domains breakdown), a dashboard tile, and lost-citation context injected into AEO proposals.
+
+**Architecture:** (a) New `search_grounded( string $query, int $max_tokens = 1024 ): array|WP_Error` on `SWPS_AI_Provider` (default: `WP_Error('swps_search_unsupported')`), overridden per provider, returning `array{ text: string, citations: string[] }` (citation URLs). (b) New `SWPS_Citation_Tracker` (table, prompt management, cron with monthly call cap, smoothing, domain matching) + pure static helpers TDD'd. (c) UI on the Keywords page + dashboard tile + a `swps_aeo_proposal` filter callback that appends lost-citation context. Checks run via chunked AJAX (one prompt×engine per request) for manual runs and a capped loop for cron.
+
+**Branch:** `feature/ai-citation-tracker` (stacked on feature/ai-visibility-funnel). Version → 4.16.0. Conventions as all prior plans (no autoloader; require in same commit as first call site; <500 lines/file — SPLIT expected: class-citation-tracker.php + class-citation-admin.php; tabs/WPCS/docblocks; null-safe get_results; nonce+manage_options on all AJAX; gates before release commit; live smoke test on jonimms.local via the Local WP-CLI pipe; no push/PR by implementers).
+
+---
+
+## Verified integration facts (HEAD 64a951a)
+
+- `SWPS_AI_Provider` abstract: `chat()`, `chat_json()`, `test_key()`, `get_available_models()`, `get_slug()`, `get_api_key_option()`, providers read keys from options at call time; `get_validated_model()` exists per provider.
+- Keyword tracker: table `swps_keyword_tracking` (keyword, position, date UNIQUE), `get_tracked_keywords( int $limit = 100 )` (:159), tracked list option — read `track_keyword` (:86) for where the list lives; cron precedent `schedule_cron` with frequency option.
+- Competitors: option `swps_competitors` (`SWPS_Competitors::OPTION_LIST`) — read its stored shape (URLs? domains?) before matching.
+- GSC question queries: `SWPS_Search_Console::get_search_data( int $days )` (:150) returns query rows — read the shape; filter question-form queries (regex: ^(who|what|how|why|when|where|which|can|does|do|is|are|should)\b or length ≥ 5 words).
+- AEO proposal filter: `apply_filters( 'swps_aeo_proposal', $proposal, $post_id )` at class-aeo-optimizer.php:407 — read the $proposal array shape before injecting.
+- Dashboard tile + settings-section + chunked-AJAX patterns: as in all prior features (visibility funnel / digest / auto-optimize).
+- **Provider API shapes — do NOT guess; fetch current docs** (context7/WebSearch; for Anthropic consult the claude-api skill if available):
+  - Anthropic: POST /v1/messages with `tools: [{"type":"web_search_20250305","name":"web_search","max_uses":3}]`; citations appear in content blocks (`web_search_tool_result` blocks and `citations` on text blocks with `url`). Header `anthropic-version: 2023-06-01` (current provider class shows the conventions).
+  - OpenAI: the existing wrapper uses chat/completions; web search needs POST /v1/responses with `tools: [{"type":"web_search"}]`; citations in output annotations (`url_citation` with `url`).
+  - Google: generateContent with `tools: [{"google_search": {}}]`; citations from `groundingMetadata.groundingChunks[].web` — `uri` is often a vertexaisearch redirect; ALSO capture `web.title` (usually the bare domain) and prefer title-as-domain when uri is a redirect host.
+  - xAI: chat completions with `search_parameters: {"mode":"auto"}`; response carries a `citations` array of URLs.
+  - Each method: use the provider's validated model; on a 4xx whose message indicates tool/search unsupported → `WP_Error('swps_search_unsupported', ..., array('status'=>$code))`; reuse each provider's existing error/status-data conventions (`swps_api_error` + `array('status'=>...)`).
+
+## Pure helpers (TDD first — tests/unit/CitationTrackerTest.php)
+
+```php
+	/** Extract registrable hosts from citation URLs (lowercased, www-stripped); invalid skipped; deduped. */
+	public static function extract_domains( array $urls ): array
+
+	/** True when $domain (or a subdomain of it) appears in $hosts list. */
+	public static function domain_cited( string $domain, array $hosts ): bool
+
+	/** Smoothed state from newest-first cited history (bools):
+	 *  'cited' (latest 2 both true, or single true), 'lost' (≥1 true in history AND latest 2 both false),
+	 *  'never' (no true ever), 'mixed' otherwise. Empty history → 'never'. */
+	public static function citation_state( array $history ): string
+
+	/** Share of voice: prompts-cited counts per domain → pct of prompts where each domain cited; division-safe. */
+	public static function share_of_voice( array $per_domain_counts, int $total_prompts ): array
+
+	/** Question-form classifier for GSC query seeding. */
+	public static function is_question_query( string $query ): bool
+```
+
+~16 test cases across these (subdomain matching, redirect-host exclusion is NOT here — extract_domains keeps hosts verbatim; vertexaisearch handling lives in the Google provider).
+
+## Storage & behavior
+
+- Table `swps_citation_checks`: id BIGINT PK, prompt_hash CHAR(32) (md5 of prompt — used in UNIQUE), prompt VARCHAR(500), engine VARCHAR(16), check_date DATE, cited TINYINT(1), our_domains TEXT (JSON, which of our aliases matched), cited_domains TEXT (JSON all extracted domains), UNIQUE KEY idx_prompt_engine_date (prompt_hash, engine, check_date), KEY idx_engine_date (engine, check_date). DB_VERSION upgrade path per the SWPS_Backlinks/AI-referrals precedent. Retention prune: 180 days, in the check cron.
+- Prompts: option `swps_citation_prompts` = array of `{ prompt: string, post_id: int|0, added: timestamp }`, cap 25 (filterable). Seed action builds candidates from tracked keywords (as-is) + GSC question queries (top by impressions, is_question_query) — user picks via checkboxes; nothing auto-added.
+- Engines: providers with a saved API key AND search support; option `swps_citation_engines` (multi-checkbox, default = current provider only).
+- Cron `swps_citation_check`, frequency option (weekly default / daily), monthly call cap option `swps_citation_monthly_cap` (default 200) enforced against counter option `swps_citation_calls_YYYY_MM` incremented per search_grounded call (cap check BEFORE each call; stop the run when reached). Cron loops prompts×engines with the cap guard; each result row INSERT … ON DUPLICATE KEY UPDATE (re-running same day overwrites).
+- Domain matching: `home_url()` host + `apply_filters('swps_citation_our_domains', array(...))`; competitor domains parsed from `swps_competitors` entries.
+- Lost-citation → AEO: when a prompt with post_id>0 transitions to 'lost', store post meta `_swps_citation_loss` = { prompt, engines, top_cited_domains, time }; SWPS_Citation_Tracker hooks `swps_aeo_proposal` (filter, 2 args) appending a context line to the proposal prompt/payload when that meta exists (read the proposal shape first; append conservatively, e.g. to an existing context/notes field — report what you did). Clear the meta when state returns to 'cited'.
+
+## UI
+
+- Keywords page (templates/keywords-page.php + its JS — read both first): new "AI Citations" card below the keywords table: prompts table (prompt, per-engine state badges cited/lost/never/mixed via citation_state over last 3 checks, last check date), add-prompt input + seed-from-keywords/GSC modal (or simple checkbox list), remove buttons, "Run checks now" button → chunked AJAX (one prompt×engine per call, progress bar, cap-aware error), share-of-voice bars (us vs competitors over prompts checked in last 30d), cited-domains breakdown (top 10 domains AI cites for your prompts, with counts). All new AJAX: nonce `swps_citations` + manage_options.
+- Settings: frequency/cap/engines fields in a small section registered by the tracker (page 'stratawp-seo'), added to the 'discoverability' (AI Crawlers) tab's sections in get_settings_tabs().
+- Dashboard tile: "AI citations" — X of Y prompts cited (30d) with delta vs prior period; reuse safe_get pattern.
+- Cost note in UI copy: searches bill per-search surcharges on some providers; estimates only.
+
+## Task split (three dispatches)
+1. Providers: search_grounded base + 4 overrides + provider-level parsing (citations[] of URLs; Google title fallback); pure-helper TDD (extract_domains etc. live on SWPS_Citation_Tracker but are WP-free). Commit(s).
+2. Tracker core: table+upgrade, prompts CRUD, engines, cron+cap+counter, check_one(prompt, engine) runner, state queries (per-prompt histories, share-of-voice aggregates, cited-domains agg), AEO hook + loss meta, uninstall additions. Commit.
+3. UI (keywords page card + JS + chunked runner), settings section + tab line, dashboard tile, wiring, gates, live smoke on jonimms.local (wp eval: run check_one with a cheap prompt IF a key is configured — otherwise instantiation smoke only), version 4.16.0 + changelogs, plan-doc commit. Changelog:
+```
+= 4.16.0 =
+* New: AI citation tracker — monitor whether ChatGPT, Claude, Gemini, and Grok cite your site for your tracked prompts (BYO keys, search-grounded), with share-of-voice vs competitors, cited-domains breakdown, monthly call caps, and lost-citation context fed into AEO proposals.
+```
+
+## Self-review
+1. Cap enforced BEFORE every provider call; counter increments even on failed calls (they may still bill)?
+2. No provider call from page loads — only cron + explicit AJAX runs?
+3. search_grounded never used for content generation paths?
+4. Engines without keys excluded everywhere; unsupported gracefully labeled in UI?
+5. Both new classes <500 lines; everything required in stratawp-seo.php in the same commit as first call site?
+6. Smoothing prevents single-flap alarms (citation_state needs 2 consecutive misses for 'lost')?

--- a/docs/superpowers/plans/2026-06-10-ai-referral-attribution.md
+++ b/docs/superpowers/plans/2026-06-10-ai-referral-attribution.md
@@ -1,0 +1,102 @@
+# AI Referral Attribution (Crawl-to-Click Funnel) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Classify visit referrers into AI sources at insert time (the tracker already captures referrers and never reads them), persist per-source daily rollups, and report: AI-referred views by engine over time, landing posts, engagement vs organic (low-sample suppressed), a per-post crawl→visit funnel joining `swps_bot_hits_daily`, a dashboard KPI tile, and a crawled-but-no-AI-visits list.
+
+**Architecture:** New class `SWPS_AI_Referrals` owns the classifier (pure static core for TDD + filterable domain map), the bot_key→ai_source map, the daily-rollup SQL (called from the tracker's existing aggregation cron), and all reporting queries. `SWPS_Analytics_Tracker` gets two surgical touches: an `ai_source VARCHAR(32)` column (dbDelta handles column adds on activation; also add a one-time `maybe_upgrade_schema` for existing installs) and one classify call in `ajax_track()`. The new rollup table stores SUMS (total_time, total_scroll) not averages — averages computed at read time — deliberately avoiding the daily table's `(avg+new)/2` compounding bug. UI: new "AI Referrals" tab in the analytics dashboard + dashboard KPI tile.
+
+**Branch:** `feature/ai-referral-attribution`, stacked on `feature/onboarding-wizard`. Version → 4.14.0. PR base: previous branch (or main if its PR merged).
+
+**Conventions:** as previous plans (no autoloader, <500 lines, tabs/WPCS, nonce+cap on new AJAX, no Co-Authored-By, version bump + changelogs last, never push/PR — controller does).
+
+---
+
+## Verified facts (HEAD 21a339c)
+
+- Raw table `swps_analytics` (class-analytics-tracker.php:43): id, post_id, page_url, referrer VARCHAR(500), time_on_page, scroll_depth, is_bounce, created_at; `ajax_track()` (:138) inserts with `'referrer' => esc_url_raw( $_POST['referrer'] ?? '' )`.
+- Daily table `swps_analytics_daily` UNIQUE (post_id, date) — DO NOT TOUCH its key. Its ON DUPLICATE averaging `(avg + VALUES(avg)) / 2` is a known bug — do not replicate.
+- `aggregate_and_prune()` (:195): rolls raw → daily for rows `created_at < -7 days`, then DELETES those raw rows, then prunes daily past `swps_analytics_retention` (90d). The AI rollup MUST run inside this method BEFORE the raw delete.
+- Tracker JS nonce action `swps_track`; tracker disabled for admins by default.
+- Bot rollup `swps_bot_hits_daily` UNIQUE (bot_key, post_id, date) with a `hits` count (verify the count column name by reading the CREATE TABLE at class-bot-analytics-tracker.php:63-73). Bot keys from `SWPS_AI_Bots::get_bots()` (class-ai-bots.php:19+) — read the full list; relevant: gptbot, oai_searchbot?, chatgpt_user?, claudebot, claude_web?, anthropic_ai?, perplexitybot, perplexity_user?, google_extended, copilot? (use EXACT keys found).
+- Analytics dashboard AJAX pattern: `wp_ajax_swps_analytics_overview/top_pages/top_queries/post_stats` in class-analytics-dashboard.php (:25-28); read one handler fully (nonce action, response shape) + templates/analytics-page.php tab markup + admin/js JS file driving it before adding the tab.
+- Dashboard tiles: `safe_get_*` in class-dashboard.php + `$data[...]` in templates/dashboard-page.php.
+- `SWPS_Hooks` has a `filter_analytics_track`/`swps_analytics_track` filter applied in the insert path (verify name/signature at class-hooks.php:~263) — classification happens directly in ajax_track, not via the filter (simpler, always-on), but keep the filter untouched.
+- Activation table creation: `SWPS_Analytics_Tracker::create_tables()` is static, called from activation (verify where).
+
+---
+
+### Task 0: Branch check + baseline
+`git branch --show-current` → feature/ai-referral-attribution; `vendor/bin/phpunit` → 131.
+
+### Task 1: Classifier (TDD)
+Create `includes/class-ai-referrals.php` + `tests/unit/AiReferralsTest.php`. Pure static core:
+
+```php
+	/**
+	 * Default referrer-host → AI source map. Subdomains match via suffix.
+	 *
+	 * @var array<string, string>
+	 */
+	private const SOURCE_MAP = array(
+		'chatgpt.com'           => 'chatgpt',
+		'chat.openai.com'       => 'chatgpt',
+		'perplexity.ai'         => 'perplexity',
+		'claude.ai'             => 'claude',
+		'gemini.google.com'     => 'gemini',
+		'copilot.microsoft.com' => 'copilot',
+		'you.com'               => 'you',
+		'chat.deepseek.com'     => 'deepseek',
+		'grok.com'              => 'grok',
+		'meta.ai'               => 'meta',
+	);
+
+	/**
+	 * Classify a visit into an AI source.
+	 *
+	 * @param string $referrer Full referrer URL ('' when none).
+	 * @param string $page_url Landing URL (utm_source fallback).
+	 * @param array<string, string>|null $map Override map (null = default).
+	 * @return string Source key or '' when not AI-referred.
+	 */
+	public static function classify( string $referrer, string $page_url = '', ?array $map = null ): string
+```
+
+Rules (write tests FIRST): host match exact or `.host` suffix (www.chatgpt.com → chatgpt; notchatgpt.com → ''); case-insensitive; invalid/empty referrer → check page_url `utm_source` (chatgpt.com→chatgpt, perplexity.ai→perplexity, plus bare values matching a map host or source value); neither → ''. Runtime wrapper `classify_visit()` applies `apply_filters( 'swps_ai_referral_sources', self::SOURCE_MAP )` then calls classify (filter only in the wrapper so the core stays WP-free).
+Also pure + tested: `bot_source_map()` returning bot_key→ai_source for the EXACT keys in SWPS_AI_Bots (gptbot→chatgpt etc.; google_extended→gemini; bots with no visit-side counterpart omitted), and `engagement_comparison( array $ai, array $organic, int $min_n = 30 ): ?array` returning null when either sample < min_n else ratio metrics (time, scroll, bounce) — pure math, tested.
+Commit: `feat: AI referral classifier and maps`
+
+### Task 2: Capture + rollup
+- Tracker schema: add `ai_source VARCHAR(32) NOT NULL DEFAULT ''` + `KEY idx_ai_source (ai_source)` to the raw CREATE TABLE (dbDelta adds columns/keys); ALSO call `create_tables()` (or a slim `maybe_upgrade()`) from an `upgrader_process_complete`/version-check path — find how the plugin handles schema upgrades on plugin update (`grep -n "dbDelta\|db_version\|maybe_upgrade" stratawp-seo.php includes/*.php | head`); follow precedent; if none exists, add a `swps_db_version` option check on admin_init that re-runs create_tables once.
+- New rollup table (in SWPS_AI_Referrals::create_table, called alongside the tracker's): `swps_ai_referrals_daily`: id, ai_source VARCHAR(32), post_id, date, views INT, total_time INT UNSIGNED, total_scroll INT UNSIGNED, bounces INT, UNIQUE KEY idx_source_post_date (ai_source, post_id, date). SUMS not averages.
+- ajax_track: `$ai_source = SWPS_AI_Referrals::classify_visit( $referrer, $page_url );` added to the insert columns.
+- Rollup inside aggregate_and_prune BEFORE the raw delete (delegate: `SWPS_AI_Referrals::aggregate( $cutoff )`): INSERT…SELECT from raw WHERE ai_source <> '' AND created_at < cutoff GROUP BY ai_source, post_id, DATE; ON DUPLICATE: views=views+VALUES, total_time=total_time+VALUES, total_scroll=total_scroll+VALUES, bounces=bounces+VALUES (additive — correct, unlike the daily table). Prune with the same retention option.
+- Uninstall: add the new table to uninstall.php's table list (read its pattern).
+Commit: `feat: capture and roll up AI referral sources`
+
+### Task 3: Reporting queries + AJAX + UI
+In SWPS_AI_Referrals (reporting methods combine raw last-7-days + rollup, mirroring how the tracker's existing readers combine raw+daily — read get_post_views/:254 area first):
+- `get_summary( int $days )`: views by ai_source by date (chartable), totals + previous-period delta.
+- `get_landing_posts( int $days, int $limit = 10 )`: per post: views, avg time (total_time/views), avg scroll, bounce rate, ai_sources.
+- `get_engagement_vs_organic( int $days )`: AI aggregate vs non-AI aggregate from the same tables → engagement_comparison() (null ⇒ UI shows "not enough data yet").
+- `get_funnel( int $days, int $limit = 20 )`: join bot crawls to visits per post: from swps_bot_hits_daily sum hits per (post_id, mapped ai_source) via bot_source_map(), LEFT JOIN rollup sums; output rows: post, source, crawls, visits — plus `crawled_no_visits` list (crawls>0, visits=0, ordered by crawls desc). Batched single queries, no N+1.
+- AJAX `wp_ajax_swps_analytics_ai_referrals` in class-analytics-dashboard.php following its siblings exactly (same nonce/cap pattern), delegating to these methods. Wording everywhere: views/visits, never sessions; the funnel labeled "correlation, not causation" in the UI copy.
+- templates/analytics-page.php + its JS: new "AI Referrals" tab matching the existing tabs (read the markup/JS pattern first): summary chart or table, landing posts table, engagement panel (or the low-sample message), funnel table + crawled-but-no-visits list with edit links.
+- Dashboard tile: `safe_get_ai_referrals()` (30d views + prev-period delta from get_summary) + tile after the autopilot tile in dashboard-page.php (trend arrow pattern like posts_30d).
+Commit: `feat: AI referrals analytics tab, funnel, and dashboard tile`
+
+### Task 4: Wiring + release
+require_once class-ai-referrals.php; instantiate if it has hooks (create_table call wired wherever tracker's create_tables runs — activation + upgrade path); phpunit/phpstan(2G)/phpcs gates; version 4.14.0 + changelogs:
+```
+= 4.14.0 =
+* New: AI referral attribution — visits from ChatGPT, Perplexity, Claude, Gemini, Copilot and others are classified at capture, with an AI Referrals analytics tab (engine trends, landing posts, engagement vs organic), a per-post crawl-to-visit funnel joined to AI-bot crawl data, and a dashboard KPI tile.
+```
+Commits: `chore: release 4.14.0 — AI referral attribution` + `docs: implementation plan for AI referral attribution`. No push/PR.
+
+## Self-review
+1. Raw insert always sets ai_source (default '' for non-AI)?
+2. Rollup additive sums only; runs BEFORE raw delete; pruned by retention?
+3. Existing installs get the new column + table without re-activation?
+4. Low-sample suppression actually reachable (n<30 → message, not bogus ratios)?
+5. No N+1 in funnel/landing queries?
+6. Copy: views/visits; funnel labeled correlation.

--- a/docs/superpowers/plans/2026-06-10-ai-visibility-funnel.md
+++ b/docs/superpowers/plans/2026-06-10-ai-visibility-funnel.md
@@ -1,0 +1,37 @@
+# AI Visibility Funnel (Thin Slice) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Join the plugin's siloed AI datasets in the four places users already look: (1) the bot-analytics gap report gains AEO-score sorting, (2) the AEO queue gains crawl-recency/frequency AND AI-visit columns, (3) the AEO editor panel gains a per-post funnel line ("crawled 2d ago by ClaudeBot · 14 AI visits 30d"), (4) the dashboard gains a site-wide two-stage funnel tile (posts crawled → posts receiving AI visits, 30d, with stage drop-off). The "cited" stage arrives with the citation tracker (Feature 6) — design the tile so a third stage slots in.
+
+**Architecture:** No new tables, no cron. One new small class `SWPS_Visibility_Funnel` holding the batched join queries (crawl stats per post-set from `swps_bot_hits`/`swps_bot_hits_daily`, AI-visit stats per post-set from `swps_analytics`/`swps_ai_referrals_daily`, site-wide funnel counts) so the four surfaces share one query layer. Strictly batched lookups (post_id IN (...)), transient-cached dashboard tile (15 min).
+
+**Branch:** `feature/ai-visibility-funnel` (stacked on feature/ai-referral-attribution). Version → 4.15.0. Conventions as all prior plans.
+
+---
+
+## Integration points (verify each by reading before editing)
+
+- `SWPS_Bot_Analytics_Tracker::get_gap_posts( int $days = 30, int $limit = 25 )` (:562) — read it; add an `$orderby` param or join `_swps_aeo_score` postmeta so the gap report can sort by score desc (high-score-but-never-crawled first). The analytics template's AI Crawlers section renders it — find and update that rendering with the score column + sort control (match how the section currently renders; if it's server-rendered, a simple link toggle `?gap_sort=score` is fine).
+- `SWPS_AEO_Optimizer::get_scored_posts()` (:186, private) + `templates/aeo-page.php` queue table — add "Last crawl" (bot + human-time-diff) and "AI visits (30d)" columns fed by ONE batched call each from SWPS_Visibility_Funnel over the page of post ids. Read how the queue paginates first.
+- `SWPS_Analytics_Dashboard::ajax_post_stats()` (:228) — read its response shape; the AEO editor panel (includes/class-aeo-editor-panel.php + its JS) shows per-post stats; add funnel fields (last crawl bot/date, ai_visits_30d) via SWPS_Visibility_Funnel and render one line in the panel JS following its existing field pattern.
+- Dashboard tile: `safe_get_funnel()` → SWPS_Visibility_Funnel::site_funnel(30): published posts count, posts with ≥1 bot hit (30d), posts with ≥1 AI visit (30d) — two conversion percentages; transient cache 15 min (`swps_funnel_tile`); tile after the AI-referrals tile; render so a "cited" stage can be inserted later (loop over stages array, not hardcoded markup).
+- Funnel data sources: crawls = swps_bot_hits (raw, 7d) + swps_bot_hits_daily (hits col) combined like get_bot_summary does (read it); AI visits = swps_analytics raw (ai_source <> '', 7d) + swps_ai_referrals_daily — combined like SWPS_AI_Referrals_Report does (reuse its private patterns; if reuse needs a method made public, prefer adding a public method on the report class over duplicating SQL).
+
+## Tasks
+0. Branch check (feature/ai-visibility-funnel), baseline 179 tests.
+1. TDD pure helper: `SWPS_Visibility_Funnel::stage_rates( int $published, int $crawled, int $visited ): array` (per-stage counts + pct of previous stage, division-safe, clamped 0-100) + class skeleton. Test file tests/unit/VisibilityFunnelTest.php (~6 cases incl. zero-published, zero-crawled).
+2. Query layer: `crawl_stats_for_posts( array $post_ids, int $days )` (last_crawl_at, last_bot, hits), `ai_visits_for_posts( array $post_ids, int $days )`, `site_funnel( int $days )` — batched, prepared, null-safe (`?: array()` on get_results). Commit.
+3. The four surface integrations (gap sort, queue columns, editor-panel line, dashboard tile). Commit each surface or together — your call, but keep commits coherent.
+4. Wire-up (require_once; instantiate only if it has hooks — it likely needs none, static/instance methods called by the surfaces), gates (phpunit/phpstan 2G/phpcs on new+modified-new-lines), version 4.15.0 + changelogs:
+```
+= 4.15.0 =
+* New: AI visibility funnel — AEO-score sorting on the crawl-gap report, crawl recency and AI-visit columns on the AEO queue, a per-post funnel line in the AEO editor panel, and a dashboard funnel tile (crawled → AI-visited).
+```
+Commits: `chore: release 4.15.0 — AI visibility funnel` + `docs: implementation plan for AI visibility funnel`. No push/PR.
+
+## Self-review
+1. No N+1 anywhere (queue page = 2 batched queries max)?
+2. Tile cached; cache invalidation not needed (15-min staleness fine)?
+3. Funnel copy avoids causal claims?
+4. Stage renderer loop-based for the future cited stage?

--- a/includes/class-aeo-editor-panel.php
+++ b/includes/class-aeo-editor-panel.php
@@ -128,6 +128,22 @@ class SWPS_AEO_Editor_Panel {
 					?>
 				</p>
 			<?php endif; ?>
+			<?php
+			// Lost-citation context line (set by SWPS_Citation_Tracker::detect_losses()).
+			$citation_loss = get_post_meta( $post->ID, SWPS_Citation_Tracker::META_LOSS, true );
+			if ( is_array( $citation_loss ) && ! empty( $citation_loss['prompt'] ) ) :
+				?>
+				<p class="description swps-aeo-citation-loss" style="margin-top:6px;font-size:11px;color:#b32d2e;">
+					<?php
+					printf(
+						/* translators: 1: prompt text, 2: engine list. */
+						esc_html__( 'AI engines (%2$s) stopped citing this post for "%1$s" — consider re-optimizing.', 'stratawp-seo' ),
+						esc_html( (string) $citation_loss['prompt'] ),
+						esc_html( implode( ', ', (array) ( $citation_loss['engines'] ?? array() ) ) )
+					);
+					?>
+				</p>
+			<?php endif; ?>
 		</div>
 		<?php
 	}

--- a/includes/class-aeo-editor-panel.php
+++ b/includes/class-aeo-editor-panel.php
@@ -94,6 +94,40 @@ class SWPS_AEO_Editor_Panel {
 				}
 				?>
 			</p>
+			<?php
+			// AI Visibility funnel line — single batched lookup.
+			$crawl_map   = SWPS_Visibility_Funnel::crawl_stats_for_posts( array( $post->ID ), 30 );
+			$visit_map   = SWPS_Visibility_Funnel::ai_visits_for_posts( array( $post->ID ), 30 );
+			$crawl_entry = $crawl_map[ $post->ID ] ?? null;
+			$ai_visits   = isset( $visit_map[ $post->ID ] ) ? (int) $visit_map[ $post->ID ]['ai_visits'] : 0;
+
+			if ( $crawl_entry || $ai_visits > 0 ) :
+				$crawl_ago = $crawl_entry && $crawl_entry['last_crawl_at']
+					? human_time_diff( strtotime( (string) $crawl_entry['last_crawl_at'] ), time() ) . ' ago'
+					: null;
+				$crawl_bot = $crawl_entry ? (string) ( $crawl_entry['last_bot'] ?? '' ) : '';
+				?>
+				<p class="description swps-aeo-funnel-line" style="margin-top:6px;font-size:11px;color:var(--swps-text-muted);">
+					<?php if ( $crawl_ago ) : ?>
+						<?php
+						printf(
+							/* translators: 1: time since last crawl, 2: bot name. */
+							esc_html__( 'Crawled %1$s by %2$s', 'stratawp-seo' ),
+							esc_html( $crawl_ago ),
+							'<code>' . esc_html( '' !== $crawl_bot ? $crawl_bot : 'AI bot' ) . '</code>'
+						);
+						?>
+						&nbsp;&middot;&nbsp;
+					<?php endif; ?>
+					<?php
+					printf(
+						/* translators: %d: number of AI visits in 30 days. */
+						esc_html( _n( '%d AI visit (30d)', '%d AI visits (30d)', $ai_visits, 'stratawp-seo' ) ),
+						(int) $ai_visits
+					);
+					?>
+				</p>
+			<?php endif; ?>
 		</div>
 		<?php
 	}

--- a/includes/class-aeo-optimizer.php
+++ b/includes/class-aeo-optimizer.php
@@ -214,7 +214,7 @@ class SWPS_AEO_Optimizer {
 			if ( get_post_meta( $post_id, self::META_DISMISSED, true ) ) {
 				continue;
 			}
-			$coverage = get_post_meta( $post_id, SWPS_AEO_Scorer::META_SUBSCORE_PREFIX . 'coverage', true );
+			$coverage  = get_post_meta( $post_id, SWPS_AEO_Scorer::META_SUBSCORE_PREFIX . 'coverage', true );
 			$results[] = array(
 				'post_id'      => $post_id,
 				'title'        => (string) $row->post_title,
@@ -231,6 +231,25 @@ class SWPS_AEO_Optimizer {
 				'has_proposal' => '' !== get_post_meta( $post_id, self::META_PROPOSAL, true ),
 			);
 		}
+
+		// Enrich with crawl recency and AI-visit counts — two batched queries.
+		$post_ids    = array_column( $results, 'post_id' );
+		$crawl_map   = SWPS_Visibility_Funnel::crawl_stats_for_posts( $post_ids, 30 );
+		$visit_map   = SWPS_Visibility_Funnel::ai_visits_for_posts( $post_ids, 30 );
+
+		foreach ( $results as &$r ) {
+			$pid   = $r['post_id'];
+			$crawl = $crawl_map[ $pid ] ?? null;
+
+			$r['last_crawl_at']  = $crawl ? (string) $crawl['last_crawl_at'] : null;
+			$r['last_crawl_ago'] = $crawl && $crawl['last_crawl_at']
+				? human_time_diff( strtotime( (string) $crawl['last_crawl_at'] ), time() ) . ' ago'
+				: null;
+			$r['last_bot']       = $crawl ? (string) $crawl['last_bot'] : null;
+			$r['ai_visits_30d']  = isset( $visit_map[ $pid ] ) ? (int) $visit_map[ $pid ]['ai_visits'] : 0;
+		}
+		unset( $r );
+
 		return $results;
 	}
 

--- a/includes/class-ai-provider.php
+++ b/includes/class-ai-provider.php
@@ -395,6 +395,27 @@ abstract class SWPS_AI_Provider {
 	}
 
 	/**
+	 * Run a search-grounded query and return the response text with citation URLs.
+	 *
+	 * The default implementation returns an unsupported error. Providers that
+	 * support real-time web search override this method.
+	 *
+	 * @param string $query      The search query / prompt to run.
+	 * @param int    $max_tokens Maximum tokens in the response.
+	 * @return array{text: string, citations: string[]}|WP_Error
+	 */
+	public function search_grounded( string $query, int $max_tokens = 1024 ): array|WP_Error { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		return new WP_Error(
+			'swps_search_unsupported',
+			sprintf(
+				/* translators: %s: provider display name */
+				__( '%s does not support search-grounded queries.', 'stratawp-seo' ),
+				$this->get_name()
+			)
+		);
+	}
+
+	/**
 	 * Get the stored API key for this provider.
 	 */
 	public function get_api_key(): string {

--- a/includes/class-ai-referrals-report.php
+++ b/includes/class-ai-referrals-report.php
@@ -59,6 +59,7 @@ class SWPS_AI_Referrals_Report {
 			),
 			ARRAY_A
 		);
+		$rows = $rows ? $rows : array();
         // phpcs:enable
 
 		$daily       = array();
@@ -143,6 +144,7 @@ class SWPS_AI_Referrals_Report {
 			),
 			ARRAY_A
 		);
+		$rows = $rows ? $rows : array();
         // phpcs:enable
 
 		$out = array();
@@ -329,7 +331,7 @@ class SWPS_AI_Referrals_Report {
 
 		// Map crawls to (source, post_id), skipping bots with no visit-side counterpart.
 		$crawls = array();
-		foreach ( $crawl_rows as $row ) {
+		foreach ( $crawl_rows ? $crawl_rows : array() as $row ) {
 			$source = $bot_map[ $row['bot_key'] ] ?? '';
 			if ( '' === $source ) {
 				continue;
@@ -340,7 +342,7 @@ class SWPS_AI_Referrals_Report {
 		}
 
 		$visits = array();
-		foreach ( $visit_rows as $row ) {
+		foreach ( $visit_rows ? $visit_rows : array() as $row ) {
 			$visits[ $row['ai_source'] . '|' . $row['post_id'] ] = (int) $row['views'];
 		}
 

--- a/includes/class-ai-referrals-report.php
+++ b/includes/class-ai-referrals-report.php
@@ -1,0 +1,380 @@
+<?php
+/**
+ * AI Referral Attribution — reporting queries.
+ *
+ * Read-side companion to SWPS_AI_Referrals. Every reader combines the raw
+ * analytics table's last-7-days rows (not yet rolled up) with the
+ * swps_ai_referrals_daily rollup via UNION ALL, mirroring how
+ * SWPS_Analytics_Tracker::get_daily_stats() combines raw + daily.
+ *
+ * Averages are always computed at read time from summed totals
+ * (total_time / views), never stored — avoiding the daily table's
+ * compounding-average bug.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Reporting queries for AI referral attribution: per-engine summary,
+ * landing posts, engagement vs organic, and the crawl-to-visit funnel.
+ */
+class SWPS_AI_Referrals_Report {
+
+	/**
+	 * Per-source daily views over a period, with totals and a
+	 * previous-period delta.
+	 *
+	 * @param int $days Number of days to look back.
+	 * @return array{daily: array, by_source: array, total_views: int, prev_views: int, delta_pct: float|null}
+	 */
+	public static function get_summary( int $days ): array {
+		global $wpdb;
+
+		$raw        = $wpdb->prefix . 'swps_analytics';
+		$rollup     = $wpdb->prefix . 'swps_ai_referrals_daily';
+		$since      = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+		$prev_since = gmdate( 'Y-m-d', strtotime( '-' . ( $days * 2 ) . ' days' ) );
+
+		// One query covers both periods; split in PHP.
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT date, ai_source, SUM(views) AS views FROM (
+                     SELECT DATE(created_at) AS date, ai_source, 1 AS views
+                     FROM {$raw}
+                     WHERE ai_source <> '' AND DATE(created_at) >= %s
+                     UNION ALL
+                     SELECT date, ai_source, views
+                     FROM {$rollup}
+                     WHERE date >= %s
+                 ) c
+                 GROUP BY date, ai_source
+                 ORDER BY date ASC",
+				$prev_since,
+				$prev_since
+			),
+			ARRAY_A
+		);
+        // phpcs:enable
+
+		$daily       = array();
+		$by_source   = array();
+		$total_views = 0;
+		$prev_views  = 0;
+
+		foreach ( $rows as $row ) {
+			$views = (int) $row['views'];
+
+			if ( $row['date'] >= $since ) {
+				$daily[]      = array(
+					'date'      => $row['date'],
+					'ai_source' => $row['ai_source'],
+					'views'     => $views,
+				);
+				$total_views += $views;
+
+				if ( ! isset( $by_source[ $row['ai_source'] ] ) ) {
+					$by_source[ $row['ai_source'] ] = 0;
+				}
+				$by_source[ $row['ai_source'] ] += $views;
+			} else {
+				$prev_views += $views;
+			}
+		}
+
+		arsort( $by_source );
+
+		return array(
+			'daily'       => $daily,
+			'by_source'   => $by_source,
+			'total_views' => $total_views,
+			'prev_views'  => $prev_views,
+			'delta_pct'   => $prev_views > 0
+				? round( ( ( $total_views - $prev_views ) / $prev_views ) * 100, 1 )
+				: null,
+		);
+	}
+
+	/**
+	 * Top landing posts for AI-referred visits.
+	 *
+	 * Averages computed at read time from summed totals.
+	 *
+	 * @param int $days  Number of days to look back.
+	 * @param int $limit Max posts.
+	 * @return array<int, array> Rows: post_id, views, avg_time, avg_scroll, bounce_rate, ai_sources.
+	 */
+	public static function get_landing_posts( int $days, int $limit = 10 ): array {
+		global $wpdb;
+
+		$raw    = $wpdb->prefix . 'swps_analytics';
+		$rollup = $wpdb->prefix . 'swps_ai_referrals_daily';
+		$since  = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_id,
+                        SUM(views) AS views,
+                        SUM(total_time) AS total_time,
+                        SUM(total_scroll) AS total_scroll,
+                        SUM(bounces) AS bounces,
+                        GROUP_CONCAT(DISTINCT ai_source ORDER BY ai_source) AS ai_sources
+                 FROM (
+                     SELECT post_id, ai_source, 1 AS views, time_on_page AS total_time,
+                            scroll_depth AS total_scroll, is_bounce AS bounces
+                     FROM {$raw}
+                     WHERE ai_source <> '' AND DATE(created_at) >= %s AND post_id > 0
+                     UNION ALL
+                     SELECT post_id, ai_source, views, total_time, total_scroll, bounces
+                     FROM {$rollup}
+                     WHERE date >= %s AND post_id > 0
+                 ) c
+                 GROUP BY post_id
+                 ORDER BY views DESC
+                 LIMIT %d",
+				$since,
+				$since,
+				$limit
+			),
+			ARRAY_A
+		);
+        // phpcs:enable
+
+		$out = array();
+
+		foreach ( $rows as $row ) {
+			$views = (int) $row['views'];
+			$out[] = array(
+				'post_id'     => (int) $row['post_id'],
+				'views'       => $views,
+				'avg_time'    => $views > 0 ? (int) round( $row['total_time'] / $views ) : 0,
+				'avg_scroll'  => $views > 0 ? (int) round( $row['total_scroll'] / $views ) : 0,
+				'bounce_rate' => $views > 0 ? (int) round( ( $row['bounces'] / $views ) * 100 ) : 0,
+				'ai_sources'  => $row['ai_sources'],
+			);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * AI vs organic engagement comparison over a period.
+	 *
+	 * AI aggregate comes from raw + the AI rollup (exact sums). The all-traffic
+	 * aggregate comes from raw + the analytics daily table (daily stores
+	 * per-day averages, so its time/scroll contributions are weighted by views
+	 * — an approximation). Organic = all − AI.
+	 *
+	 * @param int $days  Number of days to look back.
+	 * @param int $min_n Minimum sample size per group.
+	 * @return array|null Ratio metrics, or null when either sample is too small.
+	 */
+	public static function get_engagement_vs_organic( int $days, int $min_n = 30 ): ?array {
+		global $wpdb;
+
+		$raw    = $wpdb->prefix . 'swps_analytics';
+		$rollup = $wpdb->prefix . 'swps_ai_referrals_daily';
+		$daily  = $wpdb->prefix . 'swps_analytics_daily';
+		$since  = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$ai = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT SUM(views) AS views, SUM(total_time) AS total_time,
+                        SUM(total_scroll) AS total_scroll, SUM(bounces) AS bounces
+                 FROM (
+                     SELECT 1 AS views, time_on_page AS total_time,
+                            scroll_depth AS total_scroll, is_bounce AS bounces
+                     FROM {$raw}
+                     WHERE ai_source <> '' AND DATE(created_at) >= %s
+                     UNION ALL
+                     SELECT views, total_time, total_scroll, bounces
+                     FROM {$rollup}
+                     WHERE date >= %s
+                 ) c",
+				$since,
+				$since
+			),
+			ARRAY_A
+		);
+
+		$all = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT SUM(views) AS views, SUM(total_time) AS total_time,
+                        SUM(total_scroll) AS total_scroll, SUM(bounces) AS bounces
+                 FROM (
+                     SELECT 1 AS views, time_on_page AS total_time,
+                            scroll_depth AS total_scroll, is_bounce AS bounces
+                     FROM {$raw}
+                     WHERE DATE(created_at) >= %s
+                     UNION ALL
+                     SELECT views, views * avg_time_on_page AS total_time,
+                            views * avg_scroll_depth AS total_scroll, bounces
+                     FROM {$daily}
+                     WHERE date >= %s
+                 ) c",
+				$since,
+				$since
+			),
+			ARRAY_A
+		);
+        // phpcs:enable
+
+		$ai_views  = (int) ( $ai['views'] ?? 0 );
+		$all_views = (int) ( $all['views'] ?? 0 );
+		$org_views = max( 0, $all_views - $ai_views );
+
+		$org_time   = max( 0, (int) ( $all['total_time'] ?? 0 ) - (int) ( $ai['total_time'] ?? 0 ) );
+		$org_scroll = max( 0, (int) ( $all['total_scroll'] ?? 0 ) - (int) ( $ai['total_scroll'] ?? 0 ) );
+		$org_bounce = max( 0, (int) ( $all['bounces'] ?? 0 ) - (int) ( $ai['bounces'] ?? 0 ) );
+
+		$ai_agg = array(
+			'views'       => $ai_views,
+			'avg_time'    => $ai_views > 0 ? $ai['total_time'] / $ai_views : 0,
+			'avg_scroll'  => $ai_views > 0 ? $ai['total_scroll'] / $ai_views : 0,
+			'bounce_rate' => $ai_views > 0 ? $ai['bounces'] / $ai_views : 0,
+		);
+
+		$org_agg = array(
+			'views'       => $org_views,
+			'avg_time'    => $org_views > 0 ? $org_time / $org_views : 0,
+			'avg_scroll'  => $org_views > 0 ? $org_scroll / $org_views : 0,
+			'bounce_rate' => $org_views > 0 ? $org_bounce / $org_views : 0,
+		);
+
+		$comparison = SWPS_AI_Referrals::engagement_comparison( $ai_agg, $org_agg, $min_n );
+
+		if ( null === $comparison ) {
+			return null;
+		}
+
+		// Add display-friendly absolutes alongside the ratios.
+		$comparison['ai']      = array(
+			'avg_time'    => (int) round( $ai_agg['avg_time'] ),
+			'avg_scroll'  => (int) round( $ai_agg['avg_scroll'] ),
+			'bounce_rate' => (int) round( $ai_agg['bounce_rate'] * 100 ),
+		);
+		$comparison['organic'] = array(
+			'avg_time'    => (int) round( $org_agg['avg_time'] ),
+			'avg_scroll'  => (int) round( $org_agg['avg_scroll'] ),
+			'bounce_rate' => (int) round( $org_agg['bounce_rate'] * 100 ),
+		);
+
+		return $comparison;
+	}
+
+	/**
+	 * Crawl-to-visit funnel: AI bot crawls joined to AI-referred visits per
+	 * post and source. Two batched queries joined in PHP — no N+1.
+	 *
+	 * @param int $days  Number of days to look back.
+	 * @param int $limit Max funnel rows.
+	 * @return array{rows: array, crawled_no_visits: array}
+	 */
+	public static function get_funnel( int $days, int $limit = 20 ): array {
+		global $wpdb;
+
+		$bot_raw   = $wpdb->prefix . 'swps_bot_hits';
+		$bot_daily = $wpdb->prefix . 'swps_bot_hits_daily';
+		$raw       = $wpdb->prefix . 'swps_analytics';
+		$rollup    = $wpdb->prefix . 'swps_ai_referrals_daily';
+		$since     = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+		$bot_map = SWPS_AI_Referrals::bot_source_map();
+
+		// Query 1: crawls per (bot_key, post_id) — raw + daily, like the bot tracker readers.
+        // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$crawl_rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT bot_key, post_id, SUM(hits) AS hits FROM (
+                     SELECT bot_key, post_id, 1 AS hits
+                     FROM {$bot_raw}
+                     WHERE DATE(created_at) >= %s AND post_id > 0
+                     UNION ALL
+                     SELECT bot_key, post_id, hits
+                     FROM {$bot_daily}
+                     WHERE date >= %s AND post_id > 0
+                 ) c
+                 GROUP BY bot_key, post_id",
+				$since,
+				$since
+			),
+			ARRAY_A
+		);
+
+		// Query 2: AI-referred visits per (ai_source, post_id) — raw + rollup.
+		$visit_rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT ai_source, post_id, SUM(views) AS views FROM (
+                     SELECT ai_source, post_id, 1 AS views
+                     FROM {$raw}
+                     WHERE ai_source <> '' AND DATE(created_at) >= %s AND post_id > 0
+                     UNION ALL
+                     SELECT ai_source, post_id, views
+                     FROM {$rollup}
+                     WHERE date >= %s AND post_id > 0
+                 ) c
+                 GROUP BY ai_source, post_id",
+				$since,
+				$since
+			),
+			ARRAY_A
+		);
+        // phpcs:enable
+
+		// Map crawls to (source, post_id), skipping bots with no visit-side counterpart.
+		$crawls = array();
+		foreach ( $crawl_rows as $row ) {
+			$source = $bot_map[ $row['bot_key'] ] ?? '';
+			if ( '' === $source ) {
+				continue;
+			}
+			$key = $source . '|' . $row['post_id'];
+
+			$crawls[ $key ] = ( $crawls[ $key ] ?? 0 ) + (int) $row['hits'];
+		}
+
+		$visits = array();
+		foreach ( $visit_rows as $row ) {
+			$visits[ $row['ai_source'] . '|' . $row['post_id'] ] = (int) $row['views'];
+		}
+
+		$rows = array();
+		foreach ( $crawls as $key => $crawl_count ) {
+			list( $source, $post_id ) = explode( '|', $key, 2 );
+
+			$rows[] = array(
+				'post_id'   => (int) $post_id,
+				'ai_source' => $source,
+				'crawls'    => $crawl_count,
+				'visits'    => $visits[ $key ] ?? 0,
+			);
+		}
+
+		usort(
+			$rows,
+			static function ( array $a, array $b ): int {
+				return $b['crawls'] <=> $a['crawls'];
+			}
+		);
+
+		$crawled_no_visits = array_values(
+			array_filter(
+				$rows,
+				static function ( array $row ): bool {
+					return 0 === $row['visits'];
+				}
+			)
+		);
+
+		return array(
+			'rows'              => array_slice( $rows, 0, $limit ),
+			'crawled_no_visits' => array_slice( $crawled_no_visits, 0, $limit ),
+		);
+	}
+}

--- a/includes/class-ai-referrals.php
+++ b/includes/class-ai-referrals.php
@@ -1,0 +1,371 @@
+<?php
+/**
+ * AI Referral Attribution — classifier, bot-source map, engagement comparison,
+ * daily rollup table, and aggregation.
+ *
+ * Pure static core (classify, bot_source_map, engagement_comparison) is
+ * WordPress-free so it can be unit-tested without a WP bootstrap.
+ *
+ * The runtime wrapper classify_visit() applies the swps_ai_referral_sources
+ * filter so site owners can extend the default source map.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * AI Referral Attribution — classifier, bot-source map, engagement comparison,
+ * daily rollup table, and aggregation methods.
+ */
+class SWPS_AI_Referrals {
+
+	// -------------------------------------------------------------------------
+	// Constants
+	// -------------------------------------------------------------------------
+
+	/** Schema version — bump when the rollup table DDL changes. */
+	public const DB_VERSION = '1';
+
+	/** Option key used to gate the schema upgrade. */
+	public const OPT_DB_VER = 'swps_ai_referrals_db_version';
+
+	/** Rollup table (without $wpdb->prefix). */
+	private const ROLLUP_TABLE = 'swps_ai_referrals_daily';
+
+	// -------------------------------------------------------------------------
+	// Classifier core — WP-free
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Default referrer-host → AI source map. Subdomains match via suffix.
+	 *
+	 * @var array<string, string>
+	 */
+	private const SOURCE_MAP = array(
+		'chatgpt.com'           => 'chatgpt',
+		'chat.openai.com'       => 'chatgpt',
+		'perplexity.ai'         => 'perplexity',
+		'claude.ai'             => 'claude',
+		'gemini.google.com'     => 'gemini',
+		'copilot.microsoft.com' => 'copilot',
+		'you.com'               => 'you',
+		'chat.deepseek.com'     => 'deepseek',
+		'grok.com'              => 'grok',
+		'meta.ai'               => 'meta',
+	);
+
+	/**
+	 * Classify a visit into an AI source.
+	 *
+	 * Matching rules (in priority order):
+	 * 1. referrer host exact-match or `.host` suffix match (case-insensitive).
+	 * 2. page_url utm_source fallback: value matches a map key (host) or a map
+	 *    value (source slug), case-insensitive.
+	 * 3. Returns '' when neither matches.
+	 *
+	 * @param string                     $referrer  Full referrer URL ('' when none).
+	 * @param string                     $page_url  Landing URL (utm_source fallback).
+	 * @param array<string, string>|null $map       Override map (null = default).
+	 * @return string Source key, or '' when not AI-referred.
+	 */
+	public static function classify( string $referrer, string $page_url = '', ?array $map = null ): string {
+		$map = $map ?? self::SOURCE_MAP;
+
+		// 1. Referrer host match.
+		if ( '' !== $referrer ) {
+			$host = self::parse_host( $referrer );
+
+			if ( '' !== $host ) {
+				$source = self::match_host( $host, $map );
+
+				if ( '' !== $source ) {
+					return $source;
+				}
+			}
+		}
+
+		// 2. utm_source fallback from page_url.
+		if ( '' !== $page_url ) {
+			$utm = self::extract_utm_source( $page_url );
+
+			if ( '' !== $utm ) {
+				return self::match_utm( $utm, $map );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Runtime wrapper: applies the swps_ai_referral_sources filter before classifying.
+	 *
+	 * @param string $referrer Full referrer URL.
+	 * @param string $page_url Landing page URL.
+	 * @return string Source key, or '' when not AI-referred.
+	 */
+	public static function classify_visit( string $referrer, string $page_url = '' ): string {
+		$map = (array) apply_filters( 'swps_ai_referral_sources', self::SOURCE_MAP );
+
+		return self::classify( $referrer, $page_url, $map );
+	}
+
+	// -------------------------------------------------------------------------
+	// Bot → AI source map
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Return a map of bot_key → ai_source for bot keys from SWPS_AI_Bots that
+	 * have a visit-side counterpart in the source map.
+	 *
+	 * Bots with no visit-side counterpart (applebot_extended, ccbot, bytespider,
+	 * amazonbot, duckassistbot) are omitted intentionally.
+	 *
+	 * @return array<string, string> bot_key → ai_source.
+	 */
+	public static function bot_source_map(): array {
+		return array(
+			'gptbot'             => 'chatgpt',
+			'oai_searchbot'      => 'chatgpt',
+			'chatgpt_user'       => 'chatgpt',
+			'claudebot'          => 'claude',
+			'claude_web'         => 'claude',
+			'anthropic_ai'       => 'claude',
+			'perplexitybot'      => 'perplexity',
+			'perplexity_user'    => 'perplexity',
+			'google_extended'    => 'gemini',
+			'meta_externalagent' => 'meta',
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Engagement comparison — pure math, WP-free
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Compare AI-referred engagement against organic.
+	 *
+	 * Returns null when either sample is below the minimum threshold to prevent
+	 * misleading ratios from sparse data.
+	 *
+	 * @param array{views: int, avg_time: float, avg_scroll: float, bounce_rate: float} $ai      AI aggregate metrics.
+	 * @param array{views: int, avg_time: float, avg_scroll: float, bounce_rate: float} $organic Organic aggregate metrics.
+	 * @param int                                                                       $min_n   Minimum sample size per group.
+	 * @return array{time_ratio: float, scroll_ratio: float, bounce_ratio: float, ai_n: int, organic_n: int}|null
+	 */
+	public static function engagement_comparison( array $ai, array $organic, int $min_n = 30 ): ?array {
+		if ( ( $ai['views'] ?? 0 ) < $min_n || ( $organic['views'] ?? 0 ) < $min_n ) {
+			return null;
+		}
+
+		$organic_time   = (float) ( $organic['avg_time'] ?? 1 );
+		$organic_scroll = (float) ( $organic['avg_scroll'] ?? 1 );
+		$organic_bounce = (float) ( $organic['bounce_rate'] ?? 1 );
+
+		return array(
+			'time_ratio'   => $organic_time > 0 ? round( (float) $ai['avg_time'] / $organic_time, 4 ) : 0.0,
+			'scroll_ratio' => $organic_scroll > 0 ? round( (float) $ai['avg_scroll'] / $organic_scroll, 4 ) : 0.0,
+			'bounce_ratio' => $organic_bounce > 0 ? round( (float) $ai['bounce_rate'] / $organic_bounce, 4 ) : 0.0,
+			'ai_n'         => (int) $ai['views'],
+			'organic_n'    => (int) $organic['views'],
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Schema — rollup table
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Create the AI referrals daily rollup table.
+	 * Called on activation (from stratawp-seo.php) and via maybe_upgrade().
+	 */
+	public static function create_table(): void {
+		global $wpdb;
+
+		$charset = $wpdb->get_charset_collate();
+		$table   = $wpdb->prefix . self::ROLLUP_TABLE;
+
+		$sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            ai_source VARCHAR(32) NOT NULL DEFAULT '',
+            post_id BIGINT UNSIGNED NOT NULL DEFAULT 0,
+            date DATE NOT NULL,
+            views INT UNSIGNED NOT NULL DEFAULT 0,
+            total_time INT UNSIGNED NOT NULL DEFAULT 0,
+            total_scroll INT UNSIGNED NOT NULL DEFAULT 0,
+            bounces INT UNSIGNED NOT NULL DEFAULT 0,
+            PRIMARY KEY (id),
+            UNIQUE KEY idx_source_post_date (ai_source, post_id, date),
+            KEY idx_ai_source (ai_source),
+            KEY idx_date (date)
+        ) {$charset};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Drop the rollup table. Called on uninstall.
+	 */
+	public static function drop_table(): void {
+		global $wpdb;
+		$table = $wpdb->prefix . self::ROLLUP_TABLE;
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange
+		$wpdb->query( "DROP TABLE IF EXISTS {$table}" );
+	}
+
+	/**
+	 * Ensure the rollup table exists for existing installs that did not
+	 * re-run the activation hook (i.e. plugin was updated, not reactivated).
+	 *
+	 * Mirrors the SWPS_Backlinks::__construct() upgrade pattern.
+	 */
+	public static function maybe_upgrade(): void {
+		if ( self::DB_VERSION !== get_option( self::OPT_DB_VER ) ) {
+			self::create_table();
+			update_option( self::OPT_DB_VER, self::DB_VERSION );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Aggregation — called from SWPS_Analytics_Tracker::aggregate_and_prune()
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Roll up raw analytics rows (where ai_source is set) into the daily
+	 * rollup table. Uses additive SUMS — no averaging bug.
+	 *
+	 * Must be called BEFORE the raw delete in aggregate_and_prune().
+	 *
+	 * @param string $cutoff MySQL datetime string — rows older than this are rolled up.
+	 */
+	public static function aggregate( string $cutoff ): void {
+		global $wpdb;
+
+		$raw    = $wpdb->prefix . 'swps_analytics';
+		$rollup = $wpdb->prefix . self::ROLLUP_TABLE;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$rollup} (ai_source, post_id, date, views, total_time, total_scroll, bounces)
+                 SELECT ai_source, post_id, DATE(created_at),
+                        COUNT(*), SUM(time_on_page), SUM(scroll_depth), SUM(is_bounce)
+                 FROM {$raw}
+                 WHERE ai_source <> '' AND created_at < %s
+                 GROUP BY ai_source, post_id, DATE(created_at)
+                 ON DUPLICATE KEY UPDATE
+                    views        = views        + VALUES(views),
+                    total_time   = total_time   + VALUES(total_time),
+                    total_scroll = total_scroll + VALUES(total_scroll),
+                    bounces      = bounces      + VALUES(bounces)",
+				$cutoff
+			)
+		);
+		// phpcs:enable
+
+		// Prune rollup beyond retention (same option as the analytics table).
+		$retention_days = (int) get_option( 'swps_analytics_retention', 90 );
+		$prune_date     = gmdate( 'Y-m-d', strtotime( "-{$retention_days} days" ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$rollup} WHERE date < %s",
+				$prune_date
+			)
+		);
+		// phpcs:enable
+	}
+
+	// -------------------------------------------------------------------------
+	// Internal helpers — WP-free
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Extract lowercased hostname from a URL string.
+	 * Returns '' on parse failure.
+	 *
+	 * @param string $url URL string.
+	 * @return string Lowercase hostname, or ''.
+	 */
+	private static function parse_host( string $url ): string {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+
+		if ( ! is_string( $host ) || '' === $host ) {
+			return '';
+		}
+
+		return strtolower( $host );
+	}
+
+	/**
+	 * Match a hostname (already lowercased) against the source map.
+	 * Supports exact match and dot-prefixed suffix match (subdomains).
+	 *
+	 * @param string                $host Lowercased hostname.
+	 * @param array<string, string> $map  Source map.
+	 * @return string Source key, or ''.
+	 */
+	private static function match_host( string $host, array $map ): string {
+		foreach ( $map as $entry => $source ) {
+			$entry_lower = strtolower( $entry );
+
+			if ( $host === $entry_lower || str_ends_with( $host, '.' . $entry_lower ) ) {
+				return $source;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extract the utm_source query parameter from a URL.
+	 * Returns '' when absent or unparseable.
+	 *
+	 * @param string $url URL string.
+	 * @return string utm_source value (raw, lowercased), or ''.
+	 */
+	private static function extract_utm_source( string $url ): string {
+		$query = wp_parse_url( $url, PHP_URL_QUERY );
+
+		if ( ! is_string( $query ) || '' === $query ) {
+			return '';
+		}
+
+		parse_str( $query, $params );
+
+		return strtolower( (string) ( $params['utm_source'] ?? '' ) );
+	}
+
+	/**
+	 * Resolve a utm_source value to an AI source slug.
+	 *
+	 * Checks two strategies:
+	 * 1. utm_source is a hostname — match via host-match rules (e.g. chatgpt.com).
+	 * 2. utm_source is a bare slug — match against map source values (e.g. chatgpt).
+	 *
+	 * @param string                $utm_source Lowercased utm_source value.
+	 * @param array<string, string> $map         Source map.
+	 * @return string Source key, or ''.
+	 */
+	private static function match_utm( string $utm_source, array $map ): string {
+		// Strategy 1: utm_source looks like a hostname (contains a dot).
+		if ( str_contains( $utm_source, '.' ) ) {
+			$matched = self::match_host( $utm_source, $map );
+
+			if ( '' !== $matched ) {
+				return $matched;
+			}
+		}
+
+		// Strategy 2: bare slug — check if the value is in the source values.
+		if ( in_array( $utm_source, $map, true ) ) {
+			return $utm_source;
+		}
+
+		return '';
+	}
+}

--- a/includes/class-ai-referrals.php
+++ b/includes/class-ai-referrals.php
@@ -150,9 +150,9 @@ class SWPS_AI_Referrals {
 	 * Returns null when either sample is below the minimum threshold to prevent
 	 * misleading ratios from sparse data.
 	 *
-	 * @param array{views: int, avg_time: float, avg_scroll: float, bounce_rate: float} $ai      AI aggregate metrics.
-	 * @param array{views: int, avg_time: float, avg_scroll: float, bounce_rate: float} $organic Organic aggregate metrics.
-	 * @param int                                                                       $min_n   Minimum sample size per group.
+	 * @param array{views?: int, avg_time?: float, avg_scroll?: float, bounce_rate?: float} $ai      AI aggregate metrics.
+	 * @param array{views?: int, avg_time?: float, avg_scroll?: float, bounce_rate?: float} $organic Organic aggregate metrics.
+	 * @param int                                                                           $min_n   Minimum sample size per group.
 	 * @return array{time_ratio: float, scroll_ratio: float, bounce_ratio: float, ai_n: int, organic_n: int}|null
 	 */
 	public static function engagement_comparison( array $ai, array $organic, int $min_n = 30 ): ?array {
@@ -165,11 +165,11 @@ class SWPS_AI_Referrals {
 		$organic_bounce = (float) ( $organic['bounce_rate'] ?? 1 );
 
 		return array(
-			'time_ratio'   => $organic_time > 0 ? round( (float) $ai['avg_time'] / $organic_time, 4 ) : 0.0,
-			'scroll_ratio' => $organic_scroll > 0 ? round( (float) $ai['avg_scroll'] / $organic_scroll, 4 ) : 0.0,
-			'bounce_ratio' => $organic_bounce > 0 ? round( (float) $ai['bounce_rate'] / $organic_bounce, 4 ) : 0.0,
-			'ai_n'         => (int) $ai['views'],
-			'organic_n'    => (int) $organic['views'],
+			'time_ratio'   => $organic_time > 0 ? round( (float) ( $ai['avg_time'] ?? 0 ) / $organic_time, 4 ) : 0.0,
+			'scroll_ratio' => $organic_scroll > 0 ? round( (float) ( $ai['avg_scroll'] ?? 0 ) / $organic_scroll, 4 ) : 0.0,
+			'bounce_ratio' => $organic_bounce > 0 ? round( (float) ( $ai['bounce_rate'] ?? 0 ) / $organic_bounce, 4 ) : 0.0,
+			'ai_n'         => (int) ( $ai['views'] ?? 0 ),
+			'organic_n'    => (int) ( $organic['views'] ?? 0 ),
 		);
 	}
 

--- a/includes/class-analytics-dashboard.php
+++ b/includes/class-analytics-dashboard.php
@@ -76,7 +76,7 @@ class SWPS_Analytics_Dashboard {
 				'totals'    => $bot_tracker->get_totals( 30 ),
 				'bots'      => $bot_tracker->get_bot_summary( 30 ),
 				'top_pages' => $bot_tracker->get_top_pages( 30, 15 ),
-				'gaps'      => $bot_tracker->get_gap_posts( 30, 10 ),
+				'gaps'      => $bot_tracker->get_gap_posts( 30, 10, isset( $_GET['gap_sort'] ) && 'score' === $_GET['gap_sort'] ? 'score' : 'date' ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				'top_404s'  => $bot_tracker->get_top_404s( 30, 10 ),
 			);
 		}
@@ -259,6 +259,17 @@ class SWPS_Analytics_Dashboard {
 				? human_time_diff( strtotime( $bot_stats['last_seen'] ), time() ) . ' ago'
 				: null;
 		}
+
+		// AI visibility funnel fields — one batched call each.
+		$crawl_map = SWPS_Visibility_Funnel::crawl_stats_for_posts( array( $post_id ), 30 );
+		$visit_map = SWPS_Visibility_Funnel::ai_visits_for_posts( array( $post_id ), 30 );
+
+		$crawl_entry                     = $crawl_map[ $post_id ] ?? null;
+		$result['funnel_last_crawl_ago'] = $crawl_entry && $crawl_entry['last_crawl_at']
+			? human_time_diff( strtotime( (string) $crawl_entry['last_crawl_at'] ), time() ) . ' ago'
+			: null;
+		$result['funnel_last_bot']       = $crawl_entry ? (string) ( $crawl_entry['last_bot'] ?? '' ) : null;
+		$result['funnel_ai_visits_30d']  = isset( $visit_map[ $post_id ] ) ? (int) $visit_map[ $post_id ]['ai_visits'] : 0;
 
 		// GSC queries for this post.
 		if ( $this->search_console->is_connected() ) {

--- a/includes/class-analytics-dashboard.php
+++ b/includes/class-analytics-dashboard.php
@@ -26,6 +26,7 @@ class SWPS_Analytics_Dashboard {
 		add_action( 'wp_ajax_swps_analytics_top_pages', array( $this, 'ajax_top_pages' ) );
 		add_action( 'wp_ajax_swps_analytics_top_queries', array( $this, 'ajax_top_queries' ) );
 		add_action( 'wp_ajax_swps_analytics_post_stats', array( $this, 'ajax_post_stats' ) );
+		add_action( 'wp_ajax_swps_analytics_ai_referrals', array( $this, 'ajax_ai_referrals' ) );
 		add_action( 'wp_ajax_swps_gsc_disconnect', array( $this, 'ajax_disconnect_gsc' ) );
 		add_action( 'wp_ajax_swps_gsc_refresh', array( $this, 'ajax_refresh_gsc' ) );
 		add_action( 'wp_ajax_swps_gsc_save_property', array( $this, 'ajax_save_property' ) );
@@ -281,6 +282,58 @@ class SWPS_Analytics_Dashboard {
 		}
 
 		wp_send_json_success( $result );
+	}
+
+	/**
+	 * AJAX: AI referral attribution data (summary, landing posts,
+	 * engagement vs organic, crawl-to-visit funnel).
+	 */
+	public function ajax_ai_referrals(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$days = absint( $_POST['days'] ?? 30 );
+		$days = in_array( $days, array( 7, 30, 90 ), true ) ? $days : 30;
+
+		$summary       = SWPS_AI_Referrals_Report::get_summary( $days );
+		$landing_posts = SWPS_AI_Referrals_Report::get_landing_posts( $days );
+		$engagement    = SWPS_AI_Referrals_Report::get_engagement_vs_organic( $days );
+		$funnel        = SWPS_AI_Referrals_Report::get_funnel( $days );
+
+		// Enrich post rows with titles and links (same pattern as ajax_top_pages).
+		foreach ( $landing_posts as &$row ) {
+			$post             = get_post( $row['post_id'] );
+			$row['title']     = $post ? $post->post_title : __( '(Unknown)', 'stratawp-seo' );
+			$row['url']       = $post ? get_permalink( $post ) : '';
+			$row['edit_link'] = get_edit_post_link( $row['post_id'], 'raw' ) ?? '';
+		}
+		unset( $row );
+
+		foreach ( $funnel['rows'] as &$row ) {
+			$post             = get_post( $row['post_id'] );
+			$row['title']     = $post ? $post->post_title : __( '(Unknown)', 'stratawp-seo' );
+			$row['edit_link'] = get_edit_post_link( $row['post_id'], 'raw' ) ?? '';
+		}
+		unset( $row );
+
+		foreach ( $funnel['crawled_no_visits'] as &$row ) {
+			$post             = get_post( $row['post_id'] );
+			$row['title']     = $post ? $post->post_title : __( '(Unknown)', 'stratawp-seo' );
+			$row['edit_link'] = get_edit_post_link( $row['post_id'], 'raw' ) ?? '';
+		}
+		unset( $row );
+
+		wp_send_json_success(
+			array(
+				'summary'       => $summary,
+				'landing_posts' => $landing_posts,
+				'engagement'    => $engagement,
+				'funnel'        => $funnel,
+			)
+		);
 	}
 
 	/**

--- a/includes/class-analytics-tracker.php
+++ b/includes/class-analytics-tracker.php
@@ -48,10 +48,12 @@ class SWPS_Analytics_Tracker {
             time_on_page SMALLINT UNSIGNED NOT NULL DEFAULT 0,
             scroll_depth TINYINT UNSIGNED NOT NULL DEFAULT 0,
             is_bounce TINYINT(1) UNSIGNED NOT NULL DEFAULT 1,
+            ai_source VARCHAR(32) NOT NULL DEFAULT '',
             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY (id),
             KEY idx_created_at (created_at),
-            KEY idx_post_id (post_id)
+            KEY idx_post_id (post_id),
+            KEY idx_ai_source (ai_source)
         ) {$charset};";
 
 		$sql_daily = "CREATE TABLE {$daily} (
@@ -146,6 +148,7 @@ class SWPS_Analytics_Tracker {
 		$time_on_page = min( absint( $_POST['time_on_page'] ?? 0 ), 3600 );
 		$scroll_depth = min( absint( $_POST['scroll_depth'] ?? 0 ), 100 );
 		$is_bounce    = absint( $_POST['is_bounce'] ?? 1 ) ? 1 : 0;
+		$ai_source    = SWPS_AI_Referrals::classify_visit( $referrer, $page_url );
 
 		$data = array(
 			'post_id'      => $post_id,
@@ -154,6 +157,7 @@ class SWPS_Analytics_Tracker {
 			'time_on_page' => $time_on_page,
 			'scroll_depth' => $scroll_depth,
 			'is_bounce'    => $is_bounce,
+			'ai_source'    => $ai_source,
 		);
 
 		/**
@@ -183,6 +187,7 @@ class SWPS_Analytics_Tracker {
 				'%d',
 				'%d',
 				'%d',
+				'%s',
 			)
 		);
 
@@ -217,6 +222,9 @@ class SWPS_Analytics_Tracker {
 				$cutoff
 			)
 		);
+
+		// Roll up AI referral data BEFORE deleting raw rows.
+		SWPS_AI_Referrals::aggregate( $cutoff );
 
 		// Delete aggregated raw rows.
 		$wpdb->query(

--- a/includes/class-bot-analytics-tracker.php
+++ b/includes/class-bot-analytics-tracker.php
@@ -557,9 +557,12 @@ class SWPS_Bot_Analytics_Tracker {
 	/**
 	 * Published posts with ZERO bot hits in the window — the AEO gap report.
 	 *
-	 * @return array<int, array{post_id:int, title:string, url:string, post_date:string}>
+	 * @param int    $days    Look-back window in days.
+	 * @param int    $limit   Max rows (1–100).
+	 * @param string $orderby 'date' (default) or 'score' (AEO score desc — high-score-but-uncrawled first).
+	 * @return array<int, array{post_id:int, title:string, url:string, post_date:string, aeo_score:int|null}>
 	 */
-	public function get_gap_posts( int $days = 30, int $limit = 25 ): array {
+	public function get_gap_posts( int $days = 30, int $limit = 25, string $orderby = 'date' ): array {
 		global $wpdb;
 		$raw   = $wpdb->prefix . self::RAW_TABLE;
 		$daily = $wpdb->prefix . self::DAILY_TABLE;
@@ -582,18 +585,41 @@ class SWPS_Bot_Analytics_Tracker {
 
 		$exclude = array_map( 'intval', (array) $hit_ids );
 
-		$query = new WP_Query(
-			array(
-				'post_type'      => array( 'post', 'page' ),
-				'post_status'    => 'publish',
-				'posts_per_page' => $limit,
-				'post__not_in'   => empty( $exclude ) ? array( 0 ) : $exclude,
-				'orderby'        => 'date',
-				'order'          => 'DESC',
-				'fields'         => 'ids',
-				'no_found_rows'  => true,
+		$wp_orderby = 'score' === $orderby
+			? array(
+				'meta_value_num' => 'DESC',
+				'date'           => 'DESC',
 			)
+			: 'date';
+		$wp_order   = 'score' === $orderby ? 'DESC' : 'DESC';
+
+		$query_args = array(
+			'post_type'      => array( 'post', 'page' ),
+			'post_status'    => 'publish',
+			'posts_per_page' => $limit,
+			'post__not_in'   => empty( $exclude ) ? array( 0 ) : $exclude,
+			'orderby'        => $wp_orderby,
+			'order'          => $wp_order,
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
 		);
+
+		if ( 'score' === $orderby ) {
+			$query_args['meta_key']  = \SWPS_AEO_Scorer::META_TOTAL;
+			$query_args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+				'relation' => 'OR',
+				array(
+					'key'     => \SWPS_AEO_Scorer::META_TOTAL,
+					'compare' => 'EXISTS',
+				),
+				array(
+					'key'     => \SWPS_AEO_Scorer::META_TOTAL,
+					'compare' => 'NOT EXISTS',
+				),
+			);
+		}
+
+		$query = new WP_Query( $query_args );
 
 		$out = array();
 		foreach ( $query->posts as $pid ) {
@@ -601,11 +627,13 @@ class SWPS_Bot_Analytics_Tracker {
 			if ( ! $post ) {
 				continue;
 			}
+			$raw_score = get_post_meta( $post->ID, \SWPS_AEO_Scorer::META_TOTAL, true );
 			$out[] = array(
 				'post_id'   => (int) $post->ID,
 				'title'     => (string) get_the_title( $post ),
 				'url'       => (string) get_permalink( $post ),
 				'post_date' => (string) $post->post_date,
+				'aeo_score' => '' !== $raw_score ? (int) $raw_score : null,
 			);
 		}
 		return $out;

--- a/includes/class-bot-analytics-tracker.php
+++ b/includes/class-bot-analytics-tracker.php
@@ -585,38 +585,37 @@ class SWPS_Bot_Analytics_Tracker {
 
 		$exclude = array_map( 'intval', (array) $hit_ids );
 
-		$wp_orderby = 'score' === $orderby
-			? array(
-				'meta_value_num' => 'DESC',
-				'date'           => 'DESC',
-			)
-			: 'date';
-		$wp_order   = 'score' === $orderby ? 'DESC' : 'DESC';
-
 		$query_args = array(
 			'post_type'      => array( 'post', 'page' ),
 			'post_status'    => 'publish',
 			'posts_per_page' => $limit,
 			'post__not_in'   => empty( $exclude ) ? array( 0 ) : $exclude,
-			'orderby'        => $wp_orderby,
-			'order'          => $wp_order,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
 			'fields'         => 'ids',
 			'no_found_rows'  => true,
 		);
 
 		if ( 'score' === $orderby ) {
-			$query_args['meta_key']  = \SWPS_AEO_Scorer::META_TOTAL;
+			// Named OR meta_query clauses keep unscored posts in the result
+			// (LEFT JOIN), while ordering scored posts first by score desc.
 			$query_args['meta_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-				'relation' => 'OR',
-				array(
+				'relation'  => 'OR',
+				'has_score' => array(
 					'key'     => \SWPS_AEO_Scorer::META_TOTAL,
 					'compare' => 'EXISTS',
+					'type'    => 'NUMERIC',
 				),
-				array(
+				'no_score'  => array(
 					'key'     => \SWPS_AEO_Scorer::META_TOTAL,
 					'compare' => 'NOT EXISTS',
 				),
 			);
+			$query_args['orderby']    = array(
+				'has_score' => 'DESC',
+				'date'      => 'DESC',
+			);
+			unset( $query_args['order'] );
 		}
 
 		$query = new WP_Query( $query_args );
@@ -628,7 +627,7 @@ class SWPS_Bot_Analytics_Tracker {
 				continue;
 			}
 			$raw_score = get_post_meta( $post->ID, \SWPS_AEO_Scorer::META_TOTAL, true );
-			$out[] = array(
+			$out[]     = array(
 				'post_id'   => (int) $post->ID,
 				'title'     => (string) get_the_title( $post ),
 				'url'       => (string) get_permalink( $post ),

--- a/includes/class-citation-admin.php
+++ b/includes/class-citation-admin.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * Citation tracker admin — AJAX endpoints, settings section, and asset
+ * enqueue for the AI Citations card on the Keywords page.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * AJAX + settings surface for the AI citation tracker.
+ */
+class SWPS_Citation_Admin {
+
+	/** Nonce action shared by all citation AJAX endpoints. */
+	private const NONCE = 'swps_citations';
+
+	/**
+	 * Citation tracker core.
+	 *
+	 * @var SWPS_Citation_Tracker
+	 */
+	private SWPS_Citation_Tracker $tracker;
+
+	/**
+	 * Wire AJAX endpoints, settings, and assets.
+	 *
+	 * @param SWPS_Citation_Tracker $tracker Citation tracker instance.
+	 */
+	public function __construct( SWPS_Citation_Tracker $tracker ) {
+		$this->tracker = $tracker;
+
+		add_action( 'admin_init', array( $this, 'register_settings' ), 20 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+
+		add_action( 'wp_ajax_swps_citations_state', array( $this, 'ajax_state' ) );
+		add_action( 'wp_ajax_swps_citations_add_prompt', array( $this, 'ajax_add_prompt' ) );
+		add_action( 'wp_ajax_swps_citations_remove_prompt', array( $this, 'ajax_remove_prompt' ) );
+		add_action( 'wp_ajax_swps_citations_seed', array( $this, 'ajax_seed' ) );
+		add_action( 'wp_ajax_swps_citations_run_one', array( $this, 'ajax_run_one' ) );
+	}
+
+	/**
+	 * Verify nonce + capability on every endpoint.
+	 */
+	private function verify_request(): void {
+		check_ajax_referer( self::NONCE, 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ), 403 );
+		}
+	}
+
+	/**
+	 * Enqueue the citations JS on the Keywords page only.
+	 *
+	 * @param string $hook Current admin page hook.
+	 */
+	public function enqueue_assets( string $hook ): void {
+		if ( ! str_contains( $hook, 'swps-keywords' ) ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'swps-citations',
+			SWPS_PLUGIN_URL . 'admin/js/citations.js',
+			array( 'jquery' ),
+			SWPS_VERSION,
+			true
+		);
+
+		$engines = array();
+		foreach ( SWPS_Provider_Factory::all_ai_providers() as $slug => $provider ) {
+			$engines[ $slug ] = $provider->get_name();
+		}
+
+		wp_localize_script(
+			'swps-citations',
+			'swpsCitations',
+			array(
+				'ajax_url'        => admin_url( 'admin-ajax.php' ),
+				'nonce'           => wp_create_nonce( self::NONCE ),
+				'engines'         => $engines,
+				'enabled_engines' => $this->tracker->prompts()->enabled_engines(),
+			)
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// AJAX endpoints
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Full card state: prompt states, share of voice, cited-domains breakdown,
+	 * and monthly cap usage.
+	 */
+	public function ajax_state(): void {
+		$this->verify_request();
+
+		wp_send_json_success(
+			array(
+				'prompt_states'  => $this->tracker->prompt_states(),
+				'share_of_voice' => $this->tracker->share_of_voice_data( 30 ),
+				'breakdown'      => $this->tracker->cited_domains_breakdown( 30, 10 ),
+				'engines'        => $this->tracker->prompts()->enabled_engines(),
+				'cap'            => array(
+					'used'  => (int) get_option( SWPS_Citation_Tracker::counter_option(), 0 ),
+					'limit' => (int) get_option( SWPS_Citation_Tracker::OPTION_CAP, 200 ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Add a tracked prompt.
+	 */
+	public function ajax_add_prompt(): void {
+		$this->verify_request();
+
+		$prompt  = sanitize_text_field( wp_unslash( $_POST['prompt'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- verified in verify_request().
+		$post_id = absint( $_POST['post_id'] ?? 0 ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- verified in verify_request().
+
+		$result = $this->tracker->prompts()->add_prompt( $prompt, $post_id );
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+		}
+
+		wp_send_json_success();
+	}
+
+	/**
+	 * Remove a tracked prompt.
+	 */
+	public function ajax_remove_prompt(): void {
+		$this->verify_request();
+
+		$prompt = sanitize_text_field( wp_unslash( $_POST['prompt'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- verified in verify_request().
+		if ( '' === $prompt ) {
+			wp_send_json_error( array( 'message' => __( 'Prompt is required.', 'stratawp-seo' ) ) );
+		}
+
+		$this->tracker->prompts()->remove_prompt( $prompt );
+		wp_send_json_success();
+	}
+
+	/**
+	 * Build seed candidates from tracked keywords + GSC question queries.
+	 * Only callable via this explicit AJAX — never on page load (GSC API cost).
+	 */
+	public function ajax_seed(): void {
+		$this->verify_request();
+
+		wp_send_json_success( $this->tracker->prompts()->seed_candidates( 20 ) );
+	}
+
+	/**
+	 * Run one chunked check (one prompt × engine per request). A cap-reached
+	 * error returns code 'cap' so the JS can abort the run cleanly.
+	 */
+	public function ajax_run_one(): void {
+		$this->verify_request();
+
+		$prompt = sanitize_text_field( wp_unslash( $_POST['prompt'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- verified in verify_request().
+		$engine = sanitize_key( $_POST['engine'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- verified in verify_request().
+
+		if ( '' === $prompt || '' === $engine ) {
+			wp_send_json_error( array( 'message' => __( 'Prompt and engine are required.', 'stratawp-seo' ) ) );
+		}
+
+		$result = $this->tracker->check_one( $prompt, $engine );
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error(
+				array(
+					'message' => $result->get_error_message(),
+					'code'    => 'swps_citation_cap_reached' === $result->get_error_code() ? 'cap' : $result->get_error_code(),
+				)
+			);
+		}
+
+		$this->tracker->detect_losses();
+		wp_send_json_success( $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// Settings section (page 'stratawp-seo', AI Crawlers tab)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Register the AI Citations settings section + fields.
+	 */
+	public function register_settings(): void {
+		add_settings_section(
+			'swps_citations_section',
+			__( 'AI Citation Tracking', 'stratawp-seo' ),
+			array( $this, 'render_section_description' ),
+			'stratawp-seo'
+		);
+
+		register_setting( 'stratawp-seo', SWPS_Citation_Tracker::OPTION_FREQUENCY, array( 'sanitize_callback' => array( $this, 'sanitize_frequency' ) ) );
+		register_setting( 'stratawp-seo', SWPS_Citation_Tracker::OPTION_CAP, array( 'sanitize_callback' => 'absint' ) );
+		register_setting( 'stratawp-seo', SWPS_Citation_Prompts::OPTION_ENGINES, array( 'sanitize_callback' => array( $this, 'sanitize_engines' ) ) );
+
+		add_settings_field( SWPS_Citation_Tracker::OPTION_FREQUENCY, __( 'Check Frequency', 'stratawp-seo' ), array( $this, 'render_frequency_field' ), 'stratawp-seo', 'swps_citations_section' );
+		add_settings_field( SWPS_Citation_Tracker::OPTION_CAP, __( 'Monthly Call Cap', 'stratawp-seo' ), array( $this, 'render_cap_field' ), 'stratawp-seo', 'swps_citations_section' );
+		add_settings_field( SWPS_Citation_Prompts::OPTION_ENGINES, __( 'Engines', 'stratawp-seo' ), array( $this, 'render_engines_field' ), 'stratawp-seo', 'swps_citations_section' );
+	}
+
+	/**
+	 * Section intro copy with the cost note.
+	 */
+	public function render_section_description(): void {
+		echo '<p>' . esc_html__( 'Scheduled checks ask your AI providers (search-grounded) whether they cite your site for your tracked prompts. Checks use your API keys; some providers bill per search — estimates only.', 'stratawp-seo' ) . '</p>';
+	}
+
+	/**
+	 * Keep frequency within the supported set.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string 'daily' or 'weekly'.
+	 */
+	public function sanitize_frequency( $value ): string {
+		return in_array( $value, array( 'daily', 'weekly' ), true ) ? (string) $value : 'weekly';
+	}
+
+	/**
+	 * Keep only valid provider slugs in the engines selection.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string[] Valid slugs.
+	 */
+	public function sanitize_engines( $value ): array {
+		$valid = array_keys( SWPS_Provider_Factory::all_ai_providers() );
+		$out   = array();
+		foreach ( (array) $value as $slug ) {
+			if ( in_array( $slug, $valid, true ) ) {
+				$out[] = (string) $slug;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Render the frequency select.
+	 */
+	public function render_frequency_field(): void {
+		$current = (string) get_option( SWPS_Citation_Tracker::OPTION_FREQUENCY, 'weekly' );
+		echo '<select name="' . esc_attr( SWPS_Citation_Tracker::OPTION_FREQUENCY ) . '">';
+		foreach ( array(
+			'weekly' => __( 'Weekly', 'stratawp-seo' ),
+			'daily'  => __( 'Daily', 'stratawp-seo' ),
+		) as $value => $label ) {
+			printf( '<option value="%s" %s>%s</option>', esc_attr( $value ), selected( $current, $value, false ), esc_html( $label ) );
+		}
+		echo '</select>';
+	}
+
+	/**
+	 * Render the monthly cap number input.
+	 */
+	public function render_cap_field(): void {
+		printf(
+			'<input type="number" min="0" step="1" name="%s" value="%d" class="small-text" /> <p class="description">%s</p>',
+			esc_attr( SWPS_Citation_Tracker::OPTION_CAP ),
+			(int) get_option( SWPS_Citation_Tracker::OPTION_CAP, 200 ),
+			esc_html__( 'Maximum search-grounded calls per calendar month across all engines.', 'stratawp-seo' )
+		);
+	}
+
+	/**
+	 * Render the engines multi-checkbox (providers without keys are disabled).
+	 */
+	public function render_engines_field(): void {
+		$selected = get_option( SWPS_Citation_Prompts::OPTION_ENGINES, array( (string) get_option( 'swps_ai_provider', 'anthropic' ) ) );
+		$selected = is_array( $selected ) ? $selected : array();
+
+		foreach ( SWPS_Provider_Factory::all_ai_providers() as $slug => $provider ) {
+			$has_key = '' !== $provider->get_api_key();
+			printf(
+				'<label style="display:block;margin-bottom:4px;"><input type="checkbox" name="%s[]" value="%s" %s %s /> %s%s</label>',
+				esc_attr( SWPS_Citation_Prompts::OPTION_ENGINES ),
+				esc_attr( $slug ),
+				checked( in_array( $slug, $selected, true ), true, false ),
+				disabled( ! $has_key, true, false ),
+				esc_html( $provider->get_name() ),
+				$has_key ? '' : ' <em>' . esc_html__( '(no API key saved)', 'stratawp-seo' ) . '</em>'
+			);
+		}
+	}
+}

--- a/includes/class-citation-prompts.php
+++ b/includes/class-citation-prompts.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Citation prompt management — tracked prompt list (option-backed CRUD),
+ * seed-candidate builder, enabled engines, and domain configuration for the
+ * AI citation tracker.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Prompt list, engines, and domain configuration for citation checks.
+ */
+class SWPS_Citation_Prompts {
+
+	public const OPTION_PROMPTS = 'swps_citation_prompts';
+	public const OPTION_ENGINES = 'swps_citation_engines';
+
+	/** Maximum tracked prompts (filterable via swps_citation_prompts_cap). */
+	private const PROMPTS_CAP = 25;
+
+	/**
+	 * Keyword tracker — seed-candidate source.
+	 *
+	 * @var SWPS_Keyword_Tracker
+	 */
+	private SWPS_Keyword_Tracker $keyword_tracker;
+
+	/**
+	 * Search Console — GSC question-query seed source.
+	 *
+	 * @var SWPS_Search_Console
+	 */
+	private SWPS_Search_Console $search_console;
+
+	/**
+	 * Inject the seed-candidate sources.
+	 *
+	 * @param SWPS_Keyword_Tracker $keyword_tracker Keyword tracker instance.
+	 * @param SWPS_Search_Console  $search_console  Search Console instance.
+	 */
+	public function __construct( SWPS_Keyword_Tracker $keyword_tracker, SWPS_Search_Console $search_console ) {
+		$this->keyword_tracker = $keyword_tracker;
+		$this->search_console  = $search_console;
+	}
+
+	/**
+	 * Get the tracked prompts list.
+	 *
+	 * @return array[] Entries: { prompt: string, post_id: int, added: int }.
+	 */
+	public function get_prompts(): array {
+		$raw = get_option( self::OPTION_PROMPTS, array() );
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $raw as $entry ) {
+			if ( ! is_array( $entry ) || empty( $entry['prompt'] ) ) {
+				continue;
+			}
+			$out[] = array(
+				'prompt'  => (string) $entry['prompt'],
+				'post_id' => (int) ( $entry['post_id'] ?? 0 ),
+				'added'   => (int) ( $entry['added'] ?? 0 ),
+			);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Add a prompt to the tracked list (sanitized, deduped, capped).
+	 *
+	 * @param string $prompt  The prompt text.
+	 * @param int    $post_id Optional linked post ID.
+	 * @return true|WP_Error
+	 */
+	public function add_prompt( string $prompt, int $post_id = 0 ): bool|WP_Error {
+		$prompt = sanitize_text_field( trim( $prompt ) );
+		$prompt = mb_substr( $prompt, 0, 500 );
+
+		if ( '' === $prompt ) {
+			return new WP_Error( 'swps_citation_empty_prompt', __( 'Prompt cannot be empty.', 'stratawp-seo' ) );
+		}
+
+		$prompts = $this->get_prompts();
+
+		// Dedupe (case-insensitive).
+		foreach ( $prompts as $entry ) {
+			if ( strtolower( $entry['prompt'] ) === strtolower( $prompt ) ) {
+				return true; // Already tracked.
+			}
+		}
+
+		/** Filter the maximum number of tracked citation prompts. */
+		$cap = (int) apply_filters( 'swps_citation_prompts_cap', self::PROMPTS_CAP );
+		if ( count( $prompts ) >= $cap ) {
+			return new WP_Error(
+				'swps_citation_prompts_cap',
+				/* translators: %d: maximum number of prompts */
+				sprintf( __( 'Prompt limit reached (%d). Remove a prompt before adding another.', 'stratawp-seo' ), $cap )
+			);
+		}
+
+		$prompts[] = array(
+			'prompt'  => $prompt,
+			'post_id' => max( 0, $post_id ),
+			'added'   => time(),
+		);
+		update_option( self::OPTION_PROMPTS, $prompts, false );
+
+		return true;
+	}
+
+	/**
+	 * Remove a prompt from the tracked list (matched case-insensitively).
+	 *
+	 * @param string $prompt The prompt text to remove.
+	 * @return bool True when a prompt was removed.
+	 */
+	public function remove_prompt( string $prompt ): bool {
+		$prompt  = strtolower( sanitize_text_field( trim( $prompt ) ) );
+		$prompts = $this->get_prompts();
+		$kept    = array();
+
+		foreach ( $prompts as $entry ) {
+			if ( strtolower( $entry['prompt'] ) !== $prompt ) {
+				$kept[] = $entry;
+			}
+		}
+
+		if ( count( $kept ) === count( $prompts ) ) {
+			return false;
+		}
+
+		update_option( self::OPTION_PROMPTS, $kept, false );
+		return true;
+	}
+
+	/**
+	 * Build seed candidates from tracked keywords and GSC question queries.
+	 * Returns candidates only — never auto-adds.
+	 *
+	 * @param int $limit Max candidates returned.
+	 * @return array[] Entries: { prompt: string, post_id: int, source: 'keyword'|'gsc' }.
+	 */
+	public function seed_candidates( int $limit = 20 ): array {
+		$candidates = array();
+		$seen       = array();
+		$tracked    = array();
+
+		foreach ( $this->get_prompts() as $entry ) {
+			$tracked[ strtolower( $entry['prompt'] ) ] = true;
+		}
+
+		// 1. Tracked keywords, as-is (already impression-sorted).
+		foreach ( $this->keyword_tracker->get_tracked_keywords( 50 ) as $row ) {
+			$keyword = strtolower( trim( (string) ( $row['keyword'] ?? '' ) ) );
+			if ( '' === $keyword || isset( $seen[ $keyword ] ) || isset( $tracked[ $keyword ] ) ) {
+				continue;
+			}
+			$seen[ $keyword ] = true;
+			$candidates[]     = array(
+				'prompt'  => $keyword,
+				'post_id' => (int) ( $row['post_id'] ?? 0 ),
+				'source'  => 'keyword',
+			);
+		}
+
+		// 2. GSC question-form queries, top by impressions.
+		// Row shape: { keys: [query], clicks, impressions, ctr, position }.
+		$gsc     = $this->search_console->get_search_data( 90 );
+		$queries = is_array( $gsc['queries'] ?? null ) ? $gsc['queries'] : array();
+		usort(
+			$queries,
+			static function ( $a, $b ) {
+				return (int) ( $b['impressions'] ?? 0 ) <=> (int) ( $a['impressions'] ?? 0 );
+			}
+		);
+		foreach ( $queries as $row ) {
+			$query = strtolower( trim( (string) ( $row['keys'][0] ?? '' ) ) );
+			if ( '' === $query || isset( $seen[ $query ] ) || isset( $tracked[ $query ] ) ) {
+				continue;
+			}
+			if ( ! SWPS_Citation_Tracker::is_question_query( $query ) ) {
+				continue;
+			}
+			$seen[ $query ] = true;
+			$candidates[]   = array(
+				'prompt'  => $query,
+				'post_id' => 0,
+				'source'  => 'gsc',
+			);
+		}
+
+		return array_slice( $candidates, 0, $limit );
+	}
+
+	/**
+	 * Engines enabled for citation checks: the swps_citation_engines selection
+	 * (default: the current AI provider) intersected with providers that have
+	 * a saved API key.
+	 *
+	 * @return string[] Provider slugs.
+	 */
+	public function enabled_engines(): array {
+		$selected = get_option( self::OPTION_ENGINES, array( (string) get_option( 'swps_ai_provider', 'anthropic' ) ) );
+		if ( ! is_array( $selected ) ) {
+			$selected = array();
+		}
+
+		$out = array();
+		foreach ( SWPS_Provider_Factory::all_ai_providers() as $slug => $provider ) {
+			if ( in_array( $slug, $selected, true ) && '' !== $provider->get_api_key() ) {
+				$out[] = $slug;
+			}
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Our domain aliases: home_url() host plus swps_citation_our_domains filter.
+	 *
+	 * @return string[] Lowercased, www-stripped domains.
+	 */
+	public function our_domains(): array {
+		$host = strtolower( (string) wp_parse_url( home_url(), PHP_URL_HOST ) );
+		if ( 0 === strpos( $host, 'www.' ) ) {
+			$host = substr( $host, 4 );
+		}
+
+		/** Filter the list of domains considered "ours" for citation matching. */
+		$domains = (array) apply_filters( 'swps_citation_our_domains', array( $host ) );
+
+		return array_values( array_unique( array_filter( array_map( 'strval', $domains ) ) ) );
+	}
+
+	/**
+	 * Competitor domains parsed from the swps_competitors option entries' URLs.
+	 *
+	 * @return string[] Lowercased, www-stripped domains.
+	 */
+	public function competitor_domains(): array {
+		$list = get_option( 'swps_competitors', array() );
+		if ( ! is_array( $list ) ) {
+			return array();
+		}
+
+		$urls = array();
+		foreach ( $list as $competitor ) {
+			if ( is_array( $competitor ) && ! empty( $competitor['url'] ) ) {
+				$urls[] = (string) $competitor['url'];
+			}
+		}
+
+		return SWPS_Citation_Tracker::extract_domains( $urls );
+	}
+}

--- a/includes/class-citation-store.php
+++ b/includes/class-citation-store.php
@@ -1,0 +1,325 @@
+<?php
+/**
+ * Citation check storage — table schema, upsert, retention prune, and
+ * aggregate state queries for the AI citation tracker.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Persistence layer for swps_citation_checks rows.
+ */
+class SWPS_Citation_Store {
+
+	/** Schema version — bump when the checks table DDL changes. */
+	public const DB_VERSION = '1';
+
+	/** Option key used to gate the schema upgrade. */
+	public const OPT_DB_VER = 'swps_citation_db_version';
+
+	/** Checks table (without $wpdb->prefix). */
+	private const TABLE = 'swps_citation_checks';
+
+	/**
+	 * Create the citation checks table.
+	 * Called on activation (from stratawp-seo.php) and via maybe_upgrade().
+	 */
+	public static function create_table(): void {
+		global $wpdb;
+
+		$charset = $wpdb->get_charset_collate();
+		$table   = $wpdb->prefix . self::TABLE;
+
+		$sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            prompt_hash CHAR(32) NOT NULL,
+            prompt VARCHAR(500) NOT NULL,
+            engine VARCHAR(16) NOT NULL,
+            check_date DATE NOT NULL,
+            cited TINYINT(1) NOT NULL DEFAULT 0,
+            our_domains TEXT,
+            cited_domains TEXT,
+            PRIMARY KEY (id),
+            UNIQUE KEY idx_prompt_engine_date (prompt_hash, engine, check_date),
+            KEY idx_engine_date (engine, check_date)
+        ) {$charset};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Ensure the checks table exists for installs updated without reactivation.
+	 * Mirrors the SWPS_AI_Referrals::maybe_upgrade() pattern.
+	 */
+	public static function maybe_upgrade(): void {
+		if ( self::DB_VERSION !== get_option( self::OPT_DB_VER ) ) {
+			self::create_table();
+			update_option( self::OPT_DB_VER, self::DB_VERSION );
+		}
+	}
+
+	/**
+	 * Insert or update today's check row for a prompt × engine pair.
+	 * Re-running on the same day overwrites the previous result.
+	 *
+	 * @param array $row Keys: prompt_hash, prompt, engine, check_date, cited (int 0/1),
+	 *                   our_domains (JSON string), cited_domains (JSON string).
+	 */
+	public static function upsert_check( array $row ): void {
+		global $wpdb;
+
+		$table = $wpdb->prefix . self::TABLE;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$table} (prompt_hash, prompt, engine, check_date, cited, our_domains, cited_domains)
+                 VALUES (%s, %s, %s, %s, %d, %s, %s)
+                 ON DUPLICATE KEY UPDATE
+                     cited = VALUES(cited),
+                     our_domains = VALUES(our_domains),
+                     cited_domains = VALUES(cited_domains)",
+				$row['prompt_hash'],
+				$row['prompt'],
+				$row['engine'],
+				$row['check_date'],
+				(int) $row['cited'],
+				$row['our_domains'],
+				$row['cited_domains']
+			)
+		);
+		// phpcs:enable
+	}
+
+	/**
+	 * Delete check rows older than the retention window.
+	 *
+	 * @param int $days Retention in days (default 180).
+	 */
+	public static function prune( int $days = 180 ): void {
+		global $wpdb;
+
+		$table  = $wpdb->prefix . self::TABLE;
+		$cutoff = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			$wpdb->prepare( "DELETE FROM {$table} WHERE check_date < %s", $cutoff )
+		);
+		// phpcs:enable
+	}
+
+	/**
+	 * Fetch recent check rows for a set of prompt hashes, newest first.
+	 *
+	 * @param string[] $hashes Prompt hashes (md5).
+	 * @param int      $limit_per_pair Max rows per prompt × engine pair.
+	 * @return array<string, array<string, array>> hash => engine => rows
+	 *               (each row: check_date, cited (bool), cited_domains (array)).
+	 */
+	public static function histories( array $hashes, int $limit_per_pair = 3 ): array {
+		global $wpdb;
+
+		if ( empty( $hashes ) ) {
+			return array();
+		}
+
+		$table        = $wpdb->prefix . self::TABLE;
+		$placeholders = implode( ',', array_fill( 0, count( $hashes ), '%s' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT prompt_hash, engine, check_date, cited, cited_domains
+                 FROM {$table}
+                 WHERE prompt_hash IN ({$placeholders})
+                 ORDER BY check_date DESC",
+				$hashes
+			),
+			ARRAY_A
+		);
+		// phpcs:enable
+
+		$out = array();
+		foreach ( (array) $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$hash   = (string) $row['prompt_hash'];
+			$engine = (string) $row['engine'];
+			if ( ! isset( $out[ $hash ][ $engine ] ) ) {
+				$out[ $hash ][ $engine ] = array();
+			}
+			if ( count( $out[ $hash ][ $engine ] ) >= $limit_per_pair ) {
+				continue;
+			}
+			$out[ $hash ][ $engine ][] = array(
+				'check_date'    => (string) $row['check_date'],
+				'cited'         => (bool) (int) $row['cited'],
+				'cited_domains' => (array) json_decode( (string) $row['cited_domains'], true ),
+			);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Fetch all check rows in the last N days (for share-of-voice and breakdowns).
+	 *
+	 * @param int $days Window in days.
+	 * @return array[] Rows: prompt_hash, engine, cited (bool), cited_domains (array).
+	 */
+	public static function recent_checks( int $days = 30 ): array {
+		global $wpdb;
+
+		$table = $wpdb->prefix . self::TABLE;
+		$since = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT prompt_hash, engine, cited, cited_domains
+                 FROM {$table}
+                 WHERE check_date >= %s",
+				$since
+			),
+			ARRAY_A
+		);
+		// phpcs:enable
+
+		$out = array();
+		foreach ( (array) $rows as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$out[] = array(
+				'prompt_hash'   => (string) $row['prompt_hash'],
+				'engine'        => (string) $row['engine'],
+				'cited'         => (bool) (int) $row['cited'],
+				'cited_domains' => (array) json_decode( (string) $row['cited_domains'], true ),
+			);
+		}
+
+		return $out;
+	}
+
+	// -------------------------------------------------------------------------
+	// Aggregate state queries
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Per-prompt per-engine citation states (smoothed over last 3 checks).
+	 *
+	 * @param array[]  $prompts Tracked prompt entries ({ prompt, post_id, added }).
+	 * @param string[] $engines Enabled engine slugs.
+	 * @return array[] Entries: { prompt, post_id, states: engine => { state, last_date } }.
+	 */
+	public static function prompt_states( array $prompts, array $engines ): array {
+		$hashes = array();
+		foreach ( $prompts as $entry ) {
+			$hashes[] = md5( (string) $entry['prompt'] );
+		}
+
+		$histories = self::histories( $hashes, 3 );
+		$out       = array();
+
+		foreach ( $prompts as $entry ) {
+			$hash   = md5( (string) $entry['prompt'] );
+			$states = array();
+			foreach ( $engines as $engine ) {
+				$rows    = $histories[ $hash ][ $engine ] ?? array();
+				$history = array_map(
+					static function ( $row ) {
+						return (bool) $row['cited'];
+					},
+					$rows
+				);
+
+				$states[ $engine ] = array(
+					'state'     => SWPS_Citation_Tracker::citation_state( $history ),
+					'last_date' => $rows[0]['check_date'] ?? '',
+				);
+			}
+			$out[] = array(
+				'prompt'  => (string) $entry['prompt'],
+				'post_id' => (int) ( $entry['post_id'] ?? 0 ),
+				'states'  => $states,
+			);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Share-of-voice data: per-domain prompts-cited counts over the window for
+	 * us + competitors, with division-safe percentages.
+	 *
+	 * @param string[] $our_domains        Our domain aliases (first = primary).
+	 * @param string[] $competitor_domains Competitor domains.
+	 * @param int      $days               Window in days.
+	 * @return array { total_prompts: int, counts: domain => int, pct: domain => float, us: string }.
+	 */
+	public static function share_of_voice_data( array $our_domains, array $competitor_domains, int $days = 30 ): array {
+		$checks  = self::recent_checks( $days );
+		$us      = $our_domains[0] ?? '';
+		$domains = array_values( array_filter( array_unique( array_merge( array( $us ), $competitor_domains ) ) ) );
+
+		// Distinct prompts checked in the window; per-domain prompt-hash sets.
+		$prompt_hashes = array();
+		$cited_by      = array_fill_keys( $domains, array() );
+
+		foreach ( $checks as $check ) {
+			$hash                   = $check['prompt_hash'];
+			$prompt_hashes[ $hash ] = true;
+			$hosts                  = array_map( 'strval', $check['cited_domains'] );
+			foreach ( $domains as $domain ) {
+				if ( SWPS_Citation_Tracker::domain_cited( $domain, $hosts ) ) {
+					$cited_by[ $domain ][ $hash ] = true;
+				}
+			}
+		}
+
+		$total  = count( $prompt_hashes );
+		$counts = array();
+		foreach ( $domains as $domain ) {
+			$counts[ $domain ] = count( $cited_by[ $domain ] );
+		}
+
+		return array(
+			'total_prompts' => $total,
+			'counts'        => $counts,
+			'pct'           => SWPS_Citation_Tracker::share_of_voice( $counts, $total ),
+			'us'            => $us,
+		);
+	}
+
+	/**
+	 * Top domains cited by AI engines for our prompts over the window.
+	 *
+	 * @param int $days  Window in days.
+	 * @param int $limit Max domains returned.
+	 * @return array<string, int> domain => citation count, descending.
+	 */
+	public static function cited_domains_breakdown( int $days = 30, int $limit = 10 ): array {
+		$counts = array();
+
+		foreach ( self::recent_checks( $days ) as $check ) {
+			foreach ( $check['cited_domains'] as $domain ) {
+				$domain = (string) $domain;
+				if ( '' === $domain ) {
+					continue;
+				}
+				$counts[ $domain ] = ( $counts[ $domain ] ?? 0 ) + 1;
+			}
+		}
+
+		arsort( $counts );
+
+		return array_slice( $counts, 0, $limit, true );
+	}
+}

--- a/includes/class-citation-store.php
+++ b/includes/class-citation-store.php
@@ -138,6 +138,7 @@ class SWPS_Citation_Store {
 				"SELECT prompt_hash, engine, check_date, cited, cited_domains
                  FROM {$table}
                  WHERE prompt_hash IN ({$placeholders})
+                   AND check_date >= DATE_SUB(CURDATE(), INTERVAL 90 DAY)
                  ORDER BY check_date DESC",
 				$hashes
 			),

--- a/includes/class-citation-tracker.php
+++ b/includes/class-citation-tracker.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Citation tracker — storage, cron runner, and pure static helpers.
+ *
+ * This file ships the pure static helpers only (Task 1). Table creation,
+ * cron runner, admin CRUD, and AEO hook are wired in Task 2 once the first
+ * call site exists (no require_once in stratawp-seo.php yet).
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages AI citation tracking: storage, cron runner, and pure static helpers.
+ *
+ * @package StrataWP_SEO
+ */
+class SWPS_Citation_Tracker {
+
+	// -------------------------------------------------------------------------
+	// Pure static helpers (WP-free; fully unit-tested)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Extract registrable hosts from an array of citation URLs.
+	 *
+	 * Rules:
+	 * - Parse each entry with wp_parse_url(); skip anything without a valid host.
+	 * - Lowercase and strip a leading "www." prefix.
+	 * - Deduplicate; return an indexed (0-based) array.
+	 *
+	 * Note: entries that are already bare domain strings (no scheme) are treated
+	 * as-is after lowercasing and www-stripping — they are not parsed as URLs.
+	 * The Google provider stores vertexaisearch titles (bare domains) directly,
+	 * so this function intentionally does NOT skip non-URL strings.
+	 *
+	 * @param string[] $urls Raw citation entries (URLs or bare domain strings).
+	 * @return string[]      Lowercased, www-stripped, deduplicated hosts.
+	 */
+	public static function extract_domains( array $urls ): array {
+		$seen  = array();
+		$hosts = array();
+
+		foreach ( $urls as $entry ) {
+			if ( ! is_string( $entry ) || '' === trim( $entry ) ) {
+				continue;
+			}
+
+			$parsed = wp_parse_url( $entry );
+
+			if ( ! empty( $parsed['host'] ) ) {
+				// Full URL with a recognisable host component.
+				$host = strtolower( $parsed['host'] );
+			} elseif ( empty( $parsed['scheme'] ) && empty( $parsed['path'] ) === false ) {
+				// No scheme → parse_url put everything in 'path'; treat it as the
+				// raw domain string (Google vertexaisearch title fall-through).
+				$raw  = trim( $parsed['path'] );
+				$host = strtolower( $raw );
+				// Reject strings that contain slashes — they are paths, not domains.
+				if ( false !== strpos( $host, '/' ) ) {
+					continue;
+				}
+				// Must contain at least one dot to look like a domain.
+				if ( false === strpos( $host, '.' ) ) {
+					continue;
+				}
+			} else {
+				continue;
+			}
+
+			// Strip leading "www.".
+			if ( 0 === strpos( $host, 'www.' ) ) {
+				$host = substr( $host, 4 );
+			}
+
+			if ( '' === $host || isset( $seen[ $host ] ) ) {
+				continue;
+			}
+
+			$seen[ $host ] = true;
+			$hosts[]       = $host;
+		}
+
+		return $hosts;
+	}
+
+	/**
+	 * Return true when $domain (or any subdomain of it) appears in $hosts.
+	 *
+	 * Examples (domain = "example.com"):
+	 * - "example.com"     → true  (exact match)
+	 * - "sub.example.com" → true  (subdomain match)
+	 * - "notexample.com"  → false (different registrable domain)
+	 *
+	 * @param string   $domain The registrable domain to look for (e.g. "example.com").
+	 * @param string[] $hosts  List of lowercased, www-stripped host strings.
+	 * @return bool
+	 */
+	public static function domain_cited( string $domain, array $hosts ): bool {
+		$domain = strtolower( $domain );
+		$suffix = '.' . $domain;
+
+		foreach ( $hosts as $host ) {
+			$host = strtolower( (string) $host );
+			if ( $host === $domain || str_ends_with( $host, $suffix ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Compute a smoothed citation state from a newest-first history of booleans.
+	 *
+	 * States:
+	 * - 'cited'  — latest two checks both true  (or history has exactly one entry and it is true).
+	 * - 'lost'   — at least one true anywhere in history AND the latest two checks are both false.
+	 * - 'never'  — no true value anywhere in history (including empty history).
+	 * - 'mixed'  — none of the above (e.g. one true, one false in the last two; or only one false).
+	 *
+	 * @param bool[] $history Newest-first array of cited booleans.
+	 * @return string 'cited' | 'lost' | 'never' | 'mixed'
+	 */
+	public static function citation_state( array $history ): string {
+		if ( empty( $history ) ) {
+			return 'never';
+		}
+
+		$has_any_true = in_array( true, $history, true );
+
+		if ( ! $has_any_true ) {
+			return 'never';
+		}
+
+		$count  = count( $history );
+		$latest = $history[0];
+
+		// Single-entry history.
+		if ( 1 === $count ) {
+			return $latest ? 'cited' : 'lost';
+		}
+
+		$second_latest = $history[1];
+
+		// Latest two both true → cited.
+		if ( $latest && $second_latest ) {
+			return 'cited';
+		}
+
+		// Latest two both false AND there is at least one true → lost.
+		if ( ! $latest && ! $second_latest ) {
+			return 'lost';
+		}
+
+		// One true and one false in the latest two — ambiguous.
+		return 'mixed';
+	}
+
+	/**
+	 * Compute share-of-voice percentages from per-domain cited counts.
+	 *
+	 * Returns an associative array of the same keys as $per_domain_counts, each
+	 * value being the percentage (0–100, rounded to one decimal) of total prompts
+	 * where that domain was cited. Division-safe: returns 0.0 for all when
+	 * $total_prompts is zero.
+	 *
+	 * @param array<string, int> $per_domain_counts Domain => number of prompts cited.
+	 * @param int                $total_prompts     Total prompts checked.
+	 * @return array<string, float>                 Domain => percentage (0–100).
+	 */
+	public static function share_of_voice( array $per_domain_counts, int $total_prompts ): array {
+		$result = array();
+
+		foreach ( $per_domain_counts as $domain => $count ) {
+			if ( $total_prompts <= 0 ) {
+				$result[ $domain ] = 0.0;
+			} else {
+				$result[ $domain ] = round( ( (int) $count / $total_prompts ) * 100, 1 );
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Classify a GSC query string as a question-form query.
+	 *
+	 * A query qualifies when it:
+	 * (a) begins with a question word at a word boundary (who|what|how|why|when|where|which|can|does|do|is|are|should), OR
+	 * (b) contains 5 or more whitespace-delimited words (long-tail).
+	 *
+	 * @param string $query Raw GSC query string.
+	 * @return bool True when the query looks like a question or long-tail phrase.
+	 */
+	public static function is_question_query( string $query ): bool {
+		$query = trim( $query );
+
+		if ( '' === $query ) {
+			return false;
+		}
+
+		// Rule (a): starts with a question word (case-insensitive, word boundary).
+		if ( (bool) preg_match( '/^(who|what|how|why|when|where|which|can|does|do|is|are|should)\b/i', $query ) ) {
+			return true;
+		}
+
+		// Rule (b): 5 or more words.
+		$words = preg_split( '/\s+/', $query, -1, PREG_SPLIT_NO_EMPTY );
+		return count( $words ) >= 5;
+	}
+}

--- a/includes/class-citation-tracker.php
+++ b/includes/class-citation-tracker.php
@@ -1,10 +1,7 @@
 <?php
 /**
- * Citation tracker — storage, cron runner, and pure static helpers.
- *
- * This file ships the pure static helpers only (Task 1). Table creation,
- * cron runner, admin CRUD, and AEO hook are wired in Task 2 once the first
- * call site exists (no require_once in stratawp-seo.php yet).
+ * Citation tracker — prompts, capped search-grounded checks, cron, AEO loss
+ * hook, and pure static helpers. Storage lives in SWPS_Citation_Store.
  *
  * @package StrataWP_SEO
  */
@@ -14,11 +11,52 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Manages AI citation tracking: storage, cron runner, and pure static helpers.
+ * Manages AI citation tracking: prompts, capped checks, cron, AEO loss hook,
+ * and pure static helpers.
  *
  * @package StrataWP_SEO
  */
 class SWPS_Citation_Tracker {
+
+	public const CRON_HOOK        = 'swps_citation_check';
+	public const OPTION_FREQUENCY = 'swps_citation_frequency';
+	public const OPTION_CAP       = 'swps_citation_monthly_cap';
+	public const META_LOSS        = '_swps_citation_loss';
+
+	/** Default monthly search-call cap. */
+	private const DEFAULT_CAP = 200;
+
+	/**
+	 * Prompt list, engines, and domain configuration.
+	 *
+	 * @var SWPS_Citation_Prompts
+	 */
+	private SWPS_Citation_Prompts $prompts;
+
+	/**
+	 * Wire cron, reschedule-on-change, and the AEO proposal filter.
+	 *
+	 * @param SWPS_Citation_Prompts $prompts Prompt/engine/domain configuration.
+	 */
+	public function __construct( SWPS_Citation_Prompts $prompts ) {
+		$this->prompts = $prompts;
+
+		add_action( self::CRON_HOOK, array( $this, 'run_checks' ) );
+
+		// Reschedule when the frequency changes (both add_ and update_ in case
+		// activation defaults were never seeded) — digest precedent.
+		add_action( 'update_option_' . self::OPTION_FREQUENCY, array( __CLASS__, 'reschedule_cron' ), 10, 0 );
+		add_action( 'add_option_' . self::OPTION_FREQUENCY, array( __CLASS__, 'reschedule_cron' ), 10, 0 );
+
+		add_filter( 'swps_aeo_proposal', array( $this, 'filter_aeo_proposal' ), 10, 2 );
+	}
+
+	/**
+	 * Prompt/engine/domain configuration (for admin UI access).
+	 */
+	public function prompts(): SWPS_Citation_Prompts {
+		return $this->prompts;
+	}
 
 	// -------------------------------------------------------------------------
 	// Pure static helpers (WP-free; fully unit-tested)
@@ -211,5 +249,245 @@ class SWPS_Citation_Tracker {
 		// Rule (b): 5 or more words.
 		$words = preg_split( '/\s+/', $query, -1, PREG_SPLIT_NO_EMPTY );
 		return count( $words ) >= 5;
+	}
+
+	// -------------------------------------------------------------------------
+	// Cron scheduling (keyword-tracker precedent)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Schedule the citation check cron at the configured frequency.
+	 */
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			$frequency = get_option( self::OPTION_FREQUENCY, 'weekly' );
+			$frequency = in_array( $frequency, array( 'daily', 'weekly' ), true ) ? $frequency : 'weekly';
+			wp_schedule_event( time(), $frequency, self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Unschedule the citation check cron.
+	 */
+	public static function unschedule_cron(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Reschedule with the new frequency (hooked to option changes).
+	 */
+	public static function reschedule_cron(): void {
+		self::unschedule_cron();
+		self::schedule_cron();
+	}
+
+	// -------------------------------------------------------------------------
+	// Capped check runner
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Current month's call-counter option name (swps_citation_calls_YYYY_MM).
+	 */
+	public static function counter_option(): string {
+		return 'swps_citation_calls_' . gmdate( 'Y_m' );
+	}
+
+	/**
+	 * Whether the monthly call cap has been reached.
+	 */
+	public function cap_reached(): bool {
+		$cap = (int) get_option( self::OPTION_CAP, self::DEFAULT_CAP );
+		return (int) get_option( self::counter_option(), 0 ) >= $cap;
+	}
+
+	/**
+	 * Run one search-grounded citation check for a prompt × engine pair and
+	 * persist today's row. The cap is checked FIRST and the counter increments
+	 * BEFORE the provider call (failed calls may still bill).
+	 *
+	 * @param string $prompt The prompt to check.
+	 * @param string $engine Provider slug (anthropic|openai|google|xai).
+	 * @return array|WP_Error The stored row data on success.
+	 */
+	public function check_one( string $prompt, string $engine ): array|WP_Error {
+		$prompt = mb_substr( sanitize_text_field( trim( $prompt ) ), 0, 500 );
+		if ( '' === $prompt ) {
+			return new WP_Error( 'swps_citation_empty_prompt', __( 'Prompt cannot be empty.', 'stratawp-seo' ) );
+		}
+
+		// Cap guard FIRST.
+		if ( $this->cap_reached() ) {
+			return new WP_Error(
+				'swps_citation_cap_reached',
+				__( 'Monthly AI search call cap reached. Raise the cap in settings or wait for next month.', 'stratawp-seo' )
+			);
+		}
+
+		$providers = SWPS_Provider_Factory::all_ai_providers();
+		if ( ! isset( $providers[ $engine ] ) ) {
+			return new WP_Error( 'swps_citation_invalid_engine', __( 'Unknown AI engine.', 'stratawp-seo' ) );
+		}
+
+		// Increment BEFORE the call — failed calls may still bill.
+		$counter = self::counter_option();
+		update_option( $counter, (int) get_option( $counter, 0 ) + 1, false );
+
+		$result = $providers[ $engine ]->search_grounded( $prompt, 1024 );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$hosts   = self::extract_domains( $result['citations'] );
+		$matched = array();
+		foreach ( $this->prompts->our_domains() as $domain ) {
+			if ( self::domain_cited( $domain, $hosts ) ) {
+				$matched[] = $domain;
+			}
+		}
+
+		$row = array(
+			'prompt_hash'   => md5( $prompt ),
+			'prompt'        => $prompt,
+			'engine'        => $engine,
+			'check_date'    => gmdate( 'Y-m-d' ),
+			'cited'         => empty( $matched ) ? 0 : 1,
+			'our_domains'   => (string) wp_json_encode( $matched ),
+			'cited_domains' => (string) wp_json_encode( $hosts ),
+		);
+
+		SWPS_Citation_Store::upsert_check( $row );
+
+		return $row;
+	}
+
+	/**
+	 * Cron callback: loop prompts × enabled engines with the cap guard, prune
+	 * old rows, then run the loss detector.
+	 */
+	public function run_checks(): void {
+		$engines = $this->prompts->enabled_engines();
+
+		foreach ( $this->prompts->get_prompts() as $entry ) {
+			foreach ( $engines as $engine ) {
+				$result = $this->check_one( $entry['prompt'], $engine );
+				if ( is_wp_error( $result ) && 'swps_citation_cap_reached' === $result->get_error_code() ) {
+					break 2; // Cap hit — stop the whole run.
+				}
+			}
+		}
+
+		SWPS_Citation_Store::prune( 180 );
+		$this->detect_losses();
+	}
+
+	// -------------------------------------------------------------------------
+	// State queries (implementations live in SWPS_Citation_Store)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Per-prompt per-engine citation states (smoothed over last 3 checks).
+	 *
+	 * @return array[] Entries: { prompt, post_id, states: engine => { state, last_date } }.
+	 */
+	public function prompt_states(): array {
+		return SWPS_Citation_Store::prompt_states( $this->prompts->get_prompts(), $this->prompts->enabled_engines() );
+	}
+
+	/**
+	 * Share-of-voice data over the window for us + competitors.
+	 *
+	 * @param int $days Window in days.
+	 * @return array { total_prompts: int, counts: domain => int, pct: domain => float, us: string }.
+	 */
+	public function share_of_voice_data( int $days = 30 ): array {
+		return SWPS_Citation_Store::share_of_voice_data( $this->prompts->our_domains(), $this->prompts->competitor_domains(), $days );
+	}
+
+	/**
+	 * Top domains cited by AI engines for our prompts over the window.
+	 *
+	 * @param int $days  Window in days.
+	 * @param int $limit Max domains returned.
+	 * @return array<string, int> domain => citation count, descending.
+	 */
+	public function cited_domains_breakdown( int $days = 30, int $limit = 10 ): array {
+		return SWPS_Citation_Store::cited_domains_breakdown( $days, $limit );
+	}
+
+	// -------------------------------------------------------------------------
+	// Lost-citation → AEO context
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Detect prompts (with post_id > 0) in the 'lost' state and store loss
+	 * context as post meta; clear the meta when the state returns to 'cited'.
+	 */
+	public function detect_losses(): void {
+		foreach ( $this->prompt_states() as $row ) {
+			$post_id = (int) $row['post_id'];
+			if ( $post_id <= 0 ) {
+				continue;
+			}
+
+			$lost_engines = array();
+			$cited_any    = false;
+			foreach ( $row['states'] as $engine => $info ) {
+				if ( 'lost' === $info['state'] ) {
+					$lost_engines[] = $engine;
+				} elseif ( 'cited' === $info['state'] ) {
+					$cited_any = true;
+				}
+			}
+
+			if ( ! empty( $lost_engines ) ) {
+				update_post_meta(
+					$post_id,
+					self::META_LOSS,
+					array(
+						'prompt'            => $row['prompt'],
+						'engines'           => $lost_engines,
+						'top_cited_domains' => array_keys( array_slice( SWPS_Citation_Store::cited_domains_breakdown( 30, 5 ), 0, 5, true ) ),
+						'time'              => time(),
+					)
+				);
+			} elseif ( $cited_any ) {
+				delete_post_meta( $post_id, self::META_LOSS );
+			}
+		}
+	}
+
+	/**
+	 * Append lost-citation context to an AEO proposal payload.
+	 *
+	 * The swps_aeo_proposal filter fires AFTER the AI call, so this cannot
+	 * influence the generation prompt; instead it conservatively attaches a
+	 * citation_loss key (raw meta) and a human-readable citation_loss_note to
+	 * the proposal payload for the editor UI to surface alongside the edits.
+	 *
+	 * @param array $proposal The AI proposal payload.
+	 * @param int   $post_id  The post being optimized.
+	 * @return array The (possibly annotated) proposal.
+	 */
+	public function filter_aeo_proposal( $proposal, $post_id ): array {
+		$proposal = (array) $proposal;
+		$loss     = get_post_meta( (int) $post_id, self::META_LOSS, true );
+
+		if ( ! is_array( $loss ) || empty( $loss['prompt'] ) ) {
+			return $proposal;
+		}
+
+		$proposal['citation_loss']      = $loss;
+		$proposal['citation_loss_note'] = sprintf(
+			/* translators: 1: prompt text, 2: engine list, 3: domain list */
+			__( 'AI engines (%2$s) recently stopped citing this site for the prompt "%1$s". Competing domains being cited: %3$s.', 'stratawp-seo' ),
+			(string) $loss['prompt'],
+			implode( ', ', (array) ( $loss['engines'] ?? array() ) ),
+			implode( ', ', (array) ( $loss['top_cited_domains'] ?? array() ) )
+		);
+
+		return $proposal;
 	}
 }

--- a/includes/class-citation-tracker.php
+++ b/includes/class-citation-tracker.php
@@ -331,6 +331,10 @@ class SWPS_Citation_Tracker {
 			return new WP_Error( 'swps_citation_invalid_engine', __( 'Unknown AI engine.', 'stratawp-seo' ) );
 		}
 
+		if ( ! in_array( $engine, $this->prompts->enabled_engines(), true ) ) {
+			return new WP_Error( 'swps_citation_engine_disabled', __( 'This engine is not enabled for citation checks.', 'stratawp-seo' ) );
+		}
+
 		// Increment BEFORE the call — failed calls may still bill.
 		$counter = self::counter_option();
 		update_option( $counter, (int) get_option( $counter, 0 ) + 1, false );

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -100,6 +100,7 @@ class SWPS_Dashboard {
 			'autopilot'           => $this->safe_get_autopilot(),
 			'posts_30d'           => $this->safe_get_post_views(),
 			'ai_referrals'        => $this->safe_get_ai_referrals(),
+			'ai_funnel'           => $this->safe_get_funnel(),
 			'top_issues'          => $this->safe_get_top_issues(),
 			'top_queries'         => $this->safe_get_top_gsc_queries(),
 			'auto_optimize_queue' => array(), // Phase 7 fills in.
@@ -318,6 +319,19 @@ class SWPS_Dashboard {
 				'views'     => 0,
 				'delta_pct' => null,
 			);
+		}
+	}
+
+	/**
+	 * Site-wide AI visibility funnel (crawled → AI-visited), transient-cached.
+	 *
+	 * @return array{published:int, crawled:int, visited:int, stages:array}|array{}
+	 */
+	private function safe_get_funnel(): array {
+		try {
+			return SWPS_Visibility_Funnel::site_funnel( 30 );
+		} catch ( \Throwable $e ) {
+			return array();
 		}
 	}
 

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -101,6 +101,7 @@ class SWPS_Dashboard {
 			'posts_30d'           => $this->safe_get_post_views(),
 			'ai_referrals'        => $this->safe_get_ai_referrals(),
 			'ai_funnel'           => $this->safe_get_funnel(),
+			'ai_citations'        => $this->safe_get_citations(),
 			'top_issues'          => $this->safe_get_top_issues(),
 			'top_queries'         => $this->safe_get_top_gsc_queries(),
 			'auto_optimize_queue' => array(), // Phase 7 fills in.
@@ -330,6 +331,35 @@ class SWPS_Dashboard {
 	private function safe_get_funnel(): array {
 		try {
 			return SWPS_Visibility_Funnel::site_funnel( 30 );
+		} catch ( \Throwable $e ) {
+			return array();
+		}
+	}
+
+	/**
+	 * AI citations tile: X of Y prompts currently cited (any enabled engine).
+	 *
+	 * @return array{cited: int, total: int}|array{}
+	 */
+	private function safe_get_citations(): array {
+		try {
+			$states = stratawp_seo()->citation_tracker->prompt_states();
+			if ( empty( $states ) ) {
+				return array();
+			}
+			$cited = 0;
+			foreach ( $states as $row ) {
+				foreach ( $row['states'] as $info ) {
+					if ( 'cited' === $info['state'] ) {
+						++$cited;
+						break;
+					}
+				}
+			}
+			return array(
+				'cited' => $cited,
+				'total' => count( $states ),
+			);
 		} catch ( \Throwable $e ) {
 			return array();
 		}

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -99,6 +99,7 @@ class SWPS_Dashboard {
 			'ai_cost_30d'         => $this->safe_get_ai_cost(),
 			'autopilot'           => $this->safe_get_autopilot(),
 			'posts_30d'           => $this->safe_get_post_views(),
+			'ai_referrals'        => $this->safe_get_ai_referrals(),
 			'top_issues'          => $this->safe_get_top_issues(),
 			'top_queries'         => $this->safe_get_top_gsc_queries(),
 			'auto_optimize_queue' => array(), // Phase 7 fills in.
@@ -290,6 +291,27 @@ class SWPS_Dashboard {
 			return array(
 				'views'     => $views_30,
 				'delta_pct' => $delta,
+			);
+		} catch ( \Throwable $e ) {
+			return array(
+				'views'     => 0,
+				'delta_pct' => null,
+			);
+		}
+	}
+
+	/**
+	 * AI-referred views over the last 30 days with a previous-period delta.
+	 *
+	 * @return array{views: int, delta_pct: float|null}
+	 */
+	private function safe_get_ai_referrals(): array {
+		try {
+			$summary = SWPS_AI_Referrals_Report::get_summary( 30 );
+
+			return array(
+				'views'     => (int) $summary['total_views'],
+				'delta_pct' => $summary['delta_pct'],
 			);
 		} catch ( \Throwable $e ) {
 			return array(

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1626,6 +1626,7 @@ class SWPS_Settings {
 				'label'    => __( 'AI Crawlers', 'stratawp-seo' ),
 				'sections' => array(
 					'swps_ai_crawlers_section',
+					'swps_citations_section',
 				),
 			),
 			'analytics'       => array(

--- a/includes/class-visibility-funnel.php
+++ b/includes/class-visibility-funnel.php
@@ -1,0 +1,287 @@
+<?php
+/**
+ * AI Visibility Funnel — shared query layer.
+ *
+ * Provides three batched, prepared query methods consumed by the four
+ * surfaces that show crawl ↔ AI-visit data: the bot-analytics gap report,
+ * the AEO queue, the AEO editor panel, and the dashboard funnel tile.
+ *
+ * No new tables, no cron.  All reads are batched (IN (...)) or site-wide
+ * aggregates; all results are null-safe.  The dashboard tile is transient-
+ * cached for 15 minutes.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Batched queries joining crawl data and AI-visit data for the funnel surfaces.
+ */
+class SWPS_Visibility_Funnel {
+
+	private const TRANSIENT_FUNNEL = 'swps_funnel_tile';
+	private const FUNNEL_TTL       = 900; // 15 minutes.
+
+	// -------------------------------------------------------------------------
+	// Pure helper — no DB, no WP (testable in isolation)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Convert raw funnel counts into per-stage rates.
+	 *
+	 * Each stage's `pct` is expressed as a percentage of the *previous* stage
+	 * (i.e. the conversion from one step to the next), division-safe and
+	 * clamped to 0–100.  Stage 0 (published) is always 100 % of itself.
+	 *
+	 * @param int $published Total published posts.
+	 * @param int $crawled   Posts with ≥1 bot hit in the window.
+	 * @param int $visited   Posts with ≥1 AI visit in the window.
+	 * @return array<int, array{label:string, count:int, pct:int}>  Three-element array.
+	 */
+	public static function stage_rates( int $published, int $crawled, int $visited ): array {
+		$crawled_pct = $published > 0
+			? min( 100, (int) round( ( $crawled / $published ) * 100 ) )
+			: 0;
+
+		$visited_pct = $crawled > 0
+			? min( 100, (int) round( ( $visited / $crawled ) * 100 ) )
+			: 0;
+
+		// If published is zero the whole funnel is meaningless — zero everything.
+		if ( 0 === $published ) {
+			$crawled_pct = 0;
+			$visited_pct = 0;
+		}
+
+		return array(
+			array(
+				'label' => __( 'Published', 'stratawp-seo' ),
+				'count' => $published,
+				'pct'   => $published > 0 ? 100 : 0,
+			),
+			array(
+				'label' => __( 'Crawled by AI (30d)', 'stratawp-seo' ),
+				'count' => $crawled,
+				'pct'   => $crawled_pct,
+			),
+			array(
+				'label' => __( 'Received AI visits (30d)', 'stratawp-seo' ),
+				'count' => $visited,
+				'pct'   => $visited_pct,
+			),
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Batched query: crawl stats per post set
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Crawl statistics for a set of post IDs.
+	 *
+	 * Returns one row per post_id that had ≥1 bot hit in the window.
+	 * Posts with no hits are absent (callers should default to zero).
+	 *
+	 * @param int[] $post_ids Non-empty array of post IDs.
+	 * @param int   $days     Look-back window in days.
+	 * @return array<int, array{post_id:int, hits:int, last_crawl_at:string|null, last_bot:string|null}>
+	 *              Keyed by post_id for O(1) lookup.
+	 */
+	public static function crawl_stats_for_posts( array $post_ids, int $days ): array {
+		if ( empty( $post_ids ) ) {
+			return array();
+		}
+
+		global $wpdb;
+
+		$bot_raw   = $wpdb->prefix . 'swps_bot_hits';
+		$bot_daily = $wpdb->prefix . 'swps_bot_hits_daily';
+		$since     = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+		$ids_int      = array_map( 'intval', $post_ids );
+		$placeholders = implode( ', ', array_fill( 0, count( $ids_int ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_id,
+				        SUM(hits)       AS hits,
+				        MAX(last_seen)  AS last_crawl_at,
+				        MAX(bot_key)    AS last_bot
+				 FROM (
+				     SELECT post_id, 1 AS hits,
+				            created_at AS last_seen,
+				            bot_key
+				     FROM {$bot_raw}
+				     WHERE DATE(created_at) >= %s
+				       AND post_id IN ({$placeholders})
+				     UNION ALL
+				     SELECT post_id, hits, CONCAT(date, ' 00:00:00') AS last_seen, bot_key
+				     FROM {$bot_daily}
+				     WHERE date >= %s
+				       AND post_id IN ({$placeholders})
+				 ) c
+				 GROUP BY post_id",
+				array_merge( array( $since ), $ids_int, array( $since ), $ids_int )
+			),
+			ARRAY_A
+		);
+		// phpcs:enable
+
+		$out = array();
+		foreach ( (array) $rows ?: array() as $row ) {
+			$pid         = (int) $row['post_id'];
+			$out[ $pid ] = array(
+				'post_id'      => $pid,
+				'hits'         => (int) $row['hits'],
+				'last_crawl_at' => $row['last_crawl_at'] ?: null,
+				'last_bot'     => $row['last_bot'] ?: null,
+			);
+		}
+
+		return $out;
+	}
+
+	// -------------------------------------------------------------------------
+	// Batched query: AI-visit stats per post set
+	// -------------------------------------------------------------------------
+
+	/**
+	 * AI-visit counts for a set of post IDs.
+	 *
+	 * Combines the raw analytics table (last 7 days, not yet rolled up) with
+	 * the swps_ai_referrals_daily rollup — mirroring SWPS_AI_Referrals_Report.
+	 *
+	 * @param int[] $post_ids Non-empty array of post IDs.
+	 * @param int   $days     Look-back window in days.
+	 * @return array<int, array{post_id:int, ai_visits:int}>  Keyed by post_id.
+	 */
+	public static function ai_visits_for_posts( array $post_ids, int $days ): array {
+		if ( empty( $post_ids ) ) {
+			return array();
+		}
+
+		global $wpdb;
+
+		$raw    = $wpdb->prefix . 'swps_analytics';
+		$rollup = $wpdb->prefix . 'swps_ai_referrals_daily';
+		$since  = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+		$ids_int      = array_map( 'intval', $post_ids );
+		$placeholders = implode( ', ', array_fill( 0, count( $ids_int ), '%d' ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_id, SUM(views) AS ai_visits
+				 FROM (
+				     SELECT post_id, 1 AS views
+				     FROM {$raw}
+				     WHERE ai_source <> ''
+				       AND DATE(created_at) >= %s
+				       AND post_id IN ({$placeholders})
+				     UNION ALL
+				     SELECT post_id, views
+				     FROM {$rollup}
+				     WHERE date >= %s
+				       AND post_id IN ({$placeholders})
+				 ) c
+				 GROUP BY post_id",
+				array_merge( array( $since ), $ids_int, array( $since ), $ids_int )
+			),
+			ARRAY_A
+		);
+		// phpcs:enable
+
+		$out = array();
+		foreach ( (array) $rows ?: array() as $row ) {
+			$pid         = (int) $row['post_id'];
+			$out[ $pid ] = array(
+				'post_id'   => $pid,
+				'ai_visits' => (int) $row['ai_visits'],
+			);
+		}
+
+		return $out;
+	}
+
+	// -------------------------------------------------------------------------
+	// Site-wide funnel aggregate (dashboard tile)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Site-wide two-stage funnel: published → crawled → AI-visited.
+	 *
+	 * Results are transient-cached for 15 minutes.
+	 *
+	 * @param int $days Look-back window in days.
+	 * @return array{published:int, crawled:int, visited:int, stages: array}
+	 */
+	public static function site_funnel( int $days ): array {
+		$cached = get_transient( self::TRANSIENT_FUNNEL );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		global $wpdb;
+
+		$bot_raw   = $wpdb->prefix . 'swps_bot_hits';
+		$bot_daily = $wpdb->prefix . 'swps_bot_hits_daily';
+		$raw       = $wpdb->prefix . 'swps_analytics';
+		$rollup    = $wpdb->prefix . 'swps_ai_referrals_daily';
+		$since     = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+		// Count published posts (posts + pages).
+		$published = (int) $wpdb->get_var(
+			"SELECT COUNT(*) FROM {$wpdb->posts}
+			 WHERE post_status = 'publish'
+			   AND post_type IN ('post', 'page')"
+		);
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$crawled = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(DISTINCT post_id)
+				 FROM (
+				     SELECT post_id FROM {$bot_raw}
+				     WHERE DATE(created_at) >= %s AND post_id > 0
+				     UNION
+				     SELECT post_id FROM {$bot_daily}
+				     WHERE date >= %s AND post_id > 0
+				 ) c",
+				$since,
+				$since
+			)
+		);
+
+		$visited = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(DISTINCT post_id)
+				 FROM (
+				     SELECT post_id FROM {$raw}
+				     WHERE ai_source <> '' AND DATE(created_at) >= %s AND post_id > 0
+				     UNION
+				     SELECT post_id FROM {$rollup}
+				     WHERE date >= %s AND post_id > 0
+				 ) c",
+				$since,
+				$since
+			)
+		);
+		// phpcs:enable
+
+		$result = array(
+			'published' => $published,
+			'crawled'   => $crawled,
+			'visited'   => $visited,
+			'stages'    => self::stage_rates( $published, $crawled, $visited ),
+		);
+
+		set_transient( self::TRANSIENT_FUNNEL, $result, self::FUNNEL_TTL );
+
+		return $result;
+	}
+}

--- a/includes/class-visibility-funnel.php
+++ b/includes/class-visibility-funnel.php
@@ -104,7 +104,7 @@ class SWPS_Visibility_Funnel {
 		$ids_int      = array_map( 'intval', $post_ids );
 		$placeholders = implode( ', ', array_fill( 0, count( $ids_int ), '%d' ) );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT post_id,
@@ -132,13 +132,13 @@ class SWPS_Visibility_Funnel {
 		// phpcs:enable
 
 		$out = array();
-		foreach ( (array) $rows ?: array() as $row ) {
+		foreach ( ( $rows ? $rows : array() ) as $row ) {
 			$pid         = (int) $row['post_id'];
 			$out[ $pid ] = array(
-				'post_id'      => $pid,
-				'hits'         => (int) $row['hits'],
-				'last_crawl_at' => $row['last_crawl_at'] ?: null,
-				'last_bot'     => $row['last_bot'] ?: null,
+				'post_id'       => $pid,
+				'hits'          => (int) $row['hits'],
+				'last_crawl_at' => $row['last_crawl_at'] ? (string) $row['last_crawl_at'] : null,
+				'last_bot'      => $row['last_bot'] ? (string) $row['last_bot'] : null,
 			);
 		}
 
@@ -173,7 +173,7 @@ class SWPS_Visibility_Funnel {
 		$ids_int      = array_map( 'intval', $post_ids );
 		$placeholders = implode( ', ', array_fill( 0, count( $ids_int ), '%d' ) );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT post_id, SUM(views) AS ai_visits
@@ -197,7 +197,7 @@ class SWPS_Visibility_Funnel {
 		// phpcs:enable
 
 		$out = array();
-		foreach ( (array) $rows ?: array() as $row ) {
+		foreach ( ( $rows ? $rows : array() ) as $row ) {
 			$pid         = (int) $row['post_id'];
 			$out[ $pid ] = array(
 				'post_id'   => $pid,
@@ -235,13 +235,14 @@ class SWPS_Visibility_Funnel {
 		$since     = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
 
 		// Count published posts (posts + pages).
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- post count has no caching requirement; $wpdb->posts is safe.
 		$published = (int) $wpdb->get_var(
 			"SELECT COUNT(*) FROM {$wpdb->posts}
 			 WHERE post_status = 'publish'
 			   AND post_type IN ('post', 'page')"
 		);
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$crawled = (int) $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(DISTINCT post_id)

--- a/includes/class-visibility-funnel.php
+++ b/includes/class-visibility-funnel.php
@@ -221,7 +221,9 @@ class SWPS_Visibility_Funnel {
 	 * @return array{published:int, crawled:int, visited:int, stages: array}
 	 */
 	public static function site_funnel( int $days ): array {
-		$cached = get_transient( self::TRANSIENT_FUNNEL );
+		$transient_key = self::TRANSIENT_FUNNEL . '_' . (int) $days;
+
+		$cached = get_transient( $transient_key );
 		if ( is_array( $cached ) ) {
 			return $cached;
 		}
@@ -281,7 +283,7 @@ class SWPS_Visibility_Funnel {
 			'stages'    => self::stage_rates( $published, $crawled, $visited ),
 		);
 
-		set_transient( self::TRANSIENT_FUNNEL, $result, self::FUNNEL_TTL );
+		set_transient( $transient_key, $result, self::FUNNEL_TTL );
 
 		return $result;
 	}

--- a/includes/providers/ai/class-anthropic-provider.php
+++ b/includes/providers/ai/class-anthropic-provider.php
@@ -168,6 +168,112 @@ class SWPS_Anthropic_Provider extends SWPS_AI_Provider {
 		return $models;
 	}
 
+	/**
+	 * Run a search-grounded query via the Anthropic web_search_20250305 tool.
+	 *
+	 * API: POST /v1/messages with tools[{type:"web_search_20250305",name:"web_search"}].
+	 * Citations surface on text content blocks as citations[]{type:"web_search_result_location",url:string}.
+	 * Ref: https://platform.claude.com/docs/en/api/cli/beta/messages
+	 *
+	 * @param string $query      The search query / prompt.
+	 * @param int    $max_tokens Maximum tokens in the response.
+	 * @return array{text: string, citations: string[]}|WP_Error
+	 */
+	public function search_grounded( string $query, int $max_tokens = 1024 ): array|WP_Error {
+		$api_key = $this->get_api_key();
+
+		if ( empty( $api_key ) ) {
+			return new WP_Error( 'swps_no_api_key', __( 'Please enter your Anthropic API key in StrataWP SEO settings.', 'stratawp-seo' ) );
+		}
+
+		$body = array(
+			'model'      => $this->get_validated_model(),
+			'max_tokens' => $max_tokens,
+			'messages'   => array(
+				array(
+					'role'    => 'user',
+					'content' => $query,
+				),
+			),
+			'tools'      => array(
+				array(
+					'type'     => 'web_search_20250305',
+					'name'     => 'web_search',
+					'max_uses' => 3,
+				),
+			),
+		);
+
+		$response = wp_remote_post(
+			self::API_URL,
+			array(
+				'timeout' => 180,
+				'headers' => array(
+					'Content-Type'      => 'application/json',
+					'x-api-key'         => $api_key,
+					'anthropic-version' => '2023-06-01',
+				),
+				'body'    => wp_json_encode( $body ),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'swps_api_request_failed',
+				/* translators: %s: error message */
+				sprintf( __( 'API request failed: %s', 'stratawp-seo' ), $response->get_error_message() )
+			);
+		}
+
+		$status_code   = wp_remote_retrieve_response_code( $response );
+		$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( 200 !== $status_code ) {
+			$error_message = $response_body['error']['message'] ?? __( 'Unknown API error.', 'stratawp-seo' );
+			$error_type    = $response_body['error']['type'] ?? '';
+			// 4xx indicating tool/search unsupported for this model.
+			if ( $status_code >= 400 && $status_code < 500 &&
+				( false !== strpos( $error_message, 'web_search' ) || false !== strpos( $error_type, 'invalid_request' ) ) ) {
+				return new WP_Error(
+					'swps_search_unsupported',
+					/* translators: 1: HTTP status code, 2: error message */
+					sprintf( __( 'Claude API error (%1$d): %2$s', 'stratawp-seo' ), $status_code, $error_message ),
+					array( 'status' => (int) $status_code )
+				);
+			}
+			return new WP_Error(
+				'swps_api_error',
+				/* translators: 1: HTTP status code, 2: error message */
+				sprintf( __( 'Claude API error (%1$d): %2$s', 'stratawp-seo' ), $status_code, $error_message ),
+				array( 'status' => (int) $status_code )
+			);
+		}
+
+		// Collect text from all text content blocks; gather citation URLs.
+		$text_parts = array();
+		$urls       = array();
+		foreach ( $response_body['content'] ?? array() as $block ) {
+			if ( 'text' === ( $block['type'] ?? '' ) ) {
+				$text_parts[] = (string) ( $block['text'] ?? '' );
+				foreach ( $block['citations'] ?? array() as $citation ) {
+					if ( 'web_search_result_location' === ( $citation['type'] ?? '' ) && ! empty( $citation['url'] ) ) {
+						$urls[] = (string) $citation['url'];
+					}
+				}
+			}
+		}
+
+		$text = implode( '', $text_parts );
+		if ( '' === $text ) {
+			return new WP_Error( 'swps_empty_response', __( 'Received empty response from Claude.', 'stratawp-seo' ) );
+		}
+
+		return array(
+			'text'      => $text,
+			'citations' => array_values( array_unique( $urls ) ),
+		);
+	}
+
 	public function test_key( string $api_key ): bool|WP_Error {
 		$response = wp_remote_post(
 			self::API_URL,

--- a/includes/providers/ai/class-google-provider.php
+++ b/includes/providers/ai/class-google-provider.php
@@ -159,6 +159,124 @@ class SWPS_Google_Provider extends SWPS_AI_Provider {
 		return $models;
 	}
 
+	/**
+	 * Run a search-grounded query via the Gemini google_search grounding tool.
+	 *
+	 * API: POST /v1beta/models/{model}:generateContent with tools[{google_search:{}}].
+	 * Citations from groundingMetadata.groundingChunks[]{web:{uri,title}}.
+	 * When uri is a vertexaisearch redirect host, title (usually the bare domain) is used.
+	 * Ref: https://ai.google.dev/gemini-api/docs/grounding
+	 *
+	 * @param string $query      The search query / prompt.
+	 * @param int    $max_tokens Maximum tokens in the response.
+	 * @return array{text: string, citations: string[]}|WP_Error
+	 */
+	public function search_grounded( string $query, int $max_tokens = 1024 ): array|WP_Error {
+		$api_key = $this->get_api_key();
+
+		if ( empty( $api_key ) ) {
+			return new WP_Error( 'swps_no_api_key', __( 'Please enter your Google API key in StrataWP SEO settings.', 'stratawp-seo' ) );
+		}
+
+		$model = $this->get_validated_model();
+		$url   = self::API_BASE . $model . ':generateContent?key=' . $api_key;
+
+		$body = array(
+			'contents'         => array(
+				array(
+					'parts' => array(
+						array( 'text' => $query ),
+					),
+				),
+			),
+			'tools'            => array(
+				array( 'google_search' => (object) array() ),
+			),
+			'generationConfig' => array(
+				'maxOutputTokens' => $max_tokens,
+			),
+		);
+
+		$response = wp_remote_post(
+			$url,
+			array(
+				'timeout' => 180,
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+				'body'    => wp_json_encode( $body ),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'swps_api_request_failed',
+				/* translators: %s: error message */
+				sprintf( __( 'API request failed: %s', 'stratawp-seo' ), $response->get_error_message() )
+			);
+		}
+
+		$status_code   = wp_remote_retrieve_response_code( $response );
+		$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( 200 !== $status_code ) {
+			$error_message = $response_body['error']['message'] ?? __( 'Unknown API error.', 'stratawp-seo' );
+			// 4xx indicating tool/search unsupported for this model.
+			$err_lc = strtolower( $error_message );
+			if ( $status_code >= 400 && $status_code < 500 &&
+				( false !== strpos( $err_lc, 'google_search' ) ||
+					false !== strpos( $err_lc, 'grounding' ) ||
+					false !== strpos( $err_lc, 'tool' ) ) ) {
+				return new WP_Error(
+					'swps_search_unsupported',
+					/* translators: 1: HTTP status code, 2: error message */
+					sprintf( __( 'Gemini API error (%1$d): %2$s', 'stratawp-seo' ), $status_code, $error_message ),
+					array( 'status' => (int) $status_code )
+				);
+			}
+			return new WP_Error(
+				'swps_api_error',
+				/* translators: 1: HTTP status code, 2: error message */
+				sprintf( __( 'Gemini API error (%1$d): %2$s', 'stratawp-seo' ), $status_code, $error_message ),
+				array( 'status' => (int) $status_code )
+			);
+		}
+
+		$text = $response_body['candidates'][0]['content']['parts'][0]['text'] ?? '';
+		if ( '' === $text ) {
+			return new WP_Error( 'swps_empty_response', __( 'Received empty response from Gemini.', 'stratawp-seo' ) );
+		}
+
+		// Extract citation entries from groundingChunks. When the URI is a
+		// vertexaisearch redirect host, the title (usually the bare domain) is more
+		// useful as a citation entry.
+		$urls   = array();
+		$chunks = $response_body['candidates'][0]['groundingMetadata']['groundingChunks'] ?? array();
+		foreach ( $chunks as $chunk ) {
+			$web   = $chunk['web'] ?? array();
+			$uri   = (string) ( $web['uri'] ?? '' );
+			$title = (string) ( $web['title'] ?? '' );
+
+			if ( '' === $uri ) {
+				continue;
+			}
+
+			// Detect vertexaisearch redirect hosts.
+			$host = (string) wp_parse_url( $uri, PHP_URL_HOST );
+			if ( false !== strpos( $host, 'vertexaisearch' ) ) {
+				// Use title (bare domain) when available; fall back to the redirect URI.
+				$urls[] = '' !== $title ? $title : $uri;
+			} else {
+				$urls[] = $uri;
+			}
+		}
+
+		return array(
+			'text'      => $text,
+			'citations' => array_values( array_unique( $urls ) ),
+		);
+	}
+
 	public function test_key( string $api_key ): bool|WP_Error {
 		$model = $this->get_validated_model();
 		$url   = self::API_BASE . $model . ':generateContent?key=' . $api_key;

--- a/includes/providers/ai/class-google-provider.php
+++ b/includes/providers/ai/class-google-provider.php
@@ -42,7 +42,7 @@ class SWPS_Google_Provider extends SWPS_AI_Provider {
 		}
 
 		$model = $this->get_validated_model();
-		$url   = self::API_BASE . $model . ':generateContent?key=' . $api_key;
+		$url   = self::API_BASE . $model . ':generateContent?key=' . rawurlencode( $api_key );
 
 		$body = array(
 			'system_instruction' => array(
@@ -179,7 +179,7 @@ class SWPS_Google_Provider extends SWPS_AI_Provider {
 		}
 
 		$model = $this->get_validated_model();
-		$url   = self::API_BASE . $model . ':generateContent?key=' . $api_key;
+		$url   = self::API_BASE . $model . ':generateContent?key=' . rawurlencode( $api_key );
 
 		$body = array(
 			'contents'         => array(
@@ -279,7 +279,7 @@ class SWPS_Google_Provider extends SWPS_AI_Provider {
 
 	public function test_key( string $api_key ): bool|WP_Error {
 		$model = $this->get_validated_model();
-		$url   = self::API_BASE . $model . ':generateContent?key=' . $api_key;
+		$url   = self::API_BASE . $model . ':generateContent?key=' . rawurlencode( $api_key );
 
 		$response = wp_remote_post(
 			$url,

--- a/includes/providers/ai/class-openai-provider.php
+++ b/includes/providers/ai/class-openai-provider.php
@@ -159,6 +159,111 @@ class SWPS_OpenAI_Provider extends SWPS_AI_Provider {
 		return $models;
 	}
 
+	/**
+	 * Run a search-grounded query via the OpenAI Responses API web_search tool.
+	 *
+	 * API: POST /v1/responses with tools[{type:"web_search"}].
+	 * Citations surface in output[].content[].annotations[]{type:"url_citation",url:string}.
+	 * Ref: https://developers.openai.com/api/reference/responses/overview
+	 *
+	 * @param string $query      The search query / prompt.
+	 * @param int    $max_tokens Maximum tokens in the response.
+	 * @return array{text: string, citations: string[]}|WP_Error
+	 */
+	public function search_grounded( string $query, int $max_tokens = 1024 ): array|WP_Error {
+		$api_key = $this->get_api_key();
+
+		if ( empty( $api_key ) ) {
+			return new WP_Error( 'swps_no_api_key', __( 'Please enter your OpenAI API key in StrataWP SEO settings.', 'stratawp-seo' ) );
+		}
+
+		$body = array(
+			'model'             => $this->get_validated_model(),
+			'max_output_tokens' => $max_tokens,
+			'input'             => array(
+				array(
+					'role'    => 'user',
+					'content' => $query,
+				),
+			),
+			'tools'             => array(
+				array( 'type' => 'web_search' ),
+			),
+		);
+
+		$response = wp_remote_post(
+			'https://api.openai.com/v1/responses',
+			array(
+				'timeout' => 180,
+				'headers' => array(
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Bearer ' . $api_key,
+				),
+				'body'    => wp_json_encode( $body ),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'swps_api_request_failed',
+				/* translators: %s: error message */
+				sprintf( __( 'API request failed: %s', 'stratawp-seo' ), $response->get_error_message() )
+			);
+		}
+
+		$status_code   = wp_remote_retrieve_response_code( $response );
+		$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( 200 !== $status_code ) {
+			$error_message = $response_body['error']['message'] ?? __( 'Unknown API error.', 'stratawp-seo' );
+			// 4xx indicating tool/search unsupported for this model.
+			if ( $status_code >= 400 && $status_code < 500 &&
+				( false !== strpos( $error_message, 'web_search' ) || false !== strpos( $error_message, 'tool' ) ) ) {
+				return new WP_Error(
+					'swps_search_unsupported',
+					/* translators: 1: HTTP status code, 2: error message */
+					sprintf( __( 'OpenAI API error (%1$d): %2$s', 'stratawp-seo' ), $status_code, $error_message ),
+					array( 'status' => (int) $status_code )
+				);
+			}
+			return new WP_Error(
+				'swps_api_error',
+				/* translators: 1: HTTP status code, 2: error message */
+				sprintf( __( 'OpenAI API error (%1$d): %2$s', 'stratawp-seo' ), $status_code, $error_message ),
+				array( 'status' => (int) $status_code )
+			);
+		}
+
+		// Walk output items; collect text from message content blocks and URLs from annotations.
+		$text_parts = array();
+		$urls       = array();
+		foreach ( $response_body['output'] ?? array() as $item ) {
+			if ( 'message' !== ( $item['type'] ?? '' ) ) {
+				continue;
+			}
+			foreach ( $item['content'] ?? array() as $block ) {
+				if ( 'output_text' === ( $block['type'] ?? '' ) ) {
+					$text_parts[] = (string) ( $block['text'] ?? '' );
+					foreach ( $block['annotations'] ?? array() as $annotation ) {
+						if ( 'url_citation' === ( $annotation['type'] ?? '' ) && ! empty( $annotation['url'] ) ) {
+							$urls[] = (string) $annotation['url'];
+						}
+					}
+				}
+			}
+		}
+
+		$text = implode( '', $text_parts );
+		if ( '' === $text ) {
+			return new WP_Error( 'swps_empty_response', __( 'Received empty response from OpenAI.', 'stratawp-seo' ) );
+		}
+
+		return array(
+			'text'      => $text,
+			'citations' => array_values( array_unique( $urls ) ),
+		);
+	}
+
 	public function test_key( string $api_key ): bool|WP_Error {
 		$response = wp_remote_post(
 			self::API_URL,

--- a/includes/providers/ai/class-xai-provider.php
+++ b/includes/providers/ai/class-xai-provider.php
@@ -150,6 +150,104 @@ class SWPS_XAI_Provider extends SWPS_AI_Provider {
 		return $models;
 	}
 
+	/**
+	 * Run a search-grounded query via xAI Grok's search_parameters in chat completions.
+	 *
+	 * API: POST /v1/chat/completions with search_parameters:{mode:"on"}.
+	 * Citations surface as a top-level citations[] array of URL strings.
+	 * Ref: https://docs.x.ai/developers/rest-api-reference/inference/chat.md
+	 *
+	 * @param string $query      The search query / prompt.
+	 * @param int    $max_tokens Maximum tokens in the response.
+	 * @return array{text: string, citations: string[]}|WP_Error
+	 */
+	public function search_grounded( string $query, int $max_tokens = 1024 ): array|WP_Error {
+		$api_key = $this->get_api_key();
+
+		if ( empty( $api_key ) ) {
+			return new WP_Error( 'swps_no_api_key', __( 'Please enter your xAI API key in StrataWP SEO settings.', 'stratawp-seo' ) );
+		}
+
+		$body = array(
+			'model'             => $this->get_validated_model(),
+			'max_tokens'        => $max_tokens,
+			'messages'          => array(
+				array(
+					'role'    => 'user',
+					'content' => $query,
+				),
+			),
+			'search_parameters' => array(
+				'mode'             => 'on',
+				'return_citations' => true,
+			),
+		);
+
+		$response = wp_remote_post(
+			self::API_URL,
+			array(
+				'timeout' => 180,
+				'headers' => array(
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Bearer ' . $api_key,
+				),
+				'body'    => wp_json_encode( $body ),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'swps_api_request_failed',
+				/* translators: %s: error message */
+				sprintf( __( 'API request failed: %s', 'stratawp-seo' ), $response->get_error_message() )
+			);
+		}
+
+		$status_code   = wp_remote_retrieve_response_code( $response );
+		$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( 200 !== $status_code ) {
+			$error_message = $response_body['error']['message'] ?? __( 'Unknown API error.', 'stratawp-seo' );
+			// 4xx indicating search is unsupported for this model.
+			$err_lc = strtolower( $error_message );
+			if ( $status_code >= 400 && $status_code < 500 &&
+				( false !== strpos( $err_lc, 'search' ) ||
+					false !== strpos( $err_lc, 'search_parameters' ) ) ) {
+				return new WP_Error(
+					'swps_search_unsupported',
+					/* translators: 1: HTTP status code, 2: error message */
+					sprintf( __( 'Grok API error (%1$d): %2$s', 'stratawp-seo' ), $status_code, $error_message ),
+					array( 'status' => (int) $status_code )
+				);
+			}
+			return new WP_Error(
+				'swps_api_error',
+				/* translators: 1: HTTP status code, 2: error message */
+				sprintf( __( 'Grok API error (%1$d): %2$s', 'stratawp-seo' ), $status_code, $error_message ),
+				array( 'status' => (int) $status_code )
+			);
+		}
+
+		$text = $response_body['choices'][0]['message']['content'] ?? '';
+		if ( '' === $text ) {
+			return new WP_Error( 'swps_empty_response', __( 'Received empty response from Grok.', 'stratawp-seo' ) );
+		}
+
+		// Citations are a top-level array of URL strings.
+		$raw_citations = $response_body['citations'] ?? array();
+		$urls          = array();
+		foreach ( $raw_citations as $url ) {
+			if ( is_string( $url ) && '' !== $url ) {
+				$urls[] = $url;
+			}
+		}
+
+		return array(
+			'text'      => $text,
+			'citations' => array_values( array_unique( $urls ) ),
+		);
+	}
+
 	public function test_key( string $api_key ): bool|WP_Error {
 		$response = wp_remote_post(
 			self::API_URL,

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.13.0
+Stable tag: 4.14.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -293,6 +293,9 @@ No. GSC integration is optional. The on-site analytics works entirely without an
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.14.0 =
+* New: AI referral attribution — visits from ChatGPT, Perplexity, Claude, Gemini, Copilot and others are classified at capture, with an AI Referrals analytics tab (engine trends, landing posts, engagement vs organic), a per-post crawl-to-visit funnel joined to AI-bot crawl data, and a dashboard KPI tile.
 
 = 4.13.0 =
 * New: 5-minute onboarding wizard — migrate from Yoast/Rank Math, validate your AI key, AI-suggest your site description, run the audit, and generate a preview post; setup checklist on the dashboard until complete.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.15.0
+Stable tag: 4.16.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -293,6 +293,9 @@ No. GSC integration is optional. The on-site analytics works entirely without an
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.16.0 =
+* New: AI citation tracker — monitor whether ChatGPT, Claude, Gemini, and Grok cite your site for your tracked prompts (BYO keys, search-grounded), with share-of-voice vs competitors, cited-domains breakdown, monthly call caps, and lost-citation context fed into AEO proposals.
 
 = 4.15.0 =
 * New: AI visibility funnel — AEO-score sorting on the crawl-gap report, crawl recency and AI-visit columns on the AEO queue, a per-post funnel line in the AEO editor panel, and a dashboard funnel tile (crawled → AI-visited).

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.14.0
+Stable tag: 4.15.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -293,6 +293,9 @@ No. GSC integration is optional. The on-site analytics works entirely without an
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.15.0 =
+* New: AI visibility funnel — AEO-score sorting on the crawl-gap report, crawl recency and AI-visit columns on the AEO queue, a per-post funnel line in the AEO editor panel, and a dashboard funnel tile (crawled → AI-visited).
 
 = 4.14.0 =
 * New: AI referral attribution — visits from ChatGPT, Perplexity, Claude, Gemini, Copilot and others are classified at capture, with an AI Referrals analytics tab (engine trends, landing posts, engagement vs organic), a per-post crawl-to-visit funnel joined to AI-bot crawl data, and a dashboard KPI tile.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -88,6 +88,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-schema.php';
 
 // Analytics.
 require_once SWPS_PLUGIN_DIR . 'includes/class-ai-referrals.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-ai-referrals-report.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-analytics-tracker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-search-console.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-bot-analytics-tracker.php';

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.13.0
+ * Version: 4.14.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.13.0' );
+define( 'SWPS_VERSION', '4.14.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.15.0
+ * Version: 4.16.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.15.0' );
+define( 'SWPS_VERSION', '4.16.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.14.0
+ * Version: 4.15.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.14.0' );
+define( 'SWPS_VERSION', '4.15.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -89,6 +89,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-schema.php';
 // Analytics.
 require_once SWPS_PLUGIN_DIR . 'includes/class-ai-referrals.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-ai-referrals-report.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-visibility-funnel.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-analytics-tracker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-search-console.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-bot-analytics-tracker.php';

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -100,6 +100,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-keyword-tracker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-citation-store.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-citation-prompts.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-citation-tracker.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-citation-admin.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-keywords-page.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-meta-editor.php';
 
@@ -217,6 +218,13 @@ final class StrataWP_SEO {
 	 * @var SWPS_Citation_Tracker
 	 */
 	public SWPS_Citation_Tracker $citation_tracker;
+
+	/**
+	 * AI citation tracker admin (AJAX + settings).
+	 *
+	 * @var SWPS_Citation_Admin
+	 */
+	public SWPS_Citation_Admin $citation_admin;
 	public SWPS_Keywords_Page $keywords_page;
 	public SWPS_Meta_Editor $meta_editor;
 	public SWPS_Head_Cleanup $head_cleanup;
@@ -289,6 +297,7 @@ final class StrataWP_SEO {
 		$this->analytics_dashboard   = new SWPS_Analytics_Dashboard( $this->analytics_tracker, $this->search_console );
 		$this->keyword_tracker       = new SWPS_Keyword_Tracker( $this->search_console );
 		$this->citation_tracker      = new SWPS_Citation_Tracker( new SWPS_Citation_Prompts( $this->keyword_tracker, $this->search_console ) );
+		$this->citation_admin        = new SWPS_Citation_Admin( $this->citation_tracker );
 		$this->keywords_page         = new SWPS_Keywords_Page( $this->keyword_tracker );
 		$this->meta_editor           = new SWPS_Meta_Editor();
 		$this->head_cleanup          = new SWPS_Head_Cleanup();

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -97,6 +97,9 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-analytics-dashboard.php';
 
 // Keywords & Meta Editor.
 require_once SWPS_PLUGIN_DIR . 'includes/class-keyword-tracker.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-citation-store.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-citation-prompts.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-citation-tracker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-keywords-page.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-meta-editor.php';
 
@@ -208,6 +211,12 @@ final class StrataWP_SEO {
 	public SWPS_Search_Console $search_console;
 	public SWPS_Analytics_Dashboard $analytics_dashboard;
 	public SWPS_Keyword_Tracker $keyword_tracker;
+	/**
+	 * AI citation tracker.
+	 *
+	 * @var SWPS_Citation_Tracker
+	 */
+	public SWPS_Citation_Tracker $citation_tracker;
 	public SWPS_Keywords_Page $keywords_page;
 	public SWPS_Meta_Editor $meta_editor;
 	public SWPS_Head_Cleanup $head_cleanup;
@@ -273,11 +282,13 @@ final class StrataWP_SEO {
 		$this->seo_audit             = new SWPS_SEO_Audit();
 		$this->schema                = new SWPS_Schema();
 		SWPS_AI_Referrals::maybe_upgrade();
+		SWPS_Citation_Store::maybe_upgrade();
 		$this->analytics_tracker     = new SWPS_Analytics_Tracker();
 		$this->bot_analytics_tracker = new SWPS_Bot_Analytics_Tracker();
 		$this->search_console        = new SWPS_Search_Console();
 		$this->analytics_dashboard   = new SWPS_Analytics_Dashboard( $this->analytics_tracker, $this->search_console );
 		$this->keyword_tracker       = new SWPS_Keyword_Tracker( $this->search_console );
+		$this->citation_tracker      = new SWPS_Citation_Tracker( new SWPS_Citation_Prompts( $this->keyword_tracker, $this->search_console ) );
 		$this->keywords_page         = new SWPS_Keywords_Page( $this->keyword_tracker );
 		$this->meta_editor           = new SWPS_Meta_Editor();
 		$this->head_cleanup          = new SWPS_Head_Cleanup();
@@ -1323,6 +1334,9 @@ function swps_activate(): void {
 	SWPS_Search_Console::schedule_cron();
 	SWPS_Keyword_Tracker::create_tables();
 	SWPS_Keyword_Tracker::schedule_cron();
+	SWPS_Citation_Store::create_table();
+	update_option( SWPS_Citation_Store::OPT_DB_VER, SWPS_Citation_Store::DB_VERSION );
+	SWPS_Citation_Tracker::schedule_cron();
 
 	SWPS_Redirect_Manager::create_tables();
 	SWPS_Link_Keyword_Engine::create_tables();
@@ -1353,6 +1367,7 @@ function swps_deactivate(): void {
 	SWPS_Bot_Analytics_Tracker::unschedule_cron();
 	SWPS_Search_Console::unschedule_cron();
 	SWPS_Keyword_Tracker::unschedule_cron();
+	SWPS_Citation_Tracker::unschedule_cron();
 	SWPS_Competitors::unschedule_cron();
 	SWPS_Backlinks::unschedule_cron();
 	wp_clear_scheduled_hook( 'swps_aeo_sweep_proposals' );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -87,6 +87,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/audit/class-pagespeed-module.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-schema.php';
 
 // Analytics.
+require_once SWPS_PLUGIN_DIR . 'includes/class-ai-referrals.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-analytics-tracker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-search-console.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-bot-analytics-tracker.php';
@@ -269,6 +270,7 @@ final class StrataWP_SEO {
 		$this->image_inserter        = new SWPS_Image_Inserter( $this->images );
 		$this->seo_audit             = new SWPS_SEO_Audit();
 		$this->schema                = new SWPS_Schema();
+		SWPS_AI_Referrals::maybe_upgrade();
 		$this->analytics_tracker     = new SWPS_Analytics_Tracker();
 		$this->bot_analytics_tracker = new SWPS_Bot_Analytics_Tracker();
 		$this->search_console        = new SWPS_Search_Console();
@@ -1314,6 +1316,8 @@ function swps_activate(): void {
 	SWPS_Analytics_Tracker::schedule_cron();
 	SWPS_Bot_Analytics_Tracker::create_tables();
 	SWPS_Bot_Analytics_Tracker::schedule_cron();
+	SWPS_AI_Referrals::create_table();
+	update_option( SWPS_AI_Referrals::OPT_DB_VER, SWPS_AI_Referrals::DB_VERSION );
 	SWPS_Search_Console::schedule_cron();
 	SWPS_Keyword_Tracker::create_tables();
 	SWPS_Keyword_Tracker::schedule_cron();

--- a/templates/aeo-page.php
+++ b/templates/aeo-page.php
@@ -76,11 +76,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<th><?php esc_html_e( 'Score', 'stratawp-seo' ); ?></th>
 				<th><?php esc_html_e( 'Title', 'stratawp-seo' ); ?></th>
 				<th><?php esc_html_e( 'Sub-scores', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Last crawl', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'AI visits (30d)', 'stratawp-seo' ); ?></th>
 				<th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>
-			<tr class="swps-aeo-empty"><td colspan="4"><?php esc_html_e( 'No posts scored yet. Click "Re-scan all posts" to start.', 'stratawp-seo' ); ?></td></tr>
+			<tr class="swps-aeo-empty"><td colspan="6"><?php esc_html_e( 'No posts scored yet. Click "Re-scan all posts" to start.', 'stratawp-seo' ); ?></td></tr>
 		</tbody>
 	</table>
 </div>

--- a/templates/analytics-page.php
+++ b/templates/analytics-page.php
@@ -360,10 +360,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php endif; ?>
 
 		<?php if ( ! empty( $gaps ) ) : ?>
+		<?php
+		$gap_current_sort = isset( $_GET['gap_sort'] ) && 'score' === $_GET['gap_sort'] ? 'score' : 'date'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$gap_sort_score_url = esc_url( add_query_arg( 'gap_sort', 'score' ) );
+		$gap_sort_date_url  = esc_url( add_query_arg( 'gap_sort', 'date' ) );
+		?>
 		<div class="swps-section-h" style="margin-top:24px">
 			<h3><?php esc_html_e( 'AEO Gap — Posts Never Crawled (30d)', 'stratawp-seo' ); ?></h3>
 			<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
 				<?php esc_html_e( 'Published content that no AI crawler has fetched. Candidates for sitemap re-submission, internal linking, or refresh.', 'stratawp-seo' ); ?>
+				&nbsp;
+				<?php esc_html_e( 'Sort:', 'stratawp-seo' ); ?>
+				<?php if ( 'score' === $gap_current_sort ) : ?>
+					<a href="<?php echo $gap_sort_date_url; ?>"><?php esc_html_e( 'By date', 'stratawp-seo' ); ?></a>
+					&middot; <strong><?php esc_html_e( 'By AEO score ↓', 'stratawp-seo' ); ?></strong>
+				<?php else : ?>
+					<strong><?php esc_html_e( 'By date', 'stratawp-seo' ); ?></strong>
+					&middot; <a href="<?php echo $gap_sort_score_url; ?>"><?php esc_html_e( 'By AEO score ↓', 'stratawp-seo' ); ?></a>
+				<?php endif; ?>
 			</p>
 		</div>
 		<table class="widefat striped">
@@ -371,6 +385,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<tr>
 					<th><?php esc_html_e( 'Post', 'stratawp-seo' ); ?></th>
 					<th><?php esc_html_e( 'Published', 'stratawp-seo' ); ?></th>
+					<th style="text-align:right"><?php esc_html_e( 'AEO Score', 'stratawp-seo' ); ?></th>
 					<th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
 				</tr>
 			</thead>
@@ -391,6 +406,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 							&nbsp;<a href="<?php echo esc_url( $gap['url'] ); ?>" target="_blank" rel="noopener" style="color:var(--swps-text-muted);font-size:11px">↗</a>
 						</td>
 						<td style="color:var(--swps-text-muted)"><?php echo esc_html( mysql2date( get_option( 'date_format' ), $gap['post_date'] ) ); ?></td>
+						<td style="text-align:right">
+							<?php echo null !== $gap['aeo_score'] ? esc_html( (string) $gap['aeo_score'] ) : '<span style="color:var(--swps-text-faint)">—</span>'; ?>
+						</td>
 						<td>
 							<a class="button button-small" href="<?php echo esc_url( $aeo_gap_url ); ?>">
 								<?php esc_html_e( 'Optimize for AEO →', 'stratawp-seo' ); ?>

--- a/templates/analytics-page.php
+++ b/templates/analytics-page.php
@@ -146,6 +146,108 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</table>
 	<?php endif; ?>
 
+	<div class="swps-section-h" style="margin-top:40px">
+		<h3><?php esc_html_e( 'AI Referrals', 'stratawp-seo' ); ?></h3>
+		<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+			<?php esc_html_e( 'Visits referred from AI assistants (ChatGPT, Perplexity, Claude, Gemini, Copilot, and others), classified at capture time.', 'stratawp-seo' ); ?>
+		</p>
+	</div>
+
+	<div class="swps-summary-tiles" style="margin-bottom:16px">
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'AI-Referred Views', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad" id="swps-ai-ref-views">—</div>
+			<div class="swps-summary-tile-foot" id="swps-ai-ref-change"></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Top Engine', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad" id="swps-ai-ref-top-engine">—</div>
+		</div>
+	</div>
+
+	<div class="swps-tile" style="margin-bottom:16px">
+		<div class="swps-tile-h"><?php esc_html_e( 'Views by Engine', 'stratawp-seo' ); ?></div>
+		<table class="widefat striped" id="swps-ai-ref-engines-table" style="margin-top:8px">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Engine', 'stratawp-seo' ); ?></th>
+					<th style="text-align:right"><?php esc_html_e( 'Views', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr><td colspan="2" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+			</tbody>
+		</table>
+	</div>
+
+	<div class="swps-section-h" style="margin-top:24px">
+		<h3><?php esc_html_e( 'AI Landing Posts', 'stratawp-seo' ); ?></h3>
+		<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+			<?php esc_html_e( 'Posts receiving the most AI-referred visits.', 'stratawp-seo' ); ?>
+		</p>
+	</div>
+	<table class="widefat striped" id="swps-ai-ref-landing-table">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Post', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Views', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Avg Time', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Scroll', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Bounce', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Engines', 'stratawp-seo' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td colspan="6" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+		</tbody>
+	</table>
+
+	<div class="swps-section-h" style="margin-top:24px">
+		<h3><?php esc_html_e( 'Engagement: AI vs Organic', 'stratawp-seo' ); ?></h3>
+	</div>
+	<div class="swps-tile" id="swps-ai-ref-engagement">
+		<p class="swps-loading" style="margin:0;color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></p>
+	</div>
+
+	<div class="swps-section-h" style="margin-top:24px">
+		<h3><?php esc_html_e( 'Crawl-to-Visit Funnel', 'stratawp-seo' ); ?></h3>
+		<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+			<?php esc_html_e( 'AI bot crawls of a post next to AI-referred visits to it. Crawls vs visits are correlational, not causal.', 'stratawp-seo' ); ?>
+		</p>
+	</div>
+	<table class="widefat striped" id="swps-ai-ref-funnel-table">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Post', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Engine', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Crawls', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Visits', 'stratawp-seo' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td colspan="4" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+		</tbody>
+	</table>
+
+	<div class="swps-section-h" style="margin-top:24px">
+		<h3><?php esc_html_e( 'Crawled but No AI Visits', 'stratawp-seo' ); ?></h3>
+		<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
+			<?php esc_html_e( 'Posts AI bots crawl that have not yet received AI-referred visits — candidates for AEO optimization.', 'stratawp-seo' ); ?>
+		</p>
+	</div>
+	<table class="widefat striped" id="swps-ai-ref-novisits-table">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Post', 'stratawp-seo' ); ?></th>
+				<th><?php esc_html_e( 'Engine', 'stratawp-seo' ); ?></th>
+				<th style="text-align:right"><?php esc_html_e( 'Crawls', 'stratawp-seo' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr><td colspan="3" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+		</tbody>
+	</table>
+
 	<?php
 	if ( ! empty( $bot_data ) ) :
 		$totals    = $bot_data['totals'];

--- a/templates/analytics-page.php
+++ b/templates/analytics-page.php
@@ -360,23 +360,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php endif; ?>
 
 		<?php if ( ! empty( $gaps ) ) : ?>
-		<?php
-		$gap_current_sort = isset( $_GET['gap_sort'] ) && 'score' === $_GET['gap_sort'] ? 'score' : 'date'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$gap_sort_score_url = esc_url( add_query_arg( 'gap_sort', 'score' ) );
-		$gap_sort_date_url  = esc_url( add_query_arg( 'gap_sort', 'date' ) );
-		?>
+			<?php
+			$swps_gap_sort           = isset( $_GET['gap_sort'] ) && 'score' === $_GET['gap_sort'] ? 'score' : 'date'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$swps_gap_sort_score_url = add_query_arg( 'gap_sort', 'score' );
+			$swps_gap_sort_date_url  = add_query_arg( 'gap_sort', 'date' );
+			?>
 		<div class="swps-section-h" style="margin-top:24px">
 			<h3><?php esc_html_e( 'AEO Gap — Posts Never Crawled (30d)', 'stratawp-seo' ); ?></h3>
 			<p style="color:var(--swps-text-muted);font-size:12px;margin:4px 0 0">
 				<?php esc_html_e( 'Published content that no AI crawler has fetched. Candidates for sitemap re-submission, internal linking, or refresh.', 'stratawp-seo' ); ?>
 				&nbsp;
 				<?php esc_html_e( 'Sort:', 'stratawp-seo' ); ?>
-				<?php if ( 'score' === $gap_current_sort ) : ?>
-					<a href="<?php echo $gap_sort_date_url; ?>"><?php esc_html_e( 'By date', 'stratawp-seo' ); ?></a>
+				<?php if ( 'score' === $swps_gap_sort ) : ?>
+					<a href="<?php echo esc_url( $swps_gap_sort_date_url ); ?>"><?php esc_html_e( 'By date', 'stratawp-seo' ); ?></a>
 					&middot; <strong><?php esc_html_e( 'By AEO score ↓', 'stratawp-seo' ); ?></strong>
 				<?php else : ?>
 					<strong><?php esc_html_e( 'By date', 'stratawp-seo' ); ?></strong>
-					&middot; <a href="<?php echo $gap_sort_score_url; ?>"><?php esc_html_e( 'By AEO score ↓', 'stratawp-seo' ); ?></a>
+					&middot; <a href="<?php echo esc_url( $swps_gap_sort_score_url ); ?>"><?php esc_html_e( 'By AEO score ↓', 'stratawp-seo' ); ?></a>
 				<?php endif; ?>
 			</p>
 		</div>

--- a/templates/dashboard-page.php
+++ b/templates/dashboard-page.php
@@ -276,6 +276,28 @@ $welcome_msg = sprintf(
 			</div>
 		<?php endif; ?>
 
+		<?php $ai_referrals = $data['ai_referrals'] ?? array(); ?>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'AI referrals (30d)', 'stratawp-seo' ); ?></div>
+			<div class="swps-tile-stat"><?php echo number_format( (int) ( $ai_referrals['views'] ?? 0 ) ); ?></div>
+			<?php
+			if ( null !== ( $ai_referrals['delta_pct'] ?? null ) ) :
+				$ai_ref_delta = (float) $ai_referrals['delta_pct'];
+				$ai_ref_cls   = $ai_ref_delta >= 0 ? '' : ' is-down';
+				$ai_ref_arrow = $ai_ref_delta >= 0 ? '↑' : '↓';
+				?>
+				<div class="swps-tile-trend<?php echo esc_attr( $ai_ref_cls ); ?>">
+					<?php echo esc_html( $ai_ref_arrow ); ?>
+					<?php echo esc_html( number_format( abs( $ai_ref_delta ), 1 ) ); ?>%
+					<?php esc_html_e( 'vs prev 30d', 'stratawp-seo' ); ?>
+				</div>
+			<?php else : ?>
+				<div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+					<?php esc_html_e( 'Views from AI assistants — no data yet', 'stratawp-seo' ); ?>
+				</div>
+			<?php endif; ?>
+		</div>
+
 		<a class="swps-tile swps-tile-aeo" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-aeo-optimize' ) ); ?>" style="text-decoration:none;color:inherit;display:block">
 			<div class="swps-tile-h"><?php esc_html_e( 'AEO health (avg)', 'stratawp-seo' ); ?></div>
 			<div class="swps-tile-stat">

--- a/templates/dashboard-page.php
+++ b/templates/dashboard-page.php
@@ -319,6 +319,21 @@ $welcome_msg = sprintf(
 		</div>
 		<?php endif; ?>
 
+		<?php
+		$swps_ai_citations = $data['ai_citations'] ?? array();
+		if ( ! empty( $swps_ai_citations ) && $swps_ai_citations['total'] > 0 ) :
+			?>
+		<a class="swps-tile swps-tile-citations" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-keywords#swps-citations-card' ) ); ?>" style="text-decoration:none;color:inherit;display:block">
+			<div class="swps-tile-h"><?php esc_html_e( 'AI citations', 'stratawp-seo' ); ?></div>
+			<div class="swps-tile-stat">
+				<?php echo esc_html( $swps_ai_citations['cited'] . ' / ' . $swps_ai_citations['total'] ); ?>
+			</div>
+			<div class="swps-tile-trend" style="color:var(--swps-text-muted)">
+				<?php esc_html_e( 'prompts cited by AI engines', 'stratawp-seo' ); ?>
+			</div>
+		</a>
+		<?php endif; ?>
+
 		<a class="swps-tile swps-tile-aeo" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-aeo-optimize' ) ); ?>" style="text-decoration:none;color:inherit;display:block">
 			<div class="swps-tile-h"><?php esc_html_e( 'AEO health (avg)', 'stratawp-seo' ); ?></div>
 			<div class="swps-tile-stat">

--- a/templates/dashboard-page.php
+++ b/templates/dashboard-page.php
@@ -298,6 +298,27 @@ $welcome_msg = sprintf(
 			<?php endif; ?>
 		</div>
 
+		<?php
+		$ai_funnel  = $data['ai_funnel'] ?? array();
+		$funnel_stages = $ai_funnel['stages'] ?? array();
+		if ( ! empty( $funnel_stages ) ) :
+			?>
+		<div class="swps-tile swps-tile-funnel">
+			<div class="swps-tile-h"><?php esc_html_e( 'AI Visibility Funnel (30d)', 'stratawp-seo' ); ?></div>
+			<ul class="swps-funnel-stages" style="list-style:none;padding:0;margin:8px 0 0;font-size:12px;">
+				<?php foreach ( $funnel_stages as $swps_stage ) : ?>
+					<li style="display:flex;justify-content:space-between;align-items:center;padding:4px 0;border-bottom:1px solid #eee;">
+						<span style="color:var(--swps-text-muted)"><?php echo esc_html( $swps_stage['label'] ); ?></span>
+						<span>
+							<strong><?php echo esc_html( number_format_i18n( $swps_stage['count'] ) ); ?></strong>
+							<span style="color:var(--swps-text-faint);margin-left:4px;"><?php echo esc_html( $swps_stage['pct'] . '%' ); ?></span>
+						</span>
+					</li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
+		<?php endif; ?>
+
 		<a class="swps-tile swps-tile-aeo" href="<?php echo esc_url( admin_url( 'admin.php?page=swps-aeo-optimize' ) ); ?>" style="text-decoration:none;color:inherit;display:block">
 			<div class="swps-tile-h"><?php esc_html_e( 'AEO health (avg)', 'stratawp-seo' ); ?></div>
 			<div class="swps-tile-stat">

--- a/templates/keywords-page.php
+++ b/templates/keywords-page.php
@@ -84,6 +84,52 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</div>
 	<?php endif; ?>
 
+	<div class="swps-settings-panel" id="swps-citations-card">
+		<h2 style="margin-top:0"><?php esc_html_e( 'AI Citations', 'stratawp-seo' ); ?></h2>
+		<p style="color:var(--swps-text-muted);font-size:12px;margin:0 0 12px">
+			<?php esc_html_e( 'Track whether AI assistants cite your site for your key prompts. Checks use your API keys; some providers bill per search — estimates only.', 'stratawp-seo' ); ?>
+		</p>
+
+		<div class="swps-citations-toolbar" style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-bottom:12px">
+			<input type="text" id="swps-citation-prompt-input" class="regular-text" style="flex:1;min-width:240px"
+					placeholder="<?php esc_attr_e( 'Add a prompt to track (e.g., best running shoes for flat feet)', 'stratawp-seo' ); ?>" />
+			<button class="button" id="swps-citation-add-btn"><?php esc_html_e( 'Add Prompt', 'stratawp-seo' ); ?></button>
+			<button class="button" id="swps-citation-seed-btn"><?php esc_html_e( 'Seed from keywords & GSC', 'stratawp-seo' ); ?></button>
+			<button class="swps-btn swps-btn-grad" id="swps-citation-run-btn"><?php esc_html_e( 'Run checks now', 'stratawp-seo' ); ?></button>
+			<span class="spinner" id="swps-citation-spinner"></span>
+		</div>
+
+		<div id="swps-citation-progress" style="display:none;font-size:12px;color:var(--swps-text-muted);margin-bottom:8px"></div>
+		<div id="swps-citation-seed-panel" style="display:none;margin-bottom:12px;border:1px solid #e0e0e0;border-radius:4px;padding:10px"></div>
+
+		<table class="widefat striped" id="swps-citations-table">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Prompt', 'stratawp-seo' ); ?></th>
+					<th id="swps-citation-engine-cols"><?php esc_html_e( 'Engines', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Last Check', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Actions', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr><td colspan="4" class="swps-loading" style="color:var(--swps-text-muted)"><?php esc_html_e( 'Loading...', 'stratawp-seo' ); ?></td></tr>
+			</tbody>
+		</table>
+
+		<div style="display:flex;gap:24px;flex-wrap:wrap;margin-top:16px">
+			<div style="flex:1;min-width:280px">
+				<h3 style="font-size:13px;margin:0 0 8px"><?php esc_html_e( 'Share of Voice (30d)', 'stratawp-seo' ); ?></h3>
+				<div id="swps-citation-sov"><span style="color:var(--swps-text-muted);font-size:12px"><?php esc_html_e( 'No checks yet.', 'stratawp-seo' ); ?></span></div>
+			</div>
+			<div style="flex:1;min-width:280px">
+				<h3 style="font-size:13px;margin:0 0 8px"><?php esc_html_e( 'Domains AI Cites (30d, top 10)', 'stratawp-seo' ); ?></h3>
+				<ol id="swps-citation-breakdown" style="margin:0;padding-left:18px;font-size:12px"></ol>
+			</div>
+		</div>
+
+		<p id="swps-citation-cap-line" style="color:var(--swps-text-muted);font-size:12px;margin:12px 0 0"></p>
+	</div>
+
 	<div id="swps-keyword-history-modal" class="swps-modal" style="display:none;">
 		<div class="swps-modal-content">
 			<span class="swps-modal-close">&times;</span>

--- a/tests/unit/AiReferralsTest.php
+++ b/tests/unit/AiReferralsTest.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * Tests for SWPS_AI_Referrals — classifier, bot source map, engagement comparison.
+ *
+ * Pure-static core: no WordPress functions required. The runtime wrapper
+ * classify_visit() uses apply_filters(), so we stub it here; the core
+ * classify() method is WP-free and tested directly.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+// Stub WordPress functions used only in the runtime wrapper, not in the core.
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( string $tag, $value ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	/**
+	 * Thin wrapper around parse_url() that mirrors the WP function signature.
+	 *
+	 * @param string $url       URL to parse.
+	 * @param int    $component PHP_URL_* constant, or -1 for the full array.
+	 * @return mixed
+	 */
+	function wp_parse_url( string $url, int $component = -1 ) {
+		return parse_url( $url, $component );
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-ai-referrals.php';
+
+/**
+ * @covers SWPS_AI_Referrals
+ */
+class AiReferralsTest extends TestCase {
+
+	// -------------------------------------------------------------------------
+	// classify() — referrer matching
+	// -------------------------------------------------------------------------
+
+	public function test_exact_host_match_returns_source(): void {
+		$this->assertSame( 'chatgpt', SWPS_AI_Referrals::classify( 'https://chatgpt.com/c/abc' ) );
+	}
+
+	public function test_subdomain_suffix_match(): void {
+		$this->assertSame( 'chatgpt', SWPS_AI_Referrals::classify( 'https://www.chatgpt.com/share/xyz' ) );
+	}
+
+	public function test_case_insensitive_host(): void {
+		$this->assertSame( 'chatgpt', SWPS_AI_Referrals::classify( 'https://ChatGPT.COM/c/abc' ) );
+	}
+
+	public function test_perplexity_referrer(): void {
+		$this->assertSame( 'perplexity', SWPS_AI_Referrals::classify( 'https://perplexity.ai/search/foo' ) );
+	}
+
+	public function test_claude_referrer(): void {
+		$this->assertSame( 'claude', SWPS_AI_Referrals::classify( 'https://claude.ai/chat/abc' ) );
+	}
+
+	public function test_gemini_referrer(): void {
+		$this->assertSame( 'gemini', SWPS_AI_Referrals::classify( 'https://gemini.google.com/app' ) );
+	}
+
+	public function test_copilot_referrer(): void {
+		$this->assertSame( 'copilot', SWPS_AI_Referrals::classify( 'https://copilot.microsoft.com/' ) );
+	}
+
+	public function test_you_referrer(): void {
+		$this->assertSame( 'you', SWPS_AI_Referrals::classify( 'https://you.com/search?q=test' ) );
+	}
+
+	public function test_deepseek_referrer(): void {
+		$this->assertSame( 'deepseek', SWPS_AI_Referrals::classify( 'https://chat.deepseek.com/' ) );
+	}
+
+	public function test_grok_referrer(): void {
+		$this->assertSame( 'grok', SWPS_AI_Referrals::classify( 'https://grok.com/chat' ) );
+	}
+
+	public function test_meta_ai_referrer(): void {
+		$this->assertSame( 'meta', SWPS_AI_Referrals::classify( 'https://meta.ai/chat' ) );
+	}
+
+	public function test_chat_openai_maps_to_chatgpt(): void {
+		$this->assertSame( 'chatgpt', SWPS_AI_Referrals::classify( 'https://chat.openai.com/share/abc' ) );
+	}
+
+	public function test_non_ai_referrer_returns_empty(): void {
+		$this->assertSame( '', SWPS_AI_Referrals::classify( 'https://google.com/search?q=foo' ) );
+	}
+
+	public function test_partial_host_match_not_accepted(): void {
+		// notchatgpt.com must NOT match chatgpt.com.
+		$this->assertSame( '', SWPS_AI_Referrals::classify( 'https://notchatgpt.com/' ) );
+	}
+
+	public function test_empty_referrer_no_page_url_returns_empty(): void {
+		$this->assertSame( '', SWPS_AI_Referrals::classify( '' ) );
+	}
+
+	public function test_invalid_referrer_url_returns_empty(): void {
+		$this->assertSame( '', SWPS_AI_Referrals::classify( 'not a url' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// classify() — page_url utm_source fallback
+	// -------------------------------------------------------------------------
+
+	public function test_utm_source_chatgpt_dot_com_maps_to_chatgpt(): void {
+		$this->assertSame(
+			'chatgpt',
+			SWPS_AI_Referrals::classify( '', 'https://example.com/post/?utm_source=chatgpt.com' )
+		);
+	}
+
+	public function test_utm_source_perplexity_ai_maps_to_perplexity(): void {
+		$this->assertSame(
+			'perplexity',
+			SWPS_AI_Referrals::classify( '', 'https://example.com/post/?utm_source=perplexity.ai' )
+		);
+	}
+
+	public function test_utm_source_bare_source_value_maps(): void {
+		// utm_source=chatgpt (bare source value, not a host) should resolve.
+		$this->assertSame(
+			'chatgpt',
+			SWPS_AI_Referrals::classify( '', 'https://example.com/post/?utm_source=chatgpt' )
+		);
+	}
+
+	public function test_utm_source_takes_precedence_when_referrer_empty(): void {
+		$this->assertSame(
+			'claude',
+			SWPS_AI_Referrals::classify( '', 'https://example.com/?utm_source=claude.ai' )
+		);
+	}
+
+	public function test_referrer_wins_over_utm_source(): void {
+		// If referrer is set and matches, it takes priority (utm_source irrelevant).
+		$this->assertSame(
+			'perplexity',
+			SWPS_AI_Referrals::classify(
+				'https://perplexity.ai/search',
+				'https://example.com/?utm_source=chatgpt.com'
+			)
+		);
+	}
+
+	public function test_utm_source_unknown_value_returns_empty(): void {
+		$this->assertSame(
+			'',
+			SWPS_AI_Referrals::classify( '', 'https://example.com/?utm_source=unknownbot' )
+		);
+	}
+
+	public function test_no_utm_source_in_page_url_returns_empty(): void {
+		$this->assertSame( '', SWPS_AI_Referrals::classify( '', 'https://example.com/post/' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// classify() — custom map override
+	// -------------------------------------------------------------------------
+
+	public function test_custom_map_overrides_default(): void {
+		$map = array( 'custom-ai.example' => 'custom_ai' );
+		$this->assertSame( 'custom_ai', SWPS_AI_Referrals::classify( 'https://custom-ai.example/chat', '', $map ) );
+	}
+
+	public function test_custom_map_ignores_default_entries(): void {
+		$map = array( 'custom-ai.example' => 'custom_ai' );
+		// chatgpt.com is NOT in the custom map, so it should return ''.
+		$this->assertSame( '', SWPS_AI_Referrals::classify( 'https://chatgpt.com/', '', $map ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// bot_source_map()
+	// -------------------------------------------------------------------------
+
+	public function test_bot_source_map_returns_array(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertIsArray( $map );
+	}
+
+	public function test_gptbot_maps_to_chatgpt(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'chatgpt', $map['gptbot'] );
+	}
+
+	public function test_oai_searchbot_maps_to_chatgpt(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'chatgpt', $map['oai_searchbot'] );
+	}
+
+	public function test_chatgpt_user_maps_to_chatgpt(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'chatgpt', $map['chatgpt_user'] );
+	}
+
+	public function test_claudebot_maps_to_claude(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'claude', $map['claudebot'] );
+	}
+
+	public function test_claude_web_maps_to_claude(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'claude', $map['claude_web'] );
+	}
+
+	public function test_anthropic_ai_maps_to_claude(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'claude', $map['anthropic_ai'] );
+	}
+
+	public function test_perplexitybot_maps_to_perplexity(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'perplexity', $map['perplexitybot'] );
+	}
+
+	public function test_perplexity_user_maps_to_perplexity(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'perplexity', $map['perplexity_user'] );
+	}
+
+	public function test_google_extended_maps_to_gemini(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'gemini', $map['google_extended'] );
+	}
+
+	public function test_bots_without_visit_counterpart_omitted(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		// applebot_extended, ccbot, bytespider, amazonbot, duckassistbot
+		// have no visit-side counterpart and should not be in the map.
+		$this->assertArrayNotHasKey( 'applebot_extended', $map );
+		$this->assertArrayNotHasKey( 'ccbot', $map );
+		$this->assertArrayNotHasKey( 'bytespider', $map );
+		$this->assertArrayNotHasKey( 'amazonbot', $map );
+		$this->assertArrayNotHasKey( 'duckassistbot', $map );
+	}
+
+	public function test_meta_externalagent_maps_to_meta(): void {
+		$map = SWPS_AI_Referrals::bot_source_map();
+		$this->assertSame( 'meta', $map['meta_externalagent'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// engagement_comparison()
+	// -------------------------------------------------------------------------
+
+	public function test_returns_null_when_ai_sample_below_min(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 10, 'avg_time' => 120, 'avg_scroll' => 50, 'bounce_rate' => 0.4 ),
+			array( 'views' => 500, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+		$this->assertNull( $result );
+	}
+
+	public function test_returns_null_when_organic_sample_below_min(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 500, 'avg_time' => 120, 'avg_scroll' => 50, 'bounce_rate' => 0.4 ),
+			array( 'views' => 5, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+		$this->assertNull( $result );
+	}
+
+	public function test_returns_null_when_both_samples_below_min(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 10, 'avg_time' => 120, 'avg_scroll' => 50, 'bounce_rate' => 0.4 ),
+			array( 'views' => 10, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+		$this->assertNull( $result );
+	}
+
+	public function test_returns_ratio_metrics_when_sufficient_sample(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 100, 'avg_time' => 120, 'avg_scroll' => 60, 'bounce_rate' => 0.3 ),
+			array( 'views' => 500, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'time_ratio', $result );
+		$this->assertArrayHasKey( 'scroll_ratio', $result );
+		$this->assertArrayHasKey( 'bounce_ratio', $result );
+	}
+
+	public function test_time_ratio_calculated_correctly(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 100, 'avg_time' => 120, 'avg_scroll' => 60, 'bounce_rate' => 0.3 ),
+			array( 'views' => 100, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+
+		// 120/80 = 1.5.
+		$this->assertEqualsWithDelta( 1.5, $result['time_ratio'], 0.001 );
+	}
+
+	public function test_scroll_ratio_calculated_correctly(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 100, 'avg_time' => 120, 'avg_scroll' => 60, 'bounce_rate' => 0.3 ),
+			array( 'views' => 100, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+
+		// 60/40 = 1.5.
+		$this->assertEqualsWithDelta( 1.5, $result['scroll_ratio'], 0.001 );
+	}
+
+	public function test_bounce_ratio_calculated_correctly(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 100, 'avg_time' => 120, 'avg_scroll' => 60, 'bounce_rate' => 0.3 ),
+			array( 'views' => 100, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+
+		// 0.3/0.6 = 0.5.
+		$this->assertEqualsWithDelta( 0.5, $result['bounce_ratio'], 0.001 );
+	}
+
+	public function test_exact_min_n_threshold_is_sufficient(): void {
+		// Exactly 30 should not return null.
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 30, 'avg_time' => 120, 'avg_scroll' => 60, 'bounce_rate' => 0.3 ),
+			array( 'views' => 30, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+		$this->assertNotNull( $result );
+	}
+
+	public function test_result_includes_ai_and_organic_counts(): void {
+		$result = SWPS_AI_Referrals::engagement_comparison(
+			array( 'views' => 100, 'avg_time' => 120, 'avg_scroll' => 60, 'bounce_rate' => 0.3 ),
+			array( 'views' => 500, 'avg_time' => 80, 'avg_scroll' => 40, 'bounce_rate' => 0.6 ),
+			30
+		);
+
+		$this->assertArrayHasKey( 'ai_n', $result );
+		$this->assertArrayHasKey( 'organic_n', $result );
+		$this->assertSame( 100, $result['ai_n'] );
+		$this->assertSame( 500, $result['organic_n'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// classify_visit() — runtime wrapper applies filter
+	// -------------------------------------------------------------------------
+
+	public function test_classify_visit_returns_source_via_default_map(): void {
+		// apply_filters is stubbed to return the value unchanged above.
+		$this->assertSame( 'chatgpt', SWPS_AI_Referrals::classify_visit( 'https://chatgpt.com/c/abc' ) );
+	}
+
+	public function test_classify_visit_returns_empty_for_non_ai(): void {
+		$this->assertSame( '', SWPS_AI_Referrals::classify_visit( 'https://example.com/' ) );
+	}
+}

--- a/tests/unit/CitationTrackerTest.php
+++ b/tests/unit/CitationTrackerTest.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Tests for SWPS_Citation_Tracker pure static helpers.
+ *
+ * All helpers are WP-free. wp_parse_url() is stubbed via the test bootstrap.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-citation-tracker.php';
+
+/**
+ * @covers SWPS_Citation_Tracker
+ */
+class CitationTrackerTest extends TestCase {
+
+	// -------------------------------------------------------------------------
+	// extract_domains
+	// -------------------------------------------------------------------------
+
+	public function test_extract_domains_strips_www(): void {
+		$result = SWPS_Citation_Tracker::extract_domains( array( 'https://www.example.com/page' ) );
+		$this->assertSame( array( 'example.com' ), $result );
+	}
+
+	public function test_extract_domains_lowercases_host(): void {
+		$result = SWPS_Citation_Tracker::extract_domains( array( 'https://EXAMPLE.COM/' ) );
+		$this->assertSame( array( 'example.com' ), $result );
+	}
+
+	public function test_extract_domains_deduplicates(): void {
+		$result = SWPS_Citation_Tracker::extract_domains( array(
+			'https://example.com/a',
+			'https://example.com/b',
+			'https://www.example.com/c',
+		) );
+		$this->assertSame( array( 'example.com' ), $result );
+	}
+
+	public function test_extract_domains_skips_invalid_urls(): void {
+		$result = SWPS_Citation_Tracker::extract_domains( array( ':::not-a-url:::', '', '  ' ) );
+		$this->assertSame( array(), $result );
+	}
+
+	public function test_extract_domains_accepts_bare_domain_string(): void {
+		// Google vertexaisearch titles arrive as bare domain strings.
+		$result = SWPS_Citation_Tracker::extract_domains( array( 'aljazeera.com', 'uefa.com' ) );
+		$this->assertSame( array( 'aljazeera.com', 'uefa.com' ), $result );
+	}
+
+	public function test_extract_domains_strips_www_from_bare_domain(): void {
+		$result = SWPS_Citation_Tracker::extract_domains( array( 'www.example.com' ) );
+		$this->assertSame( array( 'example.com' ), $result );
+	}
+
+	public function test_extract_domains_multiple_providers(): void {
+		$result = SWPS_Citation_Tracker::extract_domains( array(
+			'https://sub.example.com/path',
+			'https://other.org/',
+		) );
+		$this->assertSame( array( 'sub.example.com', 'other.org' ), $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// domain_cited
+	// -------------------------------------------------------------------------
+
+	public function test_domain_cited_exact_match(): void {
+		$this->assertTrue( SWPS_Citation_Tracker::domain_cited( 'example.com', array( 'example.com' ) ) );
+	}
+
+	public function test_domain_cited_subdomain_match(): void {
+		$this->assertTrue( SWPS_Citation_Tracker::domain_cited( 'example.com', array( 'blog.example.com' ) ) );
+	}
+
+	public function test_domain_cited_no_false_positive_on_suffix(): void {
+		// "notexample.com" should NOT match "example.com".
+		$this->assertFalse( SWPS_Citation_Tracker::domain_cited( 'example.com', array( 'notexample.com' ) ) );
+	}
+
+	public function test_domain_cited_returns_false_when_absent(): void {
+		$this->assertFalse( SWPS_Citation_Tracker::domain_cited( 'example.com', array( 'other.org', 'foo.net' ) ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// citation_state
+	// -------------------------------------------------------------------------
+
+	public function test_citation_state_empty_history_is_never(): void {
+		$this->assertSame( 'never', SWPS_Citation_Tracker::citation_state( array() ) );
+	}
+
+	public function test_citation_state_all_false_is_never(): void {
+		$this->assertSame( 'never', SWPS_Citation_Tracker::citation_state( array( false, false, false ) ) );
+	}
+
+	public function test_citation_state_latest_two_true_is_cited(): void {
+		$this->assertSame( 'cited', SWPS_Citation_Tracker::citation_state( array( true, true, false ) ) );
+	}
+
+	public function test_citation_state_single_true_is_cited(): void {
+		$this->assertSame( 'cited', SWPS_Citation_Tracker::citation_state( array( true ) ) );
+	}
+
+	public function test_citation_state_single_false_after_history_is_not_lost(): void {
+		// One false entry with no previous true → never (no true in history).
+		$this->assertSame( 'never', SWPS_Citation_Tracker::citation_state( array( false ) ) );
+	}
+
+	public function test_citation_state_lost_requires_at_least_one_historical_true(): void {
+		// Two falses but one earlier true → lost.
+		$this->assertSame( 'lost', SWPS_Citation_Tracker::citation_state( array( false, false, true ) ) );
+	}
+
+	public function test_citation_state_lost_requires_latest_two_both_false(): void {
+		// Latest two: false, true — not lost.
+		$this->assertSame( 'mixed', SWPS_Citation_Tracker::citation_state( array( false, true, true ) ) );
+	}
+
+	public function test_citation_state_mixed_when_latest_two_alternate(): void {
+		$this->assertSame( 'mixed', SWPS_Citation_Tracker::citation_state( array( true, false ) ) );
+	}
+
+	public function test_citation_state_single_false_with_prior_true_is_lost(): void {
+		// History has exactly one element (false), but per the single-element rule:
+		// single element with has_any_true=false → never (the sole entry is false).
+		// If we pass two entries [false, true] → mixed per the latest-two rule.
+		// Edge: single entry false, but a prior run had true — can't express in
+		// a one-element array; single false means no prior data → 'never'.
+		$this->assertSame( 'never', SWPS_Citation_Tracker::citation_state( array( false ) ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// share_of_voice
+	// -------------------------------------------------------------------------
+
+	public function test_share_of_voice_basic(): void {
+		$result = SWPS_Citation_Tracker::share_of_voice( array( 'a.com' => 2, 'b.com' => 1 ), 4 );
+		$this->assertSame( 50.0, $result['a.com'] );
+		$this->assertSame( 25.0, $result['b.com'] );
+	}
+
+	public function test_share_of_voice_division_safe_zero_prompts(): void {
+		$result = SWPS_Citation_Tracker::share_of_voice( array( 'a.com' => 5 ), 0 );
+		$this->assertSame( 0.0, $result['a.com'] );
+	}
+
+	public function test_share_of_voice_empty_counts(): void {
+		$result = SWPS_Citation_Tracker::share_of_voice( array(), 10 );
+		$this->assertSame( array(), $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// is_question_query
+	// -------------------------------------------------------------------------
+
+	public function test_is_question_query_starts_with_what(): void {
+		$this->assertTrue( SWPS_Citation_Tracker::is_question_query( 'what is the best SEO plugin' ) );
+	}
+
+	public function test_is_question_query_starts_with_how(): void {
+		$this->assertTrue( SWPS_Citation_Tracker::is_question_query( 'how to improve site speed' ) );
+	}
+
+	public function test_is_question_query_case_insensitive(): void {
+		$this->assertTrue( SWPS_Citation_Tracker::is_question_query( 'How do I rank on Google' ) );
+	}
+
+	public function test_is_question_query_word_boundary_enforced(): void {
+		// "island" starts with "is" but is not "is\b".
+		$this->assertFalse( SWPS_Citation_Tracker::is_question_query( 'island holidays in Spain' ) );
+	}
+
+	public function test_is_question_query_five_word_long_tail(): void {
+		$this->assertTrue( SWPS_Citation_Tracker::is_question_query( 'best wordpress seo plugin for beginners' ) );
+	}
+
+	public function test_is_question_query_four_words_not_question_word(): void {
+		$this->assertFalse( SWPS_Citation_Tracker::is_question_query( 'wordpress seo plugin review' ) );
+	}
+
+	public function test_is_question_query_empty_string(): void {
+		$this->assertFalse( SWPS_Citation_Tracker::is_question_query( '' ) );
+	}
+
+	public function test_is_question_query_starts_with_should(): void {
+		$this->assertTrue( SWPS_Citation_Tracker::is_question_query( 'should I use Yoast or StrataWP' ) );
+	}
+
+	public function test_is_question_query_starts_with_are(): void {
+		$this->assertTrue( SWPS_Citation_Tracker::is_question_query( 'are meta descriptions still important' ) );
+	}
+}

--- a/tests/unit/VisibilityFunnelTest.php
+++ b/tests/unit/VisibilityFunnelTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Tests for SWPS_Visibility_Funnel::stage_rates() — pure helper, no WP.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+// Stub WordPress i18n functions — not loaded in unit context.
+if ( ! function_exists( '__' ) ) {
+	function __( string $text, string $domain = 'default' ): string {
+		return $text;
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-visibility-funnel.php';
+
+/**
+ * @covers SWPS_Visibility_Funnel::stage_rates
+ */
+class VisibilityFunnelTest extends TestCase {
+
+	// -------------------------------------------------------------------------
+	// Normal cases
+	// -------------------------------------------------------------------------
+
+	public function test_all_stages_present_calculates_rates(): void {
+		$result = SWPS_Visibility_Funnel::stage_rates( 100, 60, 20 );
+
+		$this->assertSame( 100, $result[0]['count'] );
+		$this->assertSame( 60,  $result[1]['count'] );
+		$this->assertSame( 20,  $result[2]['count'] );
+
+		// Stage 0 (published): always 100 % of itself.
+		$this->assertSame( 100, $result[0]['pct'] );
+		// Stage 1 (crawled): 60 % of published (60/100).
+		$this->assertSame( 60,  $result[1]['pct'] );
+		// Stage 2 (visited): 33 % of crawled (20/60, rounded).
+		$this->assertSame( 33,  $result[2]['pct'] );
+	}
+
+	public function test_returns_three_stages(): void {
+		$result = SWPS_Visibility_Funnel::stage_rates( 50, 25, 10 );
+		$this->assertCount( 3, $result );
+	}
+
+	public function test_stage_keys_present(): void {
+		$result = SWPS_Visibility_Funnel::stage_rates( 10, 5, 2 );
+		foreach ( $result as $stage ) {
+			$this->assertArrayHasKey( 'count', $stage );
+			$this->assertArrayHasKey( 'pct',   $stage );
+			$this->assertArrayHasKey( 'label', $stage );
+		}
+	}
+
+	public function test_pct_clamped_at_100_when_crawled_exceeds_published(): void {
+		// Crawled > published should not produce > 100 %.
+		$result = SWPS_Visibility_Funnel::stage_rates( 10, 15, 5 );
+		$this->assertLessThanOrEqual( 100, $result[1]['pct'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Zero-denominator cases
+	// -------------------------------------------------------------------------
+
+	public function test_zero_published_returns_zero_pcts(): void {
+		$result = SWPS_Visibility_Funnel::stage_rates( 0, 0, 0 );
+		$this->assertSame( 0, $result[0]['pct'] );
+		$this->assertSame( 0, $result[1]['pct'] );
+		$this->assertSame( 0, $result[2]['pct'] );
+	}
+
+	public function test_zero_crawled_makes_visited_pct_zero(): void {
+		// visited/crawled with crawled = 0 must not divide by zero.
+		$result = SWPS_Visibility_Funnel::stage_rates( 50, 0, 0 );
+		$this->assertSame( 0, $result[2]['pct'] );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -88,6 +88,7 @@ $swps_tables = array(
 	'swps_404_log',
 	'swps_analytics',
 	'swps_analytics_daily',
+	'swps_ai_referrals_daily',
 	'swps_bot_hits',
 	'swps_bot_hits_daily',
 	'swps_keyword_tracking',

--- a/uninstall.php
+++ b/uninstall.php
@@ -36,6 +36,7 @@ $swps_cron_hooks = array(
 	'swps_refresh_models',
 	'swps_aeo_sweep_proposals',
 	'swps_send_digest',
+	'swps_citation_check',
 );
 
 foreach ( $swps_cron_hooks as $swps_cron_hook ) {
@@ -95,6 +96,7 @@ $swps_tables = array(
 	'swps_link_index',
 	'swps_link_graph',
 	'swps_backlinks',
+	'swps_citation_checks',
 );
 
 foreach ( $swps_tables as $swps_table ) {


### PR DESCRIPTION
## Summary
- **Search-grounded provider layer**: `search_grounded()` on all four providers, verified against current API docs — Anthropic web-search tool, OpenAI Responses API with url_citation annotations, Gemini Google-Search grounding (vertexaisearch redirect → domain-title fallback), xAI live search — each returning text + citation URLs with the house error conventions
- **Citation tracker core** (3 classes): `swps_citation_checks` table with DB-version upgrades; tracked prompts (cap 25, seeded on demand from tracked keywords + GSC question queries); per-engine checks with a **monthly call cap checked before and counted before every provider call**; weekly cron with 180-day retention; smoothed cited/lost/never/mixed states (2 consecutive misses required for "lost"); lost citations write post meta and inject context (`citation_loss_note`) into AEO proposals via the existing filter
- **Keywords-page "AI Citations" card**: prompts CRUD, seed modal, chunked "Run checks now" with progress + cap-aware abort, share-of-voice bars vs competitors, top cited-domains breakdown, cap usage line
- **Settings** (AI Crawlers tab): frequency, monthly cap, engine selection; **dashboard tile**: X of Y prompts cited; AEO metabox shows the lost-citation line
- 32 new unit tests (domains, smoothing, share-of-voice, question classifier) — suite at 217; PHPStan/PHPCS clean; **live smoke test passed on jonimms.local** (no provider calls)
- Version 4.16.0

## Merge order
Stacked: #55 → #56 → this. I'll retarget as parents land.

## Review trail
Three per-task spec reviews + final whole-branch review; final fixes: enabled-engine whitelist inside `check_one` (an unchecked engine could otherwise be invoked via AJAX), `rawurlencode` on the Google API key in URLs, history query bounded to 90 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)