### PR TITLE
Link LocalBusiness into the schema @graph (4.20.4)

### DIFF
--- a/includes/class-local-seo.php
+++ b/includes/class-local-seo.php
@@ -76,9 +76,9 @@ class SWPS_Local_SEO {
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
-		if ( ! is_admin() && $this->is_enabled() && ! $this->other_seo_plugin_active() ) {
-			add_action( 'wp_head', array( $this, 'output_schema' ), 2 );
-		}
+		// The LocalBusiness node is absorbed into the main SWPS_Schema @graph (with an
+		// @id and a founder link to the site entity) via SWPS_Schema::add_local_business_node(),
+		// rather than emitted as a disconnected standalone <script> block.
 	}
 
 	public function register_menu(): void {
@@ -125,7 +125,7 @@ class SWPS_Local_SEO {
 		);
 	}
 
-	public function defaults(): array {
+	public static function defaults(): array {
 		return array(
 			'enabled'       => 0,
 			'business_type' => 'LocalBusiness',
@@ -262,18 +262,44 @@ class SWPS_Local_SEO {
 	}
 
 	public function build_schema(): array {
-		$d = $this->get();
+		$node = self::graph_node();
+		if ( empty( $node ) ) {
+			return array();
+		}
+		return array_merge( array( '@context' => 'https://schema.org' ), $node );
+	}
+
+	/**
+	 * Build the LocalBusiness node for embedding in the main schema @graph.
+	 *
+	 * Carries a stable @id (#localbusiness) and a link to the site's
+	 * Person/Organization entity, so the business is connected within the graph
+	 * instead of floating as a disconnected node. No @context — the @graph
+	 * envelope carries it. Empty array when not configured (no name set).
+	 *
+	 * @return array
+	 */
+	public static function graph_node(): array {
+		$stored = get_option( self::OPTION_KEY, array() );
+		$d      = wp_parse_args( is_array( $stored ) ? $stored : array(), self::defaults() );
 
 		if ( '' === trim( (string) $d['name'] ) ) {
 			return array();
 		}
 
 		$schema = array(
-			'@context' => 'https://schema.org',
-			'@type'    => $d['business_type'] ?: 'LocalBusiness',
-			'name'     => $d['name'],
-			'url'      => home_url( '/' ),
+			'@type' => $d['business_type'] ?: 'LocalBusiness',
+			'@id'   => SWPS_Schema_Graph::local_business_id(),
+			'name'  => $d['name'],
+			'url'   => home_url( '/' ),
 		);
+
+		// Connect the business to the site entity so the node is linked in the graph.
+		if ( 'Person' === get_option( 'swps_schema_entity_type', 'Organization' ) ) {
+			$schema['founder'] = array( '@id' => SWPS_Schema_Graph::org_id() );
+		} else {
+			$schema['parentOrganization'] = array( '@id' => SWPS_Schema_Graph::org_id() );
+		}
 
 		if ( '' !== trim( $d['phone'] ) ) {
 			$schema['telephone'] = $d['phone'];

--- a/includes/class-schema-graph.php
+++ b/includes/class-schema-graph.php
@@ -134,6 +134,15 @@ class SWPS_Schema_Graph {
 	}
 
 	/**
+	 * Build the LocalBusiness @id for this site.
+	 *
+	 * @return string Fragment identifier.
+	 */
+	public static function local_business_id(): string {
+		return home_url( '/#localbusiness' );
+	}
+
+	/**
 	 * Build the WebPage @id for a URL.
 	 *
 	 * @param string $url Canonical URL.

--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -108,6 +108,11 @@ class SWPS_Schema {
 			$this->add_website_node( $graph );
 		}
 
+		// LocalBusiness absorbed into the graph on the homepage when Local SEO is on.
+		if ( is_front_page() || is_home() ) {
+			$this->add_local_business_node( $graph );
+		}
+
 		// WebPage node on every non-front-page so Article.mainEntityOfPage resolves.
 		if ( ! is_front_page() ) {
 			$this->add_webpage_node( $graph );
@@ -322,6 +327,37 @@ class SWPS_Schema {
 		}
 
 		$graph->add_node( $node );
+	}
+
+	/**
+	 * Absorb the Local SEO LocalBusiness node into the graph (homepage only).
+	 *
+	 * The node carries a stable @id and a link to the site entity, so it is
+	 * connected within the @graph rather than emitted as a disconnected block.
+	 *
+	 * @param SWPS_Schema_Graph $graph Target graph.
+	 */
+	private function add_local_business_node( SWPS_Schema_Graph $graph ): void {
+		if ( ! class_exists( 'SWPS_Local_SEO' ) ) {
+			return;
+		}
+
+		$opts = get_option( 'swps_local_seo', array() );
+		if ( empty( $opts['enabled'] ) ) {
+			return;
+		}
+
+		/** This filter mirrors the legacy standalone emitter's context gate. */
+		if ( ! (bool) apply_filters( 'swps_local_seo_emit', true ) ) {
+			return;
+		}
+
+		$node = SWPS_Local_SEO::graph_node();
+		if ( ! empty( $node ) ) {
+			$graph->add_node(
+				SWPS_Schema_Graph::normalize_node( $node, SWPS_Schema_Graph::local_business_id() )
+			);
+		}
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.20.3
+Stable tag: 4.20.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.20.3
+ * Version: 4.20.4
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.20.3' );
+define( 'SWPS_VERSION', '4.20.4' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
## Problem
The Local SEO module emitted its `LocalBusiness`/`ProfessionalService` as a **standalone, `@id`-less `<script>` block**, disconnected from the main `SWPS_Schema` `@graph`. Two blocks, no link between the business and the site's Person/Organization entity.

## Fix
`SWPS_Schema::output_schema()` now **absorbs** the LocalBusiness node into the `@graph` (homepage only) with:
- a stable `@id` (`#localbusiness`)
- a `founder` link → `#person` (personal-brand) or `parentOrganization` → `#organization`

`SWPS_Local_SEO::graph_node()` is the shared, side-effect-free builder (used by both the graph path and the legacy `build_schema()`); the standalone `wp_head` emitter is removed, mirroring how FAQ/Takeaways are already absorbed. `defaults()` is now static.

## Verified (local)
Homepage: **1** ld+json block, `@graph` = Person `#person` + WebSite `#website` + ProfessionalService `#localbusiness` (`founder → #person`, address Omaha). Posts unaffected (no LocalBusiness leak, `author → #person`). `php -l` clean; no test references to the changed methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)