### PR TITLE
Unify author entity on personal-brand sites (4.20.3)

### DIFF
--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -373,12 +373,17 @@ class SWPS_Schema {
 		// swps_schema_article filter consumers can still read/modify author data.
 		if ( $author ) {
 			$node['author'] = $this->build_person_node( $author );
-			// Also emit a standalone Person node in the graph.
-			$person_node = array_merge(
-				array( '@id' => SWPS_Schema_Graph::person_id( $author->ID ) ),
-				$node['author']
-			);
-			$graph->add_node( $person_node );
+			// Organization-entity sites get a standalone author Person node. On
+			// personal-brand (Person) sites the site entity (#person) IS the author,
+			// so we skip the duplicate node and point author at the main entity after
+			// the filter runs — keeping one coherent Person across the whole graph.
+			if ( 'Person' !== get_option( 'swps_schema_entity_type', 'Organization' ) ) {
+				$person_node = array_merge(
+					array( '@id' => SWPS_Schema_Graph::person_id( $author->ID ) ),
+					$node['author']
+				);
+				$graph->add_node( $person_node );
+			}
 		}
 
 		$thumb_id = get_post_thumbnail_id( $post );
@@ -409,10 +414,15 @@ class SWPS_Schema {
 			SWPS_Schema_Graph::article_id( $permalink )
 		);
 
-		// After filter: replace inline author object with @id reference so
-		// the graph stays interlinked. The separate Person node was already added.
+		// After filter: replace inline author object with an @id reference so the
+		// graph stays interlinked. On personal-brand (Person) sites that @id is the
+		// single #person entity; on Organization sites it's the standalone author node.
 		if ( $author && isset( $node['author'] ) && is_array( $node['author'] ) ) {
-			$node['author'] = array( '@id' => SWPS_Schema_Graph::person_id( $author->ID ) );
+			$node['author'] = array(
+				'@id' => 'Person' === get_option( 'swps_schema_entity_type', 'Organization' )
+					? SWPS_Schema_Graph::org_id()
+					: SWPS_Schema_Graph::person_id( $author->ID ),
+			);
 		}
 
 		$graph->add_node( $node );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.20.2
+Stable tag: 4.20.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.20.2
+ * Version: 4.20.3
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.20.2' );
+define( 'SWPS_VERSION', '4.20.3' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Problem
On personal-brand sites (`swps_schema_entity_type = Person`), `Article.author` was emitted as a **separate** `Person` node (`#/schema/person/{id}`) distinct from the site's main `#person` entity. Result: two `Person` nodes for the same human — and, when the entity name and the WP display name differ, two different names. This prevents Google/AI from forming one coherent author identity.

## Fix
When the site entity is a Person, `Article.author` now references the single **`#person`** entity and **no duplicate author node** is created. Organization-entity sites are unchanged (still mint a standalone author Person node).

## Verified (local)
Blog post graph: **1** `Person` node (`@id=#person`), `Article.author → {@id: #person}` (was 2 person nodes). `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)