### PR TITLE
Fix Person entity @id (#person) + release 4.20.2

### DIFF
--- a/includes/class-schema-graph.php
+++ b/includes/class-schema-graph.php
@@ -111,12 +111,17 @@ class SWPS_Schema_Graph {
 	}
 
 	/**
-	 * Build the Organization @id for this site.
+	 * Build the main-entity @id for this site.
+	 *
+	 * On personal-brand sites (entity type Person) the fragment is #person so the
+	 * node's @id and @type stay aligned; otherwise #organization. All publisher /
+	 * author references resolve through this method, so they remain consistent.
 	 *
 	 * @return string Fragment identifier.
 	 */
 	public static function org_id(): string {
-		return home_url( '/#organization' );
+		$type = get_option( 'swps_schema_entity_type', 'Organization' );
+		return home_url( 'Person' === $type ? '/#person' : '/#organization' );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.20.1
+Stable tag: 4.20.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.20.1
+ * Version: 4.20.2
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.20.1' );
+define( 'SWPS_VERSION', '4.20.2' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Problem
On personal-brand sites (`swps_schema_entity_type = Person`), `SWPS_Schema_Graph::org_id()` always returned `#organization`, so the main-entity **`Person`** node was emitted with **`@id=#organization`** — a `@type`/`@id` mismatch that breaks entity resolution for Google's Knowledge Graph and AI engines. Surfaced on jonimms.com (`Person` … `@id=…/#organization`, name "Jonathan Imms").

## Fix
`org_id()` now derives the fragment from the entity type — `#person` for `Person`, `#organization` otherwise. All publisher/author references route through `org_id()`, so they stay consistent automatically. Version bumped to **4.20.2** so the release workflow ships it.

## Verified (local)
Homepage `@graph` `Person` node now renders `@id=…/#person` (was `#organization`), single JSON-LD block. `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)