### PR TITLE
Fix: SEO meta box post types won't save + early-translation notice (4.21.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1712,6 +1712,11 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 
 ## Changelog
 
+### v4.21.4 — June 2026
+- **SEO meta box post types now save** — ticking Products (or any custom post type) under *Search Appearance → SEO Meta Box → Show on post types* now persists. A leftover legacy text setting was re-sanitizing the checkbox selection as a string and silently discarding it on save
+- **No more early-translation notice** — fixed the `_load_textdomain_just_in_time` ("translation loading triggered too early") notice on WordPress 6.7+ by building the Abilities registry's definitions lazily instead of during `plugins_loaded`
+- **Fresh-install polish** — the SEO Meta Box post-type checkboxes no longer appear unticked until the first save on new installs
+
 ### v4.21.1 — June 2026
 - **Update notifications restored (temporary)** — the self-hosted GitHub updater is re-enabled so existing installs keep receiving update notifications until the plugin is live in the WordPress.org directory, at which point it will be removed again (.org prohibits plugins updating themselves outside the official directory)
 

--- a/includes/class-abilities.php
+++ b/includes/class-abilities.php
@@ -43,18 +43,35 @@ class SWPS_Abilities {
 	/**
 	 * Canonical ability definitions.
 	 *
-	 * Populated by SWPS_Ability_Defs::build_defs() in the constructor.
+	 * Populated lazily by defs() on first access (never in the constructor).
 	 * Each def: name, label, description, write (bool), input_schema, output_schema, callback.
 	 *
-	 * @var array[]
+	 * @var array[]|null
 	 */
-	private array $defs = array();
+	private ?array $defs = null;
 
 	/**
-	 * Constructor — build ability definitions via trait.
+	 * Constructor.
+	 *
+	 * Intentionally does NOT build the ability definitions: build_defs() calls
+	 * __() for every label/description, and this object is instantiated on
+	 * plugins_loaded. Translating that early trips WordPress 6.7's
+	 * _load_textdomain_just_in_time notice. defs() defers the build (and its
+	 * __() calls) to first use — REST, admin, or the WP Abilities API — all of
+	 * which run on or after init.
 	 */
-	public function __construct() {
-		$this->defs = $this->build_defs();
+	public function __construct() {}
+
+	/**
+	 * Lazily build and memoize the ability definitions.
+	 *
+	 * @return array[]
+	 */
+	private function defs(): array {
+		if ( null === $this->defs ) {
+			$this->defs = $this->build_defs();
+		}
+		return $this->defs;
 	}
 
 	// =========================================================================
@@ -67,7 +84,7 @@ class SWPS_Abilities {
 	 * @return array[]
 	 */
 	public function get_defs(): array {
-		return $this->defs;
+		return $this->defs();
 	}
 
 	/**
@@ -305,7 +322,7 @@ class SWPS_Abilities {
 	 * @return array|null
 	 */
 	private function find_def( string $name ): ?array {
-		foreach ( $this->defs as $def ) {
+		foreach ( $this->defs() as $def ) {
 			if ( $def['name'] === $name ) {
 				return $def;
 			}

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -852,16 +852,11 @@ class SWPS_Settings {
 			)
 		);
 
-		$this->add_field(
-			'meta_editor_post_types',
-			__( 'Post Types', 'stratawp-seo' ),
-			'text',
-			'swps_meta_section',
-			array(
-				'placeholder' => 'post,page',
-				'description' => __( 'Comma-separated post types to show the meta editor on. Default: post,page', 'stratawp-seo' ),
-			)
-		);
+		// NOTE: The post-type selector for the meta box lives under Search Appearance
+		// → SEO Meta Box (swps_meta_editor_post_types, registered below as an array).
+		// The legacy comma-separated text field that used to be here was removed: it
+		// re-registered the same option with sanitize_text_field, which silently
+		// stripped the array value on save (e.g. ticking Products never persisted).
 
 		$this->add_field(
 			'meta_auto_generate',

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.21.3
+Stable tag: 4.21.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,11 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.21.4 =
+* Fixed: choosing which post types show the SEO meta box (Search Appearance → SEO Meta Box → "Show on post types") now saves correctly. Ticking Products — or any custom post type — previously never persisted, because a leftover legacy setting re-sanitized the checkbox selection as plain text and silently dropped it on save.
+* Fixed: a "translation loading triggered too early" notice (`_load_textdomain_just_in_time`) on WordPress 6.7+, caused by the Abilities registry translating its labels during `plugins_loaded`. Ability definitions are now built lazily, after `init`.
+* Fixed: on fresh installs the SEO Meta Box post-type checkboxes could appear unticked until the first save.
 
 = 4.21.3 =
 * Fixed: the legacy `/swps-sitemap.xml` address returned a 404 instead of redirecting to your current sitemap. It now reliably 301-redirects to `/sitemap_index.xml`.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.21.3
+ * Version: 4.21.4
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.21.3' );
+define( 'SWPS_VERSION', '4.21.4' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -1381,7 +1381,7 @@ function swps_activate(): void {
 		'gsc_client_secret'           => '',
 		// Keywords & Meta defaults.
 		'meta_editor_enabled'         => 1,
-		'meta_editor_post_types'      => 'post,page',
+		'meta_editor_post_types'      => array( 'post', 'page' ),
 		'meta_auto_generate'          => 0,
 		'keyword_tracking_frequency'  => 'weekly',
 		// RSS Feed defaults.


### PR DESCRIPTION
Fixes two bugs reported by a user (Costa) running 4.21.3 on WordPress 6.7+.

## 1. "Show on post types" doesn't save (e.g. Products) — root cause
`swps_meta_editor_post_types` was registered **twice**:
- a leftover legacy `add_field('meta_editor_post_types', …, 'text', …)` (registers the option with `sanitize_text_field`), and
- the newer checkbox UI's `register_setting(…, [array closure])`.

WordPress stacks both `sanitize_option_swps_meta_editor_post_types` filters. The legacy one runs first and `sanitize_text_field()` returns `''` for an array, so the posted `['post','page','product']` collapses to `''` and the array closure falls back to the default `['post','page']`. The selection is silently discarded. (The Post-List SEO Column setting works because it has only its single array registration.) This was the dangling half of `a6a7ae2`. **Fix:** remove the dead legacy field.

## 2. `_load_textdomain_just_in_time` notice on WP 6.7+
`SWPS_Abilities` is constructed on `plugins_loaded` and eagerly called `build_defs()`, which runs `__()` on every ability label — translating before `init`. **Fix:** build the definitions lazily (`?array $defs = null`, built on first access), so all `__()` calls now run on/after `init`.

## Also
`swps_activate()` seeded the option as the legacy **string** `'post,page'`; switched to `array('post','page')` so the Search Appearance checkboxes render correctly on fresh installs.

## Verification
- Reproduced both bugs and verified both fixes **live** via WP-CLI on a real install (`sanitize_option()` now preserves the full array; `$defs` is `null` after construction, `get_defs()` still returns all 13 abilities).
- A 4-agent audit confirmed **no other** early-translation sites and **no other** double-registered options.
- Local gates green: PHPUnit 445/445, PHPStan clean, PHPCS adds zero new violations, syntax clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)