### PR TITLE
Fix: page sitemap lists the static front page twice

### DIFF
--- a/includes/class-sitemap-manager.php
+++ b/includes/class-sitemap-manager.php
@@ -248,15 +248,28 @@ class SWPS_Sitemap_Manager {
 		echo '        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">' . "\n";
 
 		// Include homepage on first page of 'page' sitemap.
+		$front_page_id = 0;
 		if ( 'page' === $post_type && 1 === $page ) {
 			printf(
 				"<url>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n  <priority>1.0</priority>\n</url>\n",
 				esc_url( home_url( '/' ) ),
 				gmdate( 'Y-m-d\TH:i:s+00:00' )
 			);
+
+			// When a static front page is set, it is emitted above as the
+			// homepage URL. Skip it in the loop below so it is not listed
+			// twice (the static front page's permalink is home_url('/')).
+			if ( 'page' === (string) get_option( 'show_on_front' ) ) {
+				$front_page_id = (int) get_option( 'page_on_front' );
+			}
 		}
 
 		foreach ( $posts as $post ) {
+			// Skip the static front page; already emitted as the homepage URL.
+			if ( $front_page_id && (int) $post->ID === $front_page_id ) {
+				continue;
+			}
+
 			// Respect exclusions.
 			if ( get_post_meta( $post->ID, '_swps_sitemap_exclude', true ) ) {
 				continue;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.21.1
+Stable tag: 4.21.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,9 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.21.2 =
+* Fixed: the XML sitemap listed your homepage twice when the site uses a static front page. The homepage now appears only once in the page sitemap.
 
 = 4.21.1 =
 * Restored: the self-hosted GitHub updater is back temporarily so you keep getting update notifications until the plugin is available in the WordPress.org directory. It will be removed again once the .org listing is live.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.21.1
+ * Version: 4.21.2
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.21.1' );
+define( 'SWPS_VERSION', '4.21.2' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/tests/unit/SitemapHomepageTest.php
+++ b/tests/unit/SitemapHomepageTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Regression test: the page sitemap must not list the static front page twice.
+ *
+ * render_post_type_sitemap() prepends the homepage (home_url('/')) to the
+ * 'page' sitemap, then loops every published page. When a static front page
+ * is configured (show_on_front = 'page'), that page's permalink is also
+ * home_url('/'), so it was emitted a second time inside the loop — a
+ * duplicate <loc> in the sitemap. The fix skips page_on_front in the loop.
+ *
+ * Stubs run in a separate process so they do not collide with the suite-wide
+ * get_option()/home_url() stubs defined in other test files.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return 'https://example.com' . $path;
+	}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default_value = false ) {
+		return $GLOBALS['swps_test_options'][ $option ] ?? $default_value;
+	}
+}
+if ( ! function_exists( 'get_posts' ) ) {
+	function get_posts( $args = array() ) {
+		return $GLOBALS['swps_test_posts'] ?? array();
+	}
+}
+if ( ! function_exists( 'get_permalink' ) ) {
+	function get_permalink( $post = 0 ) {
+		$id = is_object( $post ) ? $post->ID : (int) $post;
+		return $GLOBALS['swps_test_permalinks'][ $id ] ?? home_url( '/?p=' . $id );
+	}
+}
+if ( ! function_exists( 'get_post_meta' ) ) {
+	function get_post_meta( $id, $key = '', $single = false ) {
+		return '';
+	}
+}
+if ( ! function_exists( 'get_post_modified_time' ) ) {
+	function get_post_modified_time( $format = 'U', $gmt = false, $post = null ) {
+		return 1700000000;
+	}
+}
+if ( ! function_exists( 'esc_url' ) ) {
+	function esc_url( $url ) {
+		return $url;
+	}
+}
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $text ) {
+		return $text;
+	}
+}
+if ( ! function_exists( 'esc_xml' ) ) {
+	function esc_xml( $text ) {
+		return $text;
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-sitemap-manager.php';
+
+class SitemapHomepageTest extends TestCase {
+
+	/**
+	 * Render the first page of the 'page' sitemap and capture its XML.
+	 */
+	private function render_page_sitemap(): string {
+		$ref    = new ReflectionClass( SWPS_Sitemap_Manager::class );
+		$obj    = $ref->newInstanceWithoutConstructor();
+		$method = $ref->getMethod( 'render_post_type_sitemap' );
+		$method->setAccessible( true );
+
+		ob_start();
+		$method->invoke( $obj, 'page', 1 );
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * With a static front page, the homepage URL must appear exactly once.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_static_front_page_is_not_listed_twice(): void {
+		$GLOBALS['swps_test_options'] = array(
+			'show_on_front'               => 'page',
+			'page_on_front'               => 2,
+			'swps_sitemap_exclude_images' => 1,
+		);
+		// Front page (ID 2, permalink = home_url('/')) plus a normal page.
+		$GLOBALS['swps_test_posts']      = array(
+			(object) array( 'ID' => 2 ),
+			(object) array( 'ID' => 5 ),
+		);
+		$GLOBALS['swps_test_permalinks'] = array(
+			2 => home_url( '/' ),
+			5 => home_url( '/about/' ),
+		);
+
+		$xml = $this->render_page_sitemap();
+
+		$this->assertSame(
+			1,
+			substr_count( $xml, '<loc>' . home_url( '/' ) . '</loc>' ),
+			'Homepage URL must appear exactly once in the page sitemap.'
+		);
+		$this->assertStringContainsString( '<loc>' . home_url( '/about/' ) . '</loc>', $xml );
+	}
+
+	/**
+	 * With a "latest posts" front page there is no static page to dedupe, so
+	 * the loop must still emit every page normally (no over-skipping).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_posts_front_page_does_not_skip_pages(): void {
+		$GLOBALS['swps_test_options'] = array(
+			'show_on_front'               => 'posts',
+			'swps_sitemap_exclude_images' => 1,
+		);
+		$GLOBALS['swps_test_posts']      = array( (object) array( 'ID' => 5 ) );
+		$GLOBALS['swps_test_permalinks'] = array( 5 => home_url( '/about/' ) );
+
+		$xml = $this->render_page_sitemap();
+
+		$this->assertSame(
+			1,
+			substr_count( $xml, '<loc>' . home_url( '/' ) . '</loc>' ),
+			'Homepage is prepended once regardless of front-page type.'
+		);
+		$this->assertStringContainsString( '<loc>' . home_url( '/about/' ) . '</loc>', $xml );
+	}
+}


### PR DESCRIPTION
## Problem

`SWPS_Sitemap_Manager::render_post_type_sitemap()` prepends the homepage (`home_url('/')`) to the `page` sitemap, then loops over every published page. When the site uses a **static front page** (`show_on_front = 'page'`), that page's permalink is *also* `home_url('/')`, so it gets emitted a second time inside the loop:

```xml
<url><loc>https://example.com/</loc><priority>1.0</priority></url>
...
<url><loc>https://example.com/</loc>...</url>   <!-- duplicate -->
```

The homepage appears **twice** in `page-sitemap.xml`. Duplicate `<loc>` entries are untidy and dilute the sitemap's signal.

## Fix

When a static front page is configured, capture `page_on_front` and skip that post in the loop — it's already represented by the prepended homepage URL. Sites using a "latest posts" front page are unaffected (the guard stays `0`, nothing is skipped).

```php
$front_page_id = 0;
if ( 'page' === $post_type && 1 === $page ) {
    // ... prepend homepage ...
    if ( 'page' === (string) get_option( 'show_on_front' ) ) {
        $front_page_id = (int) get_option( 'page_on_front' );
    }
}

foreach ( $posts as $post ) {
    if ( $front_page_id && (int) $post->ID === $front_page_id ) {
        continue; // already emitted as the homepage URL
    }
    // ...
}
```

## Tests

Adds `tests/unit/SitemapHomepageTest.php`:

- `test_static_front_page_is_not_listed_twice` — **fails before this fix** (homepage `<loc>` appears twice), passes after.
- `test_posts_front_page_does_not_skip_pages` — guards against over-skipping when the front page is "latest posts".

Stubs run in a separate process (`@runInSeparateProcess`) so they don't collide with the suite-wide `get_option()`/`home_url()` stubs, matching the pattern already used in `SitemapUrlTest`.

### Verification
- `vendor/bin/phpunit` — **443 tests, 794 assertions, OK** (was 441 before)
- `composer analyze` (PHPStan level 5) — **No errors**
- `php -l` on the changed file — clean
- No new PHPCS findings introduced (the changed file's pre-existing WPCS backlog is unchanged)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)