### PR TITLE
IndexNow integration (4.22.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ CLAUDE.local.md
 agentdb.rvf
 agentdb.rvf.lock
 ruvector.db
+.swarm/

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Configures `/sitemap_index.xml` and sub-sitemaps.
 
 **How to use it:**
 1. **Settings tab:** toggle individual post types/taxonomies in/out of the sitemap, set per-type priority and changefreq
-2. **Submit tab:** the **Ping Search Engines** button submits 50 most-recently-modified posts to IndexNow (Bing/Yandex/Seznam — Bing's feed powers ChatGPT search). Use after a major content push.
+2. **IndexNow panel:** enable IndexNow, generate the verification key (served at `/{key}.txt`), and pick which post types auto-submit on publish/update. The **Resubmit All URLs** button re-queues every indexable URL for submission to Bing, Yandex, Seznam, and Naver (Bing's feed powers ChatGPT search; Google does not participate). Submissions are automatically paused on non-production environments.
 3. **View raw:** click "View sitemap" to see the live XML
 
 ### Internal Links (`StrataWP SEO → Internal Links`)
@@ -1423,8 +1423,7 @@ SWPS_Image_Provider (abstract)
 - Each sub-sitemap respects the `swps_sitemap_exclude_{key}` option.
 - `urls_per_page` setting controls split point (default 1000, max 50000).
 - Image sitemap entries built from post attachments.
-- **IndexNow batch submit** — `ping_search_engines()` posts up to 50 most recently modified posts to `api.indexnow.org`, returns `{submitted, status, error}` for the admin UI to display.
-- Auto-fires after publish/update via `transition_post_status` (when enabled in audit settings).
+- **IndexNow integration** — handled by `SWPS_IndexNow`: auto-submits a URL to `api.indexnow.org` on post/term publish, update, or delete (60-second debounce), plus per-post and bulk "Resubmit All URLs" AJAX actions surfaced in the IndexNow panel on the Sitemaps admin page. Paused on non-production environments.
 
 ### SEO Audit (`SWPS_SEO_Audit`)
 
@@ -1674,7 +1673,7 @@ Two things: (1) writes `Allow: /` rules in robots.txt for the AI bots you've che
 
 ### How does IndexNow batch submission work?
 
-Click **Sitemaps → Ping Search Engines** and the plugin submits your 50 most recently modified posts to `api.indexnow.org`. Bing, Yandex, and Seznam pick these up within minutes — and Bing's IndexNow feed is what powers ChatGPT's web search.
+Enable it under **Sitemaps → IndexNow** — the plugin generates a verification key (served at `/{key}.txt`) and auto-submits a URL to `api.indexnow.org` whenever a post or term is published, updated, or deleted (60-second debounce so bulk edits collapse into one batch). You can also submit a single post via the "Submit to IndexNow now" button on its edit screen, or re-queue every indexable URL at once with **Resubmit All URLs** on the Sitemaps page. Bing, Yandex, Seznam, and Naver pick these up within minutes — and Bing's IndexNow feed is what powers ChatGPT's web search. Submissions are automatically paused on non-production environments.
 
 ### Do I need a paid Ahrefs or Moz account to use Backlinks?
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This is the part Yoast doesn't have: a full pipeline for getting your content **
 #### AI Crawler Access & llms.txt
 - **AI bot allowlist** — robots.txt `Allow`/`Disallow` rules for 15 known AI crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, Applebot-Extended, CCBot, Bytespider, …)
 - **Dynamic llms.txt** at `/llms.txt`, built from your posts/pages/categories with one-line summaries — plus an in-admin editor for both `/llms.txt` (Auto/Custom) and `/robots.txt` (Auto/Append/Replace)
-- **IndexNow batch submission** — instant Bing/Yandex indexing (Bing's IndexNow feed powers ChatGPT search)
+- **IndexNow integration** — auto-generated verification key served at `/{key}.txt`; auto-submit on the post/term lifecycle with a 60-second debounce, per-post "Submit now" and bulk "Resubmit all", a dedicated panel on the Sitemaps screen, and a recent-activity log (auto-paused on non-production; Google does not participate in IndexNow)
 
 #### AI Bot Analytics, AI Referrals & the Visibility Funnel
 - **AI Bot Analytics** — server-side hit tracking for the 15 AI crawlers: per-bot dashboards, top crawled pages, recent bot 404s, and an AEO gap report sortable by AEO score (high-quality-but-uncrawled posts first)
@@ -156,7 +156,7 @@ This is the part Yoast doesn't have: a full pipeline for getting your content **
 - **Crawl budget report** — Analytics-page breakdown of crawl activity by post type (30d) so you can see where bots spend their time
 
 #### Sitemaps, Redirects & the Meta Layer
-- **Full sitemap system** — `/sitemap_index.xml` with post type / taxonomy / author sub-sitemaps, image entries, per-sitemap exclusion toggles, IndexNow batch submit
+- **Full sitemap system** — `/sitemap_index.xml` with post type / taxonomy / author sub-sitemaps, image entries, per-sitemap exclusion toggles, auto-submitting IndexNow panel
 - **Redirect manager** — 301/302/307/410 with exact + regex matching, 404 monitoring with one-click redirect creation, auto-redirect on slug change
 - **Internal links engine** — keyword and AI engines with an accept/skip review UI
 - **SEO meta editor** — per-post title/description/canonical/robots/OG/Twitter with live SERP preview, SEO checklist, and an AI Generate button
@@ -1711,6 +1711,11 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 ---
 
 ## Changelog
+
+### v4.22.0 — July 2026
+- **IndexNow integration** — instantly notify Bing, Yandex, Seznam, and Naver when you publish, update, or remove content (Google does not participate in IndexNow). An auto-generated verification key is served at `/{key}.txt`; publishing, updating, or deleting a post/term auto-submits its URL with a 60-second debounce so bulk edits collapse into one batch
+- **Manual controls** — a per-post "Submit now" action and a bulk "Resubmit all" button, plus a dedicated IndexNow panel on the Sitemaps screen with a recent-activity log
+- **Safety guard** — submissions are automatically paused on non-production environments so IndexNow never fires from a dev copy
 
 ### v4.21.4 — June 2026
 - **SEO meta box post types now save** — ticking Products (or any custom post type) under *Search Appearance → SEO Meta Box → Show on post types* now persists. A leftover legacy text setting was re-sanitizing the checkbox selection as a string and silently discarding it on save

--- a/admin/js/indexnow.js
+++ b/admin/js/indexnow.js
@@ -54,10 +54,9 @@
 	}
 
 	$( function () {
-		if ( ! $( '#swps-indexnow-log' ).length ) {
-			return;
+		if ( $( '#swps-indexnow-log' ).length ) {
+			loadLog();
 		}
-		loadLog();
 
 		$( '#swps-indexnow-generate' ).on( 'click', function () {
 			var $b = $( this ).prop( 'disabled', true );
@@ -81,6 +80,19 @@
 					r && r.success ? describeResubmit( r.data ) : ( r && r.data ? r.data.message : 'Error' )
 				);
 				loadLog();
+			} ).always( function () {
+				$b.prop( 'disabled', false );
+			} );
+		} );
+
+		$( '#swps-indexnow-submit-post' ).on( 'click', function () {
+			var $b = $( this ).prop( 'disabled', true );
+			var id = $b.data( 'post' );
+			$( '#swps-indexnow-submit-post-status' ).text( 'Submitting…' );
+			post( 'swps_indexnow_submit_post', { post_id: id } ).done( function ( r ) {
+				$( '#swps-indexnow-submit-post-status' ).text(
+					r && r.success ? ( 'Submitted (' + r.data.result + ').' ) : ( r && r.data ? r.data.message : 'Error' )
+				);
 			} ).always( function () {
 				$b.prop( 'disabled', false );
 			} );

--- a/admin/js/indexnow.js
+++ b/admin/js/indexnow.js
@@ -1,0 +1,89 @@
+/* global jQuery, swpsAdmin */
+( function ( $ ) {
+	'use strict';
+
+	function post( action, extra ) {
+		return $.post( swpsAdmin.ajax_url, Object.assign( { action: action, nonce: swpsAdmin.nonce }, extra || {} ) );
+	}
+
+	function renderLog( log ) {
+		var $body = $( '#swps-indexnow-log tbody' ).empty();
+		if ( ! log || ! log.length ) {
+			$body.append( '<tr><td colspan="4">No activity yet.</td></tr>' );
+			return;
+		}
+		log.forEach( function ( e ) {
+			var when = e.time ? new Date( e.time * 1000 ).toLocaleString() : '';
+			$body.append(
+				'<tr><td>' + when + '</td><td>' + ( e.trigger || '' ) + '</td><td>' +
+				( e.count || 0 ) + '</td><td>' + ( e.result || '' ) + '</td></tr>'
+			);
+		} );
+	}
+
+	function loadLog() {
+		post( 'swps_indexnow_get_log' ).done( function ( r ) {
+			if ( r && r.success ) {
+				renderLog( r.data.log );
+			}
+		} );
+	}
+
+	/**
+	 * Summarize a resubmit response for the status line. `submitted` is the
+	 * pre-filter URL count, not proof anything was actually sent — when no key
+	 * is configured, `batches` is empty even though `submitted` is nonzero, so
+	 * always reflect the batch results rather than the raw count alone.
+	 */
+	function describeResubmit( data ) {
+		var submitted = data && data.submitted ? data.submitted : 0;
+		var batches = ( data && data.batches ) || [];
+
+		if ( ! batches.length ) {
+			return 'No URLs submitted (found ' + submitted + '; check that an API key is generated).';
+		}
+
+		var ok = 0;
+		batches.forEach( function ( b ) {
+			if ( b && ( 'ok' === b.result || 'pending' === b.result ) ) {
+				ok++;
+			}
+		} );
+
+		return 'Submitted ' + submitted + ' URLs in ' + batches.length + ' batch(es), ' + ok + ' succeeded.';
+	}
+
+	$( function () {
+		if ( ! $( '#swps-indexnow-log' ).length ) {
+			return;
+		}
+		loadLog();
+
+		$( '#swps-indexnow-generate' ).on( 'click', function () {
+			var $b = $( this ).prop( 'disabled', true );
+			post( 'swps_indexnow_generate_key' ).done( function ( r ) {
+				if ( r && r.success ) {
+					$( '#swps-indexnow-key' ).text( r.data.key );
+					$( '#swps-indexnow-key-url' ).text( r.data.key_file_url ).attr( 'href', r.data.key_file_url );
+				} else {
+					window.alert( r && r.data ? r.data.message : 'Error' );
+				}
+			} ).always( function () {
+				$b.prop( 'disabled', false );
+			} );
+		} );
+
+		$( '#swps-indexnow-resubmit' ).on( 'click', function () {
+			var $b = $( this ).prop( 'disabled', true );
+			$( '#swps-indexnow-resubmit-status' ).text( 'Submitting…' );
+			post( 'swps_indexnow_resubmit_all' ).done( function ( r ) {
+				$( '#swps-indexnow-resubmit-status' ).text(
+					r && r.success ? describeResubmit( r.data ) : ( r && r.data ? r.data.message : 'Error' )
+				);
+				loadLog();
+			} ).always( function () {
+				$b.prop( 'disabled', false );
+			} );
+		} );
+	} );
+}( jQuery ) );

--- a/docs/superpowers/plans/2026-07-02-indexnow-integration.md
+++ b/docs/superpowers/plans/2026-07-02-indexnow-integration.md
@@ -1369,7 +1369,7 @@ Add to `SWPS_IndexNow`:
 		if ( ! $tax || empty( $tax->public ) ) {
 			return;
 		}
-		if ( ! SWPS_Sitemap_Manager::is_term_indexable( $term_id ) ) {
+		if ( ! SWPS_Sitemap_Manager::is_term_indexable( $term_id, $taxonomy ) ) {
 			return;
 		}
 		$url = get_term_link( $term_id, $taxonomy );

--- a/docs/superpowers/plans/2026-07-02-indexnow-integration.md
+++ b/docs/superpowers/plans/2026-07-02-indexnow-integration.md
@@ -556,9 +556,9 @@ Add to `SWPS_IndexNow` (after `flush()`):
 		return bin2hex( random_bytes( 16 ) );
 	}
 
-	/** IndexNow keys are 8–128 chars of [a-zA-Z0-9-]. */
+	/** IndexNow keys are 8–128 chars of [a-zA-Z0-9-]. The /D anchor rejects a trailing newline. */
 	public static function is_valid_key( string $key ): bool {
-		return (bool) preg_match( '/^[a-zA-Z0-9-]{8,128}$/', $key );
+		return (bool) preg_match( '/^[a-zA-Z0-9-]{8,128}$/D', $key );
 	}
 
 	/** Heuristic: does this host look like a local/staging environment? */

--- a/docs/superpowers/plans/2026-07-02-indexnow-integration.md
+++ b/docs/superpowers/plans/2026-07-02-indexnow-integration.md
@@ -1,0 +1,2133 @@
+# IndexNow Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Instantly notify IndexNow search engines (Bing, Yandex, Seznam, Naver) whenever a StrataWP SEO site publishes, updates, or removes a URL.
+
+**Architecture:** One new class `SWPS_IndexNow` (`includes/class-indexnow.php`) owns key management, the `/{key}.txt` verification file, post/term lifecycle triggers, a 60-second debounced queue flushed by a single wp-cron event, the batched HTTP submit, an environment guard, a ring-buffer activity log, and AJAX handlers. "What counts as an indexable URL" is centralized in three new public-static methods on `SWPS_Sitemap_Manager` so IndexNow submits exactly the sitemap's URL set. Settings persist through a dedicated `swps_indexnow_settings` option group (mirroring the existing `swps_sitemap_settings` precedent); the key is generated/rotated via AJAX and never rendered in the form.
+
+**Tech Stack:** PHP 8.0+, WordPress 6.0+, PHPUnit 9.6 (pure-PHP unit tests with inline WP function stubs — **tests do NOT load WordPress**), WordPress Settings API, wp-cron, `wp_remote_post`.
+
+## Global Constraints
+
+- **No runtime autoloader** — every new class MUST get an explicit `require_once SWPS_PLUGIN_DIR . 'includes/class-<name>.php';` in `stratawp-seo.php`. A missing require is a runtime-only fatal; PHPStan will not catch it.
+- **Option prefix** `swps_` on every option; **meta prefix** `_swps_` on every post/term meta key.
+- **Settings double-registration footgun** — register each option name exactly ONCE. Never register an array option (`multi_checkbox`) a second time as a scalar; the stacked `sanitize_option_` filter silently wipes the array on save.
+- **IndexNow key is PUBLIC** — stored plain in `swps_indexnow_api_key`; never encrypt it (it is served in cleartext at `/{key}.txt`).
+- **Text domain** `stratawp-seo` on every user-facing string.
+- **Version target** `4.22.0` (new feature → minor bump): update both the plugin header `Version:` and `define( 'SWPS_VERSION', ... )`.
+- **Files under 500 lines**; **validate input at system boundaries** (AJAX handlers: `check_ajax_referer` + `current_user_can`).
+- **Test harness:** pure PHP, no mocking framework. Each test file conditionally defines the WP functions it needs (guarded by `function_exists`) and injects data through `$GLOBALS`. Use `@runInSeparateProcess` + `@preserveGlobalState disabled` on any test method that relies on redefinable stubs or `define()`, exactly like `tests/unit/SitemapHomepageTest.php`. Run one file with `./vendor/bin/phpunit tests/unit/<File>.php`; run all with `composer test`.
+
+---
+
+## Naming Reference (used across all tasks)
+
+| Symbol | Value |
+|--------|-------|
+| Class | `SWPS_IndexNow` in `includes/class-indexnow.php` |
+| Cron hook | `SWPS_IndexNow::CRON_HOOK` = `'swps_indexnow_flush'` |
+| Endpoint | `SWPS_IndexNow::ENDPOINT` = `'https://api.indexnow.org/indexnow'` |
+| Options | `swps_indexnow_enabled`, `swps_indexnow_auto_submit`, `swps_indexnow_api_key`, `swps_indexnow_post_types` (array), `swps_indexnow_queue` (array), `swps_indexnow_log` (array), `swps_indexnow_daily_count` (int), `swps_indexnow_daily_date` (string) |
+| Post meta | `_swps_indexnow_last_url`, `_swps_indexnow_submitted` |
+| Settings group | `swps_indexnow_settings` |
+| AJAX actions | `swps_indexnow_generate_key`, `swps_indexnow_resubmit_all`, `swps_indexnow_get_log`, `swps_indexnow_submit_post` |
+| Constants | `MAX_LOG` = 50, `MAX_URLS_PER_REQUEST` = 10000, `DEBOUNCE_SECONDS` = 60, `DAILY_CAP` = 10000 |
+
+---
+
+## Task 1: Sitemap shared eligibility
+
+**Files:**
+- Modify: `includes/class-sitemap-manager.php` (make the two hidden-checks `private static`; add three new public-static methods)
+- Test: `tests/unit/SitemapIndexableTest.php` (create)
+
+**Interfaces:**
+- Produces:
+  - `SWPS_Sitemap_Manager::is_post_indexable( $post ): bool`
+  - `SWPS_Sitemap_Manager::is_term_indexable( int $term_id ): bool`
+  - `SWPS_Sitemap_Manager::get_indexable_urls(): array` (absolute URLs, deduped)
+
+**Why the renderers are NOT refactored:** the existing `render_post_type_sitemap()` loop and its regression tests (`SitemapHomepageTest`) pass bare `stdClass` objects without `post_status`/`post_type`. Routing that loop through a `WP_Post`-typed predicate would break those tests. Instead we add `is_post_indexable()` as the canonical predicate that IndexNow consumes, encoding the *identical* rules the renderer applies inline. Keep a `// Keep in sync with SWPS_Sitemap_Manager::is_post_indexable().` comment above the renderer's inline skip checks.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/SitemapIndexableTest.php`:
+
+```php
+<?php
+/**
+ * Unit tests for the shared IndexNow/sitemap eligibility predicate.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return 'https://example.com' . $path;
+	}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default_value = false ) {
+		return $GLOBALS['swps_test_options'][ $option ] ?? $default_value;
+	}
+}
+if ( ! function_exists( 'get_post_meta' ) ) {
+	function get_post_meta( $id, $key = '', $single = false ) {
+		return $GLOBALS['swps_test_postmeta'][ $id ][ $key ] ?? '';
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-sitemap-manager.php';
+
+class SitemapIndexableTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['swps_test_options']  = array();
+		$GLOBALS['swps_test_postmeta'] = array();
+	}
+
+	private function post( int $id, string $status = 'publish', string $type = 'post' ): object {
+		return (object) array( 'ID' => $id, 'post_status' => $status, 'post_type' => $type );
+	}
+
+	public function test_published_post_is_indexable(): void {
+		$this->assertTrue( SWPS_Sitemap_Manager::is_post_indexable( $this->post( 1 ) ) );
+	}
+
+	public function test_draft_is_not_indexable(): void {
+		$this->assertFalse( SWPS_Sitemap_Manager::is_post_indexable( $this->post( 1, 'draft' ) ) );
+	}
+
+	public function test_excluded_post_meta_blocks_indexing(): void {
+		$GLOBALS['swps_test_postmeta'][2]['_swps_sitemap_exclude'] = 1;
+		$this->assertFalse( SWPS_Sitemap_Manager::is_post_indexable( $this->post( 2 ) ) );
+	}
+
+	public function test_noindex_robots_meta_blocks_indexing(): void {
+		$GLOBALS['swps_test_postmeta'][3]['_swps_robots'] = 'noindex,follow';
+		$this->assertFalse( SWPS_Sitemap_Manager::is_post_indexable( $this->post( 3 ) ) );
+	}
+
+	public function test_hidden_post_type_blocks_indexing(): void {
+		$GLOBALS['swps_test_options']['swps_sitemap_exclude_product'] = 1;
+		$this->assertFalse( SWPS_Sitemap_Manager::is_post_indexable( $this->post( 4, 'publish', 'product' ) ) );
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/unit/SitemapIndexableTest.php`
+Expected: FAIL — `Error: Call to undefined method SWPS_Sitemap_Manager::is_post_indexable()`.
+
+- [ ] **Step 3: Make the hidden-checks static**
+
+In `includes/class-sitemap-manager.php`, change the two helpers from `private function` to `private static function`:
+
+```php
+	private static function is_post_type_hidden_from_sitemap( string $post_type ): bool {
+		return 'attachment' === $post_type
+			|| (bool) get_option( "swps_sitemap_exclude_{$post_type}", 0 )
+			|| (bool) get_option( "swps_noindex_{$post_type}", 0 );
+	}
+
+	private static function is_taxonomy_hidden_from_sitemap( string $taxonomy ): bool {
+		return 'post_format' === $taxonomy
+			|| (bool) get_option( "swps_sitemap_exclude_{$taxonomy}", 0 )
+			|| (bool) get_option( "swps_noindex_{$taxonomy}", 0 );
+	}
+```
+
+Then update their call sites: replace every `$this->is_post_type_hidden_from_sitemap(` with `self::is_post_type_hidden_from_sitemap(` and every `$this->is_taxonomy_hidden_from_sitemap(` with `self::is_taxonomy_hidden_from_sitemap(`. Find them with:
+
+Run: `grep -n 'is_post_type_hidden_from_sitemap\|is_taxonomy_hidden_from_sitemap' includes/class-sitemap-manager.php`
+
+- [ ] **Step 4: Add the three public-static methods**
+
+Add to `SWPS_Sitemap_Manager` (near the other helpers):
+
+```php
+	/**
+	 * Canonical "is this URL part of the sitemap" predicate, shared with IndexNow.
+	 * Mirrors the inline skip logic in render_post_type_sitemap().
+	 *
+	 * @param WP_Post|object $post Post object with ID, post_status, post_type.
+	 */
+	public static function is_post_indexable( $post ): bool {
+		if ( ! is_object( $post ) || empty( $post->ID ) ) {
+			return false;
+		}
+		if ( 'publish' !== ( $post->post_status ?? '' ) ) {
+			return false;
+		}
+		if ( self::is_post_type_hidden_from_sitemap( (string) ( $post->post_type ?? '' ) ) ) {
+			return false;
+		}
+		if ( get_post_meta( $post->ID, '_swps_sitemap_exclude', true ) ) {
+			return false;
+		}
+		$robots = get_post_meta( $post->ID, '_swps_robots', true );
+		if ( ! empty( $robots ) && str_contains( (string) $robots, 'noindex' ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Term eligibility, mirroring render_taxonomy_sitemap()'s inline checks.
+	 */
+	public static function is_term_indexable( int $term_id ): bool {
+		if ( get_term_meta( $term_id, '_swps_sitemap_exclude', true ) ) {
+			return false;
+		}
+		$robots = get_term_meta( $term_id, '_swps_robots', true );
+		if ( ! empty( $robots ) && str_contains( (string) $robots, 'noindex' ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Full indexable URL set (posts + pages + CPTs + taxonomies + authors),
+	 * applying the same eligibility rules as the sitemap. Used by "Resubmit all".
+	 *
+	 * @return string[] Absolute URLs, deduped.
+	 */
+	public static function get_indexable_urls(): array {
+		$urls = array( home_url( '/' ) );
+
+		foreach ( get_post_types( array( 'public' => true ) ) as $post_type ) {
+			if ( self::is_post_type_hidden_from_sitemap( $post_type ) ) {
+				continue;
+			}
+			$posts = get_posts(
+				array(
+					'post_type'      => $post_type,
+					'post_status'    => 'publish',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+					'no_found_rows'  => true,
+				)
+			);
+			foreach ( $posts as $post_id ) {
+				$post = get_post( $post_id );
+				if ( $post && self::is_post_indexable( $post ) ) {
+					$urls[] = get_permalink( $post );
+				}
+			}
+		}
+
+		foreach ( get_taxonomies( array( 'public' => true ) ) as $taxonomy ) {
+			if ( self::is_taxonomy_hidden_from_sitemap( $taxonomy ) ) {
+				continue;
+			}
+			$terms = get_terms( array( 'taxonomy' => $taxonomy, 'hide_empty' => true ) );
+			if ( is_wp_error( $terms ) ) {
+				continue;
+			}
+			foreach ( $terms as $term ) {
+				if ( self::is_term_indexable( (int) $term->term_id ) ) {
+					$urls[] = get_term_link( $term );
+				}
+			}
+		}
+
+		if ( ! get_option( 'swps_sitemap_exclude_author', 0 ) ) {
+			$authors = get_users( array( 'has_published_posts' => true, 'fields' => 'ID' ) );
+			foreach ( $authors as $author_id ) {
+				$urls[] = get_author_posts_url( (int) $author_id );
+			}
+		}
+
+		return array_values( array_unique( array_filter( $urls ) ) );
+	}
+```
+
+- [ ] **Step 5: Run the new test and the existing sitemap tests**
+
+Run: `./vendor/bin/phpunit tests/unit/SitemapIndexableTest.php tests/unit/SitemapHomepageTest.php tests/unit/SitemapUrlTest.php`
+Expected: PASS (all green — the existing sitemap tests must remain green, proving the static change is behavior-preserving).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add includes/class-sitemap-manager.php tests/unit/SitemapIndexableTest.php
+git commit -m "feat(indexnow): add shared sitemap eligibility predicate for IndexNow"
+```
+
+---
+
+## Task 2: SWPS_IndexNow scaffold + bootstrap wiring
+
+**Files:**
+- Create: `includes/class-indexnow.php`
+- Modify: `stratawp-seo.php` (add `require_once`; instantiate in `__construct()`)
+- Test: `tests/unit/IndexNowScaffoldTest.php` (create)
+
+**Interfaces:**
+- Produces: class `SWPS_IndexNow` with the constants from the Naming Reference; `public function flush(): void` (real body arrives in Task 7 — no-op stub for now); constructor that registers `add_action( self::CRON_HOOK, array( $this, 'flush' ) )`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/IndexNowScaffoldTest.php`:
+
+```php
+<?php
+/**
+ * Scaffold test: the IndexNow class and its public contract exist.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( ...$args ) {}
+}
+
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowScaffoldTest extends TestCase {
+
+	public function test_class_and_constants_exist(): void {
+		$this->assertTrue( class_exists( 'SWPS_IndexNow' ) );
+		$this->assertSame( 'swps_indexnow_flush', SWPS_IndexNow::CRON_HOOK );
+		$this->assertSame( 'https://api.indexnow.org/indexnow', SWPS_IndexNow::ENDPOINT );
+		$this->assertSame( 50, SWPS_IndexNow::MAX_LOG );
+		$this->assertSame( 10000, SWPS_IndexNow::MAX_URLS_PER_REQUEST );
+		$this->assertSame( 60, SWPS_IndexNow::DEBOUNCE_SECONDS );
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowScaffoldTest.php`
+Expected: FAIL — `require_once ... class-indexnow.php` → "No such file or directory".
+
+- [ ] **Step 3: Create the class file**
+
+Create `includes/class-indexnow.php`:
+
+```php
+<?php
+/**
+ * IndexNow integration — instantly notify Bing/Yandex/Seznam/Naver of URL changes.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Owns key management, the /{key}.txt verification file, lifecycle triggers,
+ * the debounced submit queue, HTTP submission, the activity log, and AJAX.
+ */
+class SWPS_IndexNow {
+
+	const CRON_HOOK           = 'swps_indexnow_flush';
+	const ENDPOINT            = 'https://api.indexnow.org/indexnow';
+	const MAX_LOG             = 50;
+	const MAX_URLS_PER_REQUEST = 10000;
+	const DEBOUNCE_SECONDS    = 60;
+	const DAILY_CAP           = 10000;
+
+	const OPT_ENABLED     = 'swps_indexnow_enabled';
+	const OPT_AUTO        = 'swps_indexnow_auto_submit';
+	const OPT_KEY         = 'swps_indexnow_api_key';
+	const OPT_POST_TYPES  = 'swps_indexnow_post_types';
+	const OPT_QUEUE       = 'swps_indexnow_queue';
+	const OPT_LOG         = 'swps_indexnow_log';
+	const OPT_DAILY_COUNT = 'swps_indexnow_daily_count';
+	const OPT_DAILY_DATE  = 'swps_indexnow_daily_date';
+
+	const META_LAST_URL  = '_swps_indexnow_last_url';
+	const META_SUBMITTED = '_swps_indexnow_submitted';
+
+	const SETTINGS_GROUP = 'swps_indexnow_settings';
+
+	public function __construct() {
+		add_action( self::CRON_HOOK, array( $this, 'flush' ) );
+	}
+
+	/**
+	 * wp-cron handler — drains the debounce queue and submits. Filled in Task 7.
+	 */
+	public function flush(): void {
+	}
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowScaffoldTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into the bootstrap**
+
+In `stratawp-seo.php`, add the require after the rate-limiter require (line 63):
+
+```php
+	require_once SWPS_PLUGIN_DIR . 'includes/class-rate-limiter.php';
+	require_once SWPS_PLUGIN_DIR . 'includes/class-indexnow.php';
+```
+
+In `StrataWP_SEO::__construct()`, instantiate it next to the sitemap manager (after line 400, `$this->sitemap_admin = new SWPS_Sitemap_Admin();`):
+
+```php
+		$this->sitemap_admin = new SWPS_Sitemap_Admin();
+		$this->indexnow      = new SWPS_IndexNow();
+```
+
+Add the property declaration alongside the other `private $...;` class properties (match the existing property block style near the top of the class):
+
+```php
+	private $indexnow;
+```
+
+- [ ] **Step 6: Lint and run the full suite**
+
+Run: `php -l includes/class-indexnow.php && php -l stratawp-seo.php && composer test`
+Expected: "No syntax errors detected" for both files; PHPUnit all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add includes/class-indexnow.php stratawp-seo.php tests/unit/IndexNowScaffoldTest.php
+git commit -m "feat(indexnow): scaffold SWPS_IndexNow class and bootstrap wiring"
+```
+
+---
+
+## Task 3: Pure helper methods
+
+**Files:**
+- Modify: `includes/class-indexnow.php`
+- Test: `tests/unit/IndexNowHelpersTest.php` (create)
+
+**Interfaces:**
+- Produces:
+  - `SWPS_IndexNow::generate_key(): string`
+  - `SWPS_IndexNow::is_valid_key( string $key ): bool`
+  - `SWPS_IndexNow::is_staging_host( string $host ): bool`
+  - `SWPS_IndexNow::should_skip_environment(): bool`
+  - `SWPS_IndexNow::build_payload( string $host, string $key, array $urls ): array`
+  - `SWPS_IndexNow::interpret_response_code( int $code ): string`
+  - `SWPS_IndexNow::key_file_path_matches( string $path, string $key ): bool`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/IndexNowHelpersTest.php`:
+
+```php
+<?php
+/**
+ * Unit tests for SWPS_IndexNow pure helpers.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return ( $GLOBALS['swps_test_home'] ?? 'https://example.com' ) . $path;
+	}
+}
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( $url, $component = -1 ) {
+		return parse_url( $url, $component );
+	}
+}
+if ( ! function_exists( 'wp_get_environment_type' ) ) {
+	function wp_get_environment_type() {
+		return $GLOBALS['swps_test_env'] ?? 'production';
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowHelpersTest extends TestCase {
+
+	public function test_generate_key_is_32_hex_chars(): void {
+		$key = SWPS_IndexNow::generate_key();
+		$this->assertSame( 32, strlen( $key ) );
+		$this->assertMatchesRegularExpression( '/^[0-9a-f]{32}$/', $key );
+		$this->assertNotSame( SWPS_IndexNow::generate_key(), $key );
+	}
+
+	public function test_is_valid_key(): void {
+		$this->assertTrue( SWPS_IndexNow::is_valid_key( str_repeat( 'a', 32 ) ) );
+		$this->assertTrue( SWPS_IndexNow::is_valid_key( 'abc1234-DEF' ) );
+		$this->assertFalse( SWPS_IndexNow::is_valid_key( 'short' ) );        // < 8
+		$this->assertFalse( SWPS_IndexNow::is_valid_key( 'has space here' ) );
+		$this->assertFalse( SWPS_IndexNow::is_valid_key( '' ) );
+	}
+
+	public function test_is_staging_host(): void {
+		$this->assertTrue( SWPS_IndexNow::is_staging_host( 'localhost' ) );
+		$this->assertTrue( SWPS_IndexNow::is_staging_host( 'jonimms.local' ) );
+		$this->assertTrue( SWPS_IndexNow::is_staging_host( 'my-site.test' ) );
+		$this->assertTrue( SWPS_IndexNow::is_staging_host( 'staging.example.com' ) );
+		$this->assertTrue( SWPS_IndexNow::is_staging_host( 'dev.example.com' ) );
+		$this->assertFalse( SWPS_IndexNow::is_staging_host( 'example.com' ) );
+		$this->assertFalse( SWPS_IndexNow::is_staging_host( 'www.jonimms.com' ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_skip_environment_on_non_production(): void {
+		$GLOBALS['swps_test_env']  = 'staging';
+		$GLOBALS['swps_test_home'] = 'https://example.com';
+		$this->assertTrue( SWPS_IndexNow::should_skip_environment() );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_skip_environment_on_staging_host(): void {
+		$GLOBALS['swps_test_env']  = 'production';
+		$GLOBALS['swps_test_home'] = 'https://staging.example.com';
+		$this->assertTrue( SWPS_IndexNow::should_skip_environment() );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_not_skip_on_production_live_host(): void {
+		$GLOBALS['swps_test_env']  = 'production';
+		$GLOBALS['swps_test_home'] = 'https://www.jonimms.com';
+		$this->assertFalse( SWPS_IndexNow::should_skip_environment() );
+	}
+
+	public function test_build_payload(): void {
+		$payload = SWPS_IndexNow::build_payload( 'example.com', 'abcdef1234', array( 'https://example.com/a', 'https://example.com/a' ) );
+		$this->assertSame( 'example.com', $payload['host'] );
+		$this->assertSame( 'abcdef1234', $payload['key'] );
+		$this->assertSame( 'https://example.com/abcdef1234.txt', $payload['keyLocation'] );
+		$this->assertSame( array( 'https://example.com/a', 'https://example.com/a' ), $payload['urlList'] );
+	}
+
+	public function test_interpret_response_code(): void {
+		$this->assertSame( 'ok', SWPS_IndexNow::interpret_response_code( 200 ) );
+		$this->assertSame( 'pending', SWPS_IndexNow::interpret_response_code( 202 ) );
+		$this->assertSame( 'invalid', SWPS_IndexNow::interpret_response_code( 400 ) );
+		$this->assertSame( 'key_not_found', SWPS_IndexNow::interpret_response_code( 403 ) );
+		$this->assertSame( 'host_mismatch', SWPS_IndexNow::interpret_response_code( 422 ) );
+		$this->assertSame( 'rate_limited', SWPS_IndexNow::interpret_response_code( 429 ) );
+		$this->assertSame( 'error', SWPS_IndexNow::interpret_response_code( 500 ) );
+	}
+
+	public function test_key_file_path_matches(): void {
+		$this->assertTrue( SWPS_IndexNow::key_file_path_matches( '/abc123.txt', 'abc123' ) );
+		$this->assertFalse( SWPS_IndexNow::key_file_path_matches( '/other.txt', 'abc123' ) );
+		$this->assertFalse( SWPS_IndexNow::key_file_path_matches( '/abc123.txt/', 'abc123' ) );
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowHelpersTest.php`
+Expected: FAIL — "Call to undefined method SWPS_IndexNow::generate_key()".
+
+- [ ] **Step 3: Implement the helpers**
+
+Add to `SWPS_IndexNow` (after `flush()`):
+
+```php
+	/** Generate a fresh 32-char hex IndexNow key (does not persist). */
+	public static function generate_key(): string {
+		return bin2hex( random_bytes( 16 ) );
+	}
+
+	/** IndexNow keys are 8–128 chars of [a-zA-Z0-9-]. */
+	public static function is_valid_key( string $key ): bool {
+		return (bool) preg_match( '/^[a-zA-Z0-9-]{8,128}$/', $key );
+	}
+
+	/** Heuristic: does this host look like a local/staging environment? */
+	public static function is_staging_host( string $host ): bool {
+		$host = strtolower( $host );
+		if ( in_array( $host, array( 'localhost', '127.0.0.1', '::1' ), true ) ) {
+			return true;
+		}
+		foreach ( array( '.local', '.test', '.localhost', '.example', '.invalid' ) as $suffix ) {
+			if ( str_ends_with( $host, $suffix ) ) {
+				return true;
+			}
+		}
+		foreach ( array( 'staging.', 'stage.', 'dev.', 'test.', 'sandbox.' ) as $prefix ) {
+			if ( str_starts_with( $host, $prefix ) ) {
+				return true;
+			}
+		}
+		return str_contains( $host, '.staging.' ) || str_contains( $host, '.dev.' );
+	}
+
+	/** True when submissions must be suppressed (non-production or staging host). */
+	public static function should_skip_environment(): bool {
+		if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+			return true;
+		}
+		$host = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+		return self::is_staging_host( $host );
+	}
+
+	/** Build the IndexNow POST body. Pure. */
+	public static function build_payload( string $host, string $key, array $urls ): array {
+		return array(
+			'host'        => $host,
+			'key'         => $key,
+			'keyLocation' => 'https://' . $host . '/' . $key . '.txt',
+			'urlList'     => array_values( $urls ),
+		);
+	}
+
+	/** Map an HTTP status code to a log-friendly result label. Pure. */
+	public static function interpret_response_code( int $code ): string {
+		switch ( $code ) {
+			case 200:
+				return 'ok';
+			case 202:
+				return 'pending';
+			case 400:
+				return 'invalid';
+			case 403:
+				return 'key_not_found';
+			case 422:
+				return 'host_mismatch';
+			case 429:
+				return 'rate_limited';
+			default:
+				return 'error';
+		}
+	}
+
+	/** Does a request path exactly match /{key}.txt? Pure. */
+	public static function key_file_path_matches( string $path, string $key ): bool {
+		return '/' . $key . '.txt' === $path;
+	}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowHelpersTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/class-indexnow.php tests/unit/IndexNowHelpersTest.php
+git commit -m "feat(indexnow): add pure helpers (key, env guard, payload, response codes)"
+```
+
+---
+
+## Task 4: Activity log ring buffer
+
+**Files:**
+- Modify: `includes/class-indexnow.php`
+- Test: `tests/unit/IndexNowLogTest.php` (create)
+
+**Interfaces:**
+- Produces: `SWPS_IndexNow::append_log( array $entry ): void`, `SWPS_IndexNow::get_log(): array`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/IndexNowLogTest.php`:
+
+```php
+<?php
+/**
+ * Unit tests for the IndexNow activity-log ring buffer.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default_value = false ) {
+		return $GLOBALS['swps_test_options'][ $option ] ?? $default_value;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $option, $value, $autoload = null ) {
+		$GLOBALS['swps_test_options'][ $option ] = $value;
+		return true;
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowLogTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['swps_test_options'] = array();
+	}
+
+	public function test_append_prepends_newest_first(): void {
+		SWPS_IndexNow::append_log( array( 'result' => 'first' ) );
+		SWPS_IndexNow::append_log( array( 'result' => 'second' ) );
+		$log = SWPS_IndexNow::get_log();
+		$this->assertSame( 'second', $log[0]['result'] );
+		$this->assertSame( 'first', $log[1]['result'] );
+	}
+
+	public function test_log_caps_at_max(): void {
+		for ( $i = 0; $i < SWPS_IndexNow::MAX_LOG + 20; $i++ ) {
+			SWPS_IndexNow::append_log( array( 'result' => "e{$i}" ) );
+		}
+		$this->assertCount( SWPS_IndexNow::MAX_LOG, SWPS_IndexNow::get_log() );
+	}
+
+	public function test_get_log_returns_empty_array_when_unset(): void {
+		$this->assertSame( array(), SWPS_IndexNow::get_log() );
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowLogTest.php`
+Expected: FAIL — "Call to undefined method SWPS_IndexNow::append_log()".
+
+- [ ] **Step 3: Implement**
+
+Add to `SWPS_IndexNow`:
+
+```php
+	/** Prepend an entry to the bounded activity log (newest first, capped at MAX_LOG). */
+	public static function append_log( array $entry ): void {
+		$log = get_option( self::OPT_LOG, array() );
+		if ( ! is_array( $log ) ) {
+			$log = array();
+		}
+		array_unshift( $log, $entry );
+		$log = array_slice( $log, 0, self::MAX_LOG );
+		update_option( self::OPT_LOG, $log, false );
+	}
+
+	/** @return array[] The activity log, newest first. */
+	public static function get_log(): array {
+		$log = get_option( self::OPT_LOG, array() );
+		return is_array( $log ) ? $log : array();
+	}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowLogTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/class-indexnow.php tests/unit/IndexNowLogTest.php
+git commit -m "feat(indexnow): activity-log ring buffer"
+```
+
+---
+
+## Task 5: Debounce queue (enqueue + dedup + schedule)
+
+**Files:**
+- Modify: `includes/class-indexnow.php`
+- Test: `tests/unit/IndexNowQueueTest.php` (create)
+
+**Interfaces:**
+- Produces: `SWPS_IndexNow::enqueue_url( string $url ): void`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/IndexNowQueueTest.php`:
+
+```php
+<?php
+/**
+ * Unit tests for the IndexNow debounce queue.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default_value = false ) {
+		return $GLOBALS['swps_test_options'][ $option ] ?? $default_value;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $option, $value, $autoload = null ) {
+		$GLOBALS['swps_test_options'][ $option ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $url ) {
+		return trim( (string) $url );
+	}
+}
+if ( ! function_exists( 'wp_next_scheduled' ) ) {
+	function wp_next_scheduled( $hook ) {
+		return $GLOBALS['swps_test_scheduled'][ $hook ] ?? false;
+	}
+}
+if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+	function wp_schedule_single_event( $ts, $hook, $args = array() ) {
+		$GLOBALS['swps_test_scheduled'][ $hook ]     = $ts;
+		$GLOBALS['swps_test_schedule_calls']         = ( $GLOBALS['swps_test_schedule_calls'] ?? 0 ) + 1;
+		return true;
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowQueueTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['swps_test_options']         = array();
+		$GLOBALS['swps_test_scheduled']       = array();
+		$GLOBALS['swps_test_schedule_calls']  = 0;
+	}
+
+	public function test_enqueue_adds_url(): void {
+		SWPS_IndexNow::enqueue_url( 'https://example.com/a' );
+		$this->assertSame( array( 'https://example.com/a' ), get_option( SWPS_IndexNow::OPT_QUEUE ) );
+	}
+
+	public function test_enqueue_dedupes(): void {
+		SWPS_IndexNow::enqueue_url( 'https://example.com/a' );
+		SWPS_IndexNow::enqueue_url( 'https://example.com/a' );
+		$this->assertCount( 1, get_option( SWPS_IndexNow::OPT_QUEUE ) );
+	}
+
+	public function test_enqueue_schedules_flush_once_per_burst(): void {
+		SWPS_IndexNow::enqueue_url( 'https://example.com/a' );
+		SWPS_IndexNow::enqueue_url( 'https://example.com/b' );
+		$this->assertSame( 1, $GLOBALS['swps_test_schedule_calls'] );
+		$this->assertArrayHasKey( SWPS_IndexNow::CRON_HOOK, $GLOBALS['swps_test_scheduled'] );
+	}
+
+	public function test_enqueue_ignores_empty(): void {
+		SWPS_IndexNow::enqueue_url( '   ' );
+		$this->assertSame( array(), get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowQueueTest.php`
+Expected: FAIL — "Call to undefined method SWPS_IndexNow::enqueue_url()".
+
+- [ ] **Step 3: Implement**
+
+Add to `SWPS_IndexNow`:
+
+```php
+	/** Add a URL to the debounce queue (deduped) and schedule a single flush. */
+	public static function enqueue_url( string $url ): void {
+		$url = esc_url_raw( $url );
+		if ( '' === $url ) {
+			return;
+		}
+		$queue = get_option( self::OPT_QUEUE, array() );
+		if ( ! is_array( $queue ) ) {
+			$queue = array();
+		}
+		if ( ! in_array( $url, $queue, true ) ) {
+			$queue[] = $url;
+			update_option( self::OPT_QUEUE, $queue, false );
+		}
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_single_event( time() + self::DEBOUNCE_SECONDS, self::CRON_HOOK );
+		}
+	}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowQueueTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/class-indexnow.php tests/unit/IndexNowQueueTest.php
+git commit -m "feat(indexnow): debounced submit queue with dedup + single-event scheduling"
+```
+
+---
+
+## Task 6: Eligibility gate + no-op suppression (auto path)
+
+**Files:**
+- Modify: `includes/class-indexnow.php`
+- Test: `tests/unit/IndexNowEligibilityTest.php` (create)
+
+**Interfaces:**
+- Consumes: `SWPS_Sitemap_Manager::is_post_indexable()` (Task 1); `SWPS_IndexNow::enqueue_url()` (Task 5); `SWPS_IndexNow::should_skip_environment()` (Task 3)
+- Produces: `SWPS_IndexNow::maybe_enqueue_post( $post ): void`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/IndexNowEligibilityTest.php`:
+
+```php
+<?php
+/**
+ * Unit tests for the IndexNow auto-enqueue eligibility gate.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default_value = false ) {
+		return $GLOBALS['swps_test_options'][ $option ] ?? $default_value;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $option, $value, $autoload = null ) {
+		$GLOBALS['swps_test_options'][ $option ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'get_post_meta' ) ) {
+	function get_post_meta( $id, $key = '', $single = false ) {
+		return $GLOBALS['swps_test_postmeta'][ $id ][ $key ] ?? '';
+	}
+}
+if ( ! function_exists( 'update_post_meta' ) ) {
+	function update_post_meta( $id, $key, $value ) {
+		$GLOBALS['swps_test_postmeta'][ $id ][ $key ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'get_permalink' ) ) {
+	function get_permalink( $post = 0 ) {
+		$id = is_object( $post ) ? $post->ID : (int) $post;
+		return 'https://example.com/?p=' . $id;
+	}
+}
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $url ) {
+		return trim( (string) $url );
+	}
+}
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return 'https://example.com' . $path;
+	}
+}
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( $url, $c = -1 ) {
+		return parse_url( $url, $c );
+	}
+}
+if ( ! function_exists( 'wp_get_environment_type' ) ) {
+	function wp_get_environment_type() {
+		return 'production';
+	}
+}
+if ( ! function_exists( 'wp_next_scheduled' ) ) {
+	function wp_next_scheduled( $hook ) {
+		return false;
+	}
+}
+if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+	function wp_schedule_single_event( $ts, $hook, $args = array() ) {
+		return true;
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-sitemap-manager.php';
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowEligibilityTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['swps_test_options']  = array(
+			SWPS_IndexNow::OPT_ENABLED    => 1,
+			SWPS_IndexNow::OPT_AUTO       => 1,
+			SWPS_IndexNow::OPT_POST_TYPES => array( 'post', 'page' ),
+		);
+		$GLOBALS['swps_test_postmeta'] = array();
+	}
+
+	private function post( int $id, string $type = 'post', string $modified = '2026-07-02 00:00:00' ): object {
+		return (object) array( 'ID' => $id, 'post_status' => 'publish', 'post_type' => $type, 'post_modified_gmt' => $modified );
+	}
+
+	public function test_eligible_post_is_enqueued(): void {
+		( new SWPS_IndexNow() )->maybe_enqueue_post( $this->post( 10 ) );
+		$this->assertContains( 'https://example.com/?p=10', get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+	}
+
+	public function test_disabled_feature_skips(): void {
+		$GLOBALS['swps_test_options'][ SWPS_IndexNow::OPT_ENABLED ] = 0;
+		( new SWPS_IndexNow() )->maybe_enqueue_post( $this->post( 10 ) );
+		$this->assertSame( array(), get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+	}
+
+	public function test_unselected_post_type_skips(): void {
+		( new SWPS_IndexNow() )->maybe_enqueue_post( $this->post( 10, 'product' ) );
+		$this->assertSame( array(), get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+	}
+
+	public function test_noop_resave_is_suppressed(): void {
+		$in = new SWPS_IndexNow();
+		$in->maybe_enqueue_post( $this->post( 10, 'post', '2026-07-02 00:00:00' ) );
+		$GLOBALS['swps_test_options'][ SWPS_IndexNow::OPT_QUEUE ] = array(); // simulate a flush
+		$in->maybe_enqueue_post( $this->post( 10, 'post', '2026-07-02 00:00:00' ) ); // identical modified
+		$this->assertSame( array(), get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+	}
+
+	public function test_edited_post_resubmits(): void {
+		$in = new SWPS_IndexNow();
+		$in->maybe_enqueue_post( $this->post( 10, 'post', '2026-07-02 00:00:00' ) );
+		$GLOBALS['swps_test_options'][ SWPS_IndexNow::OPT_QUEUE ] = array();
+		$in->maybe_enqueue_post( $this->post( 10, 'post', '2026-07-03 12:00:00' ) ); // changed
+		$this->assertContains( 'https://example.com/?p=10', get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowEligibilityTest.php`
+Expected: FAIL — "Call to undefined method SWPS_IndexNow::maybe_enqueue_post()".
+
+- [ ] **Step 3: Implement**
+
+Add to `SWPS_IndexNow`:
+
+```php
+	/**
+	 * Auto path: enqueue a post's permalink if IndexNow is enabled, auto-submit is
+	 * on, the post type is selected, the URL is sitemap-indexable, we're on
+	 * production, and the content actually changed since the last submit.
+	 *
+	 * @param WP_Post|object $post
+	 */
+	public function maybe_enqueue_post( $post ): void {
+		if ( ! is_object( $post ) || empty( $post->ID ) ) {
+			return;
+		}
+		if ( ! get_option( self::OPT_ENABLED, 0 ) || ! get_option( self::OPT_AUTO, 1 ) ) {
+			return;
+		}
+		$selected = (array) get_option( self::OPT_POST_TYPES, array() );
+		if ( ! in_array( ( $post->post_type ?? '' ), $selected, true ) ) {
+			return;
+		}
+		if ( ! SWPS_Sitemap_Manager::is_post_indexable( $post ) ) {
+			return;
+		}
+		if ( self::should_skip_environment() ) {
+			return;
+		}
+		$modified = (string) ( $post->post_modified_gmt ?? '' );
+		if ( '' !== $modified && (string) get_post_meta( $post->ID, self::META_SUBMITTED, true ) === $modified ) {
+			return; // No-op resave — content unchanged since last push.
+		}
+		$url = get_permalink( $post );
+		update_post_meta( $post->ID, self::META_LAST_URL, $url );
+		update_post_meta( $post->ID, self::META_SUBMITTED, $modified );
+		self::enqueue_url( $url );
+	}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowEligibilityTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/class-indexnow.php tests/unit/IndexNowEligibilityTest.php
+git commit -m "feat(indexnow): eligibility gate + no-op resave suppression"
+```
+
+---
+
+## Task 7: HTTP submit + flush
+
+**Files:**
+- Modify: `includes/class-indexnow.php` (fill in `flush()`, add `submit_urls()`)
+- Test: `tests/unit/IndexNowSubmitTest.php` (create)
+
+**Interfaces:**
+- Consumes: `build_payload()`, `interpret_response_code()`, `is_valid_key()`, `should_skip_environment()`, `append_log()`
+- Produces: `SWPS_IndexNow::submit_urls( array $urls, string $trigger = 'manual' ): array`; real `flush()` body
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/IndexNowSubmitTest.php`:
+
+```php
+<?php
+/**
+ * Unit tests for IndexNow HTTP submission + flush.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default_value = false ) {
+		return $GLOBALS['swps_test_options'][ $option ] ?? $default_value;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $option, $value, $autoload = null ) {
+		$GLOBALS['swps_test_options'][ $option ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return 'https://example.com' . $path;
+	}
+}
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( $url, $c = -1 ) {
+		return parse_url( $url, $c );
+	}
+}
+if ( ! function_exists( 'wp_get_environment_type' ) ) {
+	function wp_get_environment_type() {
+		return 'production';
+	}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data ) {
+		return json_encode( $data );
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
+}
+if ( ! function_exists( 'wp_remote_post' ) ) {
+	function wp_remote_post( $url, $args = array() ) {
+		$GLOBALS['swps_test_last_post'] = array( 'url' => $url, 'args' => $args );
+		return $GLOBALS['swps_test_http_response'] ?? array( 'response' => array( 'code' => 200 ), 'body' => '' );
+	}
+}
+if ( ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
+	function wp_remote_retrieve_response_code( $r ) {
+		return $r['response']['code'] ?? 0;
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowSubmitTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['swps_test_options']       = array( SWPS_IndexNow::OPT_KEY => str_repeat( 'a', 32 ) );
+		$GLOBALS['swps_test_http_response'] = array( 'response' => array( 'code' => 200 ), 'body' => '' );
+		unset( $GLOBALS['swps_test_last_post'] );
+	}
+
+	public function test_submit_posts_json_and_logs_ok(): void {
+		$results = ( new SWPS_IndexNow() )->submit_urls( array( 'https://example.com/a' ), 'manual' );
+		$this->assertSame( 'ok', $results[0]['result'] );
+		$this->assertSame( SWPS_IndexNow::ENDPOINT, $GLOBALS['swps_test_last_post']['url'] );
+		$body = json_decode( $GLOBALS['swps_test_last_post']['args']['body'], true );
+		$this->assertSame( 'example.com', $body['host'] );
+		$this->assertSame( array( 'https://example.com/a' ), $body['urlList'] );
+		$this->assertSame( 'ok', SWPS_IndexNow::get_log()[0]['result'] );
+	}
+
+	public function test_submit_without_valid_key_logs_no_key(): void {
+		$GLOBALS['swps_test_options'][ SWPS_IndexNow::OPT_KEY ] = '';
+		$results = ( new SWPS_IndexNow() )->submit_urls( array( 'https://example.com/a' ) );
+		$this->assertSame( array(), $results );
+		$this->assertSame( 'no_key', SWPS_IndexNow::get_log()[0]['result'] );
+	}
+
+	public function test_wp_error_is_logged_as_error(): void {
+		$GLOBALS['swps_test_http_response'] = new WP_Error( 'http', 'down' );
+		$results = ( new SWPS_IndexNow() )->submit_urls( array( 'https://example.com/a' ) );
+		$this->assertSame( 'error', $results[0]['result'] );
+	}
+
+	public function test_flush_drains_queue_and_submits(): void {
+		$GLOBALS['swps_test_options'][ SWPS_IndexNow::OPT_QUEUE ] = array( 'https://example.com/a', 'https://example.com/b' );
+		( new SWPS_IndexNow() )->flush();
+		$this->assertSame( array(), get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+		$body = json_decode( $GLOBALS['swps_test_last_post']['args']['body'], true );
+		$this->assertCount( 2, $body['urlList'] );
+	}
+
+	public function test_flush_on_empty_queue_does_nothing(): void {
+		( new SWPS_IndexNow() )->flush();
+		$this->assertArrayNotHasKey( 'swps_test_last_post', $GLOBALS );
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowSubmitTest.php`
+Expected: FAIL — "Call to undefined method SWPS_IndexNow::submit_urls()".
+
+- [ ] **Step 3: Implement `submit_urls()` and fill `flush()`**
+
+Add `submit_urls()` and replace the empty `flush()` body:
+
+```php
+	/**
+	 * POST one or more chunks of URLs to IndexNow. Logs each chunk's result.
+	 *
+	 * @return array[] One {code,result} per chunk.
+	 */
+	public function submit_urls( array $urls, string $trigger = 'manual' ): array {
+		$urls = array_values( array_unique( array_filter( $urls ) ) );
+		if ( empty( $urls ) ) {
+			return array();
+		}
+		$key = (string) get_option( self::OPT_KEY, '' );
+		if ( ! self::is_valid_key( $key ) ) {
+			self::append_log( array( 'time' => time(), 'trigger' => $trigger, 'count' => count( $urls ), 'code' => 0, 'result' => 'no_key' ) );
+			return array();
+		}
+		$host    = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+		$results = array();
+		foreach ( array_chunk( $urls, self::MAX_URLS_PER_REQUEST ) as $chunk ) {
+			$response = wp_remote_post(
+				self::ENDPOINT,
+				array(
+					'headers' => array( 'Content-Type' => 'application/json; charset=utf-8' ),
+					'body'    => wp_json_encode( self::build_payload( $host, $key, $chunk ) ),
+					'timeout' => 15,
+				)
+			);
+			if ( is_wp_error( $response ) ) {
+				$code   = 0;
+				$result = 'error';
+			} else {
+				$code   = (int) wp_remote_retrieve_response_code( $response );
+				$result = self::interpret_response_code( $code );
+			}
+			self::append_log( array( 'time' => time(), 'trigger' => $trigger, 'count' => count( $chunk ), 'code' => $code, 'result' => $result ) );
+			$results[] = array( 'code' => $code, 'result' => $result );
+		}
+		return $results;
+	}
+```
+
+Replace the `flush()` stub from Task 2 with:
+
+```php
+	/** wp-cron handler — drain the debounce queue and submit as one batch. */
+	public function flush(): void {
+		$queue = get_option( self::OPT_QUEUE, array() );
+		update_option( self::OPT_QUEUE, array(), false );
+		if ( ! is_array( $queue ) || empty( $queue ) ) {
+			return;
+		}
+		if ( self::should_skip_environment() ) {
+			self::append_log( array( 'time' => time(), 'trigger' => 'auto', 'count' => count( $queue ), 'code' => 0, 'result' => 'skipped_env' ) );
+			return;
+		}
+		$this->submit_urls( array_values( $queue ), 'auto' );
+	}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowSubmitTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `composer test`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add includes/class-indexnow.php tests/unit/IndexNowSubmitTest.php
+git commit -m "feat(indexnow): batched HTTP submit + cron flush"
+```
+
+---
+
+## Task 8: Lifecycle hooks + key-file serving
+
+**Files:**
+- Modify: `includes/class-indexnow.php` (register hooks in constructor; add handlers)
+
+**Interfaces:**
+- Consumes: `maybe_enqueue_post()`, `enqueue_url()`, `should_skip_environment()`, `is_valid_key()`, `key_file_path_matches()`
+- Produces: `on_transition_post_status()`, `on_delete_post()`, `on_term_change()`, `maybe_serve_key_file()`
+
+This task is WordPress-integration wiring; it is verified by the manual smoke test in Task 13 (no new unit test — the underlying logic is already covered by Tasks 3, 6, 7).
+
+- [ ] **Step 1: Register the hooks in the constructor**
+
+Replace the `SWPS_IndexNow::__construct()` body with:
+
+```php
+	public function __construct() {
+		add_action( self::CRON_HOOK, array( $this, 'flush' ) );
+
+		// Serve the verification file as early as possible.
+		add_action( 'init', array( $this, 'maybe_serve_key_file' ), 1 );
+
+		// Settings (Task 10) + admin surface (Task 11) + AJAX (Tasks 11-12).
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'wp_ajax_' . 'swps_indexnow_generate_key', array( $this, 'ajax_generate_key' ) );
+		add_action( 'wp_ajax_' . 'swps_indexnow_resubmit_all', array( $this, 'ajax_resubmit_all' ) );
+		add_action( 'wp_ajax_' . 'swps_indexnow_get_log', array( $this, 'ajax_get_log' ) );
+		add_action( 'wp_ajax_' . 'swps_indexnow_submit_post', array( $this, 'ajax_submit_post' ) );
+
+		// Lifecycle triggers.
+		add_action( 'transition_post_status', array( $this, 'on_transition_post_status' ), 10, 3 );
+		add_action( 'before_delete_post', array( $this, 'on_delete_post' ) );
+		add_action( 'wp_trash_post', array( $this, 'on_delete_post' ) );
+		add_action( 'created_term', array( $this, 'on_term_change' ), 10, 3 );
+		add_action( 'edited_term', array( $this, 'on_term_change' ), 10, 3 );
+		add_action( 'delete_term', array( $this, 'on_term_change' ), 10, 3 );
+	}
+```
+
+> The `register_settings`, `ajax_*` methods are added in Tasks 10–12; PHP only resolves them at call time, so registering the hooks now is safe as long as those tasks land before release. If running `php -l` between tasks, note it does not check method existence.
+
+- [ ] **Step 2: Add the lifecycle + key-file handlers**
+
+Add to `SWPS_IndexNow`:
+
+```php
+	/** Fired on every status change: enqueue on publish, submit the dead URL on unpublish. */
+	public function on_transition_post_status( string $new_status, string $old_status, $post ): void {
+		if ( ! is_object( $post ) || empty( $post->ID ) ) {
+			return;
+		}
+		if ( function_exists( 'wp_is_post_revision' ) && wp_is_post_revision( $post->ID ) ) {
+			return;
+		}
+		if ( 'publish' === $new_status ) {
+			$this->maybe_enqueue_post( $post );
+			return;
+		}
+		if ( 'publish' === $old_status && 'publish' !== $new_status ) {
+			$this->enqueue_removal( (int) $post->ID );
+		}
+	}
+
+	/** Fired on trash/delete: submit the last known public URL so engines recrawl (404/410). */
+	public function on_delete_post( int $post_id ): void {
+		$this->enqueue_removal( $post_id );
+	}
+
+	/** Submit a taxonomy term's URL when it changes, if its taxonomy is public + eligible. */
+	public function on_term_change( int $term_id, int $tt_id, string $taxonomy ): void {
+		if ( ! get_option( self::OPT_ENABLED, 0 ) || ! get_option( self::OPT_AUTO, 1 ) ) {
+			return;
+		}
+		if ( self::should_skip_environment() ) {
+			return;
+		}
+		$tax = get_taxonomy( $taxonomy );
+		if ( ! $tax || empty( $tax->public ) ) {
+			return;
+		}
+		if ( ! SWPS_Sitemap_Manager::is_term_indexable( $term_id ) ) {
+			return;
+		}
+		$url = get_term_link( $term_id, $taxonomy );
+		if ( ! is_wp_error( $url ) ) {
+			self::enqueue_url( (string) $url );
+		}
+	}
+
+	/** Enqueue the stashed public URL for a removed/unpublished post. */
+	private function enqueue_removal( int $post_id ): void {
+		if ( ! get_option( self::OPT_ENABLED, 0 ) || ! get_option( self::OPT_AUTO, 1 ) ) {
+			return;
+		}
+		if ( self::should_skip_environment() ) {
+			return;
+		}
+		$url = (string) get_post_meta( $post_id, self::META_LAST_URL, true );
+		if ( '' !== $url ) {
+			self::enqueue_url( $url );
+		}
+	}
+
+	/** Serve GET /{key}.txt with the raw key body (init, priority 1). */
+	public function maybe_serve_key_file(): void {
+		$key = (string) get_option( self::OPT_KEY, '' );
+		if ( ! self::is_valid_key( $key ) ) {
+			return;
+		}
+		$path = isset( $_SERVER['REQUEST_URI'] )
+			? (string) wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH )
+			: '';
+		if ( ! self::key_file_path_matches( $path, $key ) ) {
+			return;
+		}
+		nocache_headers();
+		header( 'Content-Type: text/plain; charset=utf-8' );
+		header( 'X-Robots-Tag: noindex' );
+		echo esc_html( $key );
+		exit;
+	}
+```
+
+- [ ] **Step 3: Lint and run the suite**
+
+Run: `php -l includes/class-indexnow.php && composer test`
+Expected: no syntax errors; all tests green (existing tests unaffected — the new hooks aren't fired in unit tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add includes/class-indexnow.php
+git commit -m "feat(indexnow): lifecycle triggers + /{key}.txt verification file"
+```
+
+---
+
+## Task 9: Settings registration (dedicated option group)
+
+**Files:**
+- Modify: `includes/class-indexnow.php` (add `register_settings()` + sanitizers)
+- Test: `tests/unit/IndexNowSettingsSanitizeTest.php` (create)
+
+**Interfaces:**
+- Produces: `register_settings(): void`; `sanitize_checkbox( $v ): int`; `sanitize_post_types( $v ): array`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/IndexNowSettingsSanitizeTest.php`:
+
+```php
+<?php
+/**
+ * Unit tests for IndexNow settings sanitizers (array footgun guard).
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $k ) {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $k ) );
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowSettingsSanitizeTest extends TestCase {
+
+	public function test_checkbox_sanitizes_to_int(): void {
+		$this->assertSame( 1, SWPS_IndexNow::sanitize_checkbox( '1' ) );
+		$this->assertSame( 1, SWPS_IndexNow::sanitize_checkbox( 'on' ) );
+		$this->assertSame( 0, SWPS_IndexNow::sanitize_checkbox( '' ) );
+		$this->assertSame( 0, SWPS_IndexNow::sanitize_checkbox( null ) );
+	}
+
+	public function test_post_types_stay_an_array(): void {
+		$this->assertSame( array( 'post', 'page' ), SWPS_IndexNow::sanitize_post_types( array( 'post', 'page' ) ) );
+	}
+
+	public function test_post_types_sanitizes_keys_and_drops_bad_input(): void {
+		$this->assertSame( array( 'mycpt' ), SWPS_IndexNow::sanitize_post_types( array( 'My CPT!' ) ) );
+		$this->assertSame( array(), SWPS_IndexNow::sanitize_post_types( 'not-an-array' ) );
+		$this->assertSame( array(), SWPS_IndexNow::sanitize_post_types( null ) );
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowSettingsSanitizeTest.php`
+Expected: FAIL — "Call to undefined method SWPS_IndexNow::sanitize_checkbox()".
+
+- [ ] **Step 3: Implement**
+
+Add to `SWPS_IndexNow`:
+
+```php
+	/**
+	 * Register the three form-persisted options in a DEDICATED option group so a
+	 * partial form on the Sitemaps page cannot wipe unrelated swps_* options.
+	 * The API key is NOT registered here — it is managed via the generate-key AJAX
+	 * action and never rendered in the form. Each option is registered exactly once.
+	 */
+	public function register_settings(): void {
+		register_setting(
+			self::SETTINGS_GROUP,
+			self::OPT_ENABLED,
+			array( 'sanitize_callback' => array( __CLASS__, 'sanitize_checkbox' ), 'default' => 0 )
+		);
+		register_setting(
+			self::SETTINGS_GROUP,
+			self::OPT_AUTO,
+			array( 'sanitize_callback' => array( __CLASS__, 'sanitize_checkbox' ), 'default' => 1 )
+		);
+		register_setting(
+			self::SETTINGS_GROUP,
+			self::OPT_POST_TYPES,
+			array(
+				'type'              => 'array',
+				'sanitize_callback' => array( __CLASS__, 'sanitize_post_types' ),
+				'default'           => array( 'post', 'page' ),
+			)
+		);
+	}
+
+	public static function sanitize_checkbox( $value ): int {
+		return $value ? 1 : 0;
+	}
+
+	public static function sanitize_post_types( $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+		return array_values( array_map( 'sanitize_key', $value ) );
+	}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `./vendor/bin/phpunit tests/unit/IndexNowSettingsSanitizeTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/class-indexnow.php tests/unit/IndexNowSettingsSanitizeTest.php
+git commit -m "feat(indexnow): dedicated settings group + footgun-safe sanitizers"
+```
+
+---
+
+## Task 10: AJAX handlers (generate key, resubmit all, get log)
+
+**Files:**
+- Modify: `includes/class-indexnow.php`
+
+**Interfaces:**
+- Consumes: `generate_key()`, `submit_urls()`, `get_log()`, `SWPS_Sitemap_Manager::get_indexable_urls()`
+- Produces: `ajax_generate_key()`, `ajax_resubmit_all()`, `ajax_get_log()`
+
+WordPress-integration; verified by Task 13 browser smoke test. All handlers use the shared `swps_nonce` (localized as `swpsAdmin.nonce`) and `manage_options`, matching `SWPS_Sitemap_Admin`.
+
+- [ ] **Step 1: Implement the three admin AJAX handlers**
+
+Add to `SWPS_IndexNow`:
+
+```php
+	/** AJAX: generate + persist a new IndexNow key (rotation). */
+	public function ajax_generate_key(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		$key = self::generate_key();
+		update_option( self::OPT_KEY, $key, false );
+		wp_send_json_success(
+			array(
+				'key'          => $key,
+				'key_file_url' => home_url( '/' . $key . '.txt' ),
+			)
+		);
+	}
+
+	/** AJAX: submit the full indexable URL set ("Resubmit all"). */
+	public function ajax_resubmit_all(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		if ( self::should_skip_environment() ) {
+			wp_send_json_error( array( 'message' => __( 'IndexNow is paused on non-production environments.', 'stratawp-seo' ) ) );
+		}
+		$urls    = SWPS_Sitemap_Manager::get_indexable_urls();
+		$results = $this->submit_urls( $urls, 'bulk' );
+		wp_send_json_success(
+			array(
+				'submitted' => count( $urls ),
+				'batches'   => $results,
+			)
+		);
+	}
+
+	/** AJAX: return the activity log for the admin panel. */
+	public function ajax_get_log(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		wp_send_json_success( array( 'log' => self::get_log() ) );
+	}
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `php -l includes/class-indexnow.php`
+Expected: "No syntax errors detected".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add includes/class-indexnow.php
+git commit -m "feat(indexnow): admin AJAX handlers (generate key, resubmit all, get log)"
+```
+
+---
+
+## Task 11: Admin panel on the Sitemaps page
+
+**Files:**
+- Create: `templates/indexnow-panel.php`
+- Create: `admin/js/indexnow.js`
+- Modify: `templates/sitemaps-page.php` (include the panel)
+- Modify: `stratawp-seo.php` (enqueue `indexnow.js` on the sitemaps admin page)
+
+WordPress-integration; verified by Task 13 browser smoke test.
+
+- [ ] **Step 1: Create the panel template**
+
+Create `templates/indexnow-panel.php`:
+
+```php
+<?php
+/**
+ * IndexNow panel, rendered inside the Sitemaps admin page.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$swps_in_key      = (string) get_option( SWPS_IndexNow::OPT_KEY, '' );
+$swps_in_enabled  = (bool) get_option( SWPS_IndexNow::OPT_ENABLED, 0 );
+$swps_in_auto     = (bool) get_option( SWPS_IndexNow::OPT_AUTO, 1 );
+$swps_in_selected = (array) get_option( SWPS_IndexNow::OPT_POST_TYPES, array( 'post', 'page' ) );
+$swps_in_skip_env = SWPS_IndexNow::should_skip_environment();
+$swps_in_key_url  = $swps_in_key ? home_url( '/' . $swps_in_key . '.txt' ) : '';
+?>
+<div class="postbox">
+	<div class="inside">
+		<h3><?php esc_html_e( 'IndexNow', 'stratawp-seo' ); ?></h3>
+		<p class="description">
+			<?php esc_html_e( 'Instantly notify Bing, Yandex, Seznam, and Naver when your content changes. (Google does not participate in IndexNow.)', 'stratawp-seo' ); ?>
+		</p>
+
+		<?php if ( $swps_in_skip_env ) : ?>
+			<div class="notice notice-warning inline">
+				<p><?php esc_html_e( 'IndexNow is paused: this does not look like a production site, so URLs will not be submitted.', 'stratawp-seo' ); ?></p>
+			</div>
+		<?php endif; ?>
+
+		<form method="post" action="options.php">
+			<?php settings_fields( SWPS_IndexNow::SETTINGS_GROUP ); ?>
+			<table class="form-table">
+				<tr>
+					<th><label for="swps_indexnow_enabled"><?php esc_html_e( 'Enable IndexNow', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input type="hidden" name="<?php echo esc_attr( SWPS_IndexNow::OPT_ENABLED ); ?>" value="0">
+						<input type="checkbox" id="swps_indexnow_enabled" name="<?php echo esc_attr( SWPS_IndexNow::OPT_ENABLED ); ?>" value="1" <?php checked( $swps_in_enabled ); ?>>
+					</td>
+				</tr>
+				<tr>
+					<th><label for="swps_indexnow_auto"><?php esc_html_e( 'Auto-submit on publish/update', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input type="hidden" name="<?php echo esc_attr( SWPS_IndexNow::OPT_AUTO ); ?>" value="0">
+						<input type="checkbox" id="swps_indexnow_auto" name="<?php echo esc_attr( SWPS_IndexNow::OPT_AUTO ); ?>" value="1" <?php checked( $swps_in_auto ); ?>>
+					</td>
+				</tr>
+				<tr>
+					<th><?php esc_html_e( 'Post types', 'stratawp-seo' ); ?></th>
+					<td>
+						<fieldset>
+							<?php
+							foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $swps_pt ) {
+								if ( 'attachment' === $swps_pt->name ) {
+									continue;
+								}
+								printf(
+									'<label style="display:inline-block;min-width:160px;"><input type="checkbox" name="%1$s[]" value="%2$s" %3$s> %4$s</label>',
+									esc_attr( SWPS_IndexNow::OPT_POST_TYPES ),
+									esc_attr( $swps_pt->name ),
+									checked( in_array( $swps_pt->name, $swps_in_selected, true ), true, false ),
+									esc_html( $swps_pt->label )
+								);
+							}
+							?>
+						</fieldset>
+					</td>
+				</tr>
+			</table>
+			<?php submit_button( __( 'Save IndexNow Settings', 'stratawp-seo' ) ); ?>
+		</form>
+
+		<hr>
+		<h4><?php esc_html_e( 'API Key', 'stratawp-seo' ); ?></h4>
+		<p>
+			<code id="swps-indexnow-key"><?php echo esc_html( $swps_in_key ?: __( '(not generated yet)', 'stratawp-seo' ) ); ?></code>
+			<button type="button" class="button" id="swps-indexnow-generate"><?php esc_html_e( 'Generate / Rotate Key', 'stratawp-seo' ); ?></button>
+		</p>
+		<p class="description">
+			<?php esc_html_e( 'Verification file:', 'stratawp-seo' ); ?>
+			<a id="swps-indexnow-key-url" href="<?php echo esc_url( $swps_in_key_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $swps_in_key_url ); ?></a>
+		</p>
+
+		<hr>
+		<p>
+			<button type="button" class="button button-secondary" id="swps-indexnow-resubmit"><?php esc_html_e( 'Resubmit All URLs', 'stratawp-seo' ); ?></button>
+			<span id="swps-indexnow-resubmit-status"></span>
+		</p>
+
+		<h4><?php esc_html_e( 'Recent Activity', 'stratawp-seo' ); ?></h4>
+		<table class="widefat striped" id="swps-indexnow-log">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Time', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Trigger', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'URLs', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Result', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr><td colspan="4"><?php esc_html_e( 'Loading…', 'stratawp-seo' ); ?></td></tr>
+			</tbody>
+		</table>
+	</div>
+</div>
+```
+
+- [ ] **Step 2: Include the panel from the Sitemaps page**
+
+In `templates/sitemaps-page.php`, inside the dashboard tab `<div id="tab-dashboard" ...>`, after the sitemaps `</table>` (around line 48) and before the closing `</div>` of the tab, add:
+
+```php
+		<?php require SWPS_PLUGIN_DIR . 'templates/indexnow-panel.php'; ?>
+```
+
+- [ ] **Step 3: Create the JS**
+
+Create `admin/js/indexnow.js`:
+
+```javascript
+/* global jQuery, swpsAdmin */
+( function ( $ ) {
+	'use strict';
+
+	function post( action, extra ) {
+		return $.post( swpsAdmin.ajax_url, Object.assign( { action: action, nonce: swpsAdmin.nonce }, extra || {} ) );
+	}
+
+	function renderLog( log ) {
+		var $body = $( '#swps-indexnow-log tbody' ).empty();
+		if ( ! log || ! log.length ) {
+			$body.append( '<tr><td colspan="4">No activity yet.</td></tr>' );
+			return;
+		}
+		log.forEach( function ( e ) {
+			var when = e.time ? new Date( e.time * 1000 ).toLocaleString() : '';
+			$body.append(
+				'<tr><td>' + when + '</td><td>' + ( e.trigger || '' ) + '</td><td>' +
+				( e.count || 0 ) + '</td><td>' + ( e.result || '' ) + '</td></tr>'
+			);
+		} );
+	}
+
+	function loadLog() {
+		post( 'swps_indexnow_get_log' ).done( function ( r ) {
+			if ( r && r.success ) {
+				renderLog( r.data.log );
+			}
+		} );
+	}
+
+	$( function () {
+		if ( ! $( '#swps-indexnow-log' ).length ) {
+			return;
+		}
+		loadLog();
+
+		$( '#swps-indexnow-generate' ).on( 'click', function () {
+			var $b = $( this ).prop( 'disabled', true );
+			post( 'swps_indexnow_generate_key' ).done( function ( r ) {
+				if ( r && r.success ) {
+					$( '#swps-indexnow-key' ).text( r.data.key );
+					$( '#swps-indexnow-key-url' ).text( r.data.key_file_url ).attr( 'href', r.data.key_file_url );
+				} else {
+					window.alert( r && r.data ? r.data.message : 'Error' );
+				}
+			} ).always( function () {
+				$b.prop( 'disabled', false );
+			} );
+		} );
+
+		$( '#swps-indexnow-resubmit' ).on( 'click', function () {
+			var $b = $( this ).prop( 'disabled', true );
+			$( '#swps-indexnow-resubmit-status' ).text( 'Submitting…' );
+			post( 'swps_indexnow_resubmit_all' ).done( function ( r ) {
+				$( '#swps-indexnow-resubmit-status' ).text(
+					r && r.success ? ( 'Submitted ' + r.data.submitted + ' URLs.' ) : ( r && r.data ? r.data.message : 'Error' )
+				);
+				loadLog();
+			} ).always( function () {
+				$b.prop( 'disabled', false );
+			} );
+		} );
+	} );
+}( jQuery ) );
+```
+
+- [ ] **Step 4: Enqueue the JS on the Sitemaps page**
+
+In `stratawp-seo.php`, next to the existing sitemaps script enqueue (around line 731), add:
+
+```php
+		if ( 'stratawp-seo_page_swps-sitemaps' === $hook ) {
+			wp_enqueue_script( 'swps-sitemaps', SWPS_PLUGIN_URL . 'admin/js/sitemaps.js', array( 'swps-admin' ), SWPS_VERSION, true );
+			wp_enqueue_script( 'swps-indexnow', SWPS_PLUGIN_URL . 'admin/js/indexnow.js', array( 'swps-admin', 'jquery' ), SWPS_VERSION, true );
+		}
+```
+
+- [ ] **Step 5: Lint the PHP**
+
+Run: `php -l templates/indexnow-panel.php && php -l templates/sitemaps-page.php && php -l stratawp-seo.php`
+Expected: no syntax errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add templates/indexnow-panel.php templates/sitemaps-page.php admin/js/indexnow.js stratawp-seo.php
+git commit -m "feat(indexnow): admin panel on Sitemaps page (settings, key, resubmit, log)"
+```
+
+---
+
+## Task 12: Per-post "Submit to IndexNow" button
+
+**Files:**
+- Modify: `includes/class-indexnow.php` (add `ajax_submit_post()`)
+- Modify: `templates/meta-editor-metabox.php` (add the button)
+- Modify: `admin/js/indexnow.js` (wire the button)
+
+WordPress-integration; verified by Task 13 browser smoke test.
+
+- [ ] **Step 1: Add the AJAX handler**
+
+Add to `SWPS_IndexNow`:
+
+```php
+	/** AJAX: manually submit a single post's URL now (bypasses auto-submit toggle). */
+	public function ajax_submit_post(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		$post_id = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+		if ( ! $post_id || ! current_user_can( 'edit_post', $post_id ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		if ( ! get_option( self::OPT_ENABLED, 0 ) ) {
+			wp_send_json_error( array( 'message' => __( 'IndexNow is disabled. Enable it under Sitemaps → IndexNow.', 'stratawp-seo' ) ) );
+		}
+		if ( self::should_skip_environment() ) {
+			wp_send_json_error( array( 'message' => __( 'IndexNow is paused on non-production environments.', 'stratawp-seo' ) ) );
+		}
+		$post = get_post( $post_id );
+		if ( ! $post || ! SWPS_Sitemap_Manager::is_post_indexable( $post ) ) {
+			wp_send_json_error( array( 'message' => __( 'This URL is not eligible (unpublished, excluded, or noindex).', 'stratawp-seo' ) ) );
+		}
+		$url     = get_permalink( $post );
+		update_post_meta( $post_id, self::META_LAST_URL, $url );
+		$results = $this->submit_urls( array( $url ), 'manual' );
+		$result  = $results[0]['result'] ?? 'error';
+		wp_send_json_success( array( 'result' => $result, 'url' => $url ) );
+	}
+```
+
+- [ ] **Step 2: Add the button to the meta box**
+
+In `templates/meta-editor-metabox.php`, add near the end of the template (inside the metabox markup). Use the existing `$post` variable that `render_metabox()` passes through:
+
+```php
+	<?php if ( get_option( SWPS_IndexNow::OPT_ENABLED, 0 ) && isset( $post ) ) : ?>
+		<p class="swps-indexnow-metabox">
+			<button type="button" class="button" id="swps-indexnow-submit-post" data-post="<?php echo esc_attr( $post->ID ); ?>">
+				<?php esc_html_e( 'Submit to IndexNow now', 'stratawp-seo' ); ?>
+			</button>
+			<span id="swps-indexnow-submit-post-status"></span>
+		</p>
+	<?php endif; ?>
+```
+
+> The `meta-editor-metabox.php` template runs inside `render_metabox( WP_Post $post )`, so `$post` is in scope (verified in `class-meta-editor.php:80-105`).
+
+- [ ] **Step 3: Ensure the metabox loads the IndexNow JS**
+
+The meta box appears on post-edit screens, where `admin/js/indexnow.js` is not yet enqueued. In `stratawp-seo.php`, in the admin enqueue method, add a post-edit-screen branch (near the sitemaps enqueue):
+
+```php
+		if ( in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
+			wp_enqueue_script( 'swps-indexnow', SWPS_PLUGIN_URL . 'admin/js/indexnow.js', array( 'swps-admin', 'jquery' ), SWPS_VERSION, true );
+		}
+```
+
+- [ ] **Step 4: Wire the button in JS**
+
+In `admin/js/indexnow.js`, inside the `$( function () { ... } )` ready block (after the resubmit handler), add:
+
+```javascript
+		$( '#swps-indexnow-submit-post' ).on( 'click', function () {
+			var $b = $( this ).prop( 'disabled', true );
+			var id = $b.data( 'post' );
+			$( '#swps-indexnow-submit-post-status' ).text( 'Submitting…' );
+			post( 'swps_indexnow_submit_post', { post_id: id } ).done( function ( r ) {
+				$( '#swps-indexnow-submit-post-status' ).text(
+					r && r.success ? ( 'Submitted (' + r.data.result + ').' ) : ( r && r.data ? r.data.message : 'Error' )
+				);
+			} ).always( function () {
+				$b.prop( 'disabled', false );
+			} );
+		} );
+```
+
+Also relax the early-return guard at the top of the ready block so the button works on the post editor (where `#swps-indexnow-log` is absent). Replace:
+
+```javascript
+		if ( ! $( '#swps-indexnow-log' ).length ) {
+			return;
+		}
+		loadLog();
+```
+
+with:
+
+```javascript
+		if ( $( '#swps-indexnow-log' ).length ) {
+			loadLog();
+		}
+```
+
+- [ ] **Step 5: Lint**
+
+Run: `php -l includes/class-indexnow.php && php -l templates/meta-editor-metabox.php`
+Expected: no syntax errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add includes/class-indexnow.php templates/meta-editor-metabox.php admin/js/indexnow.js stratawp-seo.php
+git commit -m "feat(indexnow): per-post 'Submit to IndexNow now' button in the SEO meta box"
+```
+
+---
+
+## Task 13: Deactivation/uninstall cleanup + manual smoke test
+
+**Files:**
+- Modify: `stratawp-seo.php` (`swps_deactivate()` — clear the flush event)
+- Modify: `uninstall.php` (add the cron hook to the unschedule list)
+
+**Interfaces:**
+- Consumes: `SWPS_IndexNow::CRON_HOOK`
+
+- [ ] **Step 1: Clear the scheduled flush on deactivation**
+
+In `stratawp-seo.php`, inside `swps_deactivate()` (before `flush_rewrite_rules();` at line 1489), add:
+
+```php
+	wp_clear_scheduled_hook( SWPS_IndexNow::CRON_HOOK );
+```
+
+- [ ] **Step 2: Unschedule the flush hook on uninstall**
+
+In `uninstall.php`, add the flush hook to the `$swps_cron_hooks` array (after `'swps_audit_ability_run',` at line 48):
+
+```php
+	'swps_audit_ability_run',
+	'swps_indexnow_flush',
+```
+
+> Options (`swps_indexnow_*`) and post/term meta (`_swps_indexnow_*`) need no explicit uninstall entries — the existing wildcard deletes (`DELETE FROM options WHERE option_name LIKE 'swps\_%'`, `postmeta LIKE '\_swps\_%'`, `termmeta LIKE '\_swps\_%'`) already remove them when "Remove Data on Uninstall" is enabled.
+
+- [ ] **Step 3: Lint + full suite**
+
+Run: `php -l stratawp-seo.php && php -l uninstall.php && composer test`
+Expected: no syntax errors; all unit tests green.
+
+- [ ] **Step 4: Manual smoke test on jonimms.local**
+
+Run these against the `jonimms.local` dev site (LocalWP; the site runs the checked-out branch live). This is the environment guard's expected "paused" state, so verify both the guard AND force a live submission.
+
+1. Confirm the class loads and options exist:
+   ```bash
+   wp eval 'var_dump( class_exists("SWPS_IndexNow") );'
+   ```
+   Expected: `bool(true)`.
+
+2. Generate a key and confirm the verification file serves:
+   ```bash
+   wp option update swps_indexnow_api_key "$(php -r 'echo bin2hex(random_bytes(16));')"
+   wp option update swps_indexnow_enabled 1
+   KEY=$(wp option get swps_indexnow_api_key)
+   curl -sI "http://jonimms.local/${KEY}.txt" | grep -i 'content-type'
+   curl -s "http://jonimms.local/${KEY}.txt"
+   ```
+   Expected: `Content-Type: text/plain`; body is exactly the key.
+
+3. Confirm the environment guard pauses submission on `.local`:
+   ```bash
+   wp eval 'var_dump( SWPS_IndexNow::should_skip_environment() );'
+   ```
+   Expected: `bool(true)` (host ends in `.local`).
+
+4. Verify `get_indexable_urls()` returns the sitemap's URL set:
+   ```bash
+   wp eval '$u = SWPS_Sitemap_Manager::get_indexable_urls(); echo count($u) . " urls\n"; echo implode("\n", array_slice($u,0,5));'
+   ```
+   Expected: a non-zero count; homepage + real permalinks; nothing excluded/noindex.
+
+5. Force a real submission (bypass the guard) and confirm the log records the IndexNow HTTP response:
+   ```bash
+   wp eval '
+     add_filter("wp_get_environment_type", fn() => "production");
+     $in = new SWPS_IndexNow();
+     $in->submit_urls( array( home_url("/") ), "manual" );
+     print_r( SWPS_IndexNow::get_log()[0] );
+   '
+   ```
+   Expected: a log entry with `result` = `ok` or `pending` (200/202) if the key file is reachable, or `key_not_found` (403) if IndexNow can't fetch `/{key}.txt` from the local host (expected on a non-public `.local` domain — that still proves the round-trip works).
+
+6. Browser check (Claude in Chrome or manual): open **StrataWP SEO → Sitemaps**, confirm the IndexNow panel renders with the pause notice, the key + verification link, the post-type checkboxes, "Resubmit All URLs", and the activity-log table. Open any post editor and confirm the "Submit to IndexNow now" button appears in the SEO meta box.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add stratawp-seo.php uninstall.php
+git commit -m "feat(indexnow): deactivation + uninstall cleanup for the flush cron"
+```
+
+---
+
+## Task 14: Version bump, docs, and deployment zip
+
+**Files:**
+- Modify: `stratawp-seo.php` (header `Version:` + `SWPS_VERSION`)
+- Modify: `README.md`, `readme.txt` (changelog + feature entry)
+- Build: deployment zip
+
+- [ ] **Step 1: Bump the version to 4.22.0**
+
+In `stratawp-seo.php`, change the header line 6 `* Version: 4.21.4` → `* Version: 4.22.0`, and line 20 `define( 'SWPS_VERSION', '4.21.4' );` → `define( 'SWPS_VERSION', '4.22.0' );`.
+
+- [ ] **Step 2: Update readme.txt**
+
+Bump `Stable tag:` to `4.22.0` and add a changelog entry under `== Changelog ==`:
+
+```
+= 4.22.0 =
+* New: IndexNow integration — instantly notify Bing, Yandex, Seznam, and Naver when you publish, update, or remove content. Includes an auto-generated verification key served at /{key}.txt, auto-submit on the post/term lifecycle with a 60-second debounce, per-post "Submit now" and bulk "Resubmit all" controls, a dedicated panel on the Sitemaps screen, and a recent-activity log. Submissions are automatically paused on non-production environments. (Google does not participate in IndexNow.)
+```
+
+Add a one-line feature bullet to the feature list section of `readme.txt` (match the existing bullet style).
+
+- [ ] **Step 3: Update README.md**
+
+Add an IndexNow entry to the feature list and a `## 4.22.0` (or equivalent) changelog section, matching the document's existing headings and tone.
+
+- [ ] **Step 4: Verify the whole suite + static analysis**
+
+Run: `composer test && composer analyze`
+Expected: PHPUnit all green; PHPStan reports no new errors (the plan introduces no untyped globals; if PHPStan flags the new class, address inline or add to the baseline only if consistent with existing project practice).
+
+- [ ] **Step 5: Build the deployment zip**
+
+Build the distribution zip the same way the repo's existing `stratawp-seo.zip` is produced (the repo ignores `*.zip`). If a build script exists, run it; otherwise:
+
+```bash
+git archive --format=zip --prefix=stratawp-seo/ -o stratawp-seo.zip HEAD
+```
+
+Confirm the zip excludes dev files (`tests/`, `.phpstan/`, `docs/`, `node_modules/`, `vendor/` dev-only) per the existing packaging convention — if the repo has a dedicated build script or `.distignore`, prefer it over `git archive`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add stratawp-seo.php README.md readme.txt
+git commit -m "release: IndexNow integration (4.22.0)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** (each spec section → task):
+
+| Spec section | Task(s) |
+|--------------|---------|
+| §1 New class + bootstrap wiring | Task 2 |
+| §2 Shared eligibility (is_post_indexable / get_indexable_urls) | Task 1 |
+| §3 Key management + /{key}.txt | Tasks 3 (key/path helpers), 8 (serving), 10 (generate AJAX) |
+| §4.1 Lifecycle triggers + removal-URL stash | Tasks 6, 8 |
+| §4.2 Debounce queue + no-op suppression | Tasks 5, 6 |
+| §4.3 Flush handler | Task 7 |
+| §5 Submission + response interpretation + manual actions | Tasks 3, 7, 10, 12 |
+| §6 Environment guard | Task 3 (logic), enforced in Tasks 7, 8, 10, 12 |
+| §7 Settings + admin UI | Tasks 9 (settings), 11 (panel) |
+| §8 Activity log | Task 4 |
+| §9 Activation/deactivation/uninstall | Task 13 |
+| §10 Testing | Tasks 1–9 unit tests; Task 13 smoke test |
+| §11 Release | Task 14 |
+| §12 Out of scope (Google, DB log, multisite dashboard, diff-sweep) | Not implemented — correct |
+
+**Deviations from spec (deliberate, and why):**
+- **Renderer not refactored to call the predicate** (Task 1) — the existing sitemap regression tests pass bare `stdClass` without `post_status`/`post_type`; routing the tested renderer through a `WP_Post` predicate would break them. `is_post_indexable()` encodes identical rules and is annotated to stay in sync. Functional "mirror the sitemap" behavior is preserved.
+- **Settings use a dedicated `swps_indexnow_settings` group** rather than `add_field()` into the main `stratawp-seo` group (spec §7.1). Reason: the panel lives on the Sitemaps page; a partial form posting to the shared group would wipe unrelated `swps_*` options. This follows the existing `swps_sitemap_settings` precedent and still registers each option exactly once (footgun-safe).
+- **API key is not a settings-form field** — managed via the generate-key AJAX action, so it is never rendered or round-tripped through the form (avoids accidental blanking).
+- **Uninstall** adds only the cron hook; options/meta are already wildcard-cleaned (verified in `uninstall.php:74-77,121`).
+
+**Placeholder scan:** none — every code step contains complete code; every test step has real assertions; every command has expected output.
+
+**Type consistency:** option/constant/meta/AJAX-action names match the Naming Reference table throughout; `is_post_indexable()`, `enqueue_url()`, `submit_urls()`, `should_skip_environment()`, `append_log()`/`get_log()`, `maybe_enqueue_post()`, `sanitize_checkbox()`/`sanitize_post_types()` are referenced with identical signatures wherever they appear.

--- a/docs/superpowers/specs/2026-07-02-indexnow-design.md
+++ b/docs/superpowers/specs/2026-07-02-indexnow-design.md
@@ -1,0 +1,300 @@
+# IndexNow Integration — Design Spec
+
+## Overview
+
+Add [IndexNow](https://www.indexnow.org/) support to StrataWP SEO so the site instantly
+notifies participating search engines (Bing, Yandex, Seznam, Naver — **not** Google) whenever a
+URL is published, updated, or removed, instead of waiting for the next crawl.
+
+The feature is auto-submit-first (fires on the post/term lifecycle) with manual controls, mirrors
+the sitemap's notion of "indexable URL" as a single source of truth, keeps a lightweight activity
+log, and refuses to submit from non-production environments.
+
+This fulfils the promise already advertised in the Sitemaps module description
+(`includes/class-modules.php:92` — *"XML index, image sitemap, IndexNow batch submit."*). No prior
+implementation or stub exists; this is greenfield.
+
+### Decisions locked in brainstorming
+
+| Decision | Choice |
+|----------|--------|
+| Trigger model | Auto-submit (default ON, toggleable) **plus** per-post "Submit now" and bulk "Resubmit all" |
+| URL eligibility | Mirror the sitemap (posts, pages, CPTs, taxonomies, authors; honors excludes + noindex) |
+| Activity log | Lightweight ring buffer (~50 entries) in an option — no DB table |
+| Environment guard | Auto-skip when not production / host looks like staging |
+| Debounce window | 60 seconds, coalesced into one batch POST |
+| Endpoint | `https://api.indexnow.org/indexnow` aggregator (one POST fans out to all participants) |
+| Per-post control location | SEO meta box (`SWPS_Meta_Editor`) |
+| Version | 4.22.0 (new feature → minor bump) |
+
+## 1. New Class: `SWPS_IndexNow`
+
+New file `includes/class-indexnow.php` defining `SWPS_IndexNow`. It owns everything except the
+persisted-setting **registration** (which goes through the settings framework) and the URL
+**eligibility/enumeration** (which stays in the sitemap manager — see §2).
+
+**Bootstrap wiring (mandatory — no runtime autoloader):**
+- Add `require_once SWPS_PLUGIN_DIR . 'includes/class-indexnow.php';` to the require block in
+  `stratawp-seo.php` (the block spanning ~lines 33–147, near `class-rate-limiter.php` @ line 63).
+  A missing require is a **runtime-only fatal**; PHPStan will not catch it.
+- Instantiate `new SWPS_IndexNow()` in `StrataWP_SEO::__construct()` (~lines 363–475), where
+  `SWPS_Cron` and peers are constructed.
+
+**Responsibilities:**
+1. Key management (generate / rotate / read).
+2. Serving the `/{key}.txt` verification file.
+3. Post/term lifecycle hooks → enqueue.
+4. The debounced queue + scheduled flush.
+5. HTTP submission + response interpretation.
+6. The activity-log ring buffer.
+7. The environment guard.
+8. AJAX handlers (generate key, submit-now, resubmit-all, fetch log).
+
+Target < 500 lines (project convention). If it grows past that, split the AJAX/admin surface into a
+sibling `SWPS_IndexNow_Admin` mirroring the `SWPS_Sitemap_Manager` / `SWPS_Sitemap_Admin` split.
+
+## 2. Shared Eligibility (small sitemap refactor)
+
+To make IndexNow submit exactly what the sitemap contains, add two **public** methods to
+`SWPS_Sitemap_Manager` and refactor the existing private renderers to call the shared predicate so
+output cannot drift:
+
+```php
+/** Is this published post part of the sitemap (single source of truth)? */
+public static function is_post_indexable( WP_Post $post ): bool;
+
+/** Full indexable URL set: posts + pages + CPTs + taxonomies + authors. */
+public static function get_indexable_urls(): array; // returns list of absolute URLs (deduped)
+```
+
+- `is_post_indexable()` consolidates the current private checks: `post_status === 'publish'`,
+  `! is_post_type_hidden_from_sitemap()` (`class-sitemap-manager.php:20-24`), no
+  `_swps_sitemap_exclude` meta, and `_swps_robots` not containing `noindex`.
+- `get_indexable_urls()` powers the bulk "Resubmit all" action, reusing the same eligibility rules
+  plus `is_taxonomy_hidden_from_sitemap()` and the author `has_published_posts` filter.
+- The private `render_post_type_sitemap()` / `render_taxonomy_sitemap()` per-item skip logic is
+  refactored to call `is_post_indexable()` / a term equivalent — **behavior-preserving**.
+
+**Regression guard:** `tests/unit/SitemapHomepageTest.php` and `SitemapUrlTest.php` must stay green
+through this refactor; the homepage-dedup and pagination behavior in the renderers must be
+untouched.
+
+## 3. Key Management & Verification File
+
+- **Option:** `swps_indexnow_api_key` — a **plain** (unencrypted) option. The key is public by
+  design (served in cleartext at `/{key}.txt`), so it must **not** be added to the encryption
+  whitelist in `SWPS_Settings::get_sanitize_callback()` (`class-settings.php:1307-1317`). Treat it
+  like `swps_gsc_client_id` (plain), never like a secret.
+- **Generation:** 32-char hex via `wp_generate_password( 32, false )` (or
+  `bin2hex( random_bytes( 16 ) )`). Triggered by a "Generate key" AJAX action; regenerating rotates
+  the key (the old `/{key}.txt` stops resolving, the new one starts — no code change needed because
+  the filename is read from the option).
+- **Verification file** — copy the proven `SWPS_AI_Bots::maybe_serve_llms_txt()` pattern
+  (`includes/class-ai-bots.php:158-174`):
+  - Hook `init` at **priority 1**.
+  - `$path = wp_parse_url( $_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH ) ?? '';`
+  - If `$path === '/' . $key . '.txt'` and a key exists: send `Content-Type: text/plain`,
+    `X-Robots-Tag: noindex`, `nocache_headers()`, `echo $key;`, `exit;`.
+  - **No rewrite rules, no `flush_rewrite_rules()`.** This deliberately sidesteps the sitemap's
+    rewrite/flush lifecycle and needs no activation-time flush.
+
+## 4. Triggers → Queue → Batch Submit
+
+### 4.1 Lifecycle hooks (enqueue side)
+
+| Hook | Handler behavior |
+|------|------------------|
+| `transition_post_status` | On `publish` (new/updated) → enqueue permalink. On `publish → non-public` → enqueue the stashed old URL (removal). |
+| `before_delete_post`, `wp_trash_post` | Enqueue the stashed public URL (removal signal → 404/410). |
+| `created_term`, `edited_term`, `delete_term` | Enqueue `get_term_link()` for eligible taxonomies. |
+
+- **Removal URL stashing:** on each publish, store `_swps_indexnow_last_url` post meta with the
+  current permalink. A status change fires *after* WP has dropped the pretty permalink, so the stash
+  is the robust source for the now-dead URL to submit on unpublish/trash/delete.
+- Every enqueue passes through **eligibility** (`SWPS_Sitemap_Manager::is_post_indexable()`) and the
+  **environment guard** (§6) before touching the queue. Autosaves, revisions, and non-eligible post
+  types are ignored.
+- Enqueue is gated by `swps_indexnow_enabled` **and** `swps_indexnow_auto_submit`. Manual actions
+  (§5) bypass `auto_submit` but still respect `enabled` + env guard.
+
+### 4.2 Debounce queue
+
+- **Queue store:** `swps_indexnow_queue` option — a set of absolute URLs, deduped on insert.
+- On first insert of a burst, schedule `wp_schedule_single_event( time() + 60, 'swps_indexnow_flush' )`
+  (only if not already scheduled) — the `SWPS_Site_Crawler` single-event pattern
+  (`class-site-crawler.php:1025/1040`). A burst of saves coalesces into one POST.
+- **No-op suppression:** stash the last-submitted `post_modified_gmt` in **post meta**
+  (`_swps_indexnow_submitted`) — and term meta for taxonomy URLs — updated on each successful
+  submit. Skip re-enqueuing a URL whose content has not changed since its last submit. Using
+  per-object meta (not a global map option) keeps this naturally bounded and avoids the
+  unbounded-option bloat footgun.
+- **Does NOT reuse `SWPS_Rate_Limiter`** — that global 60s transient lock is shared with AI
+  generation; reusing it would make IndexNow and AI generation gate each other.
+
+### 4.3 Flush handler (`swps_indexnow_flush`)
+
+1. Read + clear `swps_indexnow_queue`.
+2. Re-check the environment guard (in case the site was cloned to staging between enqueue and flush).
+3. Enforce a per-day host cap (`swps_indexnow_daily_count` + date) as a runaway backstop.
+4. Chunk to ≤ 10,000 URLs/POST (spec max — almost always a single chunk).
+5. Submit (§5), record each batch in the activity log (§7), stamp `_swps_indexnow_submitted` meta on
+   the submitted objects (§4.2).
+
+## 5. Submission & Manual Actions
+
+### 5.1 HTTP submit
+
+POST to `https://api.indexnow.org/indexnow` using the `SWPS_Search_Console` transport idiom
+(`class-search-console.php:363-420`): `wp_remote_post()` → `is_wp_error()` guard →
+`wp_remote_retrieve_response_code()` / `wp_remote_retrieve_body()`.
+
+```php
+wp_remote_post( 'https://api.indexnow.org/indexnow', [
+    'headers' => [ 'Content-Type' => 'application/json; charset=utf-8' ],
+    'body'    => wp_json_encode( [
+        'host'        => wp_parse_url( home_url(), PHP_URL_HOST ),
+        'key'         => $key,
+        'keyLocation' => home_url( '/' . $key . '.txt' ),
+        'urlList'     => $urls, // absolute URLs, same host
+    ] ),
+    'timeout' => 15,
+] );
+```
+
+**Response interpretation for the log:**
+
+| Code | Meaning |
+|------|---------|
+| 200 | OK — submitted |
+| 202 | Accepted, key validation pending |
+| 400 | Invalid request / bad key format |
+| 403 | Key not found (verification file not served) |
+| 422 | URLs don't match host, or key mismatch |
+| 429 | Too many requests |
+| `WP_Error` | Network failure — caught, logged, never fatal |
+
+Google is **not** contacted (IndexNow excludes it). The UI states this plainly rather than implying
+Google coverage.
+
+### 5.2 Manual controls
+
+| Control | Location | Behavior |
+|---------|----------|----------|
+| **Generate key** | Sitemaps admin page (§7) | AJAX → create/rotate `swps_indexnow_api_key` |
+| **Submit to IndexNow now** | SEO meta box (`SWPS_Meta_Editor`) | AJAX → submit this post's permalink immediately (bypasses `auto_submit`, still respects `enabled` + env guard + eligibility) |
+| **Resubmit all URLs** | Sitemaps admin page | AJAX → `SWPS_Sitemap_Manager::get_indexable_urls()` → enqueue/flush in ≤10k chunks |
+
+AJAX handlers mirror `SWPS_Sitemap_Admin::ajax_get_sitemaps()` (`class-sitemap-admin.php:103`):
+nonce check, capability check (`manage_options`), JSON response.
+
+## 6. Environment Guard
+
+Before any submit (auto or manual), skip and surface a notice when **either**:
+- `wp_get_environment_type() !== 'production'`, or
+- the host matches a staging/local pattern (`localhost`, `127.0.0.1`, `*.local`, `*.test`,
+  `staging.*`, `dev.*`, `*.wpengine.com` staging, etc.).
+
+The admin panel shows a persistent "IndexNow is paused on non-production" notice in this state so the
+behavior is never silent/confusing. Manual actions return the same "paused on non-production"
+message.
+
+## 7. Admin UI & Settings
+
+### 7.1 Persisted options (registered exactly once)
+
+| Option | Type | Notes |
+|--------|------|-------|
+| `swps_indexnow_enabled` | checkbox (1/0) | Master toggle |
+| `swps_indexnow_auto_submit` | checkbox (1/0) | Auto-fire on lifecycle (default 1) |
+| `swps_indexnow_api_key` | text (plain) | **Not** encrypted |
+| `swps_indexnow_post_types` | **multi_checkbox (array)** | Which post types auto-submit; defaults mirror sitemap-included types |
+
+Registered through `SWPS_Settings::add_field()` (`class-settings.php:1268`) in a new
+`swps_indexnow_section`. **Footgun (4.21.4 Products bug):** `swps_indexnow_post_types` is an array —
+register it **once** only. Registering the same option a second time as a scalar stacks a
+`sanitize_option_` filter that silently wipes the array on save. Every option here must appear in
+exactly one `add_field()`/`register_setting()` call.
+
+### 7.2 Admin surface
+
+The IndexNow controls render as a **panel on the existing Sitemaps admin page**
+(`SWPS_Sitemap_Admin` / `templates/sitemaps-page.php`) — fulfilling the module promise and where the
+feature belongs conceptually. Panel contents:
+- Enable + auto-submit toggles, post-type checklist.
+- Key display + copy button + "Generate key".
+- Verification file status (does `/{key}.txt` resolve?).
+- "Resubmit all URLs" button.
+- Environment-guard notice when paused.
+- Activity-log table (last ~50 entries).
+
+Options are registered via the settings framework (§7.1) but the controls are rendered on the
+Sitemaps page (scoped rendering, à la `render_sections_for_tab()`), not duplicated on the main
+Settings page — to keep a single registration per option.
+
+## 8. Activity Log
+
+- **Store:** `swps_indexnow_log` option — bounded ring buffer of the last ~50 entries. No DB table,
+  no migration.
+- **Entry shape:** `{ time (gmt), trigger (auto|manual|bulk), urls_count, http_code, result }`.
+- Capping: on append, `array_slice()` to the last 50.
+- Failures recorded consistently with `SWPS_Digest::record_failure()` (`class-digest.php:50`).
+
+## 9. Activation / Deactivation
+
+- **No rewrite flush needed** — the `/{key}.txt` route uses `init`+REQUEST_URI, not rewrite rules.
+- On deactivate: clear the scheduled `swps_indexnow_flush` event
+  (`wp_clear_scheduled_hook( 'swps_indexnow_flush' )`).
+- `uninstall.php`: remove `swps_indexnow_*` options and the `_swps_indexnow_last_url` /
+  `_swps_indexnow_submitted` post/term meta.
+
+## 10. Testing
+
+**Unit tests (`tests/unit/`):**
+- `SWPS_Sitemap_Manager::is_post_indexable()` — publish/draft, excluded type, `_swps_sitemap_exclude`
+  meta, `_swps_robots` noindex.
+- Queue dedup + no-op suppression (unchanged `post_modified` skipped).
+- Key-file path matching, including key rotation (old path 404s, new path serves).
+- Environment guard skips on non-production / staging host.
+- Log ring buffer caps at 50.
+- **Existing sitemap tests stay green** (regression guard on the §2 refactor).
+
+**Manual smoke test** on `jonimms.local` (symlinked dev site):
+1. Generate key → confirm `/{key}.txt` serves the key with `text/plain`.
+2. Publish a post → confirm it lands in `swps_indexnow_queue`, the `+60s` event is scheduled, the
+   flush fires, and a log entry appears.
+3. Confirm the env guard blocks submission on the local site (and the notice shows).
+4. Exercise "Submit now" (meta box) and "Resubmit all" (Sitemaps page).
+
+## 11. Release
+
+Per the standing release ritual:
+- Bump version to **4.22.0** in `stratawp-seo.php` header + `SWPS_VERSION`.
+- Update `README.md`, `readme.txt` (changelog + feature list), and docs.
+- Rebuild the deployment zip.
+
+## 12. Out of Scope (explicit non-goals)
+
+- **Google** submission — IndexNow excludes Google; no Indexing-API workaround in this feature.
+- **DB-backed log** with retention/filtering — deferred; ring buffer is sufficient for v1.
+- **Multisite network-admin** controls — per-site key/host works network-agnostically, but no
+  network-level dashboard.
+- **Sitemap-diff sweep cron** — not needed given lifecycle triggers + manual "Resubmit all".
+
+## File Reference Index
+
+| Concern | File / anchor |
+|---------|---------------|
+| New class | `includes/class-indexnow.php` (new) |
+| Bootstrap require + instantiate | `stratawp-seo.php:33-147`, `:363-475` |
+| Verification-file pattern | `includes/class-ai-bots.php:158-174` |
+| Eligibility (to refactor) | `includes/class-sitemap-manager.php:20-24, 244-390` |
+| HTTP transport idiom | `includes/class-search-console.php:363-420` |
+| Settings field registration | `includes/class-settings.php:1268` (add_field), `:1658` (tabs) |
+| Double-registration footgun | `includes/class-settings.php:855-859` |
+| Encryption whitelist (avoid) | `includes/class-settings.php:1307-1317` |
+| Debounce single-event pattern | `includes/class-site-crawler.php:1025/1040` |
+| Lifecycle-hook analog | `includes/class-cache-manager.php:18-19` |
+| Admin page + AJAX analog | `includes/class-sitemap-admin.php:27, 103` |
+| Per-post control host | `includes/class-meta-editor.php` |
+| Failure-log analog | `includes/class-digest.php:50` |
+| Module promise being fulfilled | `includes/class-modules.php:92` |

--- a/includes/class-indexnow.php
+++ b/includes/class-indexnow.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * IndexNow integration — instantly notify Bing/Yandex/Seznam/Naver of URL changes.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Owns key management, the /{key}.txt verification file, lifecycle triggers,
+ * the debounced submit queue, HTTP submission, the activity log, and AJAX.
+ */
+class SWPS_IndexNow {
+
+	const CRON_HOOK           = 'swps_indexnow_flush';
+	const ENDPOINT            = 'https://api.indexnow.org/indexnow';
+	const MAX_LOG             = 50;
+	const MAX_URLS_PER_REQUEST = 10000;
+	const DEBOUNCE_SECONDS    = 60;
+	const DAILY_CAP           = 10000;
+
+	const OPT_ENABLED     = 'swps_indexnow_enabled';
+	const OPT_AUTO        = 'swps_indexnow_auto_submit';
+	const OPT_KEY         = 'swps_indexnow_api_key';
+	const OPT_POST_TYPES  = 'swps_indexnow_post_types';
+	const OPT_QUEUE       = 'swps_indexnow_queue';
+	const OPT_LOG         = 'swps_indexnow_log';
+	const OPT_DAILY_COUNT = 'swps_indexnow_daily_count';
+	const OPT_DAILY_DATE  = 'swps_indexnow_daily_date';
+
+	const META_LAST_URL  = '_swps_indexnow_last_url';
+	const META_SUBMITTED = '_swps_indexnow_submitted';
+
+	const SETTINGS_GROUP = 'swps_indexnow_settings';
+
+	public function __construct() {
+		add_action( self::CRON_HOOK, array( $this, 'flush' ) );
+	}
+
+	/**
+	 * wp-cron handler — drains the debounce queue and submits. Filled in Task 7.
+	 */
+	public function flush(): void {
+	}
+}

--- a/includes/class-indexnow.php
+++ b/includes/class-indexnow.php
@@ -53,7 +53,7 @@ class SWPS_IndexNow {
 
 	/** IndexNow keys are 8–128 chars of [a-zA-Z0-9-]. */
 	public static function is_valid_key( string $key ): bool {
-		return (bool) preg_match( '/^[a-zA-Z0-9-]{8,128}$/', $key );
+		return (bool) preg_match( '/^[a-zA-Z0-9-]{8,128}$/D', $key );
 	}
 
 	/** Heuristic: does this host look like a local/staging environment? */

--- a/includes/class-indexnow.php
+++ b/includes/class-indexnow.php
@@ -45,4 +45,77 @@ class SWPS_IndexNow {
 	 */
 	public function flush(): void {
 	}
+
+	/** Generate a fresh 32-char hex IndexNow key (does not persist). */
+	public static function generate_key(): string {
+		return bin2hex( random_bytes( 16 ) );
+	}
+
+	/** IndexNow keys are 8–128 chars of [a-zA-Z0-9-]. */
+	public static function is_valid_key( string $key ): bool {
+		return (bool) preg_match( '/^[a-zA-Z0-9-]{8,128}$/', $key );
+	}
+
+	/** Heuristic: does this host look like a local/staging environment? */
+	public static function is_staging_host( string $host ): bool {
+		$host = strtolower( $host );
+		if ( in_array( $host, array( 'localhost', '127.0.0.1', '::1' ), true ) ) {
+			return true;
+		}
+		foreach ( array( '.local', '.test', '.localhost', '.example', '.invalid' ) as $suffix ) {
+			if ( str_ends_with( $host, $suffix ) ) {
+				return true;
+			}
+		}
+		foreach ( array( 'staging.', 'stage.', 'dev.', 'test.', 'sandbox.' ) as $prefix ) {
+			if ( str_starts_with( $host, $prefix ) ) {
+				return true;
+			}
+		}
+		return str_contains( $host, '.staging.' ) || str_contains( $host, '.dev.' );
+	}
+
+	/** True when submissions must be suppressed (non-production or staging host). */
+	public static function should_skip_environment(): bool {
+		if ( function_exists( 'wp_get_environment_type' ) && 'production' !== wp_get_environment_type() ) {
+			return true;
+		}
+		$host = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+		return self::is_staging_host( $host );
+	}
+
+	/** Build the IndexNow POST body. Pure. */
+	public static function build_payload( string $host, string $key, array $urls ): array {
+		return array(
+			'host'        => $host,
+			'key'         => $key,
+			'keyLocation' => 'https://' . $host . '/' . $key . '.txt',
+			'urlList'     => array_values( $urls ),
+		);
+	}
+
+	/** Map an HTTP status code to a log-friendly result label. Pure. */
+	public static function interpret_response_code( int $code ): string {
+		switch ( $code ) {
+			case 200:
+				return 'ok';
+			case 202:
+				return 'pending';
+			case 400:
+				return 'invalid';
+			case 403:
+				return 'key_not_found';
+			case 422:
+				return 'host_mismatch';
+			case 429:
+				return 'rate_limited';
+			default:
+				return 'error';
+		}
+	}
+
+	/** Does a request path exactly match /{key}.txt? Pure. */
+	public static function key_file_path_matches( string $path, string $key ): bool {
+		return '/' . $key . '.txt' === $path;
+	}
 }

--- a/includes/class-indexnow.php
+++ b/includes/class-indexnow.php
@@ -394,6 +394,30 @@ class SWPS_IndexNow {
 		wp_send_json_success( array( 'log' => self::get_log() ) );
 	}
 
+	/** AJAX: manually submit a single post's URL now (bypasses auto-submit toggle). */
+	public function ajax_submit_post(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		$post_id = isset( $_POST['post_id'] ) ? absint( $_POST['post_id'] ) : 0;
+		if ( ! $post_id || ! current_user_can( 'edit_post', $post_id ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		if ( ! get_option( self::OPT_ENABLED, 0 ) ) {
+			wp_send_json_error( array( 'message' => __( 'IndexNow is disabled. Enable it under Sitemaps → IndexNow.', 'stratawp-seo' ) ) );
+		}
+		if ( self::should_skip_environment() ) {
+			wp_send_json_error( array( 'message' => __( 'IndexNow is paused on non-production environments.', 'stratawp-seo' ) ) );
+		}
+		$post = get_post( $post_id );
+		if ( ! $post || ! SWPS_Sitemap_Manager::is_post_indexable( $post ) ) {
+			wp_send_json_error( array( 'message' => __( 'This URL is not eligible (unpublished, excluded, or noindex).', 'stratawp-seo' ) ) );
+		}
+		$url     = get_permalink( $post );
+		update_post_meta( $post_id, self::META_LAST_URL, $url );
+		$results = $this->submit_urls( array( $url ), 'manual' );
+		$result  = $results[0]['result'] ?? 'error';
+		wp_send_json_success( array( 'result' => $result, 'url' => $url ) );
+	}
+
 	/** Serve GET /{key}.txt with the raw key body (init, priority 1). */
 	public function maybe_serve_key_file(): void {
 		$key = (string) get_option( self::OPT_KEY, '' );

--- a/includes/class-indexnow.php
+++ b/includes/class-indexnow.php
@@ -118,4 +118,21 @@ class SWPS_IndexNow {
 	public static function key_file_path_matches( string $path, string $key ): bool {
 		return '/' . $key . '.txt' === $path;
 	}
+
+	/** Prepend an entry to the bounded activity log (newest first, capped at MAX_LOG). */
+	public static function append_log( array $entry ): void {
+		$log = get_option( self::OPT_LOG, array() );
+		if ( ! is_array( $log ) ) {
+			$log = array();
+		}
+		array_unshift( $log, $entry );
+		$log = array_slice( $log, 0, self::MAX_LOG );
+		update_option( self::OPT_LOG, $log, false );
+	}
+
+	/** @return array[] The activity log, newest first. */
+	public static function get_log(): array {
+		$log = get_option( self::OPT_LOG, array() );
+		return is_array( $log ) ? $log : array();
+	}
 }

--- a/includes/class-indexnow.php
+++ b/includes/class-indexnow.php
@@ -135,4 +135,23 @@ class SWPS_IndexNow {
 		$log = get_option( self::OPT_LOG, array() );
 		return is_array( $log ) ? $log : array();
 	}
+
+	/** Add a URL to the debounce queue (deduped) and schedule a single flush. */
+	public static function enqueue_url( string $url ): void {
+		$url = esc_url_raw( $url );
+		if ( '' === $url ) {
+			return;
+		}
+		$queue = get_option( self::OPT_QUEUE, array() );
+		if ( ! is_array( $queue ) ) {
+			$queue = array();
+		}
+		if ( ! in_array( $url, $queue, true ) ) {
+			$queue[] = $url;
+			update_option( self::OPT_QUEUE, $queue, false );
+		}
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_single_event( time() + self::DEBOUNCE_SECONDS, self::CRON_HOOK );
+		}
+	}
 }

--- a/includes/class-indexnow.php
+++ b/includes/class-indexnow.php
@@ -40,10 +40,57 @@ class SWPS_IndexNow {
 		add_action( self::CRON_HOOK, array( $this, 'flush' ) );
 	}
 
-	/**
-	 * wp-cron handler — drains the debounce queue and submits. Filled in Task 7.
-	 */
+	/** wp-cron handler — drain the debounce queue and submit as one batch. */
 	public function flush(): void {
+		$queue = get_option( self::OPT_QUEUE, array() );
+		update_option( self::OPT_QUEUE, array(), false );
+		if ( ! is_array( $queue ) || empty( $queue ) ) {
+			return;
+		}
+		if ( self::should_skip_environment() ) {
+			self::append_log( array( 'time' => time(), 'trigger' => 'auto', 'count' => count( $queue ), 'code' => 0, 'result' => 'skipped_env' ) );
+			return;
+		}
+		$this->submit_urls( array_values( $queue ), 'auto' );
+	}
+
+	/**
+	 * POST one or more chunks of URLs to IndexNow. Logs each chunk's result.
+	 *
+	 * @return array[] One {code,result} per chunk.
+	 */
+	public function submit_urls( array $urls, string $trigger = 'manual' ): array {
+		$urls = array_values( array_unique( array_filter( $urls ) ) );
+		if ( empty( $urls ) ) {
+			return array();
+		}
+		$key = (string) get_option( self::OPT_KEY, '' );
+		if ( ! self::is_valid_key( $key ) ) {
+			self::append_log( array( 'time' => time(), 'trigger' => $trigger, 'count' => count( $urls ), 'code' => 0, 'result' => 'no_key' ) );
+			return array();
+		}
+		$host    = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+		$results = array();
+		foreach ( array_chunk( $urls, self::MAX_URLS_PER_REQUEST ) as $chunk ) {
+			$response = wp_remote_post(
+				self::ENDPOINT,
+				array(
+					'headers' => array( 'Content-Type' => 'application/json; charset=utf-8' ),
+					'body'    => wp_json_encode( self::build_payload( $host, $key, $chunk ) ),
+					'timeout' => 15,
+				)
+			);
+			if ( is_wp_error( $response ) ) {
+				$code   = 0;
+				$result = 'error';
+			} else {
+				$code   = (int) wp_remote_retrieve_response_code( $response );
+				$result = self::interpret_response_code( $code );
+			}
+			self::append_log( array( 'time' => time(), 'trigger' => $trigger, 'count' => count( $chunk ), 'code' => $code, 'result' => $result ) );
+			$results[] = array( 'code' => $code, 'result' => $result );
+		}
+		return $results;
 	}
 
 	/** Generate a fresh 32-char hex IndexNow key (does not persist). */

--- a/includes/class-indexnow.php
+++ b/includes/class-indexnow.php
@@ -38,6 +38,24 @@ class SWPS_IndexNow {
 
 	public function __construct() {
 		add_action( self::CRON_HOOK, array( $this, 'flush' ) );
+
+		// Serve the verification file as early as possible.
+		add_action( 'init', array( $this, 'maybe_serve_key_file' ), 1 );
+
+		// Settings (Task 10) + admin surface (Task 11) + AJAX (Tasks 11-12).
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+		add_action( 'wp_ajax_' . 'swps_indexnow_generate_key', array( $this, 'ajax_generate_key' ) );
+		add_action( 'wp_ajax_' . 'swps_indexnow_resubmit_all', array( $this, 'ajax_resubmit_all' ) );
+		add_action( 'wp_ajax_' . 'swps_indexnow_get_log', array( $this, 'ajax_get_log' ) );
+		add_action( 'wp_ajax_' . 'swps_indexnow_submit_post', array( $this, 'ajax_submit_post' ) );
+
+		// Lifecycle triggers.
+		add_action( 'transition_post_status', array( $this, 'on_transition_post_status' ), 10, 3 );
+		add_action( 'before_delete_post', array( $this, 'on_delete_post' ) );
+		add_action( 'wp_trash_post', array( $this, 'on_delete_post' ) );
+		add_action( 'created_term', array( $this, 'on_term_change' ), 10, 3 );
+		add_action( 'edited_term', array( $this, 'on_term_change' ), 10, 3 );
+		add_action( 'delete_term', array( $this, 'on_term_change' ), 10, 3 );
 	}
 
 	/** wp-cron handler — drain the debounce queue and submit as one batch. */
@@ -234,5 +252,81 @@ class SWPS_IndexNow {
 		update_post_meta( $post->ID, self::META_LAST_URL, $url );
 		update_post_meta( $post->ID, self::META_SUBMITTED, $modified );
 		self::enqueue_url( $url );
+	}
+
+	/** Fired on every status change: enqueue on publish, submit the dead URL on unpublish. */
+	public function on_transition_post_status( string $new_status, string $old_status, $post ): void {
+		if ( ! is_object( $post ) || empty( $post->ID ) ) {
+			return;
+		}
+		if ( function_exists( 'wp_is_post_revision' ) && wp_is_post_revision( $post->ID ) ) {
+			return;
+		}
+		if ( 'publish' === $new_status ) {
+			$this->maybe_enqueue_post( $post );
+			return;
+		}
+		if ( 'publish' === $old_status && 'publish' !== $new_status ) {
+			$this->enqueue_removal( (int) $post->ID );
+		}
+	}
+
+	/** Fired on trash/delete: submit the last known public URL so engines recrawl (404/410). */
+	public function on_delete_post( int $post_id ): void {
+		$this->enqueue_removal( $post_id );
+	}
+
+	/** Submit a taxonomy term's URL when it changes, if its taxonomy is public + eligible. */
+	public function on_term_change( int $term_id, int $tt_id, string $taxonomy ): void {
+		if ( ! get_option( self::OPT_ENABLED, 0 ) || ! get_option( self::OPT_AUTO, 1 ) ) {
+			return;
+		}
+		if ( self::should_skip_environment() ) {
+			return;
+		}
+		$tax = get_taxonomy( $taxonomy );
+		if ( ! $tax || empty( $tax->public ) ) {
+			return;
+		}
+		if ( ! SWPS_Sitemap_Manager::is_term_indexable( $term_id, $taxonomy ) ) {
+			return;
+		}
+		$url = get_term_link( $term_id, $taxonomy );
+		if ( ! is_wp_error( $url ) ) {
+			self::enqueue_url( (string) $url );
+		}
+	}
+
+	/** Enqueue the stashed public URL for a removed/unpublished post. */
+	private function enqueue_removal( int $post_id ): void {
+		if ( ! get_option( self::OPT_ENABLED, 0 ) || ! get_option( self::OPT_AUTO, 1 ) ) {
+			return;
+		}
+		if ( self::should_skip_environment() ) {
+			return;
+		}
+		$url = (string) get_post_meta( $post_id, self::META_LAST_URL, true );
+		if ( '' !== $url ) {
+			self::enqueue_url( $url );
+		}
+	}
+
+	/** Serve GET /{key}.txt with the raw key body (init, priority 1). */
+	public function maybe_serve_key_file(): void {
+		$key = (string) get_option( self::OPT_KEY, '' );
+		if ( ! self::is_valid_key( $key ) ) {
+			return;
+		}
+		$path = isset( $_SERVER['REQUEST_URI'] )
+			? (string) wp_parse_url( wp_unslash( $_SERVER['REQUEST_URI'] ), PHP_URL_PATH )
+			: '';
+		if ( ! self::key_file_path_matches( $path, $key ) ) {
+			return;
+		}
+		nocache_headers();
+		header( 'Content-Type: text/plain; charset=utf-8' );
+		header( 'X-Robots-Tag: noindex' );
+		echo esc_html( $key );
+		exit;
 	}
 }

--- a/includes/class-indexnow.php
+++ b/includes/class-indexnow.php
@@ -350,6 +350,50 @@ class SWPS_IndexNow {
 		}
 	}
 
+	/** AJAX: generate + persist a new IndexNow key (rotation). */
+	public function ajax_generate_key(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		$key = self::generate_key();
+		update_option( self::OPT_KEY, $key, false );
+		wp_send_json_success(
+			array(
+				'key'          => $key,
+				'key_file_url' => home_url( '/' . $key . '.txt' ),
+			)
+		);
+	}
+
+	/** AJAX: submit the full indexable URL set ("Resubmit all"). */
+	public function ajax_resubmit_all(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		if ( self::should_skip_environment() ) {
+			wp_send_json_error( array( 'message' => __( 'IndexNow is paused on non-production environments.', 'stratawp-seo' ) ) );
+		}
+		$urls    = SWPS_Sitemap_Manager::get_indexable_urls();
+		$results = $this->submit_urls( $urls, 'bulk' );
+		wp_send_json_success(
+			array(
+				'submitted' => count( $urls ),
+				'batches'   => $results,
+			)
+		);
+	}
+
+	/** AJAX: return the activity log for the admin panel. */
+	public function ajax_get_log(): void {
+		check_ajax_referer( 'swps_nonce', 'nonce' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'stratawp-seo' ) ) );
+		}
+		wp_send_json_success( array( 'log' => self::get_log() ) );
+	}
+
 	/** Serve GET /{key}.txt with the raw key body (init, priority 1). */
 	public function maybe_serve_key_file(): void {
 		$key = (string) get_option( self::OPT_KEY, '' );

--- a/includes/class-indexnow.php
+++ b/includes/class-indexnow.php
@@ -20,7 +20,6 @@ class SWPS_IndexNow {
 	const MAX_LOG             = 50;
 	const MAX_URLS_PER_REQUEST = 10000;
 	const DEBOUNCE_SECONDS    = 60;
-	const DAILY_CAP           = 10000;
 
 	const OPT_ENABLED     = 'swps_indexnow_enabled';
 	const OPT_AUTO        = 'swps_indexnow_auto_submit';
@@ -28,8 +27,6 @@ class SWPS_IndexNow {
 	const OPT_POST_TYPES  = 'swps_indexnow_post_types';
 	const OPT_QUEUE       = 'swps_indexnow_queue';
 	const OPT_LOG         = 'swps_indexnow_log';
-	const OPT_DAILY_COUNT = 'swps_indexnow_daily_count';
-	const OPT_DAILY_DATE  = 'swps_indexnow_daily_date';
 
 	const META_LAST_URL  = '_swps_indexnow_last_url';
 	const META_SUBMITTED = '_swps_indexnow_submitted';
@@ -330,6 +327,8 @@ class SWPS_IndexNow {
 		if ( ! SWPS_Sitemap_Manager::is_term_indexable( $term_id, $taxonomy ) ) {
 			return;
 		}
+		// Note: on delete_term the term row is already gone, so get_term_link() returns WP_Error and the removal is skipped.
+		// Term de-indexing on deletion is a known gap (posts handle removal via the stashed _swps_indexnow_last_url).
 		$url = get_term_link( $term_id, $taxonomy );
 		if ( ! is_wp_error( $url ) ) {
 			self::enqueue_url( (string) $url );

--- a/includes/class-indexnow.php
+++ b/includes/class-indexnow.php
@@ -154,4 +154,38 @@ class SWPS_IndexNow {
 			wp_schedule_single_event( time() + self::DEBOUNCE_SECONDS, self::CRON_HOOK );
 		}
 	}
+
+	/**
+	 * Auto path: enqueue a post's permalink if IndexNow is enabled, auto-submit is
+	 * on, the post type is selected, the URL is sitemap-indexable, we're on
+	 * production, and the content actually changed since the last submit.
+	 *
+	 * @param WP_Post|object $post
+	 */
+	public function maybe_enqueue_post( $post ): void {
+		if ( ! is_object( $post ) || empty( $post->ID ) ) {
+			return;
+		}
+		if ( ! get_option( self::OPT_ENABLED, 0 ) || ! get_option( self::OPT_AUTO, 1 ) ) {
+			return;
+		}
+		$selected = (array) get_option( self::OPT_POST_TYPES, array() );
+		if ( ! in_array( ( $post->post_type ?? '' ), $selected, true ) ) {
+			return;
+		}
+		if ( ! SWPS_Sitemap_Manager::is_post_indexable( $post ) ) {
+			return;
+		}
+		if ( self::should_skip_environment() ) {
+			return;
+		}
+		$modified = (string) ( $post->post_modified_gmt ?? '' );
+		if ( '' !== $modified && (string) get_post_meta( $post->ID, self::META_SUBMITTED, true ) === $modified ) {
+			return; // No-op resave — content unchanged since last push.
+		}
+		$url = get_permalink( $post );
+		update_post_meta( $post->ID, self::META_LAST_URL, $url );
+		update_post_meta( $post->ID, self::META_SUBMITTED, $modified );
+		self::enqueue_url( $url );
+	}
 }

--- a/includes/class-indexnow.php
+++ b/includes/class-indexnow.php
@@ -58,6 +58,45 @@ class SWPS_IndexNow {
 		add_action( 'delete_term', array( $this, 'on_term_change' ), 10, 3 );
 	}
 
+	/**
+	 * Register the three form-persisted options in a DEDICATED option group so a
+	 * partial form on the Sitemaps page cannot wipe unrelated swps_* options.
+	 * The API key is NOT registered here — it is managed via the generate-key AJAX
+	 * action and never rendered in the form. Each option is registered exactly once.
+	 */
+	public function register_settings(): void {
+		register_setting(
+			self::SETTINGS_GROUP,
+			self::OPT_ENABLED,
+			array( 'sanitize_callback' => array( __CLASS__, 'sanitize_checkbox' ), 'default' => 0 )
+		);
+		register_setting(
+			self::SETTINGS_GROUP,
+			self::OPT_AUTO,
+			array( 'sanitize_callback' => array( __CLASS__, 'sanitize_checkbox' ), 'default' => 1 )
+		);
+		register_setting(
+			self::SETTINGS_GROUP,
+			self::OPT_POST_TYPES,
+			array(
+				'type'              => 'array',
+				'sanitize_callback' => array( __CLASS__, 'sanitize_post_types' ),
+				'default'           => array( 'post', 'page' ),
+			)
+		);
+	}
+
+	public static function sanitize_checkbox( $value ): int {
+		return $value ? 1 : 0;
+	}
+
+	public static function sanitize_post_types( $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+		return array_values( array_map( 'sanitize_key', $value ) );
+	}
+
 	/** wp-cron handler — drain the debounce queue and submit as one batch. */
 	public function flush(): void {
 		$queue = get_option( self::OPT_QUEUE, array() );

--- a/includes/class-sitemap-manager.php
+++ b/includes/class-sitemap-manager.php
@@ -17,16 +17,111 @@ class SWPS_Sitemap_Manager {
 	private function get_urls_per_sitemap(): int {
 		return max( 100, min( 50000, (int) get_option( 'swps_sitemap_urls_per_page', 1000 ) ) );
 	}
-	private function is_post_type_hidden_from_sitemap( string $post_type ): bool {
+	private static function is_post_type_hidden_from_sitemap( string $post_type ): bool {
 		return 'attachment' === $post_type
 			|| (bool) get_option( "swps_sitemap_exclude_{$post_type}", 0 )
 			|| (bool) get_option( "swps_noindex_{$post_type}", 0 );
 	}
 
-	private function is_taxonomy_hidden_from_sitemap( string $taxonomy ): bool {
+	private static function is_taxonomy_hidden_from_sitemap( string $taxonomy ): bool {
 		return 'post_format' === $taxonomy
 			|| (bool) get_option( "swps_sitemap_exclude_{$taxonomy}", 0 )
 			|| (bool) get_option( "swps_noindex_{$taxonomy}", 0 );
+	}
+
+	/**
+	 * Canonical "is this URL part of the sitemap" predicate, shared with IndexNow.
+	 * Mirrors the inline skip logic in render_post_type_sitemap().
+	 *
+	 * @param WP_Post|object $post Post object with ID, post_status, post_type.
+	 */
+	public static function is_post_indexable( $post ): bool {
+		if ( ! is_object( $post ) || empty( $post->ID ) ) {
+			return false;
+		}
+		if ( 'publish' !== ( $post->post_status ?? '' ) ) {
+			return false;
+		}
+		if ( self::is_post_type_hidden_from_sitemap( (string) ( $post->post_type ?? '' ) ) ) {
+			return false;
+		}
+		if ( get_post_meta( $post->ID, '_swps_sitemap_exclude', true ) ) {
+			return false;
+		}
+		$robots = get_post_meta( $post->ID, '_swps_robots', true );
+		if ( ! empty( $robots ) && str_contains( (string) $robots, 'noindex' ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Term eligibility, mirroring render_taxonomy_sitemap()'s inline checks.
+	 */
+	public static function is_term_indexable( int $term_id ): bool {
+		if ( get_term_meta( $term_id, '_swps_sitemap_exclude', true ) ) {
+			return false;
+		}
+		$robots = get_term_meta( $term_id, '_swps_robots', true );
+		if ( ! empty( $robots ) && str_contains( (string) $robots, 'noindex' ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Full indexable URL set (posts + pages + CPTs + taxonomies + authors),
+	 * applying the same eligibility rules as the sitemap. Used by "Resubmit all".
+	 *
+	 * @return string[] Absolute URLs, deduped.
+	 */
+	public static function get_indexable_urls(): array {
+		$urls = array( home_url( '/' ) );
+
+		foreach ( get_post_types( array( 'public' => true ) ) as $post_type ) {
+			if ( self::is_post_type_hidden_from_sitemap( $post_type ) ) {
+				continue;
+			}
+			$posts = get_posts(
+				array(
+					'post_type'      => $post_type,
+					'post_status'    => 'publish',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+					'no_found_rows'  => true,
+				)
+			);
+			foreach ( $posts as $post_id ) {
+				$post = get_post( $post_id );
+				if ( $post && self::is_post_indexable( $post ) ) {
+					$urls[] = get_permalink( $post );
+				}
+			}
+		}
+
+		foreach ( get_taxonomies( array( 'public' => true ) ) as $taxonomy ) {
+			if ( self::is_taxonomy_hidden_from_sitemap( $taxonomy ) ) {
+				continue;
+			}
+			$terms = get_terms( array( 'taxonomy' => $taxonomy, 'hide_empty' => true ) );
+			if ( is_wp_error( $terms ) ) {
+				continue;
+			}
+			foreach ( $terms as $term ) {
+				if ( self::is_term_indexable( (int) $term->term_id ) ) {
+					$urls[] = get_term_link( $term );
+				}
+			}
+		}
+
+		if ( ! get_option( 'swps_sitemap_exclude_author', 0 ) ) {
+			$authors = get_users( array( 'has_published_posts' => true, 'fields' => 'ID' ) );
+			foreach ( $authors as $author_id ) {
+				$urls[] = get_author_posts_url( (int) $author_id );
+			}
+		}
+
+		return array_values( array_unique( array_filter( $urls ) ) );
 	}
 
 	/**
@@ -157,12 +252,12 @@ class SWPS_Sitemap_Manager {
 		} else {
 			// Check if it's a taxonomy.
 			$taxonomies = get_taxonomies( array( 'public' => true ) );
-			if ( in_array( $type, $taxonomies, true ) && ! $this->is_taxonomy_hidden_from_sitemap( $type ) ) {
+			if ( in_array( $type, $taxonomies, true ) && ! self::is_taxonomy_hidden_from_sitemap( $type ) ) {
 				$this->render_taxonomy_sitemap( $type );
 			} else {
 				// Post type sitemap.
 				$post_types = get_post_types( array( 'public' => true ) );
-				if ( in_array( $type, $post_types, true ) && ! $this->is_post_type_hidden_from_sitemap( $type ) ) {
+				if ( in_array( $type, $post_types, true ) && ! self::is_post_type_hidden_from_sitemap( $type ) ) {
 					$this->render_post_type_sitemap( $type, $page );
 				} else {
 					status_header( 404 );
@@ -184,7 +279,7 @@ class SWPS_Sitemap_Manager {
 		// Post type sitemaps.
 		$post_types = get_post_types( array( 'public' => true ) );
 		foreach ( $post_types as $pt ) {
-			if ( $this->is_post_type_hidden_from_sitemap( $pt ) ) {
+			if ( self::is_post_type_hidden_from_sitemap( $pt ) ) {
 				continue;
 			}
 
@@ -204,7 +299,7 @@ class SWPS_Sitemap_Manager {
 		// Taxonomy sitemaps.
 		$taxonomies = get_taxonomies( array( 'public' => true ) );
 		foreach ( $taxonomies as $tax ) {
-			if ( $this->is_taxonomy_hidden_from_sitemap( $tax ) ) {
+			if ( self::is_taxonomy_hidden_from_sitemap( $tax ) ) {
 				continue;
 			}
 
@@ -242,7 +337,7 @@ class SWPS_Sitemap_Manager {
 	 * Render a post type sub-sitemap.
 	 */
 	private function render_post_type_sitemap( string $post_type, int $page ): void {
-		if ( $this->is_post_type_hidden_from_sitemap( $post_type ) ) {
+		if ( self::is_post_type_hidden_from_sitemap( $post_type ) ) {
 			return;
 		}
 
@@ -287,6 +382,7 @@ class SWPS_Sitemap_Manager {
 				continue;
 			}
 
+			// Keep in sync with SWPS_Sitemap_Manager::is_post_indexable().
 			// Respect exclusions.
 			if ( get_post_meta( $post->ID, '_swps_sitemap_exclude', true ) ) {
 				continue;
@@ -326,7 +422,7 @@ class SWPS_Sitemap_Manager {
 	 * Render a taxonomy sub-sitemap.
 	 */
 	private function render_taxonomy_sitemap( string $taxonomy ): void {
-		if ( $this->is_taxonomy_hidden_from_sitemap( $taxonomy ) ) {
+		if ( self::is_taxonomy_hidden_from_sitemap( $taxonomy ) ) {
 			return;
 		}
 
@@ -343,6 +439,7 @@ class SWPS_Sitemap_Manager {
 
 		if ( ! is_wp_error( $terms ) ) {
 			foreach ( $terms as $term ) {
+				// Keep in sync with SWPS_Sitemap_Manager::is_term_indexable().
 				// Respect exclusions.
 				if ( get_term_meta( $term->term_id, '_swps_sitemap_exclude', true ) ) {
 					continue;

--- a/includes/class-sitemap-manager.php
+++ b/includes/class-sitemap-manager.php
@@ -57,8 +57,17 @@ class SWPS_Sitemap_Manager {
 
 	/**
 	 * Term eligibility, mirroring render_taxonomy_sitemap()'s inline checks.
+	 * Also rejects terms whose taxonomy is hidden from the sitemap, so this
+	 * is a self-contained, taxonomy-aware public API (later tasks call it
+	 * directly on term-change hooks).
+	 *
+	 * @param int    $term_id  Term ID.
+	 * @param string $taxonomy Taxonomy name the term belongs to.
 	 */
-	public static function is_term_indexable( int $term_id ): bool {
+	public static function is_term_indexable( int $term_id, string $taxonomy ): bool {
+		if ( self::is_taxonomy_hidden_from_sitemap( $taxonomy ) ) {
+			return false;
+		}
 		if ( get_term_meta( $term_id, '_swps_sitemap_exclude', true ) ) {
 			return false;
 		}
@@ -108,8 +117,11 @@ class SWPS_Sitemap_Manager {
 				continue;
 			}
 			foreach ( $terms as $term ) {
-				if ( self::is_term_indexable( (int) $term->term_id ) ) {
-					$urls[] = get_term_link( $term );
+				if ( self::is_term_indexable( (int) $term->term_id, $taxonomy ) ) {
+					$link = get_term_link( $term );
+					if ( ! is_wp_error( $link ) ) {
+						$urls[] = $link;
+					}
 				}
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.21.4
+Stable tag: 4.22.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -140,7 +140,7 @@ It can replace Yoast/RankMath/AIOSEO outright, or coexist with them (schema and 
 * **Sitemap index** — post type, taxonomy, and author sub-sitemaps
 * **Per-URL control** — configurable priority and changefreq per URL
 * **Image sitemap entries** — image metadata included in sitemap output
-* **IndexNow support** — instant indexing notification on publish/update
+* **IndexNow integration** — auto-generated key served at /{key}.txt, auto-submit on publish/update/delete with a 60-second debounce, per-post and bulk resubmit, and a recent-activity log (auto-paused outside production)
 
 = Redirect Manager =
 
@@ -421,6 +421,9 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.22.0 =
+* New: IndexNow integration — instantly notify Bing, Yandex, Seznam, and Naver when you publish, update, or remove content. Includes an auto-generated verification key served at /{key}.txt, auto-submit on the post/term lifecycle with a 60-second debounce, per-post "Submit now" and bulk "Resubmit all" controls, a dedicated panel on the Sitemaps screen, and a recent-activity log. Submissions are automatically paused on non-production environments. (Google does not participate in IndexNow.)
 
 = 4.21.4 =
 * Fixed: choosing which post types show the SEO meta box (Search Appearance → SEO Meta Box → "Show on post types") now saves correctly. Ticking Products — or any custom post type — previously never persisted, because a leftover legacy setting re-sanitized the checkbox selection as plain text and silently dropped it on save.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -1491,6 +1491,7 @@ function swps_deactivate(): void {
 	wp_unschedule_hook( 'swps_send_digest' );
 	wp_unschedule_hook( SWPS_Site_Crawler::CRON_HOOK );
 	SWPS_Site_Crawler::unschedule_weekly_cron();
+	wp_clear_scheduled_hook( SWPS_IndexNow::CRON_HOOK );
 	flush_rewrite_rules();
 }
 register_deactivation_hook( __FILE__, 'swps_deactivate' );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.21.4
+ * Version: 4.22.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.21.4' );
+define( 'SWPS_VERSION', '4.22.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -61,6 +61,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-hooks.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-templates.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-duplicate-checker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-rate-limiter.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-indexnow.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-cost-tracker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-autopilot-guardian.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-digest.php';
@@ -271,6 +272,7 @@ final class StrataWP_SEO {
 	public SWPS_Redirect_Manager $redirect_manager;
 	public SWPS_Post_List_SEO $post_list_seo;
 	public SWPS_Sitemap_Admin $sitemap_admin;
+	public SWPS_IndexNow $indexnow;
 	public SWPS_Internal_Links $internal_links;
 	public SWPS_Internal_Links_Admin $internal_links_admin;
 	public SWPS_AI_Bots $ai_bots;
@@ -398,6 +400,7 @@ final class StrataWP_SEO {
 		$this->breadcrumbs           = new SWPS_Breadcrumbs();
 		$this->redirect_manager      = new SWPS_Redirect_Manager();
 		$this->sitemap_admin         = new SWPS_Sitemap_Admin();
+		$this->indexnow              = new SWPS_IndexNow();
 
 		if ( is_admin() ) {
 			$this->post_list_seo = new SWPS_Post_List_SEO( $this->content_scorer );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -719,6 +719,7 @@ final class StrataWP_SEO {
 				SWPS_VERSION,
 				true
 			);
+			wp_enqueue_script( 'swps-indexnow', SWPS_PLUGIN_URL . 'admin/js/indexnow.js', array( 'swps-admin', 'jquery' ), SWPS_VERSION, true );
 		}
 
 		// Search Appearance page JS.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -733,6 +733,7 @@ final class StrataWP_SEO {
 
 		if ( 'stratawp-seo_page_swps-sitemaps' === $hook ) {
 			wp_enqueue_script( 'swps-sitemaps', SWPS_PLUGIN_URL . 'admin/js/sitemaps.js', array( 'swps-admin' ), SWPS_VERSION, true );
+			wp_enqueue_script( 'swps-indexnow', SWPS_PLUGIN_URL . 'admin/js/indexnow.js', array( 'swps-admin', 'jquery' ), SWPS_VERSION, true );
 		}
 	}
 

--- a/templates/indexnow-panel.php
+++ b/templates/indexnow-panel.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * IndexNow panel, rendered inside the Sitemaps admin page.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$swps_in_key      = (string) get_option( SWPS_IndexNow::OPT_KEY, '' );
+$swps_in_enabled  = (bool) get_option( SWPS_IndexNow::OPT_ENABLED, 0 );
+$swps_in_auto     = (bool) get_option( SWPS_IndexNow::OPT_AUTO, 1 );
+$swps_in_selected = (array) get_option( SWPS_IndexNow::OPT_POST_TYPES, array( 'post', 'page' ) );
+$swps_in_skip_env = SWPS_IndexNow::should_skip_environment();
+$swps_in_key_url  = $swps_in_key ? home_url( '/' . $swps_in_key . '.txt' ) : '';
+?>
+<div class="postbox">
+	<div class="inside">
+		<h3><?php esc_html_e( 'IndexNow', 'stratawp-seo' ); ?></h3>
+		<p class="description">
+			<?php esc_html_e( 'Instantly notify Bing, Yandex, Seznam, and Naver when your content changes. (Google does not participate in IndexNow.)', 'stratawp-seo' ); ?>
+		</p>
+
+		<?php if ( $swps_in_skip_env ) : ?>
+			<div class="notice notice-warning inline">
+				<p><?php esc_html_e( 'IndexNow is paused: this does not look like a production site, so URLs will not be submitted.', 'stratawp-seo' ); ?></p>
+			</div>
+		<?php endif; ?>
+
+		<form method="post" action="options.php">
+			<?php settings_fields( SWPS_IndexNow::SETTINGS_GROUP ); ?>
+			<table class="form-table">
+				<tr>
+					<th><label for="swps_indexnow_enabled"><?php esc_html_e( 'Enable IndexNow', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input type="hidden" name="<?php echo esc_attr( SWPS_IndexNow::OPT_ENABLED ); ?>" value="0">
+						<input type="checkbox" id="swps_indexnow_enabled" name="<?php echo esc_attr( SWPS_IndexNow::OPT_ENABLED ); ?>" value="1" <?php checked( $swps_in_enabled ); ?>>
+					</td>
+				</tr>
+				<tr>
+					<th><label for="swps_indexnow_auto"><?php esc_html_e( 'Auto-submit on publish/update', 'stratawp-seo' ); ?></label></th>
+					<td>
+						<input type="hidden" name="<?php echo esc_attr( SWPS_IndexNow::OPT_AUTO ); ?>" value="0">
+						<input type="checkbox" id="swps_indexnow_auto" name="<?php echo esc_attr( SWPS_IndexNow::OPT_AUTO ); ?>" value="1" <?php checked( $swps_in_auto ); ?>>
+					</td>
+				</tr>
+				<tr>
+					<th><?php esc_html_e( 'Post types', 'stratawp-seo' ); ?></th>
+					<td>
+						<fieldset>
+							<?php
+							foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $swps_pt ) {
+								if ( 'attachment' === $swps_pt->name ) {
+									continue;
+								}
+								printf(
+									'<label style="display:inline-block;min-width:160px;"><input type="checkbox" name="%1$s[]" value="%2$s" %3$s> %4$s</label>',
+									esc_attr( SWPS_IndexNow::OPT_POST_TYPES ),
+									esc_attr( $swps_pt->name ),
+									checked( in_array( $swps_pt->name, $swps_in_selected, true ), true, false ),
+									esc_html( $swps_pt->label )
+								);
+							}
+							?>
+						</fieldset>
+					</td>
+				</tr>
+			</table>
+			<?php submit_button( __( 'Save IndexNow Settings', 'stratawp-seo' ) ); ?>
+		</form>
+
+		<hr>
+		<h4><?php esc_html_e( 'API Key', 'stratawp-seo' ); ?></h4>
+		<p>
+			<code id="swps-indexnow-key"><?php echo esc_html( $swps_in_key ?: __( '(not generated yet)', 'stratawp-seo' ) ); ?></code>
+			<button type="button" class="button" id="swps-indexnow-generate"><?php esc_html_e( 'Generate / Rotate Key', 'stratawp-seo' ); ?></button>
+		</p>
+		<p class="description">
+			<?php esc_html_e( 'Verification file:', 'stratawp-seo' ); ?>
+			<a id="swps-indexnow-key-url" href="<?php echo esc_url( $swps_in_key_url ); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html( $swps_in_key_url ); ?></a>
+		</p>
+
+		<hr>
+		<p>
+			<button type="button" class="button button-secondary" id="swps-indexnow-resubmit"><?php esc_html_e( 'Resubmit All URLs', 'stratawp-seo' ); ?></button>
+			<span id="swps-indexnow-resubmit-status"></span>
+		</p>
+
+		<h4><?php esc_html_e( 'Recent Activity', 'stratawp-seo' ); ?></h4>
+		<table class="widefat striped" id="swps-indexnow-log">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Time', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Trigger', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'URLs', 'stratawp-seo' ); ?></th>
+					<th><?php esc_html_e( 'Result', 'stratawp-seo' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr><td colspan="4"><?php esc_html_e( 'Loading…', 'stratawp-seo' ); ?></td></tr>
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/templates/meta-editor-metabox.php
+++ b/templates/meta-editor-metabox.php
@@ -178,4 +178,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</label>
 		</p>
 	</div>
+
+	<?php if ( get_option( SWPS_IndexNow::OPT_ENABLED, 0 ) && isset( $post ) ) : ?>
+		<p class="swps-indexnow-metabox">
+			<button type="button" class="button" id="swps-indexnow-submit-post" data-post="<?php echo esc_attr( $post->ID ); ?>">
+				<?php esc_html_e( 'Submit to IndexNow now', 'stratawp-seo' ); ?>
+			</button>
+			<span id="swps-indexnow-submit-post-status"></span>
+		</p>
+	<?php endif; ?>
 </div>

--- a/templates/sitemaps-page.php
+++ b/templates/sitemaps-page.php
@@ -46,6 +46,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</tr>
 			</tbody>
 		</table>
+
+		<?php require SWPS_PLUGIN_DIR . 'templates/indexnow-panel.php'; ?>
 	</div>
 
 	<div id="tab-settings" class="swps-tab-content" data-tab="settings" style="display:none;">

--- a/tests/unit/IndexNowEligibilityTest.php
+++ b/tests/unit/IndexNowEligibilityTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Unit tests for the IndexNow auto-enqueue eligibility gate.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default_value = false ) {
+		return $GLOBALS['swps_test_options'][ $option ] ?? $default_value;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $option, $value, $autoload = null ) {
+		$GLOBALS['swps_test_options'][ $option ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'get_post_meta' ) ) {
+	function get_post_meta( $id, $key = '', $single = false ) {
+		return $GLOBALS['swps_test_postmeta'][ $id ][ $key ] ?? '';
+	}
+}
+if ( ! function_exists( 'update_post_meta' ) ) {
+	function update_post_meta( $id, $key, $value ) {
+		$GLOBALS['swps_test_postmeta'][ $id ][ $key ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'get_permalink' ) ) {
+	function get_permalink( $post = 0 ) {
+		$id = is_object( $post ) ? $post->ID : (int) $post;
+		return 'https://example.com/?p=' . $id;
+	}
+}
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $url ) {
+		return trim( (string) $url );
+	}
+}
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return 'https://example.com' . $path;
+	}
+}
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( $url, $c = -1 ) {
+		return parse_url( $url, $c );
+	}
+}
+if ( ! function_exists( 'wp_get_environment_type' ) ) {
+	function wp_get_environment_type() {
+		return 'production';
+	}
+}
+if ( ! function_exists( 'wp_next_scheduled' ) ) {
+	function wp_next_scheduled( $hook ) {
+		return false;
+	}
+}
+if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+	function wp_schedule_single_event( $ts, $hook, $args = array() ) {
+		return true;
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-sitemap-manager.php';
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowEligibilityTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['swps_test_options']  = array(
+			SWPS_IndexNow::OPT_ENABLED    => 1,
+			SWPS_IndexNow::OPT_AUTO       => 1,
+			SWPS_IndexNow::OPT_POST_TYPES => array( 'post', 'page' ),
+		);
+		$GLOBALS['swps_test_postmeta'] = array();
+	}
+
+	private function post( int $id, string $type = 'post', string $modified = '2026-07-02 00:00:00' ): object {
+		return (object) array( 'ID' => $id, 'post_status' => 'publish', 'post_type' => $type, 'post_modified_gmt' => $modified );
+	}
+
+	public function test_eligible_post_is_enqueued(): void {
+		( new SWPS_IndexNow() )->maybe_enqueue_post( $this->post( 10 ) );
+		$this->assertContains( 'https://example.com/?p=10', get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+	}
+
+	public function test_disabled_feature_skips(): void {
+		$GLOBALS['swps_test_options'][ SWPS_IndexNow::OPT_ENABLED ] = 0;
+		( new SWPS_IndexNow() )->maybe_enqueue_post( $this->post( 10 ) );
+		$this->assertSame( array(), get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+	}
+
+	public function test_unselected_post_type_skips(): void {
+		( new SWPS_IndexNow() )->maybe_enqueue_post( $this->post( 10, 'product' ) );
+		$this->assertSame( array(), get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+	}
+
+	public function test_noop_resave_is_suppressed(): void {
+		$in = new SWPS_IndexNow();
+		$in->maybe_enqueue_post( $this->post( 10, 'post', '2026-07-02 00:00:00' ) );
+		$GLOBALS['swps_test_options'][ SWPS_IndexNow::OPT_QUEUE ] = array(); // simulate a flush
+		$in->maybe_enqueue_post( $this->post( 10, 'post', '2026-07-02 00:00:00' ) ); // identical modified
+		$this->assertSame( array(), get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+	}
+
+	public function test_edited_post_resubmits(): void {
+		$in = new SWPS_IndexNow();
+		$in->maybe_enqueue_post( $this->post( 10, 'post', '2026-07-02 00:00:00' ) );
+		$GLOBALS['swps_test_options'][ SWPS_IndexNow::OPT_QUEUE ] = array();
+		$in->maybe_enqueue_post( $this->post( 10, 'post', '2026-07-03 12:00:00' ) ); // changed
+		$this->assertContains( 'https://example.com/?p=10', get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+	}
+}

--- a/tests/unit/IndexNowHelpersTest.php
+++ b/tests/unit/IndexNowHelpersTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Unit tests for SWPS_IndexNow pure helpers.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return ( $GLOBALS['swps_test_home'] ?? 'https://example.com' ) . $path;
+	}
+}
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( $url, $component = -1 ) {
+		return parse_url( $url, $component );
+	}
+}
+if ( ! function_exists( 'wp_get_environment_type' ) ) {
+	function wp_get_environment_type() {
+		return $GLOBALS['swps_test_env'] ?? 'production';
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowHelpersTest extends TestCase {
+
+	public function test_generate_key_is_32_hex_chars(): void {
+		$key = SWPS_IndexNow::generate_key();
+		$this->assertSame( 32, strlen( $key ) );
+		$this->assertMatchesRegularExpression( '/^[0-9a-f]{32}$/', $key );
+		$this->assertNotSame( SWPS_IndexNow::generate_key(), $key );
+	}
+
+	public function test_is_valid_key(): void {
+		$this->assertTrue( SWPS_IndexNow::is_valid_key( str_repeat( 'a', 32 ) ) );
+		$this->assertTrue( SWPS_IndexNow::is_valid_key( 'abc1234-DEF' ) );
+		$this->assertFalse( SWPS_IndexNow::is_valid_key( 'short' ) );        // < 8
+		$this->assertFalse( SWPS_IndexNow::is_valid_key( 'has space here' ) );
+		$this->assertFalse( SWPS_IndexNow::is_valid_key( '' ) );
+	}
+
+	public function test_is_staging_host(): void {
+		$this->assertTrue( SWPS_IndexNow::is_staging_host( 'localhost' ) );
+		$this->assertTrue( SWPS_IndexNow::is_staging_host( 'jonimms.local' ) );
+		$this->assertTrue( SWPS_IndexNow::is_staging_host( 'my-site.test' ) );
+		$this->assertTrue( SWPS_IndexNow::is_staging_host( 'staging.example.com' ) );
+		$this->assertTrue( SWPS_IndexNow::is_staging_host( 'dev.example.com' ) );
+		$this->assertFalse( SWPS_IndexNow::is_staging_host( 'example.com' ) );
+		$this->assertFalse( SWPS_IndexNow::is_staging_host( 'www.jonimms.com' ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_skip_environment_on_non_production(): void {
+		$GLOBALS['swps_test_env']  = 'staging';
+		$GLOBALS['swps_test_home'] = 'https://example.com';
+		$this->assertTrue( SWPS_IndexNow::should_skip_environment() );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_skip_environment_on_staging_host(): void {
+		$GLOBALS['swps_test_env']  = 'production';
+		$GLOBALS['swps_test_home'] = 'https://staging.example.com';
+		$this->assertTrue( SWPS_IndexNow::should_skip_environment() );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_should_not_skip_on_production_live_host(): void {
+		$GLOBALS['swps_test_env']  = 'production';
+		$GLOBALS['swps_test_home'] = 'https://www.jonimms.com';
+		$this->assertFalse( SWPS_IndexNow::should_skip_environment() );
+	}
+
+	public function test_build_payload(): void {
+		$payload = SWPS_IndexNow::build_payload( 'example.com', 'abcdef1234', array( 'https://example.com/a', 'https://example.com/a' ) );
+		$this->assertSame( 'example.com', $payload['host'] );
+		$this->assertSame( 'abcdef1234', $payload['key'] );
+		$this->assertSame( 'https://example.com/abcdef1234.txt', $payload['keyLocation'] );
+		$this->assertSame( array( 'https://example.com/a', 'https://example.com/a' ), $payload['urlList'] );
+	}
+
+	public function test_interpret_response_code(): void {
+		$this->assertSame( 'ok', SWPS_IndexNow::interpret_response_code( 200 ) );
+		$this->assertSame( 'pending', SWPS_IndexNow::interpret_response_code( 202 ) );
+		$this->assertSame( 'invalid', SWPS_IndexNow::interpret_response_code( 400 ) );
+		$this->assertSame( 'key_not_found', SWPS_IndexNow::interpret_response_code( 403 ) );
+		$this->assertSame( 'host_mismatch', SWPS_IndexNow::interpret_response_code( 422 ) );
+		$this->assertSame( 'rate_limited', SWPS_IndexNow::interpret_response_code( 429 ) );
+		$this->assertSame( 'error', SWPS_IndexNow::interpret_response_code( 500 ) );
+	}
+
+	public function test_key_file_path_matches(): void {
+		$this->assertTrue( SWPS_IndexNow::key_file_path_matches( '/abc123.txt', 'abc123' ) );
+		$this->assertFalse( SWPS_IndexNow::key_file_path_matches( '/other.txt', 'abc123' ) );
+		$this->assertFalse( SWPS_IndexNow::key_file_path_matches( '/abc123.txt/', 'abc123' ) );
+	}
+}

--- a/tests/unit/IndexNowHelpersTest.php
+++ b/tests/unit/IndexNowHelpersTest.php
@@ -43,6 +43,7 @@ class IndexNowHelpersTest extends TestCase {
 		$this->assertFalse( SWPS_IndexNow::is_valid_key( 'short' ) );        // < 8
 		$this->assertFalse( SWPS_IndexNow::is_valid_key( 'has space here' ) );
 		$this->assertFalse( SWPS_IndexNow::is_valid_key( '' ) );
+		$this->assertFalse( SWPS_IndexNow::is_valid_key( "aaaaaaaa\n" ) );
 	}
 
 	public function test_is_staging_host(): void {

--- a/tests/unit/IndexNowLogTest.php
+++ b/tests/unit/IndexNowLogTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Unit tests for the IndexNow activity-log ring buffer.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default_value = false ) {
+		return $GLOBALS['swps_test_options'][ $option ] ?? $default_value;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $option, $value, $autoload = null ) {
+		$GLOBALS['swps_test_options'][ $option ] = $value;
+		return true;
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowLogTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['swps_test_options'] = array();
+	}
+
+	public function test_append_prepends_newest_first(): void {
+		SWPS_IndexNow::append_log( array( 'result' => 'first' ) );
+		SWPS_IndexNow::append_log( array( 'result' => 'second' ) );
+		$log = SWPS_IndexNow::get_log();
+		$this->assertSame( 'second', $log[0]['result'] );
+		$this->assertSame( 'first', $log[1]['result'] );
+	}
+
+	public function test_log_caps_at_max(): void {
+		for ( $i = 0; $i < SWPS_IndexNow::MAX_LOG + 20; $i++ ) {
+			SWPS_IndexNow::append_log( array( 'result' => "e{$i}" ) );
+		}
+		$this->assertCount( SWPS_IndexNow::MAX_LOG, SWPS_IndexNow::get_log() );
+	}
+
+	public function test_get_log_returns_empty_array_when_unset(): void {
+		$this->assertSame( array(), SWPS_IndexNow::get_log() );
+	}
+}

--- a/tests/unit/IndexNowQueueTest.php
+++ b/tests/unit/IndexNowQueueTest.php
@@ -60,6 +60,10 @@ class IndexNowQueueTest extends TestCase {
 		$this->assertCount( 1, get_option( SWPS_IndexNow::OPT_QUEUE ) );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function test_enqueue_schedules_flush_once_per_burst(): void {
 		SWPS_IndexNow::enqueue_url( 'https://example.com/a' );
 		SWPS_IndexNow::enqueue_url( 'https://example.com/b' );

--- a/tests/unit/IndexNowQueueTest.php
+++ b/tests/unit/IndexNowQueueTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Unit tests for the IndexNow debounce queue.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default_value = false ) {
+		return $GLOBALS['swps_test_options'][ $option ] ?? $default_value;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $option, $value, $autoload = null ) {
+		$GLOBALS['swps_test_options'][ $option ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $url ) {
+		return trim( (string) $url );
+	}
+}
+if ( ! function_exists( 'wp_next_scheduled' ) ) {
+	function wp_next_scheduled( $hook ) {
+		return $GLOBALS['swps_test_scheduled'][ $hook ] ?? false;
+	}
+}
+if ( ! function_exists( 'wp_schedule_single_event' ) ) {
+	function wp_schedule_single_event( $ts, $hook, $args = array() ) {
+		$GLOBALS['swps_test_scheduled'][ $hook ]     = $ts;
+		$GLOBALS['swps_test_schedule_calls']         = ( $GLOBALS['swps_test_schedule_calls'] ?? 0 ) + 1;
+		return true;
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowQueueTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['swps_test_options']         = array();
+		$GLOBALS['swps_test_scheduled']       = array();
+		$GLOBALS['swps_test_schedule_calls']  = 0;
+	}
+
+	public function test_enqueue_adds_url(): void {
+		SWPS_IndexNow::enqueue_url( 'https://example.com/a' );
+		$this->assertSame( array( 'https://example.com/a' ), get_option( SWPS_IndexNow::OPT_QUEUE ) );
+	}
+
+	public function test_enqueue_dedupes(): void {
+		SWPS_IndexNow::enqueue_url( 'https://example.com/a' );
+		SWPS_IndexNow::enqueue_url( 'https://example.com/a' );
+		$this->assertCount( 1, get_option( SWPS_IndexNow::OPT_QUEUE ) );
+	}
+
+	public function test_enqueue_schedules_flush_once_per_burst(): void {
+		SWPS_IndexNow::enqueue_url( 'https://example.com/a' );
+		SWPS_IndexNow::enqueue_url( 'https://example.com/b' );
+		$this->assertSame( 1, $GLOBALS['swps_test_schedule_calls'] );
+		$this->assertArrayHasKey( SWPS_IndexNow::CRON_HOOK, $GLOBALS['swps_test_scheduled'] );
+	}
+
+	public function test_enqueue_ignores_empty(): void {
+		SWPS_IndexNow::enqueue_url( '   ' );
+		$this->assertSame( array(), get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+	}
+}

--- a/tests/unit/IndexNowScaffoldTest.php
+++ b/tests/unit/IndexNowScaffoldTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Scaffold test: the IndexNow class and its public contract exist.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( ...$args ) {}
+}
+
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowScaffoldTest extends TestCase {
+
+	public function test_class_and_constants_exist(): void {
+		$this->assertTrue( class_exists( 'SWPS_IndexNow' ) );
+		$this->assertSame( 'swps_indexnow_flush', SWPS_IndexNow::CRON_HOOK );
+		$this->assertSame( 'https://api.indexnow.org/indexnow', SWPS_IndexNow::ENDPOINT );
+		$this->assertSame( 50, SWPS_IndexNow::MAX_LOG );
+		$this->assertSame( 10000, SWPS_IndexNow::MAX_URLS_PER_REQUEST );
+		$this->assertSame( 60, SWPS_IndexNow::DEBOUNCE_SECONDS );
+	}
+}

--- a/tests/unit/IndexNowSettingsSanitizeTest.php
+++ b/tests/unit/IndexNowSettingsSanitizeTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Unit tests for IndexNow settings sanitizers (array footgun guard).
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'sanitize_key' ) ) {
+	function sanitize_key( $k ) {
+		return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $k ) );
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowSettingsSanitizeTest extends TestCase {
+
+	public function test_checkbox_sanitizes_to_int(): void {
+		$this->assertSame( 1, SWPS_IndexNow::sanitize_checkbox( '1' ) );
+		$this->assertSame( 1, SWPS_IndexNow::sanitize_checkbox( 'on' ) );
+		$this->assertSame( 0, SWPS_IndexNow::sanitize_checkbox( '' ) );
+		$this->assertSame( 0, SWPS_IndexNow::sanitize_checkbox( null ) );
+	}
+
+	public function test_post_types_stay_an_array(): void {
+		$this->assertSame( array( 'post', 'page' ), SWPS_IndexNow::sanitize_post_types( array( 'post', 'page' ) ) );
+	}
+
+	public function test_post_types_sanitizes_keys_and_drops_bad_input(): void {
+		$this->assertSame( array( 'mycpt' ), SWPS_IndexNow::sanitize_post_types( array( 'My CPT!' ) ) );
+		$this->assertSame( array(), SWPS_IndexNow::sanitize_post_types( 'not-an-array' ) );
+		$this->assertSame( array(), SWPS_IndexNow::sanitize_post_types( null ) );
+	}
+}

--- a/tests/unit/IndexNowSubmitTest.php
+++ b/tests/unit/IndexNowSubmitTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Unit tests for IndexNow HTTP submission + flush.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default_value = false ) {
+		return $GLOBALS['swps_test_options'][ $option ] ?? $default_value;
+	}
+}
+if ( ! function_exists( 'update_option' ) ) {
+	function update_option( $option, $value, $autoload = null ) {
+		$GLOBALS['swps_test_options'][ $option ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return 'https://example.com' . $path;
+	}
+}
+if ( ! function_exists( 'wp_parse_url' ) ) {
+	function wp_parse_url( $url, $c = -1 ) {
+		return parse_url( $url, $c );
+	}
+}
+if ( ! function_exists( 'wp_get_environment_type' ) ) {
+	function wp_get_environment_type() {
+		return 'production';
+	}
+}
+if ( ! function_exists( 'wp_json_encode' ) ) {
+	function wp_json_encode( $data ) {
+		return json_encode( $data );
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
+}
+if ( ! function_exists( 'wp_remote_post' ) ) {
+	function wp_remote_post( $url, $args = array() ) {
+		$GLOBALS['swps_test_last_post'] = array( 'url' => $url, 'args' => $args );
+		return $GLOBALS['swps_test_http_response'] ?? array( 'response' => array( 'code' => 200 ), 'body' => '' );
+	}
+}
+if ( ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
+	function wp_remote_retrieve_response_code( $r ) {
+		return $r['response']['code'] ?? 0;
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-indexnow.php';
+
+class IndexNowSubmitTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['swps_test_options']       = array( SWPS_IndexNow::OPT_KEY => str_repeat( 'a', 32 ) );
+		$GLOBALS['swps_test_http_response'] = array( 'response' => array( 'code' => 200 ), 'body' => '' );
+		unset( $GLOBALS['swps_test_last_post'] );
+	}
+
+	public function test_submit_posts_json_and_logs_ok(): void {
+		$results = ( new SWPS_IndexNow() )->submit_urls( array( 'https://example.com/a' ), 'manual' );
+		$this->assertSame( 'ok', $results[0]['result'] );
+		$this->assertSame( SWPS_IndexNow::ENDPOINT, $GLOBALS['swps_test_last_post']['url'] );
+		$body = json_decode( $GLOBALS['swps_test_last_post']['args']['body'], true );
+		$this->assertSame( 'example.com', $body['host'] );
+		$this->assertSame( array( 'https://example.com/a' ), $body['urlList'] );
+		$this->assertSame( 'ok', SWPS_IndexNow::get_log()[0]['result'] );
+	}
+
+	public function test_submit_without_valid_key_logs_no_key(): void {
+		$GLOBALS['swps_test_options'][ SWPS_IndexNow::OPT_KEY ] = '';
+		$results = ( new SWPS_IndexNow() )->submit_urls( array( 'https://example.com/a' ) );
+		$this->assertSame( array(), $results );
+		$this->assertSame( 'no_key', SWPS_IndexNow::get_log()[0]['result'] );
+	}
+
+	public function test_wp_error_is_logged_as_error(): void {
+		$GLOBALS['swps_test_http_response'] = new WP_Error( 'http', 'down' );
+		$results = ( new SWPS_IndexNow() )->submit_urls( array( 'https://example.com/a' ) );
+		$this->assertSame( 'error', $results[0]['result'] );
+	}
+
+	public function test_flush_drains_queue_and_submits(): void {
+		$GLOBALS['swps_test_options'][ SWPS_IndexNow::OPT_QUEUE ] = array( 'https://example.com/a', 'https://example.com/b' );
+		( new SWPS_IndexNow() )->flush();
+		$this->assertSame( array(), get_option( SWPS_IndexNow::OPT_QUEUE, array() ) );
+		$body = json_decode( $GLOBALS['swps_test_last_post']['args']['body'], true );
+		$this->assertCount( 2, $body['urlList'] );
+	}
+
+	public function test_flush_on_empty_queue_does_nothing(): void {
+		( new SWPS_IndexNow() )->flush();
+		$this->assertArrayNotHasKey( 'swps_test_last_post', $GLOBALS );
+	}
+}

--- a/tests/unit/SitemapIndexableTest.php
+++ b/tests/unit/SitemapIndexableTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Unit tests for the shared IndexNow/sitemap eligibility predicate.
+ *
+ * Tests whose expected result depends on non-default get_option()/
+ * get_post_meta() stub behavior run in a separate process so they do not
+ * collide with same-named stubs defined in other suite-wide test files
+ * (e.g. SchemaGraphTest's get_option() and SitemapHomepageTest's
+ * get_post_meta(), both guarded by function_exists()).
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return 'https://example.com' . $path;
+	}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default_value = false ) {
+		return $GLOBALS['swps_test_options'][ $option ] ?? $default_value;
+	}
+}
+if ( ! function_exists( 'get_post_meta' ) ) {
+	function get_post_meta( $id, $key = '', $single = false ) {
+		return $GLOBALS['swps_test_postmeta'][ $id ][ $key ] ?? '';
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-sitemap-manager.php';
+
+class SitemapIndexableTest extends TestCase {
+
+	protected function setUp(): void {
+		$GLOBALS['swps_test_options']  = array();
+		$GLOBALS['swps_test_postmeta'] = array();
+	}
+
+	private function post( int $id, string $status = 'publish', string $type = 'post' ): object {
+		return (object) array( 'ID' => $id, 'post_status' => $status, 'post_type' => $type );
+	}
+
+	public function test_published_post_is_indexable(): void {
+		$this->assertTrue( SWPS_Sitemap_Manager::is_post_indexable( $this->post( 1 ) ) );
+	}
+
+	public function test_draft_is_not_indexable(): void {
+		$this->assertFalse( SWPS_Sitemap_Manager::is_post_indexable( $this->post( 1, 'draft' ) ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_excluded_post_meta_blocks_indexing(): void {
+		$GLOBALS['swps_test_postmeta'][2]['_swps_sitemap_exclude'] = 1;
+		$this->assertFalse( SWPS_Sitemap_Manager::is_post_indexable( $this->post( 2 ) ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_noindex_robots_meta_blocks_indexing(): void {
+		$GLOBALS['swps_test_postmeta'][3]['_swps_robots'] = 'noindex,follow';
+		$this->assertFalse( SWPS_Sitemap_Manager::is_post_indexable( $this->post( 3 ) ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_hidden_post_type_blocks_indexing(): void {
+		$GLOBALS['swps_test_options']['swps_sitemap_exclude_product'] = 1;
+		$this->assertFalse( SWPS_Sitemap_Manager::is_post_indexable( $this->post( 4, 'publish', 'product' ) ) );
+	}
+}

--- a/tests/unit/SitemapIndexableTest.php
+++ b/tests/unit/SitemapIndexableTest.php
@@ -3,10 +3,11 @@
  * Unit tests for the shared IndexNow/sitemap eligibility predicate.
  *
  * Tests whose expected result depends on non-default get_option()/
- * get_post_meta() stub behavior run in a separate process so they do not
- * collide with same-named stubs defined in other suite-wide test files
- * (e.g. SchemaGraphTest's get_option() and SitemapHomepageTest's
- * get_post_meta(), both guarded by function_exists()).
+ * get_post_meta()/get_term_meta() (or the other WP stubs defined below)
+ * stub behavior run in a separate process so they do not collide with
+ * same-named stubs defined in other suite-wide test files (e.g.
+ * SchemaGraphTest's get_option() and SitemapHomepageTest's get_post_meta()
+ * and get_permalink(), all guarded by function_exists()).
  *
  * @package StrataWP_SEO
  */
@@ -28,6 +29,63 @@ if ( ! function_exists( 'get_post_meta' ) ) {
 		return $GLOBALS['swps_test_postmeta'][ $id ][ $key ] ?? '';
 	}
 }
+if ( ! function_exists( 'get_term_meta' ) ) {
+	function get_term_meta( $term_id, $key = '', $single = false ) {
+		return $GLOBALS['swps_test_termmeta'][ $term_id ][ $key ] ?? '';
+	}
+}
+if ( ! function_exists( 'get_post_types' ) ) {
+	function get_post_types( $args = array() ) {
+		return $GLOBALS['swps_test_post_types'] ?? array();
+	}
+}
+if ( ! function_exists( 'get_posts' ) ) {
+	function get_posts( $args = array() ) {
+		return $GLOBALS['swps_test_post_ids'] ?? array();
+	}
+}
+if ( ! function_exists( 'get_post' ) ) {
+	function get_post( $id ) {
+		return $GLOBALS['swps_test_post_objects'][ $id ] ?? null;
+	}
+}
+if ( ! function_exists( 'get_permalink' ) ) {
+	function get_permalink( $post = 0 ) {
+		$id = is_object( $post ) ? $post->ID : (int) $post;
+		return $GLOBALS['swps_test_permalinks'][ $id ] ?? '';
+	}
+}
+if ( ! function_exists( 'get_taxonomies' ) ) {
+	function get_taxonomies( $args = array() ) {
+		return $GLOBALS['swps_test_taxonomies'] ?? array();
+	}
+}
+if ( ! function_exists( 'get_terms' ) ) {
+	function get_terms( $args = array() ) {
+		return $GLOBALS['swps_test_terms'] ?? array();
+	}
+}
+if ( ! function_exists( 'get_term_link' ) ) {
+	function get_term_link( $term ) {
+		$id = is_object( $term ) ? $term->term_id : (int) $term;
+		return $GLOBALS['swps_test_term_links'][ $id ] ?? '';
+	}
+}
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
+}
+if ( ! function_exists( 'get_users' ) ) {
+	function get_users( $args = array() ) {
+		return $GLOBALS['swps_test_users'] ?? array();
+	}
+}
+if ( ! function_exists( 'get_author_posts_url' ) ) {
+	function get_author_posts_url( $author_id ) {
+		return 'https://example.com/author/' . $author_id . '/';
+	}
+}
 
 require_once __DIR__ . '/../../includes/class-sitemap-manager.php';
 
@@ -36,6 +94,7 @@ class SitemapIndexableTest extends TestCase {
 	protected function setUp(): void {
 		$GLOBALS['swps_test_options']  = array();
 		$GLOBALS['swps_test_postmeta'] = array();
+		$GLOBALS['swps_test_termmeta'] = array();
 	}
 
 	private function post( int $id, string $status = 'publish', string $type = 'post' ): object {
@@ -75,5 +134,109 @@ class SitemapIndexableTest extends TestCase {
 	public function test_hidden_post_type_blocks_indexing(): void {
 		$GLOBALS['swps_test_options']['swps_sitemap_exclude_product'] = 1;
 		$this->assertFalse( SWPS_Sitemap_Manager::is_post_indexable( $this->post( 4, 'publish', 'product' ) ) );
+	}
+
+	public function test_indexable_term_is_indexable(): void {
+		$this->assertTrue( SWPS_Sitemap_Manager::is_term_indexable( 1, 'category' ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_excluded_term_meta_blocks_term_indexing(): void {
+		$GLOBALS['swps_test_termmeta'][2]['_swps_sitemap_exclude'] = 1;
+		$this->assertFalse( SWPS_Sitemap_Manager::is_term_indexable( 2, 'category' ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_noindex_robots_term_meta_blocks_term_indexing(): void {
+		$GLOBALS['swps_test_termmeta'][3]['_swps_robots'] = 'noindex,follow';
+		$this->assertFalse( SWPS_Sitemap_Manager::is_term_indexable( 3, 'category' ) );
+	}
+
+	/**
+	 * Hidden taxonomy must block term indexing even when the term itself has
+	 * no exclude/noindex meta — is_term_indexable() must be self-contained
+	 * (taxonomy-aware) so later IndexNow tasks can call it directly on
+	 * term-change hooks without re-checking taxonomy visibility themselves.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_hidden_taxonomy_blocks_term_indexing(): void {
+		$GLOBALS['swps_test_options']['swps_sitemap_exclude_product_cat'] = 1;
+		$this->assertFalse( SWPS_Sitemap_Manager::is_term_indexable( 4, 'product_cat' ) );
+	}
+
+	/**
+	 * Same as above but via the swps_noindex_{tax} option instead of the
+	 * sitemap-exclude option, covering the other half of
+	 * is_taxonomy_hidden_from_sitemap()'s OR condition.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_noindex_taxonomy_option_blocks_term_indexing(): void {
+		$GLOBALS['swps_test_options']['swps_noindex_product_cat'] = 1;
+		$this->assertFalse( SWPS_Sitemap_Manager::is_term_indexable( 5, 'product_cat' ) );
+	}
+
+	/**
+	 * Focused integration test for get_indexable_urls(): the homepage and an
+	 * eligible post permalink must be present; a post excluded via
+	 * _swps_sitemap_exclude must not appear. Also exercises the taxonomy
+	 * loop's updated is_term_indexable( $term_id, $taxonomy ) call site and
+	 * the get_term_link() WP_Error guard — an eligible term (20) whose
+	 * get_term_link() resolves normally must appear, while an eligible term
+	 * (21) whose get_term_link() returns a WP_Error must be silently
+	 * skipped rather than surviving into the URL list (previously this
+	 * WP_Error would reach array_unique() and fatal in PHP 8).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_indexable_urls_includes_eligible_excludes_ineligible(): void {
+		$GLOBALS['swps_test_postmeta'] = array(
+			11 => array( '_swps_sitemap_exclude' => 1 ),
+		);
+
+		$GLOBALS['swps_test_post_types']   = array( 'post' );
+		$GLOBALS['swps_test_post_ids']     = array( 10, 11 );
+		$GLOBALS['swps_test_post_objects'] = array(
+			10 => $this->post( 10 ),
+			11 => $this->post( 11 ),
+		);
+		$GLOBALS['swps_test_permalinks'] = array(
+			10 => 'https://example.com/eligible-post/',
+			11 => 'https://example.com/excluded-post/',
+		);
+
+		$GLOBALS['swps_test_taxonomies'] = array( 'category' );
+		$GLOBALS['swps_test_terms']      = array(
+			(object) array( 'term_id' => 20 ),
+			(object) array( 'term_id' => 21 ),
+		);
+		$GLOBALS['swps_test_term_links'] = array(
+			20 => 'https://example.com/category/eligible-term/',
+			21 => new WP_Error( 'invalid_term_link', 'no link available' ),
+		);
+
+		$GLOBALS['swps_test_users'] = array( 7 );
+
+		$urls = SWPS_Sitemap_Manager::get_indexable_urls();
+
+		$this->assertContains( home_url( '/' ), $urls, 'Homepage must be present.' );
+		$this->assertContains( 'https://example.com/eligible-post/', $urls, 'Eligible post permalink must be present.' );
+		$this->assertNotContains( 'https://example.com/excluded-post/', $urls, 'Excluded post must not be present.' );
+		$this->assertContains( 'https://example.com/category/eligible-term/', $urls, 'Eligible term link must be present.' );
+		$this->assertContains( 'https://example.com/author/7/', $urls, 'Author URL must be present.' );
+
+		foreach ( $urls as $url ) {
+			$this->assertNotInstanceOf( WP_Error::class, $url, 'A WP_Error must never survive into the URL list.' );
+		}
 	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -46,6 +46,7 @@ $swps_cron_hooks = array(
 	'swps_site_crawl_weekly',
 	'swps_cannibal_scan',
 	'swps_audit_ability_run',
+	'swps_indexnow_flush',
 );
 
 foreach ( $swps_cron_hooks as $swps_cron_hook ) {


### PR DESCRIPTION
## IndexNow integration (4.22.0)

Adds [IndexNow](https://www.indexnow.org/) support so the site instantly notifies **Bing, Yandex, Seznam, and Naver** whenever a URL is published, updated, or removed — fulfilling the "IndexNow batch submit" promise the Sitemaps module already advertised. (Google does not participate in IndexNow.)

### What it does
- **Auto-submit on the post/term lifecycle** (`transition_post_status`, delete/trash, term hooks) → a deduped queue → a single debounced (`+60s`) wp-cron flush → batched JSON POST to `api.indexnow.org` in ≤10k-URL chunks.
- **Verification key**: a 32-hex key stored plain (it's public) and served virtually at `/{key}.txt` via an `init`-priority-1 handler (no rewrite rules).
- **Manual controls**: per-post "Submit to IndexNow now" button in the SEO meta box, and a bulk "Resubmit all URLs" action.
- **URL eligibility mirrors the sitemap** — new `SWPS_Sitemap_Manager::is_post_indexable()` / `is_term_indexable()` / `get_indexable_urls()` are the single source of truth (honor `_swps_sitemap_exclude` + noindex).
- **Environment guard**: submissions auto-pause when `wp_get_environment_type() !== 'production'` or the host looks like staging/local.
- **Activity log**: ring buffer (last ~50 submissions) shown on the Sitemaps admin panel.
- Settings live in a **dedicated `swps_indexnow_settings` option group** (self-contained form) — avoids the shared-group partial-form wipe / array-option double-registration footgun.

### Architecture
One new class `SWPS_IndexNow` (`includes/class-indexnow.php`), required + instantiated in the bootstrap; a small behavior-preserving refactor exposing the sitemap's eligibility predicates; a panel template on the Sitemaps page + `admin/js/indexnow.js`. Design spec and implementation plan are under `docs/superpowers/`.

### Testing
- **486 unit tests green**, PHPStan clean, `php -l` clean.
- **Live smoke test on a dev site passed**: `/{key}.txt` serves `text/plain`+`noindex` with the key body; wrong-key path 404s; the env guard correctly pauses auto-submit on `.local`; `get_indexable_urls()` returned 269 real URLs; a real `submit_urls()` POST returned **HTTP 202** and was logged; a lifecycle publish on the dev host was correctly env-suppressed.

### Known follow-ups (non-blocking, from the whole-branch review)
- Term *deletions* aren't submitted (the term row is gone by `delete_term`, so `get_term_link()` errors) — documented in code; post removals work via the stashed last-URL.
- `get_indexable_urls()` always seeds the homepage even if the `page` type is sitemap-excluded (benign front-page case).
- Theoretical low-probability read-modify-write race on the queue option (inherent WP-options limitation).

Merging to `main` bumps the plugin to **4.22.0** (triggers the release build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
