### PR TITLE
Restore self-hosted GitHub updater (temporary) so users get update alerts (4.21.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1712,6 +1712,9 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 
 ## Changelog
 
+### v4.21.1 — June 2026
+- **Update notifications restored (temporary)** — the self-hosted GitHub updater is re-enabled so existing installs keep receiving update notifications until the plugin is live in the WordPress.org directory, at which point it will be removed again (.org prohibits plugins updating themselves outside the official directory)
+
 ### v4.21.0 — June 2026
 - **Generate Content readability fix** — the *Site Overview* and *Cost This Month* stat values were rendering dark-on-dark and looked blank until selected; they're now legible on the dark theme
 - **AEO token-waste fix** — proposals on longer posts could fail with a token-limit error after the AI provider had already been billed; the proposal output budget is raised so they complete, and the review modal now warns when a post can't reach your target score so you don't re-spend re-running it

--- a/includes/class-github-updater.php
+++ b/includes/class-github-updater.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * GitHub Updater
+ *
+ * Hooks into the WordPress plugin update API so installs of StrataWP SEO
+ * see "Update available" notices when a new release is published on GitHub,
+ * and can one-click update via the standard Plugins screen.
+ *
+ * Source of truth: latest GitHub Release (tag `v{version}`) with an asset
+ * named `stratawp-seo.zip` attached. The release.yml workflow produces this
+ * automatically when stratawp-seo.php's Version header changes.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SWPS_GitHub_Updater {
+
+	private const REPO          = 'JonImmsWordpressDev/stratawp-seo';
+	private const ASSET_NAME    = 'stratawp-seo.zip';
+	private const TRANSIENT_KEY = 'swps_github_release_v1';
+	private const TRANSIENT_TTL = 12 * HOUR_IN_SECONDS;
+
+	private string $plugin_file;
+	private string $plugin_basename;
+	private string $plugin_slug;
+	private string $current_version;
+
+	public function __construct( string $plugin_file, string $current_version ) {
+		$this->plugin_file     = $plugin_file;
+		$this->plugin_basename = plugin_basename( $plugin_file );
+		$this->plugin_slug     = dirname( $this->plugin_basename );
+		$this->current_version = $current_version;
+
+		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'inject_update' ) );
+		add_filter( 'plugins_api', array( $this, 'plugin_info' ), 10, 3 );
+		add_filter( 'upgrader_source_selection', array( $this, 'rename_source_dir' ), 10, 4 );
+		add_action( 'upgrader_process_complete', array( $this, 'flush_cache_after_update' ), 10, 2 );
+	}
+
+	/**
+	 * Inject our plugin into the WP update transient if a newer release exists.
+	 *
+	 * @param mixed $transient Update_plugins transient (object or false).
+	 * @return mixed
+	 */
+	public function inject_update( $transient ) {
+		if ( empty( $transient ) || ! is_object( $transient ) ) {
+			$transient = new stdClass();
+		}
+		if ( ! isset( $transient->response ) || ! is_array( $transient->response ) ) {
+			$transient->response = array();
+		}
+		if ( ! isset( $transient->no_update ) || ! is_array( $transient->no_update ) ) {
+			$transient->no_update = array();
+		}
+
+		$release = $this->get_latest_release();
+		if ( ! $release ) {
+			return $transient;
+		}
+
+		$remote_version = ltrim( (string) ( $release['tag_name'] ?? '' ), 'vV' );
+		$package_url    = $release['package_url'] ?? '';
+
+		if ( '' === $remote_version || '' === $package_url ) {
+			return $transient;
+		}
+
+		$item = (object) array(
+			'id'            => $this->plugin_basename,
+			'slug'          => $this->plugin_slug,
+			'plugin'        => $this->plugin_basename,
+			'new_version'   => $remote_version,
+			'url'           => 'https://github.com/' . self::REPO,
+			'package'       => $package_url,
+			'icons'         => array(),
+			'banners'       => array(),
+			'banners_rtl'   => array(),
+			'tested'        => '',
+			'requires_php'  => '8.0',
+			'compatibility' => new stdClass(),
+		);
+
+		if ( version_compare( $remote_version, $this->current_version, '>' ) ) {
+			$transient->response[ $this->plugin_basename ] = $item;
+			unset( $transient->no_update[ $this->plugin_basename ] );
+		} else {
+			$transient->no_update[ $this->plugin_basename ] = $item;
+			unset( $transient->response[ $this->plugin_basename ] );
+		}
+
+		return $transient;
+	}
+
+	/**
+	 * Provide plugin metadata for the "View details" popup.
+	 *
+	 * @param mixed  $result
+	 * @param string $action
+	 * @param object $args
+	 * @return mixed
+	 */
+	public function plugin_info( $result, $action, $args ) {
+		if ( 'plugin_information' !== $action ) {
+			return $result;
+		}
+		if ( empty( $args->slug ) || $args->slug !== $this->plugin_slug ) {
+			return $result;
+		}
+
+		$release = $this->get_latest_release();
+		if ( ! $release ) {
+			return $result;
+		}
+
+		$remote_version = ltrim( (string) ( $release['tag_name'] ?? '' ), 'vV' );
+		$body           = (string) ( $release['body'] ?? '' );
+		$package_url    = (string) ( $release['package_url'] ?? '' );
+		$published      = (string) ( $release['published_at'] ?? '' );
+
+		$info                = new stdClass();
+		$info->name          = 'StrataWP SEO';
+		$info->slug          = $this->plugin_slug;
+		$info->version       = $remote_version;
+		$info->author        = '<a href="https://jonimms.com">Jon Imms</a>';
+		$info->homepage      = 'https://github.com/' . self::REPO;
+		$info->requires      = '6.0';
+		$info->requires_php  = '8.0';
+		$info->download_link = $package_url;
+		$info->last_updated  = $published ? gmdate( 'Y-m-d H:i:s', strtotime( $published ) ) : '';
+		$info->sections      = array(
+			'description' => 'AI-powered SEO content generator for WordPress. Updates are delivered directly from the official GitHub repository.',
+			'changelog'   => '<pre style="white-space:pre-wrap;">' . esc_html( $body ) . '</pre>',
+		);
+
+		return $info;
+	}
+
+	/**
+	 * Rename the unpacked source directory to match our plugin slug.
+	 *
+	 * GitHub release zips unpack into `stratawp-seo/` (matches slug) so this
+	 * is usually a no-op, but covers cases where the asset name or branch zip
+	 * unpacks to a different folder.
+	 *
+	 * @param string      $source        Path to extracted source.
+	 * @param string      $remote_source Path to the remote source.
+	 * @param WP_Upgrader $upgrader      Upgrader instance.
+	 * @param array       $hook_extra    Extra args.
+	 * @return string|WP_Error
+	 */
+	public function rename_source_dir( $source, $remote_source, $upgrader, $hook_extra = array() ) {
+		if ( empty( $hook_extra['plugin'] ) || $hook_extra['plugin'] !== $this->plugin_basename ) {
+			return $source;
+		}
+
+		global $wp_filesystem;
+		if ( ! $wp_filesystem ) {
+			return $source;
+		}
+
+		$desired = trailingslashit( $remote_source ) . $this->plugin_slug;
+		if ( trailingslashit( $source ) === trailingslashit( $desired ) ) {
+			return $source;
+		}
+
+		if ( $wp_filesystem->move( $source, $desired ) ) {
+			return trailingslashit( $desired );
+		}
+
+		return $source;
+	}
+
+	/**
+	 * Clear our cached release info after a plugin upgrade so the new
+	 * version isn't reported as "update available" indefinitely.
+	 */
+	public function flush_cache_after_update( $upgrader, $hook_extra ): void {
+		if (
+			isset( $hook_extra['action'], $hook_extra['type'] )
+			&& 'update' === $hook_extra['action']
+			&& 'plugin' === $hook_extra['type']
+		) {
+			delete_transient( self::TRANSIENT_KEY );
+		}
+	}
+
+	/**
+	 * Fetch and cache the latest release from GitHub.
+	 *
+	 * @return array{tag_name:string,body:string,package_url:string,published_at:string}|null
+	 */
+	private function get_latest_release(): ?array {
+		$cached = get_transient( self::TRANSIENT_KEY );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		$response = wp_remote_get(
+			'https://api.github.com/repos/' . self::REPO . '/releases/latest',
+			array(
+				'timeout' => 10,
+				'headers' => array(
+					'Accept'     => 'application/vnd.github+json',
+					'User-Agent' => 'StrataWP-SEO-Updater',
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			// Cache a short empty result so we don't hammer the API on transient failures.
+			set_transient( self::TRANSIENT_KEY, array(), 15 * MINUTE_IN_SECONDS );
+			return null;
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $data ) ) {
+			set_transient( self::TRANSIENT_KEY, array(), 15 * MINUTE_IN_SECONDS );
+			return null;
+		}
+
+		// Find the stratawp-seo.zip asset's browser_download_url.
+		$package_url = '';
+		if ( ! empty( $data['assets'] ) && is_array( $data['assets'] ) ) {
+			foreach ( $data['assets'] as $asset ) {
+				if ( isset( $asset['name'], $asset['browser_download_url'] ) && self::ASSET_NAME === $asset['name'] ) {
+					$package_url = (string) $asset['browser_download_url'];
+					break;
+				}
+			}
+		}
+
+		// Fallback to releases/latest/download URL (always resolves to the asset).
+		if ( '' === $package_url ) {
+			$package_url = 'https://github.com/' . self::REPO . '/releases/latest/download/' . self::ASSET_NAME;
+		}
+
+		$release = array(
+			'tag_name'     => (string) ( $data['tag_name'] ?? '' ),
+			'body'         => (string) ( $data['body'] ?? '' ),
+			'package_url'  => $package_url,
+			'published_at' => (string) ( $data['published_at'] ?? '' ),
+		);
+
+		set_transient( self::TRANSIENT_KEY, $release, self::TRANSIENT_TTL );
+		return $release;
+	}
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -96,6 +96,26 @@ parameters:
 			path: includes/class-generator.php
 
 		-
+			message: "#^Offset 'body' on array\\{tag_name\\: string, body\\: string, package_url\\: string, published_at\\: string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/class-github-updater.php
+
+		-
+			message: "#^Offset 'package_url' on array\\{tag_name\\: string, body\\: string, package_url\\: string, published_at\\: string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 2
+			path: includes/class-github-updater.php
+
+		-
+			message: "#^Offset 'published_at' on array\\{tag_name\\: string, body\\: string, package_url\\: string, published_at\\: string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: includes/class-github-updater.php
+
+		-
+			message: "#^Offset 'tag_name' on array\\{tag_name\\: string, body\\: string, package_url\\: string, published_at\\: string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 2
+			path: includes/class-github-updater.php
+
+		-
 			message: "#^Property SWPS_AEO_Optimizer\\:\\:\\$cost is never read, only written\\.$#"
 			count: 1
 			path: includes/class-aeo-optimizer.php
@@ -104,6 +124,11 @@ parameters:
 			message: "#^Property SWPS_AEO_Optimizer\\:\\:\\$rate is never read, only written\\.$#"
 			count: 1
 			path: includes/class-aeo-optimizer.php
+
+		-
+			message: "#^Property SWPS_GitHub_Updater\\:\\:\\$plugin_file is never read, only written\\.$#"
+			count: 1
+			path: includes/class-github-updater.php
 
 		-
 			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, int\\<min, \\-1\\>\\|int\\<1, max\\> given\\.$#"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.21.0
+Stable tag: 4.21.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,9 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.21.1 =
+* Restored: the self-hosted GitHub updater is back temporarily so you keep getting update notifications until the plugin is available in the WordPress.org directory. It will be removed again once the .org listing is live.
 
 = 4.21.0 =
 * Fixed: the "Site Overview" and "Cost This Month" stat values on the Generate Content screen were rendering dark-on-dark and looked blank until you selected the text — they are now legible.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.21.0
+ * Version: 4.21.1
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.21.0' );
+define( 'SWPS_VERSION', '4.21.1' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -196,6 +196,12 @@ require_once SWPS_PLUGIN_DIR . 'includes/trait-ability-defs.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-abilities.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-abilities-rest.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-abilities-settings.php';
+
+// GitHub-based plugin updater. Temporary: re-enabled so users get update
+// notifications until the plugin is live on the WordPress.org directory, at
+// which point this self-hosted updater must be removed again (.org prohibits
+// plugins updating themselves outside the official directory).
+require_once SWPS_PLUGIN_DIR . 'includes/class-github-updater.php';
 
 // v4.0 admin shell.
 require_once SWPS_PLUGIN_DIR . 'includes/class-user-prefs.php';
@@ -494,6 +500,12 @@ final class StrataWP_SEO {
 		$this->admin_shell = new SWPS_Admin_Shell( $this->user_prefs );
 		$this->dashboard   = new SWPS_Dashboard();
 		$this->migration   = new SWPS_Migration();
+
+		// GitHub release-based updater (admin only). Temporary until the plugin
+		// ships through the WordPress.org directory — see the require above.
+		if ( is_admin() ) {
+			new SWPS_GitHub_Updater( __FILE__, SWPS_VERSION );
+		}
 
 		// Register CPT.
 		add_action( 'init', array( SWPS_Topic_Queue::class, 'register_post_type' ) );


### PR DESCRIPTION
The self-hosted GitHub updater was removed in #71 to prep for the WordPress.org directory — but the plugin **isn't on .org yet**, so installs currently receive **no update notifications at all**. This re-enables it temporarily so people keep getting notified, and will be removed again once the .org listing is live.

## Changes
- **Restore `includes/class-github-updater.php`** verbatim from before #71 (the proven version that ran through 4.20.5).
- **Re-wire it in `stratawp-seo.php`** — the `require_once` and the admin-only `new SWPS_GitHub_Updater( __FILE__, SWPS_VERSION )`, both commented as **temporary until the .org listing is live**.
- **Re-add the 5 PHPStan baseline entries** for the class — these were legitimately removed in #77 as *stale* (the file was deleted); now that the file is back they're valid suppressions again, so re-adding keeps `main` green without touching the proven update logic.
- **Bump to 4.21.1**; changelog in `readme.txt` + `README.md`.

## How it works
The updater hooks WP's `pre_set_site_transient_update_plugins` / `plugins_api`, checks the **public** `JonImmsWordpressDev/stratawp-seo` GitHub releases for a newer tag, and points WP at the `stratawp-seo.zip` release asset (which the release workflow publishes). Repo is public, so the asset download works for end users.

## ⚠️ Caveat — who actually gets notified
The updater lives **inside the installed plugin**, so:
- Installs on **4.20.5 or earlier** still have the old updater → they'll see 4.21.1 and update (and then have the updater again going forward). ✅
- Installs on **4.20.6 / 4.21.0** have **no** updater → they **won't** auto-detect 4.21.1 and will need a **one-time manual update** to 4.21.1, after which notifications resume. ⚠️

There's no way around that for the already-updated cohort, since their installed code has no updater to do the checking.

## Verification
- `composer analyze` → **No errors**
- `composer test` → **441/441 pass**
- Built zip contains `class-github-updater.php` and reports `Version: 4.21.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)