### PR TITLE
feat: content decay watchdog with reviewed one-click AI refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO content generator that knows your WordPress site.** Generate optimized blog posts with internal linking, structured data, sitemaps, redirects, AI-crawler access control, llms.txt, on-site analytics, GSC integration, a per-post meta editor, **Local SEO** (LocalBusiness schema with NAP and opening hours), **Image SEO** (auto-alt + filename sanitization + lazy-load), **Crawlers & Files** (in-admin editor for /llms.txt and /robots.txt), and **Backlinks** (manual/CSV-import tracker with daily health monitoring) — on autopilot or on demand.
 
-[![Version](https://img.shields.io/badge/version-4.17.0-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.18.0-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1446,6 +1446,10 @@ Only if you choose **Replace** mode — that serves your content verbatim with n
 ---
 
 ## Changelog
+
+### v4.18.0 — June 2026
+- **Content decay watchdog** — weekly GSC scan compares rolling 28-day windows per post, flags decays past your threshold with a heuristic cause (position drop / demand drop / CTR drop / staleness), with cooldowns, a minimum-impressions floor, and a one-email summary alert for top posts
+- **Refresh Queue** — flagged posts ranked by traffic at risk, with clicks/AEO-score sparklines and one-click AI refresh proposals that always go through the reviewed AEO apply/undo flow
 
 ### v4.17.0 — June 2026
 - **Question coverage engine** — the AEO Coverage dimension is now live: one AI call per scored post builds a query fan-out checklist (the 5–10 sub-questions an answer engine would decompose your topic into, marked answered / partial / missing) with content-hash caching

--- a/docs/superpowers/plans/2026-06-10-decay-watchdog.md
+++ b/docs/superpowers/plans/2026-06-10-decay-watchdog.md
@@ -1,0 +1,63 @@
+# Content Decay & Freshness Watchdog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A weekly cron compares each post's GSC clicks/impressions/position across rolling 28-day windows, flags posts past a configurable decline threshold (default 20% clicks, minimum-impressions floor, per-post cooldown), classifies the likely cause heuristically (position drop / demand drop / CTR-at-stable-position / staleness), and queues them in a Refresh Queue with one-click AI refresh through the existing AEO propose/apply/undo pipeline (forced diff review — never blind apply). Per-post metric + AEO-score history powers sparklines; a wp_mail alert fires when a top-traffic post decays.
+
+**Architecture:** New `SWPS_Decay_Watchdog` (cron, detection, classification, alert) + `SWPS_Metric_History` (one generic history table: post_id, metric VARCHAR(32), date, value FLOAT; UNIQUE (post_id, metric, date); used for gsc_clicks/gsc_impressions/gsc_position/aeo_score) + `SWPS_Refresh_Queue_Admin` (page cloning the Auto-Optimize queue UI, AJAX propose/apply/undo passthrough with a refresh-specific prompt addition). Pure, TDD'd: decay math + cause classification.
+
+**Branch:** `feature/decay-watchdog` off origin/main (bc6132c, v4.17.0). Version → 4.18.0. House conventions (require-with-call-site, <500 lines, tabs/WPCS, nonce+cap AJAX, null-safe wpdb, gates + jonimms.local smoke, no push/PR by implementers, no Co-Authored-By).
+
+---
+
+## Verified facts (origin/main bc6132c)
+
+- `SWPS_Search_Console::fetch_analytics( $property, $start, $end, $dimensions )` is PRIVATE, rowLimit 100 (:506,516); `get_query_page_rows( $days, $row_limit )` (added in 4.17.0) already does paginated query+page fetches — read it; for decay we need PAGE-dimension rows for two explicit windows: add public `get_page_metrics( string $start, string $end, int $row_limit = 1000 ): array` (dimensions ['page'], startRow pagination, transient 12h keyed by window) returning page → {clicks, impressions, ctr, position}.
+- `SWPS_AEO_Optimizer::do_propose(365)/do_apply(472)/do_undo(597)` public; apply goes through wp_update_post (revisions + dateModified update for free). The propose prompt already accepts appended context (coverage + citation precedents append paragraphs before the filter).
+- Authority freshness: `SWPS_AEO_Authority_Scorer::is_fresh()` private (modified <12mo or published <24mo) — expose minimally or recompute (it's two timestamps — just recompute in the watchdog; do NOT change the scorer).
+- Bot crawl deltas: `swps_bot_hits_daily` (bot_key, post_id, date, hits) — optional classification signal when bot analytics enabled.
+- Auto-Optimize queue UI precedent: `SWPS_Auto_Optimize` page (add_submenu_page :48, get_queue :174, build_queue_row :693, templates/auto-optimize-page.php + its JS) — read all before cloning.
+- wp_mail precedent: digest's guarded try/catch wp_mail (trait-digest-send.php).
+- AEO score meta `_swps_aeo_score`; URL→post mapping caveats as in prior features (url_to_postid, skip non-posts).
+- History table precedent: keyword tracker / citation store DDL + DB_VERSION upgrade pattern.
+
+## Pure logic (TDD first — tests/unit/DecayWatchdogTest.php)
+
+```php
+	/**
+	 * Decay verdict for one post given two 28d windows of GSC metrics.
+	 *
+	 * @param array $recent  {clicks, impressions, position(avg, lower=better), ctr}
+	 * @param array $prior   same shape
+	 * @param array $opts    {threshold: 0.2, min_impressions: 200}
+	 * @return array{decayed: bool, click_change: float, reason: string}
+	 *   reason ∈ position_drop | demand_drop | ctr_drop | unknown — only when decayed.
+	 */
+	public static function assess( array $recent, array $prior, array $opts = array() ): array
+```
+Rules: not decayed when prior impressions < min_impressions (sample floor) or prior clicks == 0; decayed when clicks decline ≥ threshold. Cause: position_drop when position worsened ≥ 3 spots; demand_drop when impressions fell ≥ threshold while position stable (<3 worse); ctr_drop when CTR fell ≥ threshold at stable position and stable impressions; else unknown. Plus `staleness_flags( int $published, int $modified, string $html ): array` (not_fresh per the 12/24-month rule, no_current_year mention — reuse a cheap regex, don't call the scorer). ~12 test cases incl. boundary threshold, floor, divide-safety.
+
+## Tasks (two dispatches)
+
+### Dispatch 1: history + detection core
+1. `SWPS_Metric_History` (table + DB_VERSION upgrade + activation + uninstall entry + prune >400 days in the cron): `record( int $post_id, string $metric, string $date, float $value )` (upsert), `series( int $post_id, string $metric, int $days )`, `bulk_record` for the cron.
+2. Pure helpers TDD on `SWPS_Decay_Watchdog`.
+3. Weekly cron `swps_decay_scan` (core 'weekly' schedule — it exists since WP 5.4; schedule/unschedule/deactivation/uninstall wiring per house pattern): GSC-connected guard (clean no-op otherwise); fetch recent (last 28d) + prior (29-56d) page metrics; map to posts; `bulk_record` clicks/impressions/position (recent window, dated today) + current `_swps_aeo_score` snapshot; run `assess` per post; for decayed posts NOT in cooldown (post meta `_swps_decay_flagged` < 28 days ago) write meta `_swps_decay` = {reason, click_change, recent, prior, staleness, flagged_at} + set cooldown meta; clear `_swps_decay` for posts no longer decayed. Alert: if any flagged post is in the site's top-10 by recent clicks → ONE summary wp_mail (digest-style guarded, recipients = digest recipients option fallback admin_email, suppressible via option `swps_decay_email` default on).
+4. Settings (small section, registered by the watchdog, into the 'seo' tab… read get_settings_tabs and pick 'analytics' — report): threshold %, min impressions, email toggle.
+
+### Dispatch 2: Refresh Queue UI + release
+5. `SWPS_Refresh_Queue_Admin`: submenu "Refresh Queue" under stratawp-seo (read Auto-Optimize's registration/assets and clone the structure): table of flagged posts sorted by traffic-at-risk (prior clicks × click_change), columns: post, reason badge (labeled "heuristic"), clicks then/now, AEO score sparkline (inline SVG from `series(post_id,'aeo_score',180)` + clicks sparkline), staleness chips, actions: Propose refresh → AJAX calling `do_propose` with an appended refresh instruction ("update outdated facts/years cautiously — never invent statistics; add an 'Updated' note; refresh the TL;DR"), then REUSE the AEO review UI flow if feasible (read how aeo-page JS renders proposals; if reuse is >50 lines of glue, deep-link to the AEO page with focus_post instead and note it — apply/undo must ALWAYS go through the existing reviewed-diff flow, never auto-apply), Dismiss (clears `_swps_decay`, sets cooldown).
+6. Editor metabox line when `_swps_decay` present (decay reason + flagged date) following the existing metabox-line precedents.
+7. Wiring, gates (phpunit/phpstan 2G/phpcs), jonimms.local smoke (instantiate, assess() fixtures, history record/series roundtrip, cron handler no-op without GSC), version 4.18.0 + changelogs:
+```
+= 4.18.0 =
+* New: Content decay watchdog — weekly Search Console scan flags posts losing clicks (28-day windows, configurable threshold), classifies the likely cause, tracks metric + AEO-score history with sparklines, emails you when a top post decays, and queues one-click AI refresh proposals through the reviewed AEO apply/undo pipeline.
+```
+Commits per task group + plan doc. No push/PR.
+
+## Self-review
+1. GSC calls only from cron/explicit actions; unconnected = silent no-op everywhere?
+2. Refresh NEVER auto-applies — propose → human-reviewed diff → apply/undo only?
+3. Cooldown + floor prevent alert/queue spam; email is one summary, not per-post?
+4. History table pruned; all new options/meta swps_-prefixed (uninstall wildcard)?
+5. Classification UI always labeled heuristic?

--- a/includes/class-aeo-editor-panel.php
+++ b/includes/class-aeo-editor-panel.php
@@ -145,6 +145,22 @@ class SWPS_AEO_Editor_Panel {
 				</p>
 			<?php endif; ?>
 			<?php
+			// Decay watchdog line (set by the weekly swps_decay_scan cron).
+			$decay = get_post_meta( $post->ID, '_swps_decay', true );
+			if ( is_array( $decay ) && ! empty( $decay['reason'] ) ) :
+				?>
+				<p class="description swps-aeo-decay-line" style="margin-top:6px;font-size:11px;color:#b32d2e;">
+					<?php
+					printf(
+						/* translators: 1: heuristic cause label, 2: date flagged. */
+						esc_html__( 'Traffic decay flagged %2$s (likely cause, heuristic: %1$s) — see the Refresh Queue.', 'stratawp-seo' ),
+						esc_html( SWPS_Refresh_Queue_Admin::reason_label( (string) $decay['reason'] ) ),
+						esc_html( wp_date( get_option( 'date_format' ), (int) ( $decay['flagged_at'] ?? time() ) ) )
+					);
+					?>
+				</p>
+			<?php endif; ?>
+			<?php
 			// Question coverage checklist — rendered from cached meta only (zero AI on render).
 			$coverage_payload = get_post_meta( $post->ID, SWPS_AEO_Scorer::META_COVERAGE_PAYLOAD, true );
 			if ( is_array( $coverage_payload ) && ! empty( $coverage_payload['sub_queries'] ) ) :

--- a/includes/class-aeo-optimizer.php
+++ b/includes/class-aeo-optimizer.php
@@ -408,6 +408,14 @@ class SWPS_AEO_Optimizer {
 			}
 		}
 
+		// Refresh-queue context: when the decay watchdog staged a refresh for
+		// this post (15-min transient), steer the proposal toward freshness.
+		$refresh_key = 'swps_refresh_ctx_' . $post_id;
+		if ( get_transient( $refresh_key ) ) {
+			delete_transient( $refresh_key );
+			$user .= "\n\n" . __( 'This post is losing search traffic. Prioritize a freshness refresh: update outdated facts and year references cautiously - never invent statistics or data; add a brief updated note near the top; refresh the TL;DR/summary if present.', 'stratawp-seo' );
+		}
+
 		$result = $this->ai_provider->chat_json( $system, $user, 4096 );
 		if ( is_wp_error( $result ) ) {
 			return array( 'error' => $result->get_error_message(), 'http_status' => 500 );

--- a/includes/class-aeo-optimizer.php
+++ b/includes/class-aeo-optimizer.php
@@ -410,7 +410,7 @@ class SWPS_AEO_Optimizer {
 
 		// Refresh-queue context: when the decay watchdog staged a refresh for
 		// this post (15-min transient), steer the proposal toward freshness.
-		$refresh_key = 'swps_refresh_ctx_' . $post_id;
+		$refresh_key = SWPS_Refresh_Queue_Admin::CTX_TRANSIENT_PREFIX . $post_id;
 		if ( get_transient( $refresh_key ) ) {
 			delete_transient( $refresh_key );
 			$user .= "\n\n" . __( 'This post is losing search traffic. Prioritize a freshness refresh: update outdated facts and year references cautiously - never invent statistics or data; add a brief updated note near the top; refresh the TL;DR/summary if present.', 'stratawp-seo' );

--- a/includes/class-decay-watchdog.php
+++ b/includes/class-decay-watchdog.php
@@ -1,0 +1,494 @@
+<?php
+/**
+ * Content Decay Watchdog — weekly GSC scan, per-post decay detection,
+ * cause classification, cooldown meta, and summary email alert.
+ *
+ * Pure static helpers (assess / staleness_flags) are unit-tested with no
+ * WordPress dependency. The cron handler and settings registration require WP.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Decay detection, cause classification, and weekly scan cron.
+ */
+class SWPS_Decay_Watchdog {
+
+	public const CRON_HOOK    = 'swps_decay_scan';
+	public const META_DECAY   = '_swps_decay';
+	public const META_FLAGGED = '_swps_decay_flagged';
+
+	/** Cooldown window: skip re-flagging a post within this many seconds (28 days). */
+	private const COOLDOWN = 2419200; // 28 * DAY_IN_SECONDS.
+
+	/** Default click-decline threshold (fraction). */
+	private const DEFAULT_THRESHOLD = 0.20;
+
+	/** Default minimum prior-window impressions before a post is evaluated. */
+	private const DEFAULT_MIN_IMPRESSIONS = 200;
+
+	/** Recent window: last N days. */
+	private const WINDOW_RECENT = 28;
+
+	/** Prior window offset from "today − 1": prior starts here many days back (29–56d ago). */
+	private const WINDOW_PRIOR_START = 56;
+
+	/**
+	 * GSC client.
+	 *
+	 * @var SWPS_Search_Console
+	 */
+	private SWPS_Search_Console $search_console;
+
+	/**
+	 * Metric history store.
+	 *
+	 * @var SWPS_Metric_History
+	 */
+	private SWPS_Metric_History $history;
+
+	/**
+	 * Wire cron action and register settings on admin_init.
+	 *
+	 * @param SWPS_Search_Console $search_console GSC client.
+	 * @param SWPS_Metric_History $history        Metric history store.
+	 */
+	public function __construct(
+		SWPS_Search_Console $search_console,
+		SWPS_Metric_History $history
+	) {
+		$this->search_console = $search_console;
+		$this->history        = $history;
+
+		add_action( self::CRON_HOOK, array( $this, 'run_scan' ) );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+	}
+
+	// --- Pure static helpers (unit-tested, no WP required) ---
+
+	/**
+	 * Assess decay verdict for one post given two 28-day GSC windows.
+	 *
+	 * @param array $recent {clicks: int, impressions: int, position: float, ctr: float}.
+	 * @param array $prior  Same shape as $recent.
+	 * @param array $opts   {threshold: float (default 0.20), min_impressions: int (default 200)}.
+	 * @return array{decayed: bool, click_change: float, reason: string}
+	 *   reason is '' when not decayed; one of position_drop | demand_drop | ctr_drop | unknown when decayed.
+	 */
+	public static function assess( array $recent, array $prior, array $opts = array() ): array {
+		$threshold       = isset( $opts['threshold'] ) ? (float) $opts['threshold'] : self::DEFAULT_THRESHOLD;
+		$min_impressions = isset( $opts['min_impressions'] ) ? (int) $opts['min_impressions'] : self::DEFAULT_MIN_IMPRESSIONS;
+
+		$not_decayed = array(
+			'decayed'      => false,
+			'click_change' => 0.0,
+			'reason'       => '',
+		);
+
+		// Sample floor: skip posts without meaningful prior traffic data.
+		if ( (int) ( $prior['impressions'] ?? 0 ) < $min_impressions ) {
+			return $not_decayed;
+		}
+
+		// Divide-safety: can't measure decline when prior had no clicks.
+		if ( (int) ( $prior['clicks'] ?? 0 ) === 0 ) {
+			return $not_decayed;
+		}
+
+		$prior_clicks  = (float) $prior['clicks'];
+		$recent_clicks = (float) ( $recent['clicks'] ?? 0 );
+
+		$click_change = ( $prior_clicks - $recent_clicks ) / $prior_clicks;
+
+		if ( $click_change < $threshold ) {
+			return $not_decayed;
+		}
+
+		// Post is decayed — classify cause.
+		$reason = self::classify_cause( $recent, $prior, $threshold );
+
+		return array(
+			'decayed'      => true,
+			'click_change' => $click_change,
+			'reason'       => $reason,
+		);
+	}
+
+	/**
+	 * Classify the likely cause of a confirmed decay event.
+	 *
+	 * Called only when clicks have already declined ≥ threshold.
+	 *
+	 * @param array $recent See assess().
+	 * @param array $prior  See assess().
+	 * @param float $threshold Configured threshold fraction.
+	 * @return string One of position_drop | demand_drop | ctr_drop | unknown.
+	 */
+	private static function classify_cause( array $recent, array $prior, float $threshold ): string {
+		$recent_pos = (float) ( $recent['position'] ?? 0.0 );
+		$prior_pos  = (float) ( $prior['position'] ?? 0.0 );
+		$pos_delta  = $recent_pos - $prior_pos; // positive = worsened (higher number = worse rank).
+
+		// Position worsened by ≥ 3 spots → most likely cause.
+		if ( $pos_delta >= 3.0 ) {
+			return 'position_drop';
+		}
+
+		// Position is stable (< 3 spots worse); check impressions for demand drop.
+		$prior_imp  = (float) ( $prior['impressions'] ?? 1.0 );
+		$recent_imp = (float) ( $recent['impressions'] ?? 0.0 );
+
+		if ( $prior_imp > 0.0 ) {
+			$imp_decline = ( $prior_imp - $recent_imp ) / $prior_imp;
+			if ( $imp_decline >= $threshold ) {
+				return 'demand_drop';
+			}
+		}
+
+		// Impressions stable; check CTR at stable position.
+		$prior_ctr  = (float) ( $prior['ctr'] ?? 0.0 );
+		$recent_ctr = (float) ( $recent['ctr'] ?? 0.0 );
+
+		if ( $prior_ctr > 0.0 ) {
+			$ctr_decline = ( $prior_ctr - $recent_ctr ) / $prior_ctr;
+			if ( $ctr_decline >= $threshold ) {
+				return 'ctr_drop';
+			}
+		}
+
+		return 'unknown';
+	}
+
+	/**
+	 * Return an array of staleness flags for a post.
+	 *
+	 * Recomputes the authority-freshness rule inline (modified <12mo OR
+	 * published <24mo = fresh) to avoid coupling to SWPS_AEO_Authority_Scorer.
+	 *
+	 * @param int    $published Unix timestamp of post publish date.
+	 * @param int    $modified  Unix timestamp of post last-modified date.
+	 * @param string $html      Post HTML content.
+	 * @return string[] Zero or more of: 'not_fresh', 'no_current_year'.
+	 */
+	public static function staleness_flags( int $published, int $modified, string $html ): array {
+		$flags = array();
+
+		$now       = time();
+		$twelve_mo = 12 * 30 * DAY_IN_SECONDS;
+		$twoyr_mo  = 24 * 30 * DAY_IN_SECONDS;
+
+		// not_fresh: modified > 12 months ago AND published > 24 months ago.
+		if ( ( $now - $modified ) > $twelve_mo && ( $now - $published ) > $twoyr_mo ) {
+			$flags[] = 'not_fresh';
+		}
+
+		// no_current_year: content contains no mention of the current year.
+		$current_year = (string) gmdate( 'Y' );
+		if ( false === strpos( $html, $current_year ) ) {
+			$flags[] = 'no_current_year';
+		}
+
+		return $flags;
+	}
+
+	// --- Cron handler ---
+
+	/**
+	 * Weekly scan: fetch GSC page metrics for two windows, assess decay,
+	 * write post meta, prune cleared posts, and fire alert email if needed.
+	 */
+	public function run_scan(): void {
+		if ( ! $this->search_console->is_connected() ) {
+			return;
+		}
+
+		$threshold       = (float) get_option( 'swps_decay_threshold', self::DEFAULT_THRESHOLD );
+		$min_impressions = (int) get_option( 'swps_decay_min_impressions', self::DEFAULT_MIN_IMPRESSIONS );
+		$opts            = array(
+			'threshold'       => $threshold,
+			'min_impressions' => $min_impressions,
+		);
+
+		// Build date windows.
+		// GSC has a ~2-day data delay, so anchor to 3 days ago for safety.
+		$anchor       = strtotime( '-3 days' );
+		$recent_end   = gmdate( 'Y-m-d', $anchor );
+		$recent_start = gmdate( 'Y-m-d', $anchor - ( self::WINDOW_RECENT * DAY_IN_SECONDS ) + DAY_IN_SECONDS );
+
+		$prior_end   = gmdate( 'Y-m-d', $anchor - self::WINDOW_RECENT * DAY_IN_SECONDS );
+		$prior_start = gmdate( 'Y-m-d', $anchor - self::WINDOW_PRIOR_START * DAY_IN_SECONDS + DAY_IN_SECONDS );
+
+		$recent_rows = $this->search_console->get_page_metrics( $recent_start, $recent_end );
+		$prior_rows  = $this->search_console->get_page_metrics( $prior_start, $prior_end );
+
+		if ( empty( $recent_rows ) ) {
+			return;
+		}
+
+		$today   = gmdate( 'Y-m-d' );
+		$now     = time();
+		$flagged = array();
+
+		// Build prior index keyed by URL.
+		$prior_index = array();
+		foreach ( $prior_rows as $url => $data ) {
+			$prior_index[ $url ] = $data;
+		}
+
+		// Collect bulk records for metric history.
+		$bulk = array();
+
+		foreach ( $recent_rows as $url => $data ) {
+			$post_id = url_to_postid( $url );
+			if ( ! $post_id ) {
+				continue;
+			}
+
+			// Snapshot metrics to history.
+			$bulk[] = array( $post_id, 'gsc_clicks',      $today, (float) $data['clicks'] );
+			$bulk[] = array( $post_id, 'gsc_impressions',  $today, (float) $data['impressions'] );
+			$bulk[] = array( $post_id, 'gsc_position',    $today, (float) $data['position'] );
+
+			$aeo_score = (float) get_post_meta( $post_id, '_swps_aeo_score', true );
+			$bulk[]    = array( $post_id, 'aeo_score', $today, $aeo_score );
+
+			// Skip posts without prior data.
+			if ( ! isset( $prior_index[ $url ] ) ) {
+				continue;
+			}
+
+			$prior  = $prior_index[ $url ];
+			$result = self::assess( $data, $prior, $opts );
+
+			if ( $result['decayed'] ) {
+				// Apply cooldown: skip posts flagged within the last 28 days.
+				$last_flagged = (int) get_post_meta( $post_id, self::META_FLAGGED, true );
+				if ( $last_flagged && ( $now - $last_flagged ) < self::COOLDOWN ) {
+					continue;
+				}
+
+				// Compute staleness.
+				$post      = get_post( $post_id );
+				$pub_ts    = $post ? (int) strtotime( $post->post_date_gmt ) : 0;
+				$mod_ts    = $post ? (int) strtotime( $post->post_modified_gmt ) : 0;
+				$content   = $post ? (string) $post->post_content : '';
+				$staleness = self::staleness_flags( $pub_ts, $mod_ts, $content );
+
+				$payload = array(
+					'reason'       => $result['reason'],
+					'click_change' => $result['click_change'],
+					'recent'       => $data,
+					'prior'        => $prior,
+					'staleness'    => $staleness,
+					'flagged_at'   => $now,
+				);
+
+				update_post_meta( $post_id, self::META_DECAY, $payload );
+				update_post_meta( $post_id, self::META_FLAGGED, $now );
+
+				$flagged[ $post_id ] = array_merge( $payload, array( 'url' => $url ) );
+
+			} else {
+				// Clear decay meta for posts that have recovered.
+				delete_post_meta( $post_id, self::META_DECAY );
+			}
+		}
+
+		// Bulk-record metrics.
+		if ( ! empty( $bulk ) ) {
+			$this->history->bulk_record( $bulk );
+		}
+
+		// Prune history rows older than 400 days.
+		$this->history->prune( 400 );
+
+		// Fire alert email when flagged post is in the site's top-10 by recent clicks.
+		if ( ! empty( $flagged ) ) {
+			$this->maybe_send_alert( $flagged, $recent_rows );
+		}
+	}
+
+	/**
+	 * Send a summary alert email when a flagged post appears in the top-10
+	 * by recent-window clicks.
+	 *
+	 * @param array $flagged      Map of post_id → decay payload (with url).
+	 * @param array $recent_rows  Full recent GSC page-metrics indexed by URL.
+	 */
+	private function maybe_send_alert( array $flagged, array $recent_rows ): void {
+		if ( ! (bool) get_option( 'swps_decay_email', 1 ) ) {
+			return;
+		}
+
+		// Sort all recent URLs by clicks descending to find top-10.
+		uasort(
+			$recent_rows,
+			static function ( $a, $b ) {
+				return (int) ( $b['clicks'] ?? 0 ) - (int) ( $a['clicks'] ?? 0 );
+			}
+		);
+
+		$top10_urls = array_keys( array_slice( $recent_rows, 0, 10, true ) );
+
+		$alert_posts = array();
+		foreach ( $flagged as $post_id => $payload ) {
+			if ( in_array( $payload['url'], $top10_urls, true ) ) {
+				$alert_posts[ $post_id ] = $payload;
+			}
+		}
+
+		if ( empty( $alert_posts ) ) {
+			return;
+		}
+
+		// Determine recipients: fall back to digest recipients, then admin email.
+		$recipients_raw = (string) get_option( 'swps_digest_recipients', '' );
+		if ( $recipients_raw ) {
+			$recipients = array_filter( array_map( 'trim', explode( "\n", $recipients_raw ) ) );
+		} else {
+			$recipients = array( get_option( 'admin_email' ) );
+		}
+
+		$subject = sprintf(
+			/* translators: %s: site name */
+			__( '[%s] Content decay alert — top pages losing traffic', 'stratawp-seo' ),
+			get_bloginfo( 'name' )
+		);
+
+		$lines = array();
+		foreach ( $alert_posts as $post_id => $payload ) {
+			$title   = get_the_title( $post_id );
+			$pct     = round( $payload['click_change'] * 100 );
+			$reason  = $payload['reason'];
+			$lines[] = sprintf( '- %s: -%d%% clicks (%s)', $title, $pct, $reason );
+		}
+
+		$body = sprintf(
+			/* translators: 1: site name, 2: newline-separated list of posts */
+			__( "Content decay detected on %1\$s.\n\nThe following top-traffic posts have lost significant clicks in the past 28 days:\n\n%2\$s\n\nLog in to StrataWP SEO to review and queue refresh proposals.", 'stratawp-seo' ),
+			get_bloginfo( 'name' ),
+			implode( "\n", $lines )
+		);
+
+		try {
+			wp_mail( $recipients, $subject, $body );
+		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Silent fail — email is advisory, not critical.
+			unset( $e );
+		}
+	}
+
+	// --- Cron schedule / unschedule ---
+
+	/**
+	 * Schedule the weekly scan cron event. Called from activation hook.
+	 */
+	public static function schedule_cron(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'weekly', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Unschedule the weekly scan cron event. Called from deactivation hook.
+	 */
+	public static function unschedule_cron(): void {
+		wp_clear_scheduled_hook( self::CRON_HOOK );
+	}
+
+	// --- Settings ---
+
+	/**
+	 * Register the decay watchdog settings section and fields on the
+	 * 'analytics' settings tab.
+	 */
+	public function register_settings(): void {
+		add_settings_section(
+			'swps_decay_section',
+			__( 'Content Decay Watchdog', 'stratawp-seo' ),
+			array( $this, 'render_section_intro' ),
+			'stratawp-seo'
+		);
+
+		register_setting( 'stratawp-seo', 'swps_decay_threshold', array( 'sanitize_callback' => array( $this, 'sanitize_threshold' ) ) );
+		register_setting( 'stratawp-seo', 'swps_decay_min_impressions', array( 'sanitize_callback' => 'absint' ) );
+		register_setting( 'stratawp-seo', 'swps_decay_email', array( 'sanitize_callback' => 'absint' ) );
+
+		add_settings_field(
+			'swps_decay_threshold',
+			__( 'Click decline threshold', 'stratawp-seo' ),
+			array( $this, 'render_threshold_field' ),
+			'stratawp-seo',
+			'swps_decay_section',
+			array( 'label_for' => 'swps_decay_threshold' )
+		);
+
+		add_settings_field(
+			'swps_decay_min_impressions',
+			__( 'Minimum impressions (prior window)', 'stratawp-seo' ),
+			array( $this, 'render_min_impressions_field' ),
+			'stratawp-seo',
+			'swps_decay_section',
+			array( 'label_for' => 'swps_decay_min_impressions' )
+		);
+
+		add_settings_field(
+			'swps_decay_email',
+			__( 'Decay alert email', 'stratawp-seo' ),
+			array( $this, 'render_email_toggle_field' ),
+			'stratawp-seo',
+			'swps_decay_section',
+			array( 'label_for' => 'swps_decay_email' )
+		);
+	}
+
+	/**
+	 * Sanitize threshold: must be a float in (0, 1].
+	 *
+	 * @param mixed $val Raw input.
+	 * @return float Sanitized value, clamped to [0.01, 1.0].
+	 */
+	public function sanitize_threshold( mixed $val ): float {
+		$f = (float) $val / 100.0; // Input is expected as a percentage (e.g. 20 → 0.20).
+		return max( 0.01, min( 1.0, $f ) );
+	}
+
+	/** Section intro text. */
+	public function render_section_intro(): void {
+		echo '<p>' . esc_html__( 'Weekly Search Console comparison across rolling 28-day windows. Posts that lose clicks beyond the threshold are queued for refresh.', 'stratawp-seo' ) . '</p>';
+	}
+
+	/** Threshold field. */
+	public function render_threshold_field(): void {
+		$val = (float) get_option( 'swps_decay_threshold', self::DEFAULT_THRESHOLD );
+		printf(
+			'<input type="number" id="swps_decay_threshold" name="swps_decay_threshold" value="%s" min="1" max="100" step="1" class="small-text" /> %%',
+			esc_attr( (string) round( $val * 100 ) )
+		);
+		echo ' <p class="description">' . esc_html__( 'Flag a post when its click count drops by at least this percentage (default 20%).', 'stratawp-seo' ) . '</p>';
+	}
+
+	/** Min impressions field. */
+	public function render_min_impressions_field(): void {
+		$val = (int) get_option( 'swps_decay_min_impressions', self::DEFAULT_MIN_IMPRESSIONS );
+		printf(
+			'<input type="number" id="swps_decay_min_impressions" name="swps_decay_min_impressions" value="%s" min="0" step="50" class="small-text" />',
+			esc_attr( (string) $val )
+		);
+		echo ' <p class="description">' . esc_html__( 'Ignore posts with fewer than this many impressions in the prior 28 days (default 200).', 'stratawp-seo' ) . '</p>';
+	}
+
+	/** Email toggle field. */
+	public function render_email_toggle_field(): void {
+		$checked = (bool) get_option( 'swps_decay_email', 1 );
+		printf(
+			'<label><input type="checkbox" id="swps_decay_email" name="swps_decay_email" value="1" %s /> %s</label>',
+			checked( $checked, true, false ),
+			esc_html__( 'Send a summary email when a top-10 post decays (uses digest recipients)', 'stratawp-seo' )
+		);
+	}
+}

--- a/includes/class-metric-history.php
+++ b/includes/class-metric-history.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Generic per-post metric history table.
+ *
+ * Stores one row per (post_id, metric, date) — suitable for gsc_clicks,
+ * gsc_impressions, gsc_position, aeo_score, and future metrics.
+ *
+ * DDL:
+ *   CREATE TABLE {prefix}swps_metric_history (
+ *     id   BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+ *     post_id BIGINT UNSIGNED NOT NULL,
+ *     metric  VARCHAR(32)    NOT NULL,
+ *     date    DATE           NOT NULL,
+ *     value   FLOAT          NOT NULL DEFAULT 0,
+ *     PRIMARY KEY (id),
+ *     UNIQUE KEY idx_post_metric_date (post_id, metric, date),
+ *     KEY idx_post_metric (post_id, metric)
+ *   );
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Persistence layer for swps_metric_history rows.
+ */
+class SWPS_Metric_History {
+
+	/** Schema version — bump when DDL changes. */
+	public const DB_VERSION = '1';
+
+	/** Option key used to gate the schema upgrade. */
+	public const OPT_DB_VER = 'swps_metric_history_db_version';
+
+	/** Table name (without $wpdb->prefix). */
+	private const TABLE = 'swps_metric_history';
+
+	/**
+	 * Create (or upgrade) the metric history table.
+	 * Called on activation and via maybe_upgrade().
+	 */
+	public static function create_table(): void {
+		global $wpdb;
+
+		$charset = $wpdb->get_charset_collate();
+		$table   = $wpdb->prefix . self::TABLE;
+
+		$sql = "CREATE TABLE {$table} (
+			id      BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+			post_id BIGINT UNSIGNED NOT NULL,
+			metric  VARCHAR(32) NOT NULL,
+			date    DATE NOT NULL,
+			value   FLOAT NOT NULL DEFAULT 0,
+			PRIMARY KEY (id),
+			UNIQUE KEY idx_post_metric_date (post_id, metric, date),
+			KEY idx_post_metric (post_id, metric)
+		) {$charset};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Ensure the table exists for installs updated without reactivation.
+	 */
+	public static function maybe_upgrade(): void {
+		if ( self::DB_VERSION !== get_option( self::OPT_DB_VER ) ) {
+			self::create_table();
+			update_option( self::OPT_DB_VER, self::DB_VERSION );
+		}
+	}
+
+	/**
+	 * Insert or update a single metric value for a given post and date.
+	 *
+	 * Re-running for the same (post_id, metric, date) overwrites the value.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $metric  Metric name (e.g. 'gsc_clicks').
+	 * @param string $date    Date string 'Y-m-d'.
+	 * @param float  $value   Metric value.
+	 */
+	public function record( int $post_id, string $metric, string $date, float $value ): void {
+		global $wpdb;
+
+		$table = $wpdb->prefix . self::TABLE;
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO {$table} (post_id, metric, date, value)
+				 VALUES (%d, %s, %s, %f)
+				 ON DUPLICATE KEY UPDATE value = VALUES(value)",
+				$post_id,
+				$metric,
+				$date,
+				$value
+			)
+		);
+		// phpcs:enable
+	}
+
+	/**
+	 * Upsert multiple rows in a single query for efficiency.
+	 *
+	 * @param array $rows Each element: [post_id (int), metric (string), date (string), value (float)].
+	 */
+	public function bulk_record( array $rows ): void {
+		if ( empty( $rows ) ) {
+			return;
+		}
+
+		global $wpdb;
+
+		$table        = $wpdb->prefix . self::TABLE;
+		$placeholders = array();
+		$values       = array();
+
+		foreach ( $rows as $row ) {
+			$placeholders[] = '(%d, %s, %s, %f)';
+			$values[]       = (int) $row[0];
+			$values[]       = (string) $row[1];
+			$values[]       = (string) $row[2];
+			$values[]       = (float) $row[3];
+		}
+
+		$sql = "INSERT INTO {$table} (post_id, metric, date, value) VALUES "
+			. implode( ', ', $placeholders )
+			. ' ON DUPLICATE KEY UPDATE value = VALUES(value)';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( $wpdb->prepare( $sql, $values ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:enable
+	}
+
+	/**
+	 * Return an ordered time-series array for a given post and metric.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $metric  Metric name.
+	 * @param int    $days    How many days back to look (from today).
+	 * @return array<int, array{date: string, value: float}> Ascending date order.
+	 */
+	public function series( int $post_id, string $metric, int $days ): array {
+		global $wpdb;
+
+		$table  = $wpdb->prefix . self::TABLE;
+		$cutoff = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT date, value
+				 FROM {$table}
+				 WHERE post_id = %d AND metric = %s AND date >= %s
+				 ORDER BY date ASC",
+				$post_id,
+				$metric,
+				$cutoff
+			),
+			ARRAY_A
+		);
+		// phpcs:enable
+
+		if ( ! is_array( $rows ) ) {
+			return array();
+		}
+
+		return array_map(
+			static function ( array $row ): array {
+				return array(
+					'date'  => $row['date'],
+					'value' => (float) $row['value'],
+				);
+			},
+			$rows
+		);
+	}
+
+	/**
+	 * Delete rows older than the given number of days.
+	 *
+	 * Called by the decay watchdog cron after bulk_record to keep the table lean.
+	 *
+	 * @param int $days Rows older than this many days are removed (e.g. 400).
+	 */
+	public function prune( int $days ): void {
+		global $wpdb;
+
+		$table  = $wpdb->prefix . self::TABLE;
+		$cutoff = gmdate( 'Y-m-d', strtotime( "-{$days} days" ) );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$table} WHERE date < %s",
+				$cutoff
+			)
+		);
+		// phpcs:enable
+	}
+}

--- a/includes/class-refresh-queue-admin.php
+++ b/includes/class-refresh-queue-admin.php
@@ -246,7 +246,7 @@ class SWPS_Refresh_Queue_Admin {
 		}
 
 		$post_id = absint( $_POST['post_id'] ?? 0 );
-		if ( ! $post_id ) {
+		if ( ! $post_id || ! get_post( $post_id ) ) {
 			wp_send_json_error( array( 'message' => __( 'Invalid post ID.', 'stratawp-seo' ) ) );
 		}
 

--- a/includes/class-refresh-queue-admin.php
+++ b/includes/class-refresh-queue-admin.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Refresh Queue — admin page listing decay-flagged posts with sparklines and
+ * a one-click path into the reviewed AEO propose/apply/undo pipeline.
+ *
+ * "Propose refresh" sets a short-lived transient (swps_refresh_ctx_{post_id})
+ * then deep-links to the AEO Optimize page with ?focus_post=N. The AEO page's
+ * own propose flow runs SWPS_AEO_Optimizer::do_propose(), which reads the
+ * transient and appends the refresh instruction to the prompt. Apply/undo
+ * always go through the existing reviewed-diff flow — never auto-applied.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Admin surface for the content decay refresh queue.
+ */
+class SWPS_Refresh_Queue_Admin {
+
+	public const NONCE = 'swps_refresh_queue';
+
+	/** Transient prefix read by SWPS_AEO_Optimizer::do_propose(). */
+	public const CTX_TRANSIENT_PREFIX = 'swps_refresh_ctx_';
+
+	/** Transient lifetime: long enough to land on the AEO page and propose. */
+	private const CTX_TTL = 900; // 15 minutes.
+
+	/**
+	 * Refresh instruction appended to the AEO propose prompt.
+	 * Conservative by design: never invent data, always reviewed before apply.
+	 */
+	public const REFRESH_INSTRUCTION =
+		'REFRESH CONTEXT: This post was flagged for content decay (declining search clicks). ' .
+		'Prioritize freshness: update outdated facts and year references cautiously — NEVER invent statistics or data; ' .
+		"add a short 'Updated' note near the top; refresh the TL;DR/summary if present. " .
+		'Prefer minimal, verifiable changes over rewrites.';
+
+	/**
+	 * Metric history store (sparkline series).
+	 *
+	 * @var SWPS_Metric_History
+	 */
+	private SWPS_Metric_History $history;
+
+	/**
+	 * Wire menu, assets, and AJAX handlers.
+	 *
+	 * @param SWPS_Metric_History $history Metric history store.
+	 */
+	public function __construct( SWPS_Metric_History $history ) {
+		$this->history = $history;
+
+		add_action( 'admin_menu', array( $this, 'register_menu' ), 21 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'wp_ajax_swps_refresh_propose', array( $this, 'ajax_propose' ) );
+		add_action( 'wp_ajax_swps_refresh_dismiss', array( $this, 'ajax_dismiss' ) );
+	}
+
+	/**
+	 * Enqueue jQuery for the inline page script.
+	 *
+	 * @param string $hook Current admin page hook.
+	 */
+	public function enqueue_assets( string $hook ): void {
+		if ( 'stratawp-seo_page_swps-refresh-queue' !== $hook ) {
+			return;
+		}
+		wp_enqueue_script( 'jquery' );
+	}
+
+	/**
+	 * Register the Refresh Queue submenu page.
+	 */
+	public function register_menu(): void {
+		add_submenu_page(
+			'stratawp-seo',
+			__( 'Refresh Queue', 'stratawp-seo' ),
+			__( 'Refresh Queue', 'stratawp-seo' ),
+			'manage_options',
+			'swps-refresh-queue',
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Render the queue page.
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Unauthorized.', 'stratawp-seo' ) );
+		}
+		require SWPS_PLUGIN_DIR . 'templates/refresh-queue-page.php';
+	}
+
+	// --- Queue ---
+
+	/**
+	 * Posts currently flagged for decay, sorted by traffic-at-risk
+	 * (prior-window clicks × click-change fraction, descending).
+	 *
+	 * @return array<int, array<string, mixed>> Queue rows.
+	 */
+	public function get_queue(): array {
+		$posts = get_posts(
+			array(
+				'post_type'      => array( 'post', 'page' ),
+				'post_status'    => 'publish',
+				'posts_per_page' => 100,
+				'meta_key'       => SWPS_Decay_Watchdog::META_DECAY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			)
+		);
+
+		$rows = array();
+
+		foreach ( $posts as $post ) {
+			$decay = get_post_meta( $post->ID, SWPS_Decay_Watchdog::META_DECAY, true );
+			if ( ! is_array( $decay ) || empty( $decay['reason'] ) ) {
+				continue;
+			}
+
+			$prior_clicks  = (int) ( $decay['prior']['clicks'] ?? 0 );
+			$recent_clicks = (int) ( $decay['recent']['clicks'] ?? 0 );
+			$click_change  = (float) ( $decay['click_change'] ?? 0 );
+
+			$clicks_series = array_map(
+				static fn( array $p ): float => $p['value'],
+				$this->history->series( $post->ID, 'gsc_clicks', 180 )
+			);
+			$aeo_series    = array_map(
+				static fn( array $p ): float => $p['value'],
+				$this->history->series( $post->ID, 'aeo_score', 180 )
+			);
+
+			$rows[] = array(
+				'post_id'         => $post->ID,
+				'title'           => $post->post_title,
+				'edit_url'        => get_edit_post_link( $post->ID, 'raw' ),
+				'permalink'       => get_permalink( $post->ID ),
+				'reason'          => (string) $decay['reason'],
+				'click_change'    => $click_change,
+				'prior_clicks'    => $prior_clicks,
+				'recent_clicks'   => $recent_clicks,
+				'staleness'       => (array) ( $decay['staleness'] ?? array() ),
+				'flagged_at'      => (int) ( $decay['flagged_at'] ?? 0 ),
+				'traffic_at_risk' => $prior_clicks * abs( $click_change ),
+				'clicks_svg'      => self::sparkline( $clicks_series ),
+				'aeo_svg'         => self::sparkline( $aeo_series ),
+			);
+		}
+
+		usort( $rows, static fn( array $a, array $b ): int => $b['traffic_at_risk'] <=> $a['traffic_at_risk'] );
+
+		return $rows;
+	}
+
+	// --- Sparkline (pure static, unit-tested) ---
+
+	/**
+	 * Build a tiny inline SVG sparkline polyline from a value series.
+	 *
+	 * Returns '' when fewer than two points (nothing to draw). A flat series
+	 * renders as a horizontal midline. Coordinates are rounded to 2 decimals.
+	 *
+	 * @param float[] $values Ordered series values.
+	 * @param int     $w      SVG width (viewBox units).
+	 * @param int     $h      SVG height (viewBox units).
+	 * @return string SVG markup or empty string.
+	 */
+	public static function sparkline( array $values, int $w = 120, int $h = 28 ): string {
+		$values = array_values( array_map( 'floatval', $values ) );
+		$n      = count( $values );
+		if ( $n < 2 ) {
+			return '';
+		}
+
+		$pad   = 2.0;
+		$min   = min( $values );
+		$max   = max( $values );
+		$range = $max - $min;
+
+		$points = array();
+		foreach ( $values as $i => $v ) {
+			$x = $pad + ( $i / ( $n - 1 ) ) * ( $w - 2 * $pad );
+			if ( $range > 0.0 ) {
+				$y = $pad + ( 1 - ( $v - $min ) / $range ) * ( $h - 2 * $pad );
+			} else {
+				$y = $h / 2;
+			}
+			$points[] = round( $x, 2 ) . ',' . round( $y, 2 );
+		}
+
+		return sprintf(
+			'<svg viewBox="0 0 %1$d %2$d" width="%1$d" height="%2$d" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">'
+			. '<polyline fill="none" stroke="currentColor" stroke-width="1.5" points="%3$s"/></svg>',
+			$w,
+			$h,
+			implode( ' ', $points )
+		);
+	}
+
+	// --- AJAX ---
+
+	/**
+	 * Prepare a refresh proposal: set the refresh-context transient and return
+	 * the AEO deep-link. The AEO page's focus_post flow performs the actual
+	 * do_propose() call (one AI call, existing reviewed-diff modal).
+	 */
+	public function ajax_propose(): void {
+		check_ajax_referer( self::NONCE, 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+
+		$post_id = absint( $_POST['post_id'] ?? 0 );
+		if ( ! $post_id || ! get_post( $post_id ) ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid post ID.', 'stratawp-seo' ) ) );
+		}
+
+		set_transient( self::CTX_TRANSIENT_PREFIX . $post_id, 1, self::CTX_TTL );
+
+		$redirect = add_query_arg(
+			array(
+				'page'       => 'swps-aeo-optimize',
+				'focus_post' => $post_id,
+			),
+			admin_url( 'admin.php' )
+		);
+
+		wp_send_json_success( array( 'redirect' => $redirect ) );
+	}
+
+	/**
+	 * Dismiss a flagged post: clear the decay payload and start the cooldown
+	 * so the next scan does not immediately re-flag it.
+	 */
+	public function ajax_dismiss(): void {
+		check_ajax_referer( self::NONCE, 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+
+		$post_id = absint( $_POST['post_id'] ?? 0 );
+		if ( ! $post_id ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid post ID.', 'stratawp-seo' ) ) );
+		}
+
+		delete_post_meta( $post_id, SWPS_Decay_Watchdog::META_DECAY );
+		update_post_meta( $post_id, SWPS_Decay_Watchdog::META_FLAGGED, time() );
+
+		wp_send_json_success();
+	}
+
+	// --- Labels ---
+
+	/**
+	 * Human label for a decay reason code.
+	 *
+	 * @param string $reason Reason code from assess().
+	 * @return string Translated label.
+	 */
+	public static function reason_label( string $reason ): string {
+		switch ( $reason ) {
+			case 'position_drop':
+				return __( 'Ranking dropped', 'stratawp-seo' );
+			case 'demand_drop':
+				return __( 'Search demand fell', 'stratawp-seo' );
+			case 'ctr_drop':
+				return __( 'CTR fell', 'stratawp-seo' );
+			default:
+				return __( 'Cause unclear', 'stratawp-seo' );
+		}
+	}
+
+	/**
+	 * Human label for a staleness flag code.
+	 *
+	 * @param string $flag Flag from staleness_flags().
+	 * @return string Translated label.
+	 */
+	public static function staleness_label( string $flag ): string {
+		switch ( $flag ) {
+			case 'not_fresh':
+				return __( 'Not updated in 12+ months', 'stratawp-seo' );
+			case 'no_current_year':
+				return __( 'No current-year mention', 'stratawp-seo' );
+			default:
+				return $flag;
+		}
+	}
+}

--- a/includes/class-search-console.php
+++ b/includes/class-search-console.php
@@ -495,6 +495,90 @@ class SWPS_Search_Console {
 	}
 
 	/**
+	 * Fetch per-page GSC metrics for an explicit date window.
+	 *
+	 * Returns an associative array keyed by page URL; each value is an array
+	 * with keys: clicks (int), impressions (int), ctr (float), position (float).
+	 * Results are transient-cached for 12 hours keyed on window + row_limit.
+	 *
+	 * @param string $start     Start date 'Y-m-d'.
+	 * @param string $end       End date 'Y-m-d'.
+	 * @param int    $row_limit Maximum rows to fetch (default 1000, max 25000 per batch).
+	 * @return array<string, array{clicks: int, impressions: int, ctr: float, position: float}>
+	 */
+	public function get_page_metrics( string $start, string $end, int $row_limit = 1000 ): array {
+		if ( ! $this->is_connected() ) {
+			return array();
+		}
+
+		$row_limit = max( 1, $row_limit );
+		$cache_key = self::CACHE_PREFIX . 'page_metrics_' . md5( $start . '_' . $end . '_' . $row_limit );
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return (array) $cached;
+		}
+
+		$property         = $this->get_property();
+		$encoded_property = rawurlencode( $property );
+
+		$raw_rows  = array();
+		$row_count = 0;
+		$start_row = 0;
+
+		while ( $row_count < $row_limit ) {
+			$batch_size = min( 25000, $row_limit - $row_count );
+			$response   = $this->api_request(
+				"/sites/{$encoded_property}/searchAnalytics/query",
+				'POST',
+				array(
+					'startDate'  => $start,
+					'endDate'    => $end,
+					'dimensions' => array( 'page' ),
+					'rowLimit'   => $batch_size,
+					'startRow'   => $start_row,
+				)
+			);
+
+			if ( is_wp_error( $response ) ) {
+				break;
+			}
+
+			$batch = $response['rows'] ?? array();
+			if ( empty( $batch ) ) {
+				break;
+			}
+
+			$batch_count = count( $batch );
+			$raw_rows    = array_merge( $raw_rows, $batch );
+			$row_count  += $batch_count;
+			$start_row  += $batch_count;
+
+			if ( $batch_count < $batch_size ) {
+				break;
+			}
+		}
+
+		// Re-index by page URL.
+		$result = array();
+		foreach ( $raw_rows as $row ) {
+			$url = $row['keys'][0] ?? '';
+			if ( '' === $url ) {
+				continue;
+			}
+			$result[ $url ] = array(
+				'clicks'      => (int)   ( $row['clicks']      ?? 0 ),
+				'impressions' => (int)   ( $row['impressions']  ?? 0 ),
+				'ctr'         => (float) ( $row['ctr']          ?? 0.0 ),
+				'position'    => (float) ( $row['position']     ?? 0.0 ),
+			);
+		}
+
+		set_transient( $cache_key, $result, self::CACHE_TTL );
+
+		return $result;
+	}
+
+	/**
 	 * Fetch search analytics from GSC API.
 	 *
 	 * @param string $property   Site URL.

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1634,6 +1634,7 @@ class SWPS_Settings {
 				'sections' => array(
 					'swps_analytics_section',
 					'swps_digest_section',
+					'swps_decay_section',
 				),
 			),
 			'aeo'             => array(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.17.0
+Stable tag: 4.18.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -293,6 +293,9 @@ No. GSC integration is optional. The on-site analytics works entirely without an
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.18.0 =
+* New: Content decay watchdog — weekly Search Console scan flags posts losing clicks (28-day windows, configurable threshold), classifies the likely cause, tracks metric + AEO-score history with sparklines, emails you when a top post decays, and queues one-click AI refresh proposals through the reviewed AEO apply/undo pipeline.
 
 = 4.17.0 =
 * New: Question coverage engine — the AEO Coverage dimension is now live (query fan-out sub-question checklist per post), and Search Console question mining surfaces real searcher questions your posts don't answer, feeding Q&A inserts into AEO proposals and topic suggestions into the queue.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -114,6 +114,8 @@ require_once SWPS_PLUGIN_DIR . 'includes/aeo/class-authority-scorer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/aeo/class-coverage-scorer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-scorer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-question-coverage.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-metric-history.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-decay-watchdog.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-schema-generator.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-schema-migrator.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-optimizer.php';
@@ -264,6 +266,20 @@ final class StrataWP_SEO {
 	 */
 	public SWPS_Question_Coverage $question_coverage;
 
+	/**
+	 * Generic per-post metric history store (v4.18).
+	 *
+	 * @var SWPS_Metric_History
+	 */
+	public SWPS_Metric_History $metric_history;
+
+	/**
+	 * Content decay watchdog — weekly cron, detection, and email alert (v4.18).
+	 *
+	 * @var SWPS_Decay_Watchdog
+	 */
+	public SWPS_Decay_Watchdog $decay_watchdog;
+
 	// v4.0 admin shell.
 	public SWPS_User_Prefs $user_prefs;
 	public SWPS_Modules $modules;
@@ -348,6 +364,11 @@ final class StrataWP_SEO {
 
 		// Question coverage engine (v4.17) — weekly GSC question demand mining.
 		$this->question_coverage = new SWPS_Question_Coverage( $this->search_console, $this->topic_queue );
+
+		// Content decay watchdog (v4.18) — weekly scan, metric history, email alert.
+		SWPS_Metric_History::maybe_upgrade();
+		$this->metric_history  = new SWPS_Metric_History();
+		$this->decay_watchdog  = new SWPS_Decay_Watchdog( $this->search_console, $this->metric_history );
 
 		$this->competitors          = new SWPS_Competitors();
 		$this->local_seo            = new SWPS_Local_SEO();
@@ -1357,6 +1378,9 @@ function swps_activate(): void {
 	SWPS_Citation_Store::create_table();
 	update_option( SWPS_Citation_Store::OPT_DB_VER, SWPS_Citation_Store::DB_VERSION );
 	SWPS_Citation_Tracker::schedule_cron();
+	SWPS_Metric_History::create_table();
+	update_option( SWPS_Metric_History::OPT_DB_VER, SWPS_Metric_History::DB_VERSION );
+	SWPS_Decay_Watchdog::schedule_cron();
 
 	SWPS_Redirect_Manager::create_tables();
 	SWPS_Link_Keyword_Engine::create_tables();
@@ -1392,6 +1416,7 @@ function swps_deactivate(): void {
 	SWPS_Backlinks::unschedule_cron();
 	wp_clear_scheduled_hook( 'swps_aeo_sweep_proposals' );
 	SWPS_Question_Coverage::unschedule_cron();
+	SWPS_Decay_Watchdog::unschedule_cron();
 	wp_unschedule_hook( 'swps_send_digest' );
 	flush_rewrite_rules();
 }

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.17.0
+ * Version: 4.18.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.17.0' );
+define( 'SWPS_VERSION', '4.18.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -116,6 +116,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-scorer.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-question-coverage.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-metric-history.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-decay-watchdog.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-refresh-queue-admin.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-schema-generator.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-schema-migrator.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-aeo-optimizer.php';
@@ -279,6 +280,7 @@ final class StrataWP_SEO {
 	 * @var SWPS_Decay_Watchdog
 	 */
 	public SWPS_Decay_Watchdog $decay_watchdog;
+	public SWPS_Refresh_Queue_Admin $refresh_queue_admin;
 
 	// v4.0 admin shell.
 	public SWPS_User_Prefs $user_prefs;
@@ -369,6 +371,7 @@ final class StrataWP_SEO {
 		SWPS_Metric_History::maybe_upgrade();
 		$this->metric_history  = new SWPS_Metric_History();
 		$this->decay_watchdog  = new SWPS_Decay_Watchdog( $this->search_console, $this->metric_history );
+		$this->refresh_queue_admin   = new SWPS_Refresh_Queue_Admin( $this->metric_history );
 
 		$this->competitors          = new SWPS_Competitors();
 		$this->local_seo            = new SWPS_Local_SEO();

--- a/templates/refresh-queue-page.php
+++ b/templates/refresh-queue-page.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Refresh Queue page — decay-flagged posts sorted by traffic-at-risk.
+ *
+ * Wrapped by SWPS_Admin_Shell. Clones the Auto-Optimize page structure
+ * (page-header partial + .swps-row-card list). All data comes from post meta
+ * and the metric history table — zero GSC/AI calls on render.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Refresh Queue admin page template.
+ *
+ * @var SWPS_Refresh_Queue_Admin $swps_rq
+ */
+$swps_rq    = stratawp_seo()->refresh_queue_admin;
+$swps_queue = $swps_rq->get_queue();
+?>
+<div class="wrap swps-refresh-queue-wrap">
+
+	<?php
+	// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited, WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- template-scoped vars consumed by the page-header partial.
+	$title    = __( 'Refresh Queue', 'stratawp-seo' );
+	$subtitle = __( 'Posts losing search clicks, flagged by the weekly decay scan. Cause labels are heuristic. "Propose refresh" opens the AEO review flow — every AI edit is shown as a diff and applied only on your approval.', 'stratawp-seo' );
+	$actions  = array();
+	require SWPS_PLUGIN_DIR . 'templates/partials/page-header.php';
+	// phpcs:enable
+	?>
+
+	<div class="swps-summary-tiles">
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Flagged posts', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-grad"><?php echo (int) count( $swps_queue ); ?></div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'losing clicks vs prior 28 days', 'stratawp-seo' ); ?></div>
+		</div>
+		<div class="swps-summary-tile">
+			<div class="swps-summary-tile-h"><?php esc_html_e( 'Clicks at risk', 'stratawp-seo' ); ?></div>
+			<div class="swps-summary-tile-num is-warn"><?php echo (int) round( array_sum( array_column( $swps_queue, 'traffic_at_risk' ) ) ); ?></div>
+			<div class="swps-summary-tile-foot"><?php esc_html_e( 'prior clicks × decline', 'stratawp-seo' ); ?></div>
+		</div>
+	</div>
+
+	<div class="swps-refresh-queue" id="swps-refresh-queue">
+		<?php if ( empty( $swps_queue ) ) : ?>
+			<div class="swps-row-card swps-refresh-empty">
+				<p><?php esc_html_e( 'No decayed posts. The weekly scan flags posts whose Search Console clicks drop past the threshold (Settings → Analytics → Content Decay Watchdog).', 'stratawp-seo' ); ?></p>
+			</div>
+		<?php else : ?>
+			<?php foreach ( $swps_queue as $swps_row ) : ?>
+				<div class="swps-row-card swps-refresh-row" data-post-id="<?php echo (int) $swps_row['post_id']; ?>">
+					<div class="swps-row-head">
+						<div class="swps-status-dot swps-status-dot-warn">!</div>
+						<div>
+							<div class="swps-row-head-name">
+								<a href="<?php echo esc_url( $swps_row['edit_url'] ); ?>" target="_blank" rel="noopener"><?php echo esc_html( $swps_row['title'] ); ?></a>
+								<span class="swps-refresh-reason-badge" style="margin-left:6px;padding:2px 8px;border-radius:10px;font-size:10px;background:#fcf0f1;color:#b32d2e;"
+									title="<?php esc_attr_e( 'Heuristic classification — verify before acting.', 'stratawp-seo' ); ?>">
+									<?php echo esc_html( SWPS_Refresh_Queue_Admin::reason_label( $swps_row['reason'] ) ); ?>
+									<em>(<?php esc_html_e( 'heuristic', 'stratawp-seo' ); ?>)</em>
+								</span>
+							</div>
+							<div class="swps-row-head-msg">
+								<?php
+								printf(
+									/* translators: 1: prior-window clicks, 2: recent-window clicks, 3: decline percent. */
+									esc_html__( 'Clicks: %1$d → %2$d (−%3$d%%)', 'stratawp-seo' ),
+									(int) $swps_row['prior_clicks'],
+									(int) $swps_row['recent_clicks'],
+									(int) round( $swps_row['click_change'] * 100 )
+								);
+								?>
+								<?php if ( $swps_row['flagged_at'] > 0 ) : ?>
+									&middot;
+									<?php
+									printf(
+										/* translators: %s: human time diff. */
+										esc_html__( 'flagged %s ago', 'stratawp-seo' ),
+										esc_html( human_time_diff( $swps_row['flagged_at'], time() ) )
+									);
+									?>
+								<?php endif; ?>
+								&middot; <a href="<?php echo esc_url( $swps_row['permalink'] ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'View', 'stratawp-seo' ); ?></a>
+								<?php foreach ( $swps_row['staleness'] as $swps_flag ) : ?>
+									<span class="swps-refresh-stale-chip" style="margin-left:6px;padding:1px 6px;border-radius:8px;font-size:10px;background:#fef8ee;color:#996800;">
+										<?php echo esc_html( SWPS_Refresh_Queue_Admin::staleness_label( (string) $swps_flag ) ); ?>
+									</span>
+								<?php endforeach; ?>
+							</div>
+							<div class="swps-refresh-sparklines" style="display:flex;gap:16px;margin-top:6px;font-size:10px;color:#666;">
+								<?php if ( '' !== $swps_row['clicks_svg'] ) : ?>
+									<span style="color:#2271b1;" title="<?php esc_attr_e( 'GSC clicks, last 180 days', 'stratawp-seo' ); ?>">
+										<?php esc_html_e( 'Clicks', 'stratawp-seo' ); ?>
+										<?php echo $swps_row['clicks_svg']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- SVG built by sparkline() from float data only. ?>
+									</span>
+								<?php endif; ?>
+								<?php if ( '' !== $swps_row['aeo_svg'] ) : ?>
+									<span style="color:#00a32a;" title="<?php esc_attr_e( 'AEO score, last 180 days', 'stratawp-seo' ); ?>">
+										<?php esc_html_e( 'AEO', 'stratawp-seo' ); ?>
+										<?php echo $swps_row['aeo_svg']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- SVG built by sparkline() from float data only. ?>
+									</span>
+								<?php endif; ?>
+							</div>
+						</div>
+						<div class="swps-row-head-meta">
+							<button class="swps-btn swps-btn-grad swps-refresh-propose" data-id="<?php echo (int) $swps_row['post_id']; ?>" style="padding:6px 12px;font-size:11px">
+								<?php esc_html_e( 'Propose refresh', 'stratawp-seo' ); ?>
+							</button>
+							<button class="swps-btn swps-btn-secondary swps-refresh-dismiss" data-id="<?php echo (int) $swps_row['post_id']; ?>" title="<?php esc_attr_e( 'Dismiss (28-day cooldown)', 'stratawp-seo' ); ?>" style="padding:6px 10px;font-size:11px">
+								<span class="dashicons dashicons-no-alt"></span>
+							</button>
+						</div>
+					</div>
+				</div>
+			<?php endforeach; ?>
+		<?php endif; ?>
+	</div>
+</div>
+
+<script>
+( function( $ ) {
+	var nonce = <?php echo wp_json_encode( wp_create_nonce( SWPS_Refresh_Queue_Admin::NONCE ) ); ?>;
+	var ajaxUrl = <?php echo wp_json_encode( admin_url( 'admin-ajax.php' ) ); ?>;
+
+	$( document ).on( 'click', '.swps-refresh-propose', function() {
+		var $btn = $( this );
+		$btn.prop( 'disabled', true ).text( <?php echo wp_json_encode( __( 'Preparing…', 'stratawp-seo' ) ); ?> );
+		$.post( ajaxUrl, {
+			action: 'swps_refresh_propose',
+			nonce: nonce,
+			post_id: $btn.data( 'id' )
+		} ).done( function( resp ) {
+			if ( resp && resp.success && resp.data.redirect ) {
+				window.location = resp.data.redirect;
+			} else {
+				$btn.prop( 'disabled', false ).text( <?php echo wp_json_encode( __( 'Propose refresh', 'stratawp-seo' ) ); ?> );
+				window.alert( ( resp && resp.data && resp.data.message ) || <?php echo wp_json_encode( __( 'Request failed.', 'stratawp-seo' ) ); ?> );
+			}
+		} ).fail( function() {
+			$btn.prop( 'disabled', false ).text( <?php echo wp_json_encode( __( 'Propose refresh', 'stratawp-seo' ) ); ?> );
+			window.alert( <?php echo wp_json_encode( __( 'Request failed.', 'stratawp-seo' ) ); ?> );
+		} );
+	} );
+
+	$( document ).on( 'click', '.swps-refresh-dismiss', function() {
+		if ( ! window.confirm( <?php echo wp_json_encode( __( 'Dismiss this post? It will not be re-flagged for 28 days.', 'stratawp-seo' ) ); ?> ) ) {
+			return;
+		}
+		var $btn = $( this );
+		var $row = $btn.closest( '.swps-refresh-row' );
+		$btn.prop( 'disabled', true );
+		$.post( ajaxUrl, {
+			action: 'swps_refresh_dismiss',
+			nonce: nonce,
+			post_id: $btn.data( 'id' )
+		} ).done( function( resp ) {
+			if ( resp && resp.success ) {
+				$row.fadeOut( 200, function() { $row.remove(); } );
+			} else {
+				$btn.prop( 'disabled', false );
+				window.alert( ( resp && resp.data && resp.data.message ) || <?php echo wp_json_encode( __( 'Request failed.', 'stratawp-seo' ) ); ?> );
+			}
+		} ).fail( function() {
+			$btn.prop( 'disabled', false );
+			window.alert( <?php echo wp_json_encode( __( 'Request failed.', 'stratawp-seo' ) ); ?> );
+		} );
+	} );
+} )( jQuery );
+</script>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,20 @@ if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', '/tmp/wp-fake/' );
 }
 
+// WordPress time constants.
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+    define( 'MINUTE_IN_SECONDS', 60 );
+}
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+    define( 'HOUR_IN_SECONDS', 3600 );
+}
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+    define( 'DAY_IN_SECONDS', 86400 );
+}
+if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
+    define( 'WEEK_IN_SECONDS', 604800 );
+}
+
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
     function wp_strip_all_tags( $string, $remove_breaks = false ) {
         $string = preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', (string) $string );

--- a/tests/unit/DecayWatchdogTest.php
+++ b/tests/unit/DecayWatchdogTest.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Tests for SWPS_Decay_Watchdog pure static helpers: assess() and staleness_flags().
+ *
+ * Pure-PHP, no WordPress.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-decay-watchdog.php';
+
+/**
+ * @covers SWPS_Decay_Watchdog
+ */
+class DecayWatchdogTest extends TestCase {
+
+	// -------------------------------------------------------------------------
+	// assess() — min-impressions floor
+	// -------------------------------------------------------------------------
+
+	public function test_not_decayed_when_prior_impressions_below_floor(): void {
+		$recent = array( 'clicks' => 5,  'impressions' => 100,  'ctr' => 0.05, 'position' => 5.0 );
+		$prior  = array( 'clicks' => 10, 'impressions' => 150,  'ctr' => 0.07, 'position' => 4.0 );
+		$result = SWPS_Decay_Watchdog::assess( $recent, $prior, array( 'min_impressions' => 200 ) );
+		$this->assertFalse( $result['decayed'] );
+		$this->assertSame( '', $result['reason'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// assess() — zero prior clicks (divide-safety)
+	// -------------------------------------------------------------------------
+
+	public function test_not_decayed_when_prior_clicks_zero(): void {
+		$recent = array( 'clicks' => 5,  'impressions' => 500, 'ctr' => 0.01, 'position' => 6.0 );
+		$prior  = array( 'clicks' => 0,  'impressions' => 500, 'ctr' => 0.00, 'position' => 6.0 );
+		$result = SWPS_Decay_Watchdog::assess( $recent, $prior );
+		$this->assertFalse( $result['decayed'] );
+		$this->assertSame( '', $result['reason'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// assess() — below threshold (no decay)
+	// -------------------------------------------------------------------------
+
+	public function test_not_decayed_when_click_decline_below_threshold(): void {
+		// 15% decline, default threshold 20%.
+		$recent = array( 'clicks' => 85,  'impressions' => 600, 'ctr' => 0.14, 'position' => 5.0 );
+		$prior  = array( 'clicks' => 100, 'impressions' => 600, 'ctr' => 0.17, 'position' => 5.0 );
+		$result = SWPS_Decay_Watchdog::assess( $recent, $prior );
+		$this->assertFalse( $result['decayed'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// assess() — exact threshold boundary (should decay)
+	// -------------------------------------------------------------------------
+
+	public function test_decayed_at_exact_threshold(): void {
+		// Exactly 20% decline: (100 - 80) / 100 = 0.20.
+		$recent = array( 'clicks' => 80,  'impressions' => 600, 'ctr' => 0.13, 'position' => 5.0 );
+		$prior  = array( 'clicks' => 100, 'impressions' => 600, 'ctr' => 0.17, 'position' => 5.0 );
+		$result = SWPS_Decay_Watchdog::assess( $recent, $prior );
+		$this->assertTrue( $result['decayed'] );
+		$this->assertEqualsWithDelta( 0.20, $result['click_change'], 0.0001 );
+	}
+
+	// -------------------------------------------------------------------------
+	// assess() — custom threshold
+	// -------------------------------------------------------------------------
+
+	public function test_custom_threshold_respected(): void {
+		// 15% decline, threshold set to 10% → should decay.
+		$recent = array( 'clicks' => 85,  'impressions' => 600, 'ctr' => 0.14, 'position' => 5.0 );
+		$prior  = array( 'clicks' => 100, 'impressions' => 600, 'ctr' => 0.17, 'position' => 5.0 );
+		$result = SWPS_Decay_Watchdog::assess( $recent, $prior, array( 'threshold' => 0.10 ) );
+		$this->assertTrue( $result['decayed'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// assess() — reason: position_drop
+	// -------------------------------------------------------------------------
+
+	public function test_reason_position_drop(): void {
+		// Clicks fell 30%, position worsened by 5 spots.
+		$recent = array( 'clicks' => 70,  'impressions' => 600, 'ctr' => 0.12, 'position' => 9.0 );
+		$prior  = array( 'clicks' => 100, 'impressions' => 600, 'ctr' => 0.17, 'position' => 4.0 );
+		$result = SWPS_Decay_Watchdog::assess( $recent, $prior );
+		$this->assertTrue( $result['decayed'] );
+		$this->assertSame( 'position_drop', $result['reason'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// assess() — reason: demand_drop
+	// -------------------------------------------------------------------------
+
+	public function test_reason_demand_drop(): void {
+		// Clicks fell 30%, position stable (<3 worse), impressions also fell 25%.
+		$recent = array( 'clicks' => 70,  'impressions' => 450, 'ctr' => 0.16, 'position' => 5.0 );
+		$prior  = array( 'clicks' => 100, 'impressions' => 600, 'ctr' => 0.17, 'position' => 5.0 );
+		$result = SWPS_Decay_Watchdog::assess( $recent, $prior );
+		$this->assertTrue( $result['decayed'] );
+		$this->assertSame( 'demand_drop', $result['reason'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// assess() — reason: ctr_drop
+	// -------------------------------------------------------------------------
+
+	public function test_reason_ctr_drop(): void {
+		// Clicks fell 30%, position stable, impressions stable, CTR fell 25%.
+		$recent = array( 'clicks' => 70,  'impressions' => 600, 'ctr' => 0.117, 'position' => 5.2 );
+		$prior  = array( 'clicks' => 100, 'impressions' => 600, 'ctr' => 0.167, 'position' => 5.0 );
+		$result = SWPS_Decay_Watchdog::assess( $recent, $prior );
+		$this->assertTrue( $result['decayed'] );
+		$this->assertSame( 'ctr_drop', $result['reason'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// assess() — reason: unknown
+	// -------------------------------------------------------------------------
+
+	public function test_reason_unknown_when_no_cause_matches(): void {
+		// Clicks fell 30%, but position, impressions, CTR all stable.
+		$recent = array( 'clicks' => 70,  'impressions' => 600, 'ctr' => 0.167, 'position' => 5.1 );
+		$prior  = array( 'clicks' => 100, 'impressions' => 600, 'ctr' => 0.167, 'position' => 5.0 );
+		$result = SWPS_Decay_Watchdog::assess( $recent, $prior );
+		$this->assertTrue( $result['decayed'] );
+		$this->assertSame( 'unknown', $result['reason'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// assess() — click_change sign (positive = decline)
+	// -------------------------------------------------------------------------
+
+	public function test_click_change_is_positive_fraction_when_decayed(): void {
+		$recent = array( 'clicks' => 60,  'impressions' => 600, 'ctr' => 0.10, 'position' => 10.0 );
+		$prior  = array( 'clicks' => 100, 'impressions' => 600, 'ctr' => 0.17, 'position' => 5.0 );
+		$result = SWPS_Decay_Watchdog::assess( $recent, $prior );
+		$this->assertGreaterThan( 0.0, $result['click_change'] );
+		$this->assertEqualsWithDelta( 0.40, $result['click_change'], 0.0001 );
+	}
+
+	// -------------------------------------------------------------------------
+	// staleness_flags() — not_fresh when published > 24 months ago
+	// -------------------------------------------------------------------------
+
+	public function test_not_fresh_when_published_over_24_months(): void {
+		$published = strtotime( '-25 months' );
+		$modified  = strtotime( '-25 months' );
+		$flags     = SWPS_Decay_Watchdog::staleness_flags( $published, $modified, '<p>Some content.</p>' );
+		$this->assertContains( 'not_fresh', $flags );
+	}
+
+	// -------------------------------------------------------------------------
+	// staleness_flags() — not_fresh requires BOTH modified > 12mo AND published > 24mo
+	// -------------------------------------------------------------------------
+
+	public function test_not_fresh_requires_both_modified_and_published_stale(): void {
+		// Published 30 months ago (>24mo) AND modified 14 months ago (>12mo) → not_fresh.
+		$published = strtotime( '-30 months' );
+		$modified  = strtotime( '-14 months' );
+		$flags     = SWPS_Decay_Watchdog::staleness_flags( $published, $modified, '<p>Some content.</p>' );
+		$this->assertContains( 'not_fresh', $flags );
+	}
+
+	// -------------------------------------------------------------------------
+	// staleness_flags() — not not_fresh when published < 24 months (even if old modified)
+	// -------------------------------------------------------------------------
+
+	public function test_not_not_fresh_when_published_under_24_months(): void {
+		// Published 6 months ago → fresh by published rule, even though modified is old.
+		$published = strtotime( '-6 months' );
+		$modified  = strtotime( '-13 months' );
+		$flags     = SWPS_Decay_Watchdog::staleness_flags( $published, $modified, '<p>Some content.</p>' );
+		$this->assertNotContains( 'not_fresh', $flags );
+	}
+
+	// -------------------------------------------------------------------------
+	// staleness_flags() — no not_fresh when recently modified
+	// -------------------------------------------------------------------------
+
+	public function test_fresh_when_recently_modified(): void {
+		$published = strtotime( '-30 months' );
+		$modified  = strtotime( '-3 months' );
+		$flags     = SWPS_Decay_Watchdog::staleness_flags( $published, $modified, '<p>Some content.</p>' );
+		$this->assertNotContains( 'not_fresh', $flags );
+	}
+
+	// -------------------------------------------------------------------------
+	// staleness_flags() — no_current_year when year mention missing
+	// -------------------------------------------------------------------------
+
+	public function test_no_current_year_flag_when_current_year_absent(): void {
+		$published = strtotime( '-6 months' );
+		$modified  = strtotime( '-1 month' );
+		$html      = '<p>Updated in 2022 and 2021.</p>';
+		$flags     = SWPS_Decay_Watchdog::staleness_flags( $published, $modified, $html );
+		$this->assertContains( 'no_current_year', $flags );
+	}
+
+	// -------------------------------------------------------------------------
+	// staleness_flags() — no no_current_year flag when year present
+	// -------------------------------------------------------------------------
+
+	public function test_no_no_current_year_when_year_present(): void {
+		$published = strtotime( '-6 months' );
+		$modified  = strtotime( '-1 month' );
+		$year      = (string) gmdate( 'Y' );
+		$html      = "<p>Updated in {$year}.</p>";
+		$flags     = SWPS_Decay_Watchdog::staleness_flags( $published, $modified, $html );
+		$this->assertNotContains( 'no_current_year', $flags );
+	}
+
+	// -------------------------------------------------------------------------
+	// staleness_flags() — empty flags when fresh and year present
+	// -------------------------------------------------------------------------
+
+	public function test_empty_flags_when_no_staleness(): void {
+		$published = strtotime( '-3 months' );
+		$modified  = strtotime( '-2 months' );
+		$year      = (string) gmdate( 'Y' );
+		$html      = "<p>Published this year {$year}.</p>";
+		$flags     = SWPS_Decay_Watchdog::staleness_flags( $published, $modified, $html );
+		$this->assertSame( array(), $flags );
+	}
+}

--- a/tests/unit/RefreshQueueSparklineTest.php
+++ b/tests/unit/RefreshQueueSparklineTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Tests for SWPS_Refresh_Queue_Admin::sparkline() — pure inline-SVG builder.
+ *
+ * Pure-PHP, no WordPress.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-refresh-queue-admin.php';
+
+/**
+ * @covers SWPS_Refresh_Queue_Admin
+ */
+class RefreshQueueSparklineTest extends TestCase {
+
+	public function test_empty_values_returns_empty_string(): void {
+		$this->assertSame( '', SWPS_Refresh_Queue_Admin::sparkline( array() ) );
+	}
+
+	public function test_single_value_returns_empty_string(): void {
+		$this->assertSame( '', SWPS_Refresh_Queue_Admin::sparkline( array( 5.0 ) ) );
+	}
+
+	public function test_two_values_returns_svg_polyline(): void {
+		$svg = SWPS_Refresh_Queue_Admin::sparkline( array( 1.0, 2.0 ) );
+		$this->assertStringStartsWith( '<svg', $svg );
+		$this->assertStringContainsString( '<polyline', $svg );
+		$this->assertStringContainsString( '</svg>', $svg );
+	}
+
+	public function test_default_dimensions_in_viewbox(): void {
+		$svg = SWPS_Refresh_Queue_Admin::sparkline( array( 1.0, 2.0, 3.0 ) );
+		$this->assertStringContainsString( 'viewBox="0 0 120 28"', $svg );
+	}
+
+	public function test_custom_dimensions_respected(): void {
+		$svg = SWPS_Refresh_Queue_Admin::sparkline( array( 1.0, 2.0 ), 200, 50 );
+		$this->assertStringContainsString( 'viewBox="0 0 200 50"', $svg );
+	}
+
+	public function test_flat_series_renders_horizontal_midline(): void {
+		$svg = SWPS_Refresh_Queue_Admin::sparkline( array( 7.0, 7.0, 7.0 ), 120, 28 );
+		// All y coordinates must be identical (a flat line at vertical center).
+		preg_match( '/points="([^"]+)"/', $svg, $m );
+		$this->assertNotEmpty( $m[1] );
+		$ys = array_map(
+			static fn( string $pair ): float => (float) explode( ',', trim( $pair ) )[1],
+			explode( ' ', trim( $m[1] ) )
+		);
+		$this->assertCount( 1, array_unique( $ys, SORT_REGULAR ) );
+		$this->assertEqualsWithDelta( 14.0, $ys[0], 0.01 );
+	}
+
+	public function test_scaling_maps_min_to_bottom_and_max_to_top(): void {
+		$svg = SWPS_Refresh_Queue_Admin::sparkline( array( 0.0, 10.0 ), 120, 28 );
+		preg_match( '/points="([^"]+)"/', $svg, $m );
+		$pairs = explode( ' ', trim( $m[1] ) );
+		$first = array_map( 'floatval', explode( ',', $pairs[0] ) );
+		$last  = array_map( 'floatval', explode( ',', $pairs[ count( $pairs ) - 1 ] ) );
+		// SVG y grows downward: min value → larger y, max value → smaller y.
+		$this->assertGreaterThan( $last[1], $first[1] );
+		// First x at left edge (with padding), last x at right edge.
+		$this->assertLessThan( $last[0], $first[0] );
+	}
+
+	public function test_point_count_matches_value_count(): void {
+		$values = array( 3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0 );
+		$svg    = SWPS_Refresh_Queue_Admin::sparkline( $values );
+		preg_match( '/points="([^"]+)"/', $svg, $m );
+		$this->assertCount( count( $values ), explode( ' ', trim( $m[1] ) ) );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -38,6 +38,7 @@ $swps_cron_hooks = array(
 	'swps_send_digest',
 	'swps_citation_check',
 	'swps_question_mine',
+	'swps_decay_scan',
 );
 
 foreach ( $swps_cron_hooks as $swps_cron_hook ) {
@@ -98,6 +99,7 @@ $swps_tables = array(
 	'swps_link_graph',
 	'swps_backlinks',
 	'swps_citation_checks',
+	'swps_metric_history',
 );
 
 foreach ( $swps_tables as $swps_table ) {


### PR DESCRIPTION
## Summary
- **Decay detection**: weekly cron compares each post's GSC clicks/impressions/position across rolling 28-day windows (anchored to GSC's 3-day data lag), flags declines past a configurable threshold (default 20%) with a minimum-impressions floor, 28-day per-post cooldown, and heuristic cause classification (position drop / demand drop / CTR drop / staleness via the 12/24-month freshness rule + current-year mention)
- **Metric history**: new generic per-post time-series store (clicks, impressions, position, AEO score; 400-day retention) powering inline SVG sparklines built from guaranteed-numeric values
- **Refresh Queue page**: flagged posts ranked by traffic-at-risk, heuristic-labeled cause badges, then→now clicks, sparklines, staleness chips; **Propose refresh** stages a freshness instruction (15-min transient consumed by `do_propose`) and deep-links into the existing AEO review flow — **every AI edit is human-reviewed as a diff with apply/undo; nothing auto-applies**
- **Alerting**: one guarded summary email when a top-10-traffic post decays (digest recipients, suppressible); editor metabox shows the decay flag
- Settings (Analytics tab): threshold, minimum impressions, email toggle; GSC-unconnected sites no-op everywhere
- 25 new unit tests (decay math boundaries, staleness rules, sparkline builder) — suite at 268; PHPStan/PHPCS clean; **live smoke on jonimms.local** (history roundtrip, assess verdicts, scan no-op without GSC)
- Version 4.18.0

## Review trail
Dispatch-1 spec review (clean pass, all 8 checklist areas), final whole-branch review covering the interrupted-then-completed Dispatch 2; final fixes: transient-prefix constant usage, post-existence guard in dismiss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)