### PR TITLE
Fix: /swps-sitemap.xml 404s instead of redirecting to the index

### DIFF
--- a/includes/class-sitemap-manager.php
+++ b/includes/class-sitemap-manager.php
@@ -51,6 +51,23 @@ class SWPS_Sitemap_Manager {
 		return home_url( '/sitemap_index.xml' );
 	}
 
+	/**
+	 * Whether a resolved sitemap "type" is the legacy /swps-sitemap.xml URL
+	 * that should 301 to the canonical index.
+	 *
+	 * The dedicated rewrite maps `swps-sitemap.xml` to `legacy_redirect`, but
+	 * the generic `{type}-sitemap(\d*).xml` rule matches the same URL and can
+	 * win the ordering, yielding the raw prefix `swps` instead. Treating both
+	 * as the legacy redirect makes /swps-sitemap.xml resolve regardless of
+	 * which rewrite rule fires first (no public post type/taxonomy is named
+	 * `swps`, so there is nothing legitimate to shadow).
+	 *
+	 * @param string $type The resolved swps_sitemap query var.
+	 */
+	public static function is_legacy_redirect_type( string $type ): bool {
+		return 'legacy_redirect' === $type || 'swps' === $type;
+	}
+
 	public function __construct() {
 		// Disable WP core sitemaps to prevent conflict detection from blocking us.
 		add_filter( 'wp_sitemaps_enabled', '__return_false' );
@@ -120,7 +137,7 @@ class SWPS_Sitemap_Manager {
 		}
 
 		// Legacy redirect.
-		if ( 'legacy_redirect' === $type ) {
+		if ( self::is_legacy_redirect_type( $type ) ) {
 			wp_redirect( home_url( '/sitemap_index.xml' ), 301 );
 			exit;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.21.2
+Stable tag: 4.21.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,9 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.21.3 =
+* Fixed: the legacy `/swps-sitemap.xml` address returned a 404 instead of redirecting to your current sitemap. It now reliably 301-redirects to `/sitemap_index.xml`.
 
 = 4.21.2 =
 * Fixed: the XML sitemap listed your homepage twice when the site uses a static front page. The homepage now appears only once in the page sitemap.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.21.2
+ * Version: 4.21.3
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.21.2' );
+define( 'SWPS_VERSION', '4.21.3' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/tests/unit/SitemapUrlTest.php
+++ b/tests/unit/SitemapUrlTest.php
@@ -64,4 +64,35 @@ class SitemapUrlTest extends TestCase {
 			SWPS_Sitemap_Manager::get_sitemap_url()
 		);
 	}
+
+	/**
+	 * The legacy /swps-sitemap.xml URL must 301 to the canonical index. Its
+	 * dedicated rewrite resolves to `legacy_redirect`, but the generic
+	 * `{type}-sitemap.xml` rule can win the ordering and yield the raw prefix
+	 * `swps`. Both must be treated as the legacy redirect so the URL resolves
+	 * regardless of which rewrite rule fires first (issue: /swps-sitemap.xml
+	 * 404'd in production because the generic rule matched first).
+	 */
+	public function test_legacy_redirect_type_covers_both_resolutions(): void {
+		$this->assertTrue(
+			SWPS_Sitemap_Manager::is_legacy_redirect_type( 'legacy_redirect' ),
+			'The dedicated legacy rewrite must redirect.'
+		);
+		$this->assertTrue(
+			SWPS_Sitemap_Manager::is_legacy_redirect_type( 'swps' ),
+			'The generic rule matching swps-sitemap.xml (type "swps") must redirect too.'
+		);
+	}
+
+	/**
+	 * Real sitemap types must NOT be treated as the legacy redirect.
+	 */
+	public function test_real_sitemap_types_are_not_redirected(): void {
+		foreach ( array( 'index', 'author', 'post', 'page', 'category', 'post_tag', '' ) as $type ) {
+			$this->assertFalse(
+				SWPS_Sitemap_Manager::is_legacy_redirect_type( $type ),
+				"Type '{$type}' must not be treated as a legacy redirect."
+			);
+		}
+	}
 }


### PR DESCRIPTION
## Problem

The legacy `/swps-sitemap.xml` URL is meant to 301-redirect to the canonical `/sitemap_index.xml`. In production it returns **404** instead.

Root cause is rewrite-rule ordering, not a missing rule. `register_rewrite_rules()` adds two rules that both match `swps-sitemap.xml`:

```php
// generic post-type sitemaps
add_rewrite_rule( '([a-z0-9_-]+)-sitemap(\d*)\.xml$', 'index.php?swps_sitemap=$matches[1]...', 'top' );
// legacy redirect
add_rewrite_rule( 'swps-sitemap\.xml$', 'index.php?swps_sitemap=legacy_redirect', 'top' );
```

When the **generic** rule wins, `swps-sitemap.xml` resolves to `swps_sitemap=swps`. `serve_sitemap()` only special-cased `legacy_redirect`, so `swps` fell through: not the index, not author, not a taxonomy, not a post type → `status_header( 404 )`.

## Fix

Handle the redirect at the **serve layer** so it no longer depends on which rewrite rule fires first. A small testable static helper treats both resolutions as the legacy redirect:

```php
public static function is_legacy_redirect_type( string $type ): bool {
    return 'legacy_redirect' === $type || 'swps' === $type;
}
```

```php
// serve_sitemap()
if ( self::is_legacy_redirect_type( $type ) ) {
    wp_redirect( home_url( '/sitemap_index.xml' ), 301 );
    exit;
}
```

No public post type or taxonomy is named `swps` (it's the plugin's own prefix), so nothing legitimate is shadowed.

## Tests

Extends `SitemapUrlTest` (same pattern as the existing static-method coverage — no WP bootstrap needed):

- `test_legacy_redirect_type_covers_both_resolutions` — `legacy_redirect` **and** `swps` both redirect.
- `test_real_sitemap_types_are_not_redirected` — `index`, `author`, `post`, `page`, `category`, `post_tag`, `''` are **not** redirected.

### Verification
- `vendor/bin/phpunit` — **445 tests, 803 assertions, OK** (was 443)
- `composer analyze` (PHPStan L5) — **No errors**
- `php -l` on changed files — clean
- No new PHPCS findings (changed file: 18 errors on HEAD and on this branch — unchanged)

Follow-up to #79. Bumps version to **4.21.3**; merging to `main` triggers the release workflow.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)