### PR TITLE
Fix duplicate rel=canonical on singular views

### DIFF
--- a/includes/audit/class-canonical-module.php
+++ b/includes/audit/class-canonical-module.php
@@ -93,8 +93,19 @@ class SWPS_Canonical_Module extends SWPS_Audit_Module {
 			return;
 		}
 
+		// Defer to the Meta Editor when a per-post canonical override exists — it
+		// emits its own canonical (and removes the core tag) at priority 2.
+		$post_id = get_the_ID();
+		if ( $post_id && get_post_meta( $post_id, '_swps_canonical_url', true ) ) {
+			return;
+		}
+
 		$url = wp_get_canonical_url();
 		if ( $url ) {
+			// This module is the single canonical owner on singular views; suppress
+			// WordPress core's default rel_canonical (priority 10) so the page does
+			// not render two <link rel="canonical"> tags.
+			remove_action( 'wp_head', 'rel_canonical' );
 			printf( '<link rel="canonical" href="%s" />' . "\n", esc_url( $url ) );
 		}
 	}


### PR DESCRIPTION
## Problem

On singular views the plugin rendered **two `<link rel="canonical">` tags**.

`SWPS_Canonical_Module::output_canonical()` is hooked to `wp_head` at priority 1 and emits a self-referencing canonical, but it never removed WordPress core's default `rel_canonical` (priority 10). The only place core's canonical was removed was inside `SWPS_Meta_Editor::output_meta_tags()` — and that runs **only** when a per-post `_swps_canonical_url` override exists. So on every normal page (homepage, posts without an override) both the module's canonical and core's canonical were output.

This was surfaced during an SEO audit of jonimms.com (which runs this plugin) — the homepage carried two canonical tags (and, separately, two meta descriptions from a theme-side issue fixed in the theme repo).

## Fix

In `SWPS_Canonical_Module::output_canonical()`:

1. **Remove WordPress core's `rel_canonical`** when this module emits its own — the module is the single canonical owner on singular views.
2. **Defer entirely** when a per-post `_swps_canonical_url` override exists, so the Meta Editor (priority 2) remains the sole emitter in that case and the two paths never collide.

Yoast/RankMath deference and the `swps_audit_auto_canonical` toggle are unchanged.

## Verification

Rendered against a local install (`https://jonimms.local`) before/after:

| Page | `rel=canonical` before | after |
|------|:---:|:---:|
| Homepage (static front page) | 2 | **1** |
| Singular post | 2 | **1** |

- `php -l` clean.
- Change is 1 file, +11 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)