### PR TITLE
Release 4.20.1 (ship duplicate rel=canonical fix)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.20.0
+Stable tag: 4.20.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.20.0
+ * Version: 4.20.1
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.20.0' );
+define( 'SWPS_VERSION', '4.20.1' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Bumps version to **4.20.1** (`Version:` header, `SWPS_VERSION`, readme `Stable tag`) so the auto-release workflow builds and publishes a real `v4.20.1` release with the `stratawp-seo.zip` asset.

### Why
PR #64 (duplicate `rel=canonical` fix) merged without a version bump. `release.yml` only publishes when the version changes and no `v<version>` release exists, so it skipped — and a manually-created `4.20.1` release had no zip asset. Result: `releases/latest/download/stratawp-seo.zip` 404'd and the in-WP updater reported **"Download failed. Not Found."**

### What this fixes
- Triggers `release.yml` → builds `stratawp-seo.zip`, publishes `v4.20.1` as latest.
- `releases/latest/download/stratawp-seo.zip` resolves again → in-WP update works.
- Installed version becomes 4.20.1, matching the release tag (no perpetual "update available").

🤖 Generated with [Claude Code](https://claude.com/claude-code)