### PR TITLE
feat: question coverage engine — fan-out checklist + GSC demand mining

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.16.0-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.17.0-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1446,6 +1446,10 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.17.0 — June 2026
+- **Question coverage engine** — the AEO Coverage dimension is now live: one AI call per scored post builds a query fan-out checklist (the 5–10 sub-questions an answer engine would decompose your topic into, marked answered / partial / missing) with content-hash caching
+- **Search Console question mining** — weekly cron finds real question queries your pages get impressions for but don't answer (heading-match with fuzzy token overlap), surfaces them in the editor panel, feeds them into AEO Q&A proposals, and queues uncovered questions as topic suggestions
 
 ### v4.16.0 — June 2026
 - **New — AI citation tracker:** monitor whether ChatGPT, Claude, Gemini, and Grok cite your site for your tracked prompts (BYO keys, search-grounded), with per-engine cited/lost/never/mixed state badges, share-of-voice bars vs competitors, a cited-domains breakdown, seed-from-keywords/GSC prompt suggestions, monthly call caps, a dashboard tile, and lost-citation context surfaced in the AEO editor panel and proposals.

--- a/admin/js/aeo-optimizer.js
+++ b/admin/js/aeo-optimizer.js
@@ -316,6 +316,29 @@
     $(document).on('click', '#swps-aeo-cancel',  function () { $modal.hide(); });
     $(document).on('click', '#swps-aeo-apply',   function () { apply(parseInt($(this).data('id'), 10)); });
 
+    // Question opportunities: queue a mined question as a topic.
+    $(document).on('click', '.swps-queue-question-topic', function () {
+        var $btn  = $(this);
+        var $card = $('#swps-aeo-question-opportunities');
+        $btn.prop('disabled', true);
+        $.post(swpsAeo.ajaxUrl, {
+            action:   'swps_queue_question_topic',
+            nonce:    $card.data('nonce'),
+            question: String($btn.data('question'))
+        }).done(function () {
+            var $row = $btn.closest('tr');
+            $row.fadeOut(200, function () {
+                $row.remove();
+                if ($card.find('tbody tr').length === 0) {
+                    $card.fadeOut(200);
+                }
+            });
+        }).fail(function (jqXHR) {
+            $btn.prop('disabled', false);
+            window.alert(extractErrorMessage(jqXHR, ''));
+        });
+    });
+
     // Support ?focus_post=N URL param: deep-link from Bot Analytics (Task 19).
     var match = window.location.search.match(/[?&]focus_post=(\d+)/);
     if (match) {

--- a/docs/superpowers/plans/2026-06-10-question-coverage.md
+++ b/docs/superpowers/plans/2026-06-10-question-coverage.md
@@ -1,0 +1,46 @@
+# Question Coverage Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Two question sources feeding the existing AEO fix pipeline. **Phase A (no GSC dependency):** activate the fully-built-but-never-invoked Coverage scorer with a rewritten fan-out prompt that emits a sub-query checklist (answered/partial/missing), persist the payload with the existing content-hash invalidation, surface the checklist in the AEO editor panel, and inject missing sub-queries into `do_propose()` (which already supports `kind:"qa"` inserts + validated FAQPage schema). **Phase B (GSC):** mine question-form queries per ranked URL, flag questions the post doesn't answer (matched against heading parsing), order by impressions, surface per-post unanswered lists, and push site-wide orphan question clusters into the topic queue as 'proposed'-style candidates (simple create_topic drafts marked clearly).
+
+**Branch:** `feature/question-coverage` (stacked on feature/ai-citation-tracker). Version → 4.17.0. House conventions as all prior plans (require in same commit as call site, <500 lines, tabs/WPCS, nonce+cap AJAX, null-safe wpdb, gates + jonimms.local smoke before release commit, no push/PR).
+
+---
+
+## Verified facts (HEAD = citation tracker tip)
+
+- `SWPS_AEO_Coverage_Scorer::score( string $title, string $html )` (includes/aeo/class-coverage-scorer.php:39) returns `{score:?int, coverage_gaps:string[], entity_issues:string[], error:?string}` via one `chat_json()` call. **Nothing calls score()**; `SWPS_AEO_Scorer::OPTION_COVERAGE_ENABLED = 'swps_aeo_coverage_enabled'` exists (class-aeo-scorer.php:33) and is **never read**; `META_CONTENT_HASH = '_swps_aeo_content_hash'` (:29) backs cache invalidation. Read class-aeo-scorer.php fully: how score_post composes dimensions/weights and where coverage was meant to slot (weights option includes a 'coverage' key, settings UI has the checkbox + weight already).
+- `SWPS_AEO_Optimizer::do_scan_chunk(:276)`, `do_score(:337)`, `do_propose(:363)` — the propose prompt (:379) already specifies `"inserts":[{"kind":"qa|tldr|list|defn",...}]`. Read do_propose fully (prompt assembly, where coverage context could append, the `swps_aeo_proposal` filter at :407 — note the citation tracker already appends keys there; coexist cleanly).
+- Markup scorer question parsing: `count_questions( $html )` and Q&A pairing detection (includes/aeo/class-markup-scorer.php:72 area) — reuse its heading/question extraction for Phase B matching (make a method public or extract a small shared helper — read first, report approach).
+- GSC: `SWPS_Search_Console::get_search_data( $days )['queries']` rows `{keys:[query], clicks, impressions, ctr, position}`; `get_page_queries( $url, $days )` (:180, rowLimit 10); private `fetch_analytics( $property, $start, $end, $dimensions )` (:435). Phase B needs a page+query two-dimension fetch with startRow pagination — add a public method generalizing fetch_analytics (read auth/caching first; 12h transient pattern).
+- Question classifier: reuse `SWPS_Citation_Tracker::is_question_query()` (already TDD'd) — do not duplicate.
+- Topic queue: `SWPS_Topic_Queue::create_topic` (:81 area — read signature).
+- Editor panel: includes/class-aeo-editor-panel.php server-rendered metabox + aeo-editor-panel.js Gutenberg sidebar; funnel line + citation loss line precedents exist in the metabox.
+- AEO weights option `swps_aeo_weights` default includes coverage 0.20 (class-settings.php:1067 area).
+
+## Phase A tasks (dispatch 1)
+
+1. **Rewrite the coverage prompt** in class-coverage-scorer.php: ask for `{"score": 0-100, "sub_queries": [{"q": "...", "status": "answered|partial|missing"}], "entity_issues": [...]}` — 5-10 sub-queries an answer engine would fan a query about this topic into, statuses judged from the outline; keep return-shape BC by still returning coverage_gaps (= missing sub-queries' q strings) alongside a new `sub_queries` key. Seed the prompt with title + focus keyword (read how scorers get context) + heading outline (cheap: strip to h2/h3 text) instead of full HTML where the current prompt sends HTML — read what it sends now and keep token use comparable.
+2. **Activate it**: in SWPS_AEO_Scorer::score_post / score_html (read which composes dimensions), when `get_option(OPTION_COVERAGE_ENABLED)` is truthy AND a cached coverage payload is invalid (content hash changed), call the coverage scorer; persist payload in NEW post meta `_swps_aeo_coverage` (sub_queries + score + hash) reusing META_CONTENT_HASH semantics; coverage sub-score feeds the existing weights composition (the dash in the UI should become a number). MUST be cost-safe: coverage runs ONLY inside do_scan_chunk/do_score explicit actions (where chat_json already happens) — never on page load or save_post. Verify by tracing call sites of score_post.
+3. **Editor panel checklist**: metabox section listing sub-queries with status icons (✓/◐/✗), from the meta (no AI call on render).
+4. **Propose injection**: in do_propose, when `_swps_aeo_coverage` has missing/partial sub-queries, append a compact instruction to the prompt: answer these questions via qa inserts (cap 3 per proposal). Unit-testable pure bit: `SWPS_Question_Coverage::format_gap_instruction( array $sub_queries, int $cap = 3 ): string` (new small class) — TDD it (missing first, then partial, empty → '', cap respected).
+
+## Phase B tasks (dispatch 2)
+
+5. **GSC page+query fetch**: public method on SWPS_Search_Console: `get_query_page_rows( int $days, int $row_limit = 1000 )` — dimensions ['query','page'], startRow pagination loop (rowLimit 25000 max per request; page until < requested), 12h transient, auth-guarded (return array() unconnected).
+6. **Demand miner** in the new `SWPS_Question_Coverage` class: weekly cron piggyback — extend the EXISTING twicedaily/GSC-adjacent cron if one fits or its own weekly hook (read what crons exist; report choice): pull rows, filter is_question_query, map page URL→post_id (url_to_postid with fallback skip), group per post ordered by impressions, store per-post meta `_swps_unanswered_questions` = questions NOT matched against the post's headings/questions (reuse markup scorer extraction; fuzzy match: normalized stopword-stripped token overlap ≥ 0.6 — implement as pure static `questions_unanswered( array $questions, array $headings ): array` + `tokens_similar( string $a, string $b ): float`, TDD both). Cap stored list at 10 per post. Site-wide: questions whose page is NOT a post (or impressions on posts ranking >20) → candidate topics list option `swps_question_topic_candidates` (cap 20).
+7. **Surfaces**: editor-panel metabox section "Questions searchers ask that this post doesn't answer" (from meta, with impressions); do_propose ALSO appends top-3 unanswered GSC questions to the qa instruction (same formatter, GSC source labeled); AEO page: small "Question opportunities" card listing top candidate topics with a "Queue topic" button per row → AJAX (nonce swps_question_coverage + manage_options) calling SWPS_Topic_Queue::create_topic with a clear title; remove from candidates on queue.
+8. **Wiring/gates/release**: requires + instantiate; uninstall additions (option + meta note — meta deletion follows existing uninstall meta pattern if one exists, else leave with comment); gates (phpunit 217+new, phpstan 2G, phpcs new files); jonimms.local smoke (instantiate, formatter + matcher on fixtures, NO AI/GSC calls); version 4.17.0 + changelogs:
+```
+= 4.17.0 =
+* New: Question coverage engine — the AEO Coverage dimension is now live (query fan-out sub-question checklist per post), and Search Console question mining surfaces real searcher questions your posts don't answer, feeding Q&A inserts into AEO proposals and topic suggestions into the queue.
+```
+Commits per dispatch; plan-doc commit at the end. No push/PR.
+
+## Self-review
+1. Coverage scorer still only fires inside explicit scan/score actions (cost safety)?
+2. Cached payload invalidated by content hash; UI never triggers AI calls on render?
+3. Formatter/matcher pure helpers TDD'd; is_question_query reused not duplicated?
+4. GSC pagination bounded (row_limit cap) + transient-cached; unconnected sites fully no-op?
+5. Both phases degrade independently (no GSC ⇒ Phase A still fully works)?

--- a/includes/aeo/class-coverage-scorer.php
+++ b/includes/aeo/class-coverage-scorer.php
@@ -32,14 +32,27 @@ class SWPS_AEO_Coverage_Scorer {
 	/**
 	 * Score the post for coverage and entity clarity by querying the AI provider.
 	 *
-	 * @param string $title Post title.
-	 * @param string $html  Raw post HTML.
-	 * @return array{score:?int, coverage_gaps:string[], entity_issues:string[], error:?string}
+	 * The prompt asks for a fan-out set of sub-queries an answer engine would
+	 * derive from the topic, each classified as answered/partial/missing based
+	 * on the heading outline.  The response shape is extended:
+	 *   - sub_queries : [{"q": "...", "status": "answered|partial|missing"}, ...]
+	 *   - coverage_gaps (BC) : q-strings for missing sub-queries only
+	 *   - entity_issues : vague entity mentions as before
+	 *   - score : 0-100
+	 *
+	 * Context uses heading outline (H2/H3) + optional focus keyword instead of
+	 * full HTML, keeping token usage comparable to the previous prompt.
+	 *
+	 * @param string $title         Post title.
+	 * @param string $html          Raw post HTML.
+	 * @param string $focus_keyword Optional focus keyword for extra context.
+	 * @return array{score:?int, sub_queries:array<int,array{q:string,status:string}>, coverage_gaps:string[], entity_issues:string[], error:?string}
 	 */
-	public function score( string $title, string $html ): array {
+	public function score( string $title, string $html, string $focus_keyword = '' ): array {
 		if ( null === $this->provider ) {
 			return array(
 				'score'         => null,
+				'sub_queries'   => array(),
 				'coverage_gaps' => array(),
 				'entity_issues' => array(),
 				'error'         => 'no_provider',
@@ -47,22 +60,27 @@ class SWPS_AEO_Coverage_Scorer {
 		}
 
 		$outline = $this->build_outline( $html );
+		$kw_line = '' !== $focus_keyword ? "\nFocus keyword: {$focus_keyword}" : '';
 		$system  = 'You evaluate how completely a blog post covers its topic for AI search citation.';
 		$user    = sprintf(
-			"Topic: %s\n\nOutline (H2s + opening sentence of each section):\n%s\n\n" .
-			'Return JSON with these exact keys: ' .
-			'{"coverage_gaps": [up to 5 sub-topics a reader would expect that are missing], ' .
-			'"entity_issues": [up to 5 entities mentioned vaguely or generically that should be named explicitly], ' .
-			'"score": integer 0-100 reflecting overall coverage and entity clarity}',
+			"Topic: %s%s\n\nHeading outline:\n%s\n\n" .
+			'Fan out 5-10 sub-questions an answer engine would ask about this topic. ' .
+			'For each, judge whether the outline answers it fully (answered), partially (partial), or not at all (missing). ' .
+			'Return JSON with exactly these keys: ' .
+			'{"sub_queries": [{"q": "...", "status": "answered|partial|missing"}], ' .
+			'"entity_issues": [up to 5 entities mentioned vaguely that should be named explicitly], ' .
+			'"score": integer 0-100 reflecting overall coverage}',
 			$title,
+			$kw_line,
 			$outline
 		);
 
-		$response = $this->provider->chat_json( $system, $user, 512 );
+		$response = $this->provider->chat_json( $system, $user, 600 );
 
 		if ( $response instanceof WP_Error ) {
 			return array(
 				'score'         => null,
+				'sub_queries'   => array(),
 				'coverage_gaps' => array(),
 				'entity_issues' => array(),
 				'error'         => $response->get_error_message(),
@@ -71,6 +89,7 @@ class SWPS_AEO_Coverage_Scorer {
 		if ( ! is_array( $response ) ) {
 			return array(
 				'score'         => null,
+				'sub_queries'   => array(),
 				'coverage_gaps' => array(),
 				'entity_issues' => array(),
 				'error'         => 'invalid_response',
@@ -83,9 +102,36 @@ class SWPS_AEO_Coverage_Scorer {
 			$score = max( 0, min( 100, (int) $raw_score ) );
 		}
 
+		// Normalise sub_queries.
+		$valid_statuses = array( 'answered', 'partial', 'missing' );
+		$sub_queries    = array();
+		foreach ( (array) ( $response['sub_queries'] ?? array() ) as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+			$q      = trim( (string) ( $item['q'] ?? '' ) );
+			$status = (string) ( $item['status'] ?? '' );
+			if ( '' === $q || ! in_array( $status, $valid_statuses, true ) ) {
+				continue;
+			}
+			$sub_queries[] = array(
+				'q'      => $q,
+				'status' => $status,
+			);
+		}
+
+		// BC: coverage_gaps = missing sub-queries' q strings.
+		$coverage_gaps = array();
+		foreach ( $sub_queries as $item ) {
+			if ( 'missing' === $item['status'] ) {
+				$coverage_gaps[] = $item['q'];
+			}
+		}
+
 		return array(
 			'score'         => $score,
-			'coverage_gaps' => array_values( array_filter( (array) ( $response['coverage_gaps'] ?? array() ), 'is_string' ) ),
+			'sub_queries'   => $sub_queries,
+			'coverage_gaps' => $coverage_gaps,
 			'entity_issues' => array_values( array_filter( (array) ( $response['entity_issues'] ?? array() ), 'is_string' ) ),
 			'error'         => null,
 		);

--- a/includes/aeo/class-coverage-scorer.php
+++ b/includes/aeo/class-coverage-scorer.php
@@ -148,12 +148,20 @@ class SWPS_AEO_Coverage_Scorer {
 		if ( preg_match_all( '#<h2[^>]*>(.*?)</h2>(.*?)(?=<h2|$)#is', $html, $m, PREG_SET_ORDER ) ) {
 			foreach ( $m as $match ) {
 				$h2   = trim( wp_strip_all_tags( $match[1] ) );
-				$body = trim( wp_strip_all_tags( $match[2] ) );
+				$lines[] = '## ' . $h2;
+
+				// H3 sub-headings within this section keep nested structure visible.
+				if ( preg_match_all( '#<h3[^>]*>(.*?)</h3>#is', $match[2], $h3m ) ) {
+					foreach ( $h3m[1] as $h3 ) {
+						$lines[] = '### ' . trim( wp_strip_all_tags( $h3 ) );
+					}
+				}
+
+				$body  = trim( wp_strip_all_tags( $match[2] ) );
 				$first = '';
 				if ( preg_match( '/^([^.?!]*[.?!])/u', $body, $sm ) ) {
 					$first = trim( $sm[1] );
 				}
-				$lines[] = '## ' . $h2;
 				if ( '' !== $first ) {
 					$lines[] = $first;
 				}

--- a/includes/aeo/class-markup-scorer.php
+++ b/includes/aeo/class-markup-scorer.php
@@ -112,6 +112,38 @@ class SWPS_AEO_Markup_Scorer {
 	}
 
 	/**
+	 * Extract heading texts (h2-h6) plus question-form <p>/<li> lines.
+	 *
+	 * Shared helper for the question-coverage matcher (Phase B): returns
+	 * the strings a searcher question could be "answered by" — all heading
+	 * texts and any body line ending in '?'. Reuses the same patterns as
+	 * count_questions() (kept in sync).
+	 *
+	 * @param string $html Raw post HTML.
+	 * @return string[] Plain-text headings/questions, tags stripped.
+	 */
+	public static function extract_headings( string $html ): array {
+		$out = array();
+		if ( preg_match_all( '#<h[2-6][^>]*>(.*?)</h[2-6]>#is', $html, $m ) ) {
+			foreach ( $m[1] as $text ) {
+				$text = trim( wp_strip_all_tags( $text ) );
+				if ( '' !== $text ) {
+					$out[] = $text;
+				}
+			}
+		}
+		if ( preg_match_all( '#(?:<p[^>]*>|<li[^>]*>)([^<]*\?)\s*(?:</p>|</li>)#i', $html, $m ) ) {
+			foreach ( $m[1] as $text ) {
+				$text = trim( wp_strip_all_tags( $text ) );
+				if ( '' !== $text ) {
+					$out[] = $text;
+				}
+			}
+		}
+		return array_values( array_unique( $out ) );
+	}
+
+	/**
 	 * For each question heading (h2-h6), check whether the next paragraph is
 	 * a short (<150 words) declarative answer. Returns fraction (0-1).
 	 *

--- a/includes/class-aeo-editor-panel.php
+++ b/includes/class-aeo-editor-panel.php
@@ -182,6 +182,39 @@ class SWPS_AEO_Editor_Panel {
 					</ul>
 				</div>
 			<?php endif; ?>
+			<?php
+			// GSC-mined unanswered searcher questions — rendered from meta only
+			// (set by SWPS_Question_Coverage::mine(), zero AI/GSC on render).
+			$unanswered = get_post_meta( $post->ID, SWPS_Question_Coverage::META_UNANSWERED, true );
+			if ( is_array( $unanswered ) && ! empty( $unanswered ) ) :
+				?>
+				<div class="swps-aeo-unanswered" style="margin-top:10px;">
+					<p style="margin:0 0 4px;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:#666;font-weight:600;">
+						<?php esc_html_e( 'Questions searchers ask that this post doesn\'t answer', 'stratawp-seo' ); ?>
+					</p>
+					<ul style="list-style:none;padding:0;margin:0;font-size:11px;">
+						<?php foreach ( $unanswered as $swps_uq ) : ?>
+							<?php
+							if ( ! is_array( $swps_uq ) || empty( $swps_uq['q'] ) ) {
+								continue;
+							}
+							?>
+							<li style="display:flex;justify-content:space-between;gap:6px;padding:3px 0;border-bottom:1px solid #f0f0f0;">
+								<span><?php echo esc_html( (string) $swps_uq['q'] ); ?></span>
+								<span style="color:#666;flex-shrink:0;">
+									<?php
+									printf(
+										/* translators: %s: impression count from Search Console. */
+										esc_html__( '%s impr.', 'stratawp-seo' ),
+										esc_html( number_format_i18n( (int) ( $swps_uq['impressions'] ?? 0 ) ) )
+									);
+									?>
+								</span>
+							</li>
+						<?php endforeach; ?>
+					</ul>
+				</div>
+			<?php endif; ?>
 		</div>
 		<?php
 	}

--- a/includes/class-aeo-editor-panel.php
+++ b/includes/class-aeo-editor-panel.php
@@ -144,6 +144,44 @@ class SWPS_AEO_Editor_Panel {
 					?>
 				</p>
 			<?php endif; ?>
+			<?php
+			// Question coverage checklist — rendered from cached meta only (zero AI on render).
+			$coverage_payload = get_post_meta( $post->ID, SWPS_AEO_Scorer::META_COVERAGE_PAYLOAD, true );
+			if ( is_array( $coverage_payload ) && ! empty( $coverage_payload['sub_queries'] ) ) :
+				$status_icons = array(
+					'answered' => '✓',
+					'partial'  => '◐',
+					'missing'  => '✗',
+				);
+				$status_colors = array(
+					'answered' => '#00a32a',
+					'partial'  => '#dba617',
+					'missing'  => '#d63638',
+				);
+				?>
+				<div class="swps-aeo-coverage-checklist" style="margin-top:10px;">
+					<p style="margin:0 0 4px;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:#666;font-weight:600;">
+						<?php esc_html_e( 'Coverage sub-questions', 'stratawp-seo' ); ?>
+					</p>
+					<ul style="list-style:none;padding:0;margin:0;font-size:11px;">
+						<?php foreach ( $coverage_payload['sub_queries'] as $item ) : ?>
+							<?php
+							if ( ! is_array( $item ) ) {
+								continue;
+							}
+							$status = (string) ( $item['status'] ?? 'missing' );
+							$q      = (string) ( $item['q']      ?? '' );
+							$icon   = $status_icons[ $status ]  ?? '?';
+							$color  = $status_colors[ $status ] ?? '#666';
+							?>
+							<li style="display:flex;gap:4px;padding:3px 0;border-bottom:1px solid #f0f0f0;align-items:flex-start;">
+								<span style="color:<?php echo esc_attr( $color ); ?>;font-weight:700;flex-shrink:0;"><?php echo esc_html( $icon ); ?></span>
+								<span><?php echo esc_html( $q ); ?></span>
+							</li>
+						<?php endforeach; ?>
+					</ul>
+				</div>
+			<?php endif; ?>
 		</div>
 		<?php
 	}

--- a/includes/class-aeo-optimizer.php
+++ b/includes/class-aeo-optimizer.php
@@ -384,6 +384,18 @@ class SWPS_AEO_Optimizer {
 			mb_substr( $post->post_content, 0, 8000 )
 		);
 
+		// Append coverage gap instruction when a cached payload has actionable gaps.
+		$coverage_payload = get_post_meta( $post_id, SWPS_AEO_Scorer::META_COVERAGE_PAYLOAD, true );
+		if ( is_array( $coverage_payload ) && ! empty( $coverage_payload['sub_queries'] ) ) {
+			$gap_instruction = SWPS_Question_Coverage::format_gap_instruction(
+				(array) $coverage_payload['sub_queries'],
+				3
+			);
+			if ( '' !== $gap_instruction ) {
+				$user .= "\n\n" . $gap_instruction;
+			}
+		}
+
 		$result = $this->ai_provider->chat_json( $system, $user, 4096 );
 		if ( is_wp_error( $result ) ) {
 			return array( 'error' => $result->get_error_message(), 'http_status' => 500 );

--- a/includes/class-aeo-optimizer.php
+++ b/includes/class-aeo-optimizer.php
@@ -79,6 +79,8 @@ class SWPS_AEO_Optimizer {
 		}
 		$threshold  = (int) get_option( 'swps_aeo_threshold', SWPS_AEO_Scorer::DEFAULT_THRESHOLD );
 		$post_types = (array) get_option( 'swps_aeo_post_types', array( 'post', 'page' ) );
+		// Question topic candidates mined from GSC (template renders the card).
+		$question_candidates = (array) get_option( SWPS_Question_Coverage::OPTION_CANDIDATES, array() );
 		// Make vars available to template (Task 15 creates the actual template).
 		if ( file_exists( SWPS_PLUGIN_DIR . 'templates/aeo-page.php' ) ) {
 			require SWPS_PLUGIN_DIR . 'templates/aeo-page.php';
@@ -393,6 +395,16 @@ class SWPS_AEO_Optimizer {
 			);
 			if ( '' !== $gap_instruction ) {
 				$user .= "\n\n" . $gap_instruction;
+			}
+		}
+
+		// Append GSC-mined unanswered searcher questions (set by the weekly
+		// question-mining cron; meta read only — no GSC call here).
+		$unanswered = get_post_meta( $post_id, SWPS_Question_Coverage::META_UNANSWERED, true );
+		if ( is_array( $unanswered ) && ! empty( $unanswered ) ) {
+			$gsc_instruction = SWPS_Question_Coverage::format_unanswered_instruction( $unanswered, 3 );
+			if ( '' !== $gsc_instruction ) {
+				$user .= "\n\n" . $gsc_instruction;
 			}
 		}
 

--- a/includes/class-aeo-scorer.php
+++ b/includes/class-aeo-scorer.php
@@ -23,10 +23,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class SWPS_AEO_Scorer {
 
-	public const META_TOTAL           = '_swps_aeo_score';
-	public const META_SUBSCORE_PREFIX = '_swps_aeo_subscore_';
-	public const META_LAST_SCAN       = '_swps_aeo_last_scan';
-	public const META_CONTENT_HASH    = '_swps_aeo_content_hash';
+	public const META_TOTAL            = '_swps_aeo_score';
+	public const META_SUBSCORE_PREFIX  = '_swps_aeo_subscore_';
+	public const META_LAST_SCAN        = '_swps_aeo_last_scan';
+	public const META_CONTENT_HASH     = '_swps_aeo_content_hash';
+	/** Stores coverage sub_queries + score keyed by content hash. */
+	public const META_COVERAGE_PAYLOAD = '_swps_aeo_coverage';
 
 	public const OPTION_THRESHOLD        = 'swps_aeo_threshold';
 	public const OPTION_WEIGHTS          = 'swps_aeo_weights';
@@ -121,6 +123,35 @@ class SWPS_AEO_Scorer {
 			);
 		}
 
+		$content_hash = md5( $post->post_content );
+		$focus_kw     = (string) get_post_meta( $post_id, '_swps_focus_keyword', true );
+
+		// Run coverage scorer when enabled and content has changed since last score.
+		// COST-SAFE: only runs inside explicit scan/score AJAX actions, never on
+		// page-load or save_post. The caller (do_scan_chunk/do_score) is the only
+		// path that reaches score_post.
+		$coverage_score_fresh = null;
+		if ( get_option( self::OPTION_COVERAGE_ENABLED ) ) {
+			$cached_payload = get_post_meta( $post_id, self::META_COVERAGE_PAYLOAD, true );
+			$cached_hash    = is_array( $cached_payload ) ? (string) ( $cached_payload['hash'] ?? '' ) : '';
+
+			if ( $cached_hash !== $content_hash ) {
+				// Content changed (or never scored): run the AI call.
+				$coverage_result = $this->coverage->score( $post->post_title, $post->post_content, $focus_kw );
+				if ( null !== $coverage_result['score'] ) {
+					$coverage_score_fresh = $coverage_result['score'];
+					update_post_meta( $post_id, self::META_COVERAGE_PAYLOAD, array(
+						'hash'        => $content_hash,
+						'score'       => $coverage_result['score'],
+						'sub_queries' => $coverage_result['sub_queries'],
+					) );
+				}
+			} else {
+				// Use the cached score; payload is still valid.
+				$coverage_score_fresh = is_array( $cached_payload ) ? (int) $cached_payload['score'] : null;
+			}
+		}
+
 		$ctx = array(
 			'title'           => $post->post_title,
 			'author'          => get_the_author_meta( 'display_name', (int) $post->post_author ),
@@ -128,7 +159,7 @@ class SWPS_AEO_Scorer {
 			'modified_unix'   => (int) strtotime( $post->post_modified_gmt ),
 			'word_count'      => str_word_count( wp_strip_all_tags( $post->post_content ) ),
 			'existing_schema' => $this->detect_existing_schema( $post ),
-			'coverage_cached' => $this->load_cached_coverage( $post_id, $post->post_content ),
+			'coverage_cached' => $coverage_score_fresh ?? $this->load_cached_coverage( $post_id, $post->post_content ),
 		);
 
 		$result = $this->score_html( $post->post_content, $ctx, $weights );
@@ -140,6 +171,10 @@ class SWPS_AEO_Scorer {
 			} else {
 				update_post_meta( $post_id, self::META_SUBSCORE_PREFIX . $k, $v );
 			}
+		}
+		// Persist the content hash when coverage ran (guards re-scoring same content).
+		if ( null !== $coverage_score_fresh ) {
+			update_post_meta( $post_id, self::META_CONTENT_HASH, $content_hash );
 		}
 		update_post_meta( $post_id, self::META_LAST_SCAN, time() );
 

--- a/includes/class-question-coverage.php
+++ b/includes/class-question-coverage.php
@@ -442,6 +442,8 @@ class SWPS_Question_Coverage {
 	 */
 	private function store_candidates( array $candidates ): void {
 		if ( empty( $candidates ) ) {
+			// A successful run that found nothing must clear last week's list.
+			update_option( self::OPTION_CANDIDATES, array(), false );
 			return;
 		}
 		arsort( $candidates );

--- a/includes/class-question-coverage.php
+++ b/includes/class-question-coverage.php
@@ -1,10 +1,20 @@
 <?php
 /**
- * Question Coverage — helpers for the AEO question-coverage engine.
+ * Question Coverage — the AEO question-coverage engine.
  *
- * Phase A (Phase B adds GSC mining): pure, WP-free formatting utility
- * consumed by SWPS_AEO_Optimizer::do_propose() to inject coverage gaps
- * as qa-insert instructions into the proposal prompt.
+ * Phase A: pure formatting utility consumed by SWPS_AEO_Optimizer::do_propose()
+ * to inject coverage gaps as qa-insert instructions into the proposal prompt.
+ *
+ * Phase B: GSC question demand mining. A weekly cron pulls query+page rows
+ * from Search Console, filters question-form queries, matches them against
+ * each post's headings (fuzzy token overlap), and stores:
+ *   - per-post meta `_swps_unanswered_questions` (≤10, with impressions)
+ *   - site-wide option `swps_question_topic_candidates` (≤20) for questions
+ *     landing on non-post pages or posts ranking >20.
+ * An AJAX handler queues a candidate as a topic via SWPS_Topic_Queue.
+ *
+ * All matchers are pure statics (unit-tested, no WP). Runtime methods are
+ * fully no-op when GSC is unconnected — no network calls, no AI calls.
  *
  * @package StrataWP_SEO
  */
@@ -16,9 +26,100 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * SWPS_Question_Coverage
  *
- * Utility class for the AEO question-coverage engine.
+ * Pure matchers + GSC demand miner for the AEO question-coverage engine.
  */
 class SWPS_Question_Coverage {
+
+	public const CRON_HOOK         = 'swps_question_mine';
+	public const META_UNANSWERED   = '_swps_unanswered_questions';
+	public const OPTION_CANDIDATES = 'swps_question_topic_candidates';
+
+	public const MAX_PER_POST   = 10;
+	public const MAX_CANDIDATES = 20;
+
+	/** Similarity threshold for a question to count as "answered by a heading". */
+	private const MATCH_THRESHOLD = 0.6;
+
+	/** Stopwords stripped before token comparison. */
+	private const STOPWORDS = array(
+		'a',
+		'an',
+		'and',
+		'are',
+		'be',
+		'can',
+		'do',
+		'does',
+		'for',
+		'how',
+		'i',
+		'in',
+		'is',
+		'it',
+		'my',
+		'of',
+		'on',
+		'or',
+		'should',
+		'the',
+		'to',
+		'vs',
+		'what',
+		'when',
+		'where',
+		'which',
+		'who',
+		'why',
+		'will',
+		'with',
+		'you',
+		'your',
+	);
+
+	/**
+	 * Search Console client (page+query rows).
+	 *
+	 * @var SWPS_Search_Console
+	 */
+	private SWPS_Search_Console $search_console;
+
+	/**
+	 * Topic queue (candidate → queued topic).
+	 *
+	 * @var SWPS_Topic_Queue
+	 */
+	private SWPS_Topic_Queue $topic_queue;
+
+	/**
+	 * Wire the weekly mining cron + the queue-topic AJAX handler.
+	 *
+	 * @param SWPS_Search_Console $search_console GSC client.
+	 * @param SWPS_Topic_Queue    $topic_queue    Topic queue.
+	 */
+	public function __construct( SWPS_Search_Console $search_console, SWPS_Topic_Queue $topic_queue ) {
+		$this->search_console = $search_console;
+		$this->topic_queue    = $topic_queue;
+
+		add_action( self::CRON_HOOK, array( $this, 'mine' ) );
+		add_action( 'wp_ajax_swps_queue_question_topic', array( $this, 'ajax_queue_topic' ) );
+
+		// Self-schedule (AEO-optimizer precedent) so existing installs pick the
+		// cron up without re-activation.
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'weekly', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Unschedule the mining cron (deactivation hook).
+	 */
+	public static function unschedule_cron(): void {
+		wp_clear_scheduled_hook( self::CRON_HOOK );
+	}
+
+	// -------------------------------------------------------------------------
+	// Pure helpers (unit-tested, no WP)
+	// -------------------------------------------------------------------------
 
 	/**
 	 * Format a compact prompt instruction from sub-query gap data.
@@ -29,7 +130,7 @@ class SWPS_Question_Coverage {
 	 * `if ( '' !== $instruction )` guard).
 	 *
 	 * @param array<int, array<string, mixed>> $sub_queries Sub-query list from coverage scorer.
-	 * @param int                                          $cap         Maximum number of questions to include (default 3).
+	 * @param int                              $cap         Maximum number of questions to include (default 3).
 	 * @return string Prompt fragment, or '' when nothing to add.
 	 */
 	public static function format_gap_instruction( array $sub_queries, int $cap = 3 ): string {
@@ -73,5 +174,339 @@ class SWPS_Question_Coverage {
 		);
 
 		return 'Also add qa inserts answering these searcher questions the post does not yet fully cover: ' . $list . '.';
+	}
+
+	/**
+	 * Format a prompt instruction from GSC-mined unanswered questions.
+	 *
+	 * Sibling of format_gap_instruction() with the Search Console source
+	 * labeled and impressions included for prioritisation context.
+	 *
+	 * @param array<int, array<string, mixed>> $questions Rows of {q, impressions}.
+	 * @param int                              $cap       Maximum questions to include (default 3).
+	 * @return string Prompt fragment, or '' when nothing to add.
+	 */
+	public static function format_unanswered_instruction( array $questions, int $cap = 3 ): string {
+		$parts = array();
+		foreach ( $questions as $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+			$q = trim( (string) ( $row['q'] ?? '' ) );
+			if ( '' === $q ) {
+				continue;
+			}
+			$impressions = (int) ( $row['impressions'] ?? 0 );
+			$parts[]     = '"' . $q . '" (' . $impressions . ' impressions)';
+			if ( count( $parts ) >= max( 1, $cap ) ) {
+				break;
+			}
+		}
+
+		if ( empty( $parts ) ) {
+			return '';
+		}
+
+		return 'Google Search Console shows real searchers ask these questions this post does not answer — add qa inserts for them: '
+			. implode( '; ', $parts ) . '.';
+	}
+
+	/**
+	 * Normalized token-overlap similarity between two short strings.
+	 *
+	 * Both strings are lowercased, punctuation-stripped, tokenised, stopword-
+	 * filtered, and lightly stemmed (trailing ing/ed/es/s). Tokens match when
+	 * equal or when one is a ≥4-char prefix of the other (store/storing).
+	 * Returns Jaccard overlap (intersection / union) in [0, 1].
+	 *
+	 * @param string $a First string.
+	 * @param string $b Second string.
+	 * @return float Similarity 0.0–1.0.
+	 */
+	public static function tokens_similar( string $a, string $b ): float {
+		$tokens_a = self::normalize_tokens( $a );
+		$tokens_b = self::normalize_tokens( $b );
+
+		if ( empty( $tokens_a ) || empty( $tokens_b ) ) {
+			return 0.0;
+		}
+
+		$matched_b = array();
+		$intersect = 0;
+		foreach ( $tokens_a as $ta ) {
+			foreach ( $tokens_b as $i => $tb ) {
+				if ( isset( $matched_b[ $i ] ) ) {
+					continue;
+				}
+				if ( self::tokens_match( $ta, $tb ) ) {
+					$matched_b[ $i ] = true;
+					++$intersect;
+					break;
+				}
+			}
+		}
+
+		$union = count( $tokens_a ) + count( $tokens_b ) - $intersect;
+		if ( $union <= 0 ) {
+			return 0.0;
+		}
+
+		return $intersect / $union;
+	}
+
+	/**
+	 * Return the questions NOT answered by any heading (similarity < 0.6).
+	 *
+	 * @param string[] $questions Question strings.
+	 * @param string[] $headings  Heading strings extracted from post content.
+	 * @return string[] Unanswered questions (original order preserved).
+	 */
+	public static function questions_unanswered( array $questions, array $headings ): array {
+		$unanswered = array();
+		foreach ( $questions as $question ) {
+			$question = (string) $question;
+			$answered = false;
+			foreach ( $headings as $heading ) {
+				if ( self::tokens_similar( $question, (string) $heading ) >= self::MATCH_THRESHOLD ) {
+					$answered = true;
+					break;
+				}
+			}
+			if ( ! $answered ) {
+				$unanswered[] = $question;
+			}
+		}
+		return array_values( $unanswered );
+	}
+
+	/**
+	 * Lowercase, strip punctuation, tokenise, drop stopwords, light-stem.
+	 *
+	 * @param string $text Input string.
+	 * @return string[] Normalised tokens.
+	 */
+	private static function normalize_tokens( string $text ): array {
+		$text   = strtolower( $text );
+		$text   = (string) preg_replace( '/[^a-z0-9\s]/', ' ', $text );
+		$tokens = preg_split( '/\s+/', $text, -1, PREG_SPLIT_NO_EMPTY );
+		if ( false === $tokens ) {
+			return array();
+		}
+
+		$out = array();
+		foreach ( $tokens as $token ) {
+			if ( in_array( $token, self::STOPWORDS, true ) ) {
+				continue;
+			}
+			$out[] = self::stem( $token );
+		}
+		return array_values( array_unique( $out ) );
+	}
+
+	/**
+	 * Crude suffix-stripping stem: ing, ed, es, s (keeps stems ≥3 chars).
+	 *
+	 * @param string $token Lowercase token.
+	 * @return string Stemmed token.
+	 */
+	private static function stem( string $token ): string {
+		foreach ( array( 'ing', 'ed', 'es', 's' ) as $suffix ) {
+			$len = strlen( $suffix );
+			if ( strlen( $token ) - $len >= 3 && str_ends_with( $token, $suffix ) ) {
+				return substr( $token, 0, -$len );
+			}
+		}
+		return $token;
+	}
+
+	/**
+	 * Two stemmed tokens match when equal, or one is a ≥4-char prefix of the other.
+	 *
+	 * @param string $a Token.
+	 * @param string $b Token.
+	 * @return bool Whether the tokens count as the same word.
+	 */
+	private static function tokens_match( string $a, string $b ): bool {
+		if ( $a === $b ) {
+			return true;
+		}
+		$min = min( strlen( $a ), strlen( $b ) );
+		if ( $min < 4 ) {
+			return false;
+		}
+		return str_starts_with( $a, $b ) || str_starts_with( $b, $a );
+	}
+
+	// -------------------------------------------------------------------------
+	// Demand miner (weekly cron)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Cron handler: mine GSC question queries and store unanswered lists.
+	 *
+	 * Fully no-op when GSC is unconnected (no network, no AI).
+	 */
+	public function mine(): void {
+		if ( ! $this->search_console->is_connected() ) {
+			return;
+		}
+
+		$rows = $this->search_console->get_query_page_rows( 90 );
+		if ( empty( $rows ) ) {
+			return;
+		}
+
+		$per_post   = array();
+		$candidates = array();
+
+		foreach ( $rows as $row ) {
+			$query = (string) ( $row['keys'][0] ?? '' );
+			$page  = (string) ( $row['keys'][1] ?? '' );
+			if ( '' === $query || '' === $page ) {
+				continue;
+			}
+			if ( ! SWPS_Citation_Tracker::is_question_query( $query ) ) {
+				continue;
+			}
+
+			$impressions = (int) ( $row['impressions'] ?? 0 );
+			$position    = (float) ( $row['position'] ?? 0 );
+			$post_id     = url_to_postid( $page );
+
+			if ( $post_id > 0 && 'post' === get_post_type( $post_id ) ) {
+				$per_post[ $post_id ][] = array(
+					'q'           => $query,
+					'impressions' => $impressions,
+				);
+				// Posts ranking deep are also topic-gap signals.
+				if ( $position > 20 ) {
+					$candidates[ $query ] = max( $candidates[ $query ] ?? 0, $impressions );
+				}
+			} else {
+				// Non-post page (or unmappable URL): site-wide topic candidate.
+				$candidates[ $query ] = max( $candidates[ $query ] ?? 0, $impressions );
+			}
+		}
+
+		foreach ( $per_post as $post_id => $questions ) {
+			$this->store_unanswered_for_post( (int) $post_id, $questions );
+		}
+
+		$this->store_candidates( $candidates );
+	}
+
+	/**
+	 * Match a post's mined questions against its headings; persist ≤10 unanswered.
+	 *
+	 * @param int                              $post_id   Post ID.
+	 * @param array<int, array<string, mixed>> $questions Rows of {q, impressions}.
+	 */
+	private function store_unanswered_for_post( int $post_id, array $questions ): void {
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return;
+		}
+
+		$headings   = SWPS_AEO_Markup_Scorer::extract_headings( $post->post_content );
+		$headings[] = $post->post_title;
+
+		$q_strings  = array_column( $questions, 'q' );
+		$unanswered = self::questions_unanswered( $q_strings, $headings );
+
+		if ( empty( $unanswered ) ) {
+			delete_post_meta( $post_id, self::META_UNANSWERED );
+			return;
+		}
+
+		$keep = array();
+		foreach ( $questions as $row ) {
+			if ( in_array( $row['q'], $unanswered, true ) ) {
+				$keep[] = $row;
+			}
+		}
+		usort(
+			$keep,
+			static function ( array $x, array $y ): int {
+				return (int) $y['impressions'] <=> (int) $x['impressions'];
+			}
+		);
+		$keep = array_slice( $keep, 0, self::MAX_PER_POST );
+
+		update_post_meta( $post_id, self::META_UNANSWERED, $keep );
+	}
+
+	/**
+	 * Persist site-wide topic candidates (≤20, impressions-ordered).
+	 *
+	 * @param array<string, int> $candidates Map of query → impressions.
+	 */
+	private function store_candidates( array $candidates ): void {
+		if ( empty( $candidates ) ) {
+			return;
+		}
+		arsort( $candidates );
+		$rows = array();
+		foreach ( array_slice( $candidates, 0, self::MAX_CANDIDATES, true ) as $q => $impressions ) {
+			$rows[] = array(
+				'q'           => (string) $q,
+				'impressions' => (int) $impressions,
+			);
+		}
+		update_option( self::OPTION_CANDIDATES, $rows, false );
+	}
+
+	// -------------------------------------------------------------------------
+	// AJAX: queue a candidate as a topic
+	// -------------------------------------------------------------------------
+
+	/**
+	 * AJAX handler: create a queued topic from a question candidate and
+	 * remove it from the candidates list.
+	 */
+	public function ajax_queue_topic(): void {
+		check_ajax_referer( 'swps_question_coverage', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => 'unauthorized' ), 403 );
+		}
+
+		$question = isset( $_POST['question'] ) ? sanitize_text_field( wp_unslash( $_POST['question'] ) ) : '';
+		if ( '' === $question ) {
+			wp_send_json_error( array( 'message' => 'missing_question' ), 400 );
+		}
+
+		$candidates = (array) get_option( self::OPTION_CANDIDATES, array() );
+		$found      = false;
+		$remaining  = array();
+		foreach ( $candidates as $row ) {
+			if ( is_array( $row ) && (string) ( $row['q'] ?? '' ) === $question ) {
+				$found = true;
+				continue;
+			}
+			$remaining[] = $row;
+		}
+
+		if ( ! $found ) {
+			wp_send_json_error( array( 'message' => 'candidate_not_found' ), 404 );
+		}
+
+		$topic_id = $this->topic_queue->create_topic(
+			ucfirst( $question ),
+			'',
+			'auto',
+			__( 'Suggested by StrataWP SEO question mining (Google Search Console question with no answering post).', 'stratawp-seo' )
+		);
+
+		if ( is_wp_error( $topic_id ) ) {
+			wp_send_json_error( array( 'message' => $topic_id->get_error_message() ), 500 );
+		}
+
+		update_option( self::OPTION_CANDIDATES, $remaining, false );
+
+		wp_send_json_success(
+			array(
+				'topic_id'  => $topic_id,
+				'remaining' => count( $remaining ),
+			)
+		);
 	}
 }

--- a/includes/class-question-coverage.php
+++ b/includes/class-question-coverage.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Question Coverage — helpers for the AEO question-coverage engine.
+ *
+ * Phase A (Phase B adds GSC mining): pure, WP-free formatting utility
+ * consumed by SWPS_AEO_Optimizer::do_propose() to inject coverage gaps
+ * as qa-insert instructions into the proposal prompt.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * SWPS_Question_Coverage
+ *
+ * Utility class for the AEO question-coverage engine.
+ */
+class SWPS_Question_Coverage {
+
+	/**
+	 * Format a compact prompt instruction from sub-query gap data.
+	 *
+	 * Missing questions are listed before partial questions. Answered
+	 * questions are excluded entirely. Returns an empty string when there
+	 * are no missing or partial queries (so callers can do a simple
+	 * `if ( '' !== $instruction )` guard).
+	 *
+	 * @param array<int, array<string, mixed>> $sub_queries Sub-query list from coverage scorer.
+	 * @param int                                          $cap         Maximum number of questions to include (default 3).
+	 * @return string Prompt fragment, or '' when nothing to add.
+	 */
+	public static function format_gap_instruction( array $sub_queries, int $cap = 3 ): string {
+		$missing = array();
+		$partial = array();
+
+		foreach ( $sub_queries as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+			$status = (string) ( $item['status'] ?? '' );
+			$q      = trim( (string) ( $item['q'] ?? '' ) );
+			if ( '' === $q ) {
+				continue;
+			}
+			if ( 'missing' === $status ) {
+				$missing[] = $q;
+			} elseif ( 'partial' === $status ) {
+				$partial[] = $q;
+			}
+			// 'answered' is skipped intentionally.
+		}
+
+		// Missing questions first, then partial.
+		$ordered = array_merge( $missing, $partial );
+
+		if ( empty( $ordered ) ) {
+			return '';
+		}
+
+		$capped = array_slice( $ordered, 0, max( 1, $cap ) );
+
+		$list = implode(
+			'; ',
+			array_map(
+				static function ( string $q ): string {
+					return '"' . $q . '"';
+				},
+				$capped
+			)
+		);
+
+		return 'Also add qa inserts answering these searcher questions the post does not yet fully cover: ' . $list . '.';
+	}
+}

--- a/includes/class-search-console.php
+++ b/includes/class-search-console.php
@@ -214,6 +214,77 @@ class SWPS_Search_Console {
 	}
 
 	/**
+	 * Fetch query+page two-dimension rows with startRow pagination.
+	 *
+	 * Each row: {keys: [query, page], clicks, impressions, ctr, position}.
+	 * Auth-guarded: returns array() when GSC is unconnected (no network call).
+	 * Cached for 12h (CACHE_TTL) like the other analytics fetches.
+	 *
+	 * @param int $days      Days to look back.
+	 * @param int $row_limit Maximum total rows to return (bounded pagination).
+	 * @return array<int, array<string, mixed>> Rows of analytics data.
+	 */
+	public function get_query_page_rows( int $days = 90, int $row_limit = 1000 ): array {
+		if ( ! $this->is_connected() ) {
+			return array();
+		}
+
+		$row_limit = max( 1, $row_limit );
+		$cache_key = self::CACHE_PREFIX . 'query_page_' . $days . '_' . $row_limit;
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return (array) $cached;
+		}
+
+		$property         = $this->get_property();
+		$encoded_property = rawurlencode( $property );
+		$start            = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+		$end              = gmdate( 'Y-m-d', strtotime( '-2 days' ) ); // GSC data has 2-day delay.
+
+		$rows      = array();
+		$row_count = 0;
+		$start_row = 0;
+		// API maximum is 25000 rows per request; page until short response or cap.
+		while ( $row_count < $row_limit ) {
+			$batch_size = min( 25000, $row_limit - $row_count );
+			$response   = $this->api_request(
+				"/sites/{$encoded_property}/searchAnalytics/query",
+				'POST',
+				array(
+					'startDate'  => $start,
+					'endDate'    => $end,
+					'dimensions' => array( 'query', 'page' ),
+					'rowLimit'   => $batch_size,
+					'startRow'   => $start_row,
+				)
+			);
+
+			if ( is_wp_error( $response ) ) {
+				break;
+			}
+
+			$batch = $response['rows'] ?? array();
+			if ( empty( $batch ) ) {
+				break;
+			}
+
+			$batch_count = count( $batch );
+			$rows        = array_merge( $rows, $batch );
+			$row_count  += $batch_count;
+			$start_row  += $batch_count;
+
+			// Short batch = no more data upstream.
+			if ( $batch_count < $batch_size ) {
+				break;
+			}
+		}
+
+		set_transient( $cache_key, $rows, self::CACHE_TTL );
+
+		return $rows;
+	}
+
+	/**
 	 * Clear all GSC cached data.
 	 */
 	public function clear_cache(): void {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -116,11 +116,6 @@ parameters:
 			path: includes/class-github-updater.php
 
 		-
-			message: "#^Property SWPS_AEO_Scorer\\:\\:\\$coverage is never read, only written\\.$#"
-			count: 1
-			path: includes/class-aeo-scorer.php
-
-		-
 			message: "#^Property SWPS_AEO_Optimizer\\:\\:\\$cost is never read, only written\\.$#"
 			count: 1
 			path: includes/class-aeo-optimizer.php

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.16.0
+Stable tag: 4.17.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -293,6 +293,9 @@ No. GSC integration is optional. The on-site analytics works entirely without an
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.17.0 =
+* New: Question coverage engine — the AEO Coverage dimension is now live (query fan-out sub-question checklist per post), and Search Console question mining surfaces real searcher questions your posts don't answer, feeding Q&A inserts into AEO proposals and topic suggestions into the queue.
 
 = 4.16.0 =
 * New: AI citation tracker — monitor whether ChatGPT, Claude, Gemini, and Grok cite your site for your tracked prompts (BYO keys, search-grounded), with share-of-voice vs competitors, cited-domains breakdown, monthly call caps, and lost-citation context fed into AEO proposals.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -257,6 +257,13 @@ final class StrataWP_SEO {
 	public SWPS_AEO_Optimizer         $aeo_optimizer;
 	public SWPS_AEO_Editor_Panel      $aeo_editor_panel;
 
+	/**
+	 * Question coverage engine (v4.17) — GSC question demand mining.
+	 *
+	 * @var SWPS_Question_Coverage
+	 */
+	public SWPS_Question_Coverage $question_coverage;
+
 	// v4.0 admin shell.
 	public SWPS_User_Prefs $user_prefs;
 	public SWPS_Modules $modules;
@@ -338,6 +345,9 @@ final class StrataWP_SEO {
 			$this->rate_limiter
 		);
 		$this->aeo_editor_panel  = new SWPS_AEO_Editor_Panel( $this->aeo_scorer );
+
+		// Question coverage engine (v4.17) — weekly GSC question demand mining.
+		$this->question_coverage = new SWPS_Question_Coverage( $this->search_console, $this->topic_queue );
 
 		$this->competitors          = new SWPS_Competitors();
 		$this->local_seo            = new SWPS_Local_SEO();
@@ -1381,6 +1391,7 @@ function swps_deactivate(): void {
 	SWPS_Competitors::unschedule_cron();
 	SWPS_Backlinks::unschedule_cron();
 	wp_clear_scheduled_hook( 'swps_aeo_sweep_proposals' );
+	SWPS_Question_Coverage::unschedule_cron();
 	wp_unschedule_hook( 'swps_send_digest' );
 	flush_rewrite_rules();
 }

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -113,6 +113,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/aeo/class-markup-scorer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/aeo/class-authority-scorer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/aeo/class-coverage-scorer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-scorer.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-question-coverage.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-schema-generator.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-schema-migrator.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-optimizer.php';

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.16.0
+ * Version: 4.17.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.16.0' );
+define( 'SWPS_VERSION', '4.17.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/templates/aeo-page.php
+++ b/templates/aeo-page.php
@@ -70,6 +70,46 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</label>
 	</div>
 
+	<?php if ( ! empty( $question_candidates ) ) : ?>
+		<div class="swps-aeo-question-opportunities" id="swps-aeo-question-opportunities"
+			data-nonce="<?php echo esc_attr( wp_create_nonce( 'swps_question_coverage' ) ); ?>"
+			style="background:#fff;border:1px solid #c3c4c7;border-radius:4px;padding:12px 16px;margin:16px 0;">
+			<h2 style="margin:0 0 4px;font-size:14px;"><?php esc_html_e( 'Question opportunities', 'stratawp-seo' ); ?></h2>
+			<p class="description" style="margin:0 0 8px;">
+				<?php esc_html_e( 'Question searches from Google Search Console with no post answering them. Queue one to draft it.', 'stratawp-seo' ); ?>
+			</p>
+			<table class="widefat striped" style="border:0;">
+				<tbody>
+					<?php foreach ( $question_candidates as $swps_candidate ) : ?>
+						<?php
+						if ( ! is_array( $swps_candidate ) || empty( $swps_candidate['q'] ) ) {
+							continue;
+						}
+						?>
+						<tr>
+							<td><?php echo esc_html( (string) $swps_candidate['q'] ); ?></td>
+							<td style="text-align:right;color:#646970;width:120px;">
+								<?php
+								printf(
+									/* translators: %s: impression count from Search Console. */
+									esc_html__( '%s impressions', 'stratawp-seo' ),
+									esc_html( number_format_i18n( (int) ( $swps_candidate['impressions'] ?? 0 ) ) )
+								);
+								?>
+							</td>
+							<td style="text-align:right;width:110px;">
+								<button type="button" class="button button-small swps-queue-question-topic"
+									data-question="<?php echo esc_attr( (string) $swps_candidate['q'] ); ?>">
+									<?php esc_html_e( 'Queue topic', 'stratawp-seo' ); ?>
+								</button>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+		</div>
+	<?php endif; ?>
+
 	<table class="wp-list-table widefat striped swps-aeo-queue" id="swps-aeo-queue">
 		<thead>
 			<tr>

--- a/tests/aeo/CoverageScorerTest.php
+++ b/tests/aeo/CoverageScorerTest.php
@@ -9,7 +9,9 @@ final class CoverageScorerTest extends TestCase {
 	public function test_score_returns_0_to_100_from_ai_response(): void {
 		$provider = new FakeAIProvider();
 		$provider->next_response = array(
-			'coverage_gaps' => array( 'How to store sourdough' ),
+			'sub_queries'   => array(
+				array( 'q' => 'How to store sourdough', 'status' => 'missing' ),
+			),
 			'entity_issues' => array(),
 			'score'         => 72,
 		);
@@ -18,6 +20,43 @@ final class CoverageScorerTest extends TestCase {
 
 		$this->assertSame( 72, $result['score'] );
 		$this->assertCount( 1, $result['coverage_gaps'] );
+		$this->assertCount( 1, $result['sub_queries'] );
+		$this->assertSame( 'How to store sourdough', $result['sub_queries'][0]['q'] );
+		$this->assertSame( 'missing', $result['sub_queries'][0]['status'] );
+	}
+
+	public function test_sub_queries_answered_excluded_from_coverage_gaps(): void {
+		$provider = new FakeAIProvider();
+		$provider->next_response = array(
+			'sub_queries' => array(
+				array( 'q' => 'What is sourdough?',    'status' => 'answered' ),
+				array( 'q' => 'How to store it?',      'status' => 'missing' ),
+				array( 'q' => 'Best flour to use?',    'status' => 'partial' ),
+			),
+			'entity_issues' => array(),
+			'score'         => 60,
+		);
+		$scorer = new SWPS_AEO_Coverage_Scorer( $provider );
+		$result = $scorer->score( 'Sourdough basics', '<p>Body.</p>' );
+
+		// BC: coverage_gaps = only missing questions.
+		$this->assertCount( 1, $result['coverage_gaps'] );
+		$this->assertSame( 'How to store it?', $result['coverage_gaps'][0] );
+		// sub_queries includes all three.
+		$this->assertCount( 3, $result['sub_queries'] );
+	}
+
+	public function test_focus_keyword_included_in_prompt(): void {
+		$provider = new FakeAIProvider();
+		$provider->next_response = array(
+			'sub_queries'   => array(),
+			'entity_issues' => array(),
+			'score'         => 80,
+		);
+		$scorer = new SWPS_AEO_Coverage_Scorer( $provider );
+		$scorer->score( 'Bread baking', '<p>Body.</p>', 'sourdough starter' );
+
+		$this->assertStringContainsString( 'sourdough starter', $provider->last_user );
 	}
 
 	public function test_score_falls_back_on_provider_failure(): void {
@@ -28,12 +67,13 @@ final class CoverageScorerTest extends TestCase {
 
 		$this->assertNull( $result['score'] );
 		$this->assertSame( 'AI provider error', $result['error'] );
+		$this->assertSame( array(), $result['sub_queries'] );
 	}
 
 	public function test_score_clamps_out_of_range_values(): void {
 		$provider = new FakeAIProvider();
 		$provider->next_response = array(
-			'coverage_gaps' => array(),
+			'sub_queries'   => array(),
 			'entity_issues' => array(),
 			'score'         => 150,
 		);
@@ -46,7 +86,7 @@ final class CoverageScorerTest extends TestCase {
 	public function test_score_handles_missing_score_field(): void {
 		$provider = new FakeAIProvider();
 		$provider->next_response = array(
-			'coverage_gaps' => array(),
+			'sub_queries'   => array(),
 			'entity_issues' => array(),
 		);
 		$scorer = new SWPS_AEO_Coverage_Scorer( $provider );

--- a/tests/aeo/MarkupScorerTest.php
+++ b/tests/aeo/MarkupScorerTest.php
@@ -51,4 +51,19 @@ final class MarkupScorerTest extends TestCase {
 		$score_right = $this->scorer->score( $html_recipe, array( 'existing_schema' => 'Recipe',  'title' => 'My favorite cookies' ) );
 		$this->assertLessThan( $score_right, $score_wrong );
 	}
+
+	public function test_extract_headings_returns_heading_texts_and_body_questions(): void {
+		$html = '<h2>Choosing flour</h2><p>Use bread flour.</p>' .
+				'<h3>How much water?</h3><p>About 75% hydration.</p>' .
+				'<p>Can you freeze the dough?</p><p>Yes, after bulk.</p>';
+		$result = SWPS_AEO_Markup_Scorer::extract_headings( $html );
+		$this->assertContains( 'Choosing flour', $result );
+		$this->assertContains( 'How much water?', $result );
+		$this->assertContains( 'Can you freeze the dough?', $result );
+		$this->assertNotContains( 'Use bread flour.', $result );
+	}
+
+	public function test_extract_headings_empty_html_returns_empty(): void {
+		$this->assertSame( array(), SWPS_AEO_Markup_Scorer::extract_headings( '' ) );
+	}
 }

--- a/tests/unit/QuestionCoverageTest.php
+++ b/tests/unit/QuestionCoverageTest.php
@@ -1,8 +1,9 @@
 <?php
 /**
- * Tests for SWPS_Question_Coverage::format_gap_instruction().
+ * Tests for SWPS_Question_Coverage pure static helpers: format_gap_instruction,
+ * tokens_similar, questions_unanswered, format_unanswered_instruction.
  *
- * Pure-PHP, no WordPress. The formatter is the only public surface tested here.
+ * Pure-PHP, no WordPress.
  *
  * @package StrataWP_SEO
  */
@@ -12,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../../includes/class-question-coverage.php';
 
 /**
- * @covers SWPS_Question_Coverage::format_gap_instruction
+ * @covers SWPS_Question_Coverage
  */
 class QuestionCoverageTest extends TestCase {
 
@@ -112,5 +113,131 @@ class QuestionCoverageTest extends TestCase {
 		$result = SWPS_Question_Coverage::format_gap_instruction( $sub_queries );
 		// The instruction should direct the AI towards qa inserts.
 		$this->assertStringContainsStringIgnoringCase( 'qa', $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// tokens_similar
+	// -------------------------------------------------------------------------
+
+	public function test_tokens_similar_exact_match_is_one(): void {
+		$score = SWPS_Question_Coverage::tokens_similar(
+			'How long does sourdough last?',
+			'How long does sourdough last'
+		);
+		$this->assertSame( 1.0, $score );
+	}
+
+	public function test_tokens_similar_paraphrase_above_threshold(): void {
+		$score = SWPS_Question_Coverage::tokens_similar(
+			'how to store sourdough bread',
+			'Storing sourdough bread'
+		);
+		$this->assertGreaterThanOrEqual( 0.6, $score );
+	}
+
+	public function test_tokens_similar_unrelated_below_threshold(): void {
+		$score = SWPS_Question_Coverage::tokens_similar(
+			'best running shoes for marathons',
+			'sourdough starter feeding schedule'
+		);
+		$this->assertLessThan( 0.6, $score );
+	}
+
+	public function test_tokens_similar_empty_inputs_return_zero(): void {
+		$this->assertSame( 0.0, SWPS_Question_Coverage::tokens_similar( '', 'anything here' ) );
+		$this->assertSame( 0.0, SWPS_Question_Coverage::tokens_similar( 'anything here', '' ) );
+		$this->assertSame( 0.0, SWPS_Question_Coverage::tokens_similar( '', '' ) );
+	}
+
+	public function test_tokens_similar_stopword_robustness(): void {
+		// Stopwords ("what is the ... for") must not dilute the overlap.
+		$score = SWPS_Question_Coverage::tokens_similar(
+			'what is the best flour for sourdough',
+			'Best flour for sourdough'
+		);
+		$this->assertGreaterThanOrEqual( 0.6, $score );
+	}
+
+	public function test_tokens_similar_only_stopwords_returns_zero(): void {
+		$this->assertSame( 0.0, SWPS_Question_Coverage::tokens_similar( 'what is the', 'how do I' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// questions_unanswered
+	// -------------------------------------------------------------------------
+
+	public function test_questions_unanswered_excludes_matched_heading(): void {
+		$questions = array( 'how long does sourdough last' );
+		$headings  = array( 'How long does sourdough last?' );
+		$this->assertSame( array(), SWPS_Question_Coverage::questions_unanswered( $questions, $headings ) );
+	}
+
+	public function test_questions_unanswered_includes_unmatched_question(): void {
+		$questions = array( 'can you freeze sourdough starter' );
+		$headings  = array( 'Choosing the right flour', 'Bulk fermentation timing' );
+		$result    = SWPS_Question_Coverage::questions_unanswered( $questions, $headings );
+		$this->assertSame( $questions, $result );
+	}
+
+	public function test_questions_unanswered_empty_headings_returns_all(): void {
+		$questions = array( 'q one here', 'q two here' );
+		$this->assertSame( $questions, SWPS_Question_Coverage::questions_unanswered( $questions, array() ) );
+	}
+
+	public function test_questions_unanswered_empty_questions_returns_empty(): void {
+		$this->assertSame( array(), SWPS_Question_Coverage::questions_unanswered( array(), array( 'A heading' ) ) );
+	}
+
+	public function test_questions_unanswered_mixed(): void {
+		$questions = array(
+			'how long does sourdough last',
+			'can you freeze sourdough starter',
+		);
+		$headings = array( 'How long does sourdough last?' );
+		$result   = SWPS_Question_Coverage::questions_unanswered( $questions, $headings );
+		$this->assertSame( array( 'can you freeze sourdough starter' ), $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// format_unanswered_instruction
+	// -------------------------------------------------------------------------
+
+	public function test_format_unanswered_empty_returns_empty_string(): void {
+		$this->assertSame( '', SWPS_Question_Coverage::format_unanswered_instruction( array() ) );
+	}
+
+	public function test_format_unanswered_contains_question_and_impressions(): void {
+		$result = SWPS_Question_Coverage::format_unanswered_instruction( array(
+			array(
+				'q'           => 'how long does sourdough last',
+				'impressions' => 420,
+			),
+		) );
+		$this->assertStringContainsString( 'how long does sourdough last', $result );
+		$this->assertStringContainsString( '420', $result );
+		$this->assertStringContainsStringIgnoringCase( 'qa', $result );
+	}
+
+	public function test_format_unanswered_cap_respected(): void {
+		$questions = array();
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$questions[] = array(
+				'q'           => "question number {$i}",
+				'impressions' => 100 - $i,
+			);
+		}
+		$result = SWPS_Question_Coverage::format_unanswered_instruction( $questions, 3 );
+		$this->assertStringContainsString( 'question number 3', $result );
+		$this->assertStringNotContainsString( 'question number 4', $result );
+	}
+
+	public function test_format_unanswered_mentions_search_console_source(): void {
+		$result = SWPS_Question_Coverage::format_unanswered_instruction( array(
+			array(
+				'q'           => 'real searcher question',
+				'impressions' => 10,
+			),
+		) );
+		$this->assertStringContainsStringIgnoringCase( 'search console', $result );
 	}
 }

--- a/tests/unit/QuestionCoverageTest.php
+++ b/tests/unit/QuestionCoverageTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tests for SWPS_Question_Coverage::format_gap_instruction().
+ *
+ * Pure-PHP, no WordPress. The formatter is the only public surface tested here.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-question-coverage.php';
+
+/**
+ * @covers SWPS_Question_Coverage::format_gap_instruction
+ */
+class QuestionCoverageTest extends TestCase {
+
+	// -------------------------------------------------------------------------
+	// format_gap_instruction — empty input
+	// -------------------------------------------------------------------------
+
+	public function test_empty_sub_queries_returns_empty_string(): void {
+		$result = SWPS_Question_Coverage::format_gap_instruction( array() );
+		$this->assertSame( '', $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// format_gap_instruction — answered excluded
+	// -------------------------------------------------------------------------
+
+	public function test_answered_sub_queries_excluded(): void {
+		$sub_queries = array(
+			array( 'q' => 'What is sourdough?', 'status' => 'answered' ),
+			array( 'q' => 'How to store it?',   'status' => 'answered' ),
+		);
+		$result = SWPS_Question_Coverage::format_gap_instruction( $sub_queries );
+		$this->assertSame( '', $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// format_gap_instruction — missing prioritised over partial
+	// -------------------------------------------------------------------------
+
+	public function test_missing_listed_before_partial(): void {
+		$sub_queries = array(
+			array( 'q' => 'Partial question one?', 'status' => 'partial' ),
+			array( 'q' => 'Missing question one?', 'status' => 'missing' ),
+			array( 'q' => 'Missing question two?', 'status' => 'missing' ),
+			array( 'q' => 'Partial question two?', 'status' => 'partial' ),
+		);
+		$result = SWPS_Question_Coverage::format_gap_instruction( $sub_queries );
+		$pos_missing = strpos( $result, 'Missing question one?' );
+		$pos_partial = strpos( $result, 'Partial question one?' );
+		$this->assertNotFalse( $pos_missing );
+		$this->assertNotFalse( $pos_partial );
+		$this->assertLessThan( $pos_partial, $pos_missing );
+	}
+
+	// -------------------------------------------------------------------------
+	// format_gap_instruction — cap respected
+	// -------------------------------------------------------------------------
+
+	public function test_cap_limits_output(): void {
+		$sub_queries = array(
+			array( 'q' => 'Q1?', 'status' => 'missing' ),
+			array( 'q' => 'Q2?', 'status' => 'missing' ),
+			array( 'q' => 'Q3?', 'status' => 'missing' ),
+			array( 'q' => 'Q4?', 'status' => 'missing' ),
+			array( 'q' => 'Q5?', 'status' => 'missing' ),
+		);
+		$result = SWPS_Question_Coverage::format_gap_instruction( $sub_queries, 3 );
+		$this->assertStringContainsString( 'Q1?', $result );
+		$this->assertStringContainsString( 'Q2?', $result );
+		$this->assertStringContainsString( 'Q3?', $result );
+		$this->assertStringNotContainsString( 'Q4?', $result );
+		$this->assertStringNotContainsString( 'Q5?', $result );
+	}
+
+	public function test_default_cap_is_three(): void {
+		$sub_queries = array(
+			array( 'q' => 'A1?', 'status' => 'missing' ),
+			array( 'q' => 'A2?', 'status' => 'missing' ),
+			array( 'q' => 'A3?', 'status' => 'missing' ),
+			array( 'q' => 'A4?', 'status' => 'missing' ),
+		);
+		$result = SWPS_Question_Coverage::format_gap_instruction( $sub_queries );
+		$this->assertStringNotContainsString( 'A4?', $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// format_gap_instruction — only partial questions present
+	// -------------------------------------------------------------------------
+
+	public function test_partial_only_produces_output(): void {
+		$sub_queries = array(
+			array( 'q' => 'Partial only?', 'status' => 'partial' ),
+		);
+		$result = SWPS_Question_Coverage::format_gap_instruction( $sub_queries );
+		$this->assertNotSame( '', $result );
+		$this->assertStringContainsString( 'Partial only?', $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// format_gap_instruction — result contains a qa-insert instruction hint
+	// -------------------------------------------------------------------------
+
+	public function test_result_contains_qa_instruction(): void {
+		$sub_queries = array(
+			array( 'q' => 'How long does it last?', 'status' => 'missing' ),
+		);
+		$result = SWPS_Question_Coverage::format_gap_instruction( $sub_queries );
+		// The instruction should direct the AI towards qa inserts.
+		$this->assertStringContainsStringIgnoringCase( 'qa', $result );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -37,6 +37,7 @@ $swps_cron_hooks = array(
 	'swps_aeo_sweep_proposals',
 	'swps_send_digest',
 	'swps_citation_check',
+	'swps_question_mine',
 );
 
 foreach ( $swps_cron_hooks as $swps_cron_hook ) {


### PR DESCRIPTION
## Summary
**Phase A — the dormant Coverage dimension is now live:**
- The fully-built-but-never-invoked Coverage scorer now runs during explicit AEO scans/scores (gated on the existing `swps_aeo_coverage_enabled` setting, default off), with a rewritten fan-out prompt returning the 5–10 sub-questions an answer engine would decompose the topic into, each marked answered / partial / missing
- Payload cached in post meta with the existing content-hash invalidation — re-renders never trigger AI calls; the Coverage sub-score finally shows a number instead of a dash
- Editor metabox shows the sub-question checklist (✓/◐/✗); missing/partial questions are injected into `do_propose()` as capped Q&A-insert instructions (existing `kind:"qa"` + FAQPage pipeline)
- H2+H3 outline extraction (review fix)

**Phase B — Search Console question demand mining:**
- New paginated `get_query_page_rows()` (query+page dimensions, startRow loop, 12h cache, no-op when GSC unconnected)
- Weekly cron mines question-form queries (reuses the citation tracker's TDD'd classifier), maps pages→posts, and flags questions a post doesn't answer via heading extraction + fuzzy token-overlap matching (TDD'd) — stored per post (≤10, with impressions), shown in the editor panel, and fed into AEO proposals (top 3)
- Site-wide uncovered questions (non-post pages or ranking >20) become "Question opportunities" on the AEO page with one-click **Queue topic**

26 new unit tests (suite at 243); PHPStan/PHPCS clean; live smoke on jonimms.local (formatter, fuzzy matcher, cron scheduled, GSC-unconnected no-op). Version 4.17.0.

## Review trail
Phase A spec review + final whole-branch review (Phase B reviewed there). Final fixes: H3 outline extraction, stale candidates cleared on empty mining runs. One reviewer finding rejected with live evidence: `weekly` IS a core cron schedule since WP 5.4 (verified via `wp_get_schedules()` on the live site — the miner cron is scheduled and the plugin floor is WP 6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)