### PR TITLE
GEO: og:type/og:image, llms.txt discovery + llms-full.txt (4.20.5)

### DIFF
--- a/includes/class-ai-bots.php
+++ b/includes/class-ai-bots.php
@@ -55,6 +55,7 @@ class SWPS_AI_Bots {
 	public function __construct() {
 		add_filter( 'robots_txt', array( $this, 'filter_robots_txt' ), 100, 2 );
 		add_action( 'init', array( $this, 'maybe_serve_llms_txt' ), 1 );
+		add_action( 'wp_head', array( $this, 'output_llms_discovery_link' ), 5 );
 	}
 
 	/**
@@ -160,15 +161,29 @@ class SWPS_AI_Bots {
 		}
 
 		$uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH ) : '';
-		if ( '/llms.txt' !== $uri ) {
+		if ( '/llms.txt' !== $uri && '/llms-full.txt' !== $uri ) {
 			return;
 		}
 
 		nocache_headers();
 		header( 'Content-Type: text/markdown; charset=utf-8' );
 		header( 'X-Robots-Tag: noindex' );
-		echo $this->generate_llms_txt(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped — markdown body
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped — markdown body
+		echo '/llms-full.txt' === $uri ? $this->generate_llms_full_txt() : $this->generate_llms_txt();
 		exit;
+	}
+
+	/**
+	 * Output the llms.txt discovery <link> in <head> so AI clients can find it.
+	 */
+	public function output_llms_discovery_link(): void {
+		if ( ! get_option( 'swps_llms_txt_enabled', 1 ) ) {
+			return;
+		}
+		printf(
+			'<link rel="alternate" type="text/plain" title="llms.txt" href="%s" />' . "\n",
+			esc_url( home_url( '/llms.txt' ) )
+		);
 	}
 
 	/**
@@ -261,6 +276,62 @@ class SWPS_AI_Bots {
 		}
 
 		return apply_filters( 'swps_llms_txt_content', $out );
+	}
+
+	/**
+	 * Build llms-full.txt: the llms.txt index followed by the full plain-text body
+	 * of the front page, top-level pages, and recent posts. Used by AI systems
+	 * (e.g. Perplexity) that prefer full prose over crawling each page.
+	 */
+	public function generate_llms_full_txt(): string {
+		$out  = $this->generate_llms_txt();
+		$out .= "\n# Full content\n\n";
+
+		$ids      = array();
+		$front_id = (int) get_option( 'page_on_front' );
+		if ( $front_id ) {
+			$ids[] = $front_id;
+		}
+
+		$pages = get_posts(
+			array(
+				'post_type'      => 'page',
+				'post_status'    => 'publish',
+				'posts_per_page' => 25,
+				'post_parent'    => 0,
+				'orderby'        => 'menu_order title',
+				'order'          => 'ASC',
+				'fields'         => 'ids',
+			)
+		);
+		$posts = get_posts(
+			array(
+				'post_type'      => 'post',
+				'post_status'    => 'publish',
+				'posts_per_page' => (int) apply_filters( 'swps_llms_full_txt_post_limit', 25 ),
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+				'fields'         => 'ids',
+			)
+		);
+
+		$all_ids = array_unique(
+			array_merge( $ids, array_map( 'intval', $pages ), array_map( 'intval', $posts ) )
+		);
+
+		foreach ( $all_ids as $id ) {
+			$post = get_post( $id );
+			if ( ! $post ) {
+				continue;
+			}
+			$title = $this->collapse_whitespace( wp_strip_all_tags( get_the_title( $post ) ) );
+			$url   = get_permalink( $post );
+			$body  = wp_strip_all_tags( strip_shortcodes( do_blocks( (string) $post->post_content ) ) );
+			$body  = trim( (string) preg_replace( "/\n{3,}/", "\n\n", (string) $body ) );
+			$out  .= "## {$title}\n{$url}\n\n{$body}\n\n";
+		}
+
+		return apply_filters( 'swps_llms_full_txt_content', $out );
 	}
 
 	/**

--- a/includes/class-meta-editor.php
+++ b/includes/class-meta-editor.php
@@ -592,9 +592,12 @@ class SWPS_Meta_Editor {
 			?: get_the_excerpt( $post_id );
 
 		$image = get_post_meta( $post_id, '_swps_social_image', true )
-				?: get_the_post_thumbnail_url( $post_id, 'large' );
+				?: get_the_post_thumbnail_url( $post_id, 'large' )
+				?: (string) get_option( 'swps_schema_logo', '' )
+				?: (string) get_site_icon_url( 512 );
 
-		printf( '<meta property="og:type" content="article" />' . "\n" );
+		// Posts are articles; the front page and other pages are websites.
+		printf( '<meta property="og:type" content="%s" />' . "\n", esc_attr( is_singular( 'post' ) ? 'article' : 'website' ) );
 		printf( '<meta property="og:title" content="%s" />' . "\n", esc_attr( $title ) );
 		printf( '<meta property="og:description" content="%s" />' . "\n", esc_attr( $desc ) );
 		printf( '<meta property="og:url" content="%s" />' . "\n", esc_url( get_permalink( $post_id ) ) );
@@ -617,7 +620,9 @@ class SWPS_Meta_Editor {
 			?: get_the_excerpt( $post_id );
 
 		$image = get_post_meta( $post_id, '_swps_social_image', true )
-				?: get_the_post_thumbnail_url( $post_id, 'large' );
+				?: get_the_post_thumbnail_url( $post_id, 'large' )
+				?: (string) get_option( 'swps_schema_logo', '' )
+				?: (string) get_site_icon_url( 512 );
 
 		printf( '<meta name="twitter:card" content="%s" />' . "\n", $image ? 'summary_large_image' : 'summary' );
 		printf( '<meta name="twitter:title" content="%s" />' . "\n", esc_attr( $title ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generator, analytics, schema
 Requires at least: 6.0
 Tested up to: 6.7
 Requires PHP: 8.0
-Stable tag: 4.20.4
+Stable tag: 4.20.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.20.4
+ * Version: 4.20.5
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.20.4' );
+define( 'SWPS_VERSION', '4.20.5' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Plugin-side GEO/AI-search fixes surfaced by an audit of jonimms.com.

## Changes
- **`og:type`** — now `website` on the front page and pages, `article` only on posts (was hard-coded `article` site-wide).
- **`og:image` / `twitter:image` fallback** — `_swps_social_image` → post thumbnail → `swps_schema_logo` → site icon, so image-less pages (incl. the homepage) get a social image. `twitter:card` upgrades to `summary_large_image` automatically.
- **`llms.txt` discovery** — adds `<link rel="alternate" type="text/plain" title="llms.txt">` to `<head>`.
- **`/llms-full.txt`** — new endpoint: the `llms.txt` index followed by a `# Full content` section with the full plain-text body of the front page, top-level pages, and recent posts (`swps_llms_full_txt_post_limit` filter, default 25). For AI systems (e.g. Perplexity) that prefer full prose.

## Verified (local)
Homepage now emits `og:type=website`, an `og:image`, `twitter:card=summary_large_image`, and the discovery link; `/llms-full.txt` returns 200 with index + full content. `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)