### PR TITLE
Enable the SEO meta box on WooCommerce products & custom post types

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 **AI-powered SEO that knows your WordPress site — and knows how AI search works.** Generate site-aware blog posts, run your technical SEO (sitemaps, redirects, schema `@graph`, audits, a full site crawler), get *cited* by AI answer engines (AEO scoring, llms.txt, AI citation tracking, AI referral analytics), and let the automation layer watch your budget, your decaying posts, and your topic pipeline while you sleep.
 
-[![Version](https://img.shields.io/badge/version-4.19.0-blue.svg)]()
+[![Version](https://img.shields.io/badge/version-4.20.0-blue.svg)]()
 [![PHP](https://img.shields.io/badge/PHP-8.0%2B-purple.svg)]()
 [![WordPress](https://img.shields.io/badge/WordPress-6.0%2B-blue.svg)]()
 [![License](https://img.shields.io/badge/license-GPL--2.0%2B-green.svg)](https://www.gnu.org/licenses/gpl-2.0.html)
@@ -1711,6 +1711,10 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 ---
 
 ## Changelog
+
+### v4.20.0 — June 2026
+- **SEO meta box on any post type** — choose which post types show the StrataWP SEO meta box (Meta Title, Description, Focus Words, social & sitemap controls) under *Search Appearance → SEO Meta Box*. Enable it on WooCommerce Products or any custom post type; previously it was limited to Posts and Pages
+- **Developer filter** — `swps_meta_editor_post_types` to enable the meta box on custom post types programmatically
 
 ### v4.19.0 — June 2026
 - **Verified crawler analytics** — search-bot tracking with CIDR/rDNS spoof detection, reconciliation alerts, opt-in fail-open 403 enforcement, and a crawl-budget report

--- a/includes/class-meta-editor.php
+++ b/includes/class-meta-editor.php
@@ -556,10 +556,27 @@ class SWPS_Meta_Editor {
 	 */
 	private function get_enabled_post_types(): array {
 		$saved = get_option( 'swps_meta_editor_post_types', '' );
-		if ( ! empty( $saved ) ) {
-			return array_map( 'sanitize_text_field', explode( ',', $saved ) );
+
+		if ( is_array( $saved ) && ! empty( $saved ) ) {
+			// New storage format (settings UI): array of post-type slugs.
+			$types = array_map( 'sanitize_text_field', $saved );
+		} elseif ( is_string( $saved ) && '' !== $saved ) {
+			// Legacy storage format: comma-separated string.
+			$types = array_map( 'sanitize_text_field', explode( ',', $saved ) );
+		} else {
+			$types = array( 'post', 'page' );
 		}
-		return array( 'post', 'page' );
+
+		/**
+		 * Filters the post types that get the StrataWP SEO meta box
+		 * (Meta Title, Description, Focus Words, social, sitemap controls).
+		 *
+		 * Useful for enabling the editor on custom post types — e.g.
+		 * WooCommerce `product` — without touching the settings UI.
+		 *
+		 * @param string[] $types Post-type slugs.
+		 */
+		return (array) apply_filters( 'swps_meta_editor_post_types', $types );
 	}
 
 	/**

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1195,6 +1195,18 @@ class SWPS_Settings {
 				'default'           => 300,
 			)
 		);
+		// Post types that get the SEO meta box (Meta Title, Focus Words, etc.).
+		// Lets users enable the editor on custom post types such as WooCommerce products.
+		register_setting(
+			'swps_search_appearance',
+			'swps_meta_editor_post_types',
+			array(
+				'sanitize_callback' => function ( $value ) {
+					return is_array( $value ) ? array_map( 'sanitize_text_field', $value ) : array( 'post', 'page' );
+				},
+				'default'           => array( 'post', 'page' ),
+			)
+		);
 
 		// Internal Links settings.
 		register_setting(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.19.0
+Stable tag: 4.20.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -400,6 +400,10 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.20.0 =
+* New: Choose which post types get the SEO meta box (Meta Title, Description, Focus Words, social & sitemap controls) under Search Appearance → SEO Meta Box. Enable it on WooCommerce Products or any custom post type — previously it was limited to Posts and Pages.
+* New: `swps_meta_editor_post_types` filter for developers to enable the meta box on custom post types programmatically.
 
 = 4.19.0 =
 * New: Verified crawler analytics — search-engine bot tracking, CIDR/rDNS spoof detection, "blocked bot still crawling" alerts, opt-in fail-open 403 enforcement, and a crawl-budget report.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.19.0
+ * Version: 4.20.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.19.0' );
+define( 'SWPS_VERSION', '4.20.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/templates/search-appearance-page.php
+++ b/templates/search-appearance-page.php
@@ -176,6 +176,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<?php esc_html_e( 'Use swps_breadcrumbs() in your theme template or the [swps_breadcrumbs] shortcode to display breadcrumbs.', 'stratawp-seo' ); ?>
 		</p>
 
+		<h2><?php esc_html_e( 'SEO Meta Box', 'stratawp-seo' ); ?></h2>
+		<table class="form-table">
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Show on post types', 'stratawp-seo' ); ?></th>
+				<td>
+					<?php
+					$meta_types = (array) get_option( 'swps_meta_editor_post_types', array( 'post', 'page' ) );
+					$all_types  = get_post_types( array( 'public' => true ), 'objects' );
+					foreach ( $all_types as $pt ) :
+						if ( 'attachment' === $pt->name ) {
+							continue;
+						}
+						?>
+						<label style="display: block; margin-bottom: 6px;">
+							<input type="checkbox" name="swps_meta_editor_post_types[]"
+								value="<?php echo esc_attr( $pt->name ); ?>"
+								<?php checked( in_array( $pt->name, $meta_types, true ) ); ?>>
+							<?php echo esc_html( $pt->labels->name ); ?>
+						</label>
+					<?php endforeach; ?>
+					<p class="description"><?php esc_html_e( 'Add the StrataWP SEO meta box (Meta Title, Description, Focus Words, social & sitemap controls) to these post types. Enable Products here to use it with WooCommerce.', 'stratawp-seo' ); ?></p>
+				</td>
+			</tr>
+		</table>
+
 		<h2><?php esc_html_e( 'Post List SEO Column', 'stratawp-seo' ); ?></h2>
 		<table class="form-table">
 			<tr>


### PR DESCRIPTION
## Problem

A user installed StrataWP SEO on a WooCommerce site and couldn't find the **Meta Title / Focus Words** fields on products.

The SEO meta box was effectively **hardcoded to Posts and Pages**. `SWPS_Meta_Editor::get_enabled_post_types()` reads the `swps_meta_editor_post_types` option, but **no settings UI ever wrote it**, so it always fell back to `array('post','page')`. WooCommerce `product` (and any other CPT) never got the box.

## Fix

- **New "SEO Meta Box" selector** under *Search Appearance*, mirroring the existing *Post List SEO Column* selector — lets users tick **Products** or any public post type to show the meta box (Meta Title, Description, Focus Words, social & sitemap controls).
- **Register `swps_meta_editor_post_types`** in the `swps_search_appearance` settings group (array, sanitized, default `post` + `page`).
- **`get_enabled_post_types()`** now accepts the array format from the new UI and keeps **back-compat** with the legacy comma-separated string.
- **New `swps_meta_editor_post_types` filter** so developers can enable the box on CPTs programmatically without the UI.
- Bumped to **4.20.0**; updated `readme.txt` + `README.md` changelogs.

The `render_metabox` / `save_meta` paths were already post-type agnostic (gated only by the nonce + `get_enabled_post_types()`), so no other changes were needed.

## Notes / scope

- This is the targeted fix for "fields missing on products." The fuller **WooCommerce SEO module** (Product schema, category SEO, variation OG tags) remains a "coming soon" placeholder in `class-modules.php` — not in scope here.
- Consistent with the existing SEO Column setting, unchecking **all** boxes leaves the prior value unchanged (WP doesn't submit an empty checkbox array).

## Testing

- `composer test` → 441 tests, 790 assertions, all pass
- `phpstan analyse` (changed files) → no errors
- `php -l` clean on all changed PHP