### PR TITLE
build: exclude .wordpress-org assets from plugin zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
             --exclude='.github' \
             --exclude='docs' \
             --exclude='screenshots' \
+            --exclude='.wordpress-org' \
             --exclude='build' \
             --exclude='node_modules' \
             --exclude='*.zip' \


### PR DESCRIPTION
`.wordpress-org/` holds WordPress.org directory assets (screenshots, icon, banner) that belong in the SVN `/assets/` path, not the plugin trunk/zip. Adds it to the `release.yml` rsync excludes so the distributed zip doesn't bundle them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)