### PR TITLE
ci: green up main — drop stale PHPStan baseline + fix failing test

### DIFF
--- a/includes/class-local-seo.php
+++ b/includes/class-local-seo.php
@@ -228,10 +228,6 @@ class SWPS_Local_SEO {
 
 	// ---------- Schema ----------
 
-	private function other_seo_plugin_active(): bool {
-		return defined( 'WPSEO_VERSION' ) || defined( 'RANK_MATH_VERSION' ) || defined( 'AIOSEO_VERSION' );
-	}
-
 	/**
 	 * Output LocalBusiness JSON-LD on the homepage (and any page slug listed
 	 * via the `swps_local_seo_schema_pages` filter — defaults to homepage only).

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -96,26 +96,6 @@ parameters:
 			path: includes/class-generator.php
 
 		-
-			message: "#^Offset 'body' on array\\{tag_name\\: string, body\\: string, package_url\\: string, published_at\\: string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: includes/class-github-updater.php
-
-		-
-			message: "#^Offset 'package_url' on array\\{tag_name\\: string, body\\: string, package_url\\: string, published_at\\: string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 2
-			path: includes/class-github-updater.php
-
-		-
-			message: "#^Offset 'published_at' on array\\{tag_name\\: string, body\\: string, package_url\\: string, published_at\\: string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: includes/class-github-updater.php
-
-		-
-			message: "#^Offset 'tag_name' on array\\{tag_name\\: string, body\\: string, package_url\\: string, published_at\\: string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 2
-			path: includes/class-github-updater.php
-
-		-
 			message: "#^Property SWPS_AEO_Optimizer\\:\\:\\$cost is never read, only written\\.$#"
 			count: 1
 			path: includes/class-aeo-optimizer.php
@@ -124,11 +104,6 @@ parameters:
 			message: "#^Property SWPS_AEO_Optimizer\\:\\:\\$rate is never read, only written\\.$#"
 			count: 1
 			path: includes/class-aeo-optimizer.php
-
-		-
-			message: "#^Property SWPS_GitHub_Updater\\:\\:\\$plugin_file is never read, only written\\.$#"
-			count: 1
-			path: includes/class-github-updater.php
 
 		-
 			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, int\\<min, \\-1\\>\\|int\\<1, max\\> given\\.$#"

--- a/tests/unit/SchemaGraphTest.php
+++ b/tests/unit/SchemaGraphTest.php
@@ -35,6 +35,11 @@ if ( ! function_exists( 'home_url' ) ) {
 		return 'https://example.com' . $path;
 	}
 }
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( string $option, $default_value = false ) {
+		return $default_value;
+	}
+}
 if ( ! function_exists( 'get_the_title' ) ) {
 	function get_the_title(): string {
 		return 'Test Post';


### PR DESCRIPTION
Fixes the pre-existing CI failures that have been red on `main` since the GitHub-updater removal (#71) and that block every PR from merging on a clean (non-admin) status.

## What was failing
1. **PHPStan** — 5 baseline entries pointed at `includes/class-github-updater.php`, which was **deleted in #71**. PHPStan errors with *"Ignored error pattern … was not matched in reported errors"* for each stale entry.
2. **PHPStan** — `SWPS_Local_SEO::other_seo_plugin_active()` is a private method that is **never called anywhere** (confirmed by grep across `includes/`, `templates/`, `admin/`, `tests/`). It was flagged *"is unused"* and wasn't baselined.
3. **PHPUnit** (all PHP versions) — `SchemaGraphTest::test_org_id_contains_hash_organization` calls `SWPS_Schema_Graph::org_id()`, which uses `get_option()`. That WP function wasn't stubbed in the test, so it errored: *"Call to undefined function get_option()"* (440/441 passing).

## Changes
- **`phpstan-baseline.neon`** — surgically remove only the 5 stale `class-github-updater.php` entries (diff touches nothing else; no reordering/regeneration).
- **`includes/class-local-seo.php`** — delete the dead `other_seo_plugin_active()` method (no behavior change — it was never called).
- **`tests/unit/SchemaGraphTest.php`** — add a `get_option()` stub matching the file's existing `home_url()` / `sanitize_*()` stubs.

## Verification (local)
- `composer analyze` → **[OK] No errors**
- `composer test` → **OK (441 tests, 790 assertions)** — was 440/441

No user-facing change, so no version bump or changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)