### PR TITLE
Fix: Sonnet 5 prefill 400 + silent proposal-save failures (4.22.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1711,6 +1711,11 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 
 ## Changelog
 
+### v4.22.1 — July 2026
+- **Sonnet 5 and newer Claude models fixed** — selecting Claude Sonnet 5 (or any Claude model newer than the 4.5 generation) no longer fails with `Claude API error (400): This model does not support assistant message prefill`. The prefill check only matched hyphen-suffixed version patterns (`5-…`), so bare model IDs like `claude-sonnet-5` slipped through; the check now allowlists the older prefill-capable generations instead, so future Claude releases work by default
+- **"No proposal cached" apply failures caught earlier** — the AEO optimizer now verifies a generated proposal actually saved (and reads back as valid JSON) before reporting success. Silent save failures — a database rejecting the write, object-cache hiccups — previously surfaced only later as a baffling "Apply failed: No proposal cached" when clicking Apply; they now produce an actionable error at generate time
+- **Claude Opus 4.8 and Claude Sonnet 5** added to the built-in Anthropic model list used when live model discovery is unavailable
+
 ### v4.22.0 — July 2026
 - **IndexNow integration** — instantly notify Bing, Yandex, Seznam, and Naver when you publish, update, or remove content (Google does not participate in IndexNow). An auto-generated verification key is served at `/{key}.txt`; publishing, updating, or deleting a post/term auto-submits its URL with a 60-second debounce so bulk edits collapse into one batch
 - **Manual controls** — a per-post "Submit now" action and a bulk "Resubmit all" button, plus a dedicated IndexNow panel on the Sitemaps screen with a recent-activity log

--- a/includes/class-aeo-optimizer.php
+++ b/includes/class-aeo-optimizer.php
@@ -449,7 +449,28 @@ class SWPS_AEO_Optimizer {
 		// Pre-slashing means the round-trip leaves the stored value as valid
 		// JSON. The same pattern is applied to META_SNAPSHOT and
 		// META_SCHEMA_JSON below.
-		update_post_meta( $post_id, self::META_PROPOSAL, wp_slash( (string) wp_json_encode( $proposal ) ) );
+		$encoded = wp_json_encode( $proposal );
+		if ( false === $encoded ) {
+			return array(
+				'error'       => __( 'The proposal could not be encoded for storage (the post or AI response contains characters that cannot be serialized). Nothing was saved — please try again.', 'stratawp-seo' ),
+				'http_status' => 500,
+			);
+		}
+		update_post_meta( $post_id, self::META_PROPOSAL, wp_slash( $encoded ) );
+
+		// Verify the save round-trips before reporting success. A silent write
+		// failure (DB charset stripping on non-utf8mb4 tables, an object-cache
+		// hiccup, a meta filter) previously surfaced only later as a baffling
+		// "No proposal cached" error when the user clicked Apply. Comparing
+		// _generated_at also catches the case where the write failed and the
+		// read-back returned a stale previous proposal.
+		$stored = json_decode( (string) get_post_meta( $post_id, self::META_PROPOSAL, true ), true );
+		if ( ! is_array( $stored ) || ( $stored['_generated_at'] ?? null ) !== ( $proposal['_generated_at'] ?? null ) ) {
+			return array(
+				'error'       => __( 'The proposal was generated but could not be saved, so applying it would fail. Check for database errors, then click "Generate proposal" again.', 'stratawp-seo' ),
+				'http_status' => 500,
+			);
+		}
 
 		return array( 'proposal' => $proposal );
 	}

--- a/includes/providers/ai/class-anthropic-provider.php
+++ b/includes/providers/ai/class-anthropic-provider.php
@@ -27,12 +27,37 @@ class SWPS_Anthropic_Provider extends SWPS_AI_Provider {
 
 	public function get_available_models(): array {
 		return array(
+			'claude-opus-4-8'            => 'Claude Opus 4.8',
+			'claude-sonnet-5'            => 'Claude Sonnet 5',
 			'claude-opus-4-7'            => 'Claude Opus 4.7',
 			'claude-opus-4-6'            => 'Claude Opus 4.6',
 			'claude-sonnet-4-6'          => 'Claude Sonnet 4.6',
 			'claude-sonnet-4-5-20250929' => 'Claude Sonnet 4.5',
 			'claude-haiku-4-5-20251001'  => 'Claude Haiku 4.5',
 		);
+	}
+
+	/**
+	 * Whether a Claude model accepts assistant-message prefill.
+	 *
+	 * Prefill was removed in the Claude 4.6 family, and every model released
+	 * since (Opus 4.7/4.8, Sonnet 5, ...) rejects it with a 400. The previous
+	 * denylist regex required a hyphen after the version number ("5-"), so
+	 * bare model aliases like `claude-sonnet-5` slipped through and the whole
+	 * request failed with "This model does not support assistant message
+	 * prefill". Allowlisting the known prefill-capable generations instead is
+	 * future-proof: an unknown or newer model simply skips the prefill (the
+	 * JSON parser copes fine without it) rather than erroring the request.
+	 *
+	 * Matches: claude-2.x, claude-3.x, and the 4.0/4.1/4.5 generations —
+	 * aliases (claude-opus-4-1, claude-haiku-4-5), dated minor IDs
+	 * (claude-sonnet-4-5-20250929), and dated 4.0 IDs (claude-opus-4-20250514).
+	 *
+	 * @param string $model Anthropic model ID.
+	 * @return bool
+	 */
+	public static function model_supports_prefill( string $model ): bool {
+		return (bool) preg_match( '/^claude-(2|3)[.-]|-4-[015](-|$)|-4-\d{8}/', $model );
 	}
 
 	public function chat( string $system_prompt, string $user_message, int $max_tokens = 4096 ): string|WP_Error {
@@ -50,9 +75,8 @@ class SWPS_Anthropic_Provider extends SWPS_AI_Provider {
 		);
 
 		// Prefill with opening brace to guide Claude toward valid JSON output.
-		// Note: Claude 4.6+ models (opus-4-6, sonnet-4-6, and newer 4-7+) do not support assistant prefill.
 		$model            = $this->get_validated_model();
-		$supports_prefill = ! preg_match( '/-(4-6|4-7|4-8|4-9|5-)/', $model );
+		$supports_prefill = self::model_supports_prefill( $model );
 
 		if ( $this->requesting_json && $supports_prefill ) {
 			$messages[] = array(

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.22.0
+Stable tag: 4.22.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,11 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.22.1 =
+* Fixed: selecting Claude Sonnet 5 (or other newer Claude models) failed with "Claude API error (400): This model does not support assistant message prefill". The prefill compatibility check now allowlists the older prefill-capable models, so new Claude releases work by default.
+* Fixed: "Apply failed: No proposal cached" could appear right after generating an AEO proposal when the save silently failed. The optimizer now verifies the proposal saved correctly before reporting success, and shows an actionable error at generate time instead.
+* Added: Claude Opus 4.8 and Claude Sonnet 5 in the built-in Anthropic model list (used when live model discovery is unavailable).
 
 = 4.22.0 =
 * New: IndexNow integration — instantly notify Bing, Yandex, Seznam, and Naver when you publish, update, or remove content. Includes an auto-generated verification key served at /{key}.txt, auto-submit on the post/term lifecycle with a 60-second debounce, per-post "Submit now" and bulk "Resubmit all" controls, a dedicated panel on the Sitemaps screen, and a recent-activity log. Submissions are automatically paused on non-production environments. (Google does not participate in IndexNow.)

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.22.0
+ * Version: 4.22.1
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.22.0' );
+define( 'SWPS_VERSION', '4.22.1' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/tests/unit/AnthropicPrefillTest.php
+++ b/tests/unit/AnthropicPrefillTest.php
@@ -1,0 +1,60 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-ai-provider.php';
+require_once __DIR__ . '/../../includes/providers/ai/class-anthropic-provider.php';
+
+/**
+ * Assistant-message prefill was removed in the Claude 4.6 family; every model
+ * since rejects it with a 400 ("This model does not support assistant message
+ * prefill"). model_supports_prefill() must allowlist only the older,
+ * prefill-capable generations.
+ */
+final class AnthropicPrefillTest extends TestCase {
+
+	/** @dataProvider prefill_capable_models */
+	public function test_older_models_support_prefill( string $model ): void {
+		$this->assertTrue( SWPS_Anthropic_Provider::model_supports_prefill( $model ), $model );
+	}
+
+	public function prefill_capable_models(): array {
+		return array(
+			array( 'claude-2.1' ),
+			array( 'claude-3-haiku-20240307' ),
+			array( 'claude-3-5-sonnet-20241022' ),
+			array( 'claude-3-7-sonnet-20250219' ),
+			array( 'claude-sonnet-4-20250514' ),
+			array( 'claude-opus-4-20250514' ),
+			array( 'claude-opus-4-0' ),
+			array( 'claude-opus-4-1-20250805' ),
+			array( 'claude-sonnet-4-5' ),
+			array( 'claude-sonnet-4-5-20250929' ),
+			array( 'claude-opus-4-5-20251101' ),
+			array( 'claude-haiku-4-5' ),
+			array( 'claude-haiku-4-5-20251001' ),
+		);
+	}
+
+	/** @dataProvider prefill_rejecting_models */
+	public function test_newer_models_do_not_support_prefill( string $model ): void {
+		$this->assertFalse( SWPS_Anthropic_Provider::model_supports_prefill( $model ), $model );
+	}
+
+	public function prefill_rejecting_models(): array {
+		return array(
+			array( 'claude-sonnet-4-6' ),
+			array( 'claude-opus-4-6' ),
+			array( 'claude-opus-4-7' ),
+			array( 'claude-opus-4-8' ),
+			// Bare 5-series aliases: the old denylist regex required a hyphen
+			// after the version ("5-"), letting these through and causing the
+			// prefill 400 reported with Sonnet 5 selected.
+			array( 'claude-sonnet-5' ),
+			array( 'claude-fable-5' ),
+			array( 'claude-haiku-5' ),
+			// Hypothetical dated 5-series / future IDs must also skip prefill.
+			array( 'claude-sonnet-5-20260901' ),
+			array( 'claude-opus-4-9' ),
+		);
+	}
+}


### PR DESCRIPTION
Fixes two user-reported errors.

## 1. `Claude API error (400): This model does not support assistant message prefill` (Sonnet 5 selected)

The JSON-coercion prefill is only accepted by Claude models older than the 4.6 family. The compatibility check was a denylist regex:

```php
$supports_prefill = ! preg_match( '/-(4-6|4-7|4-8|4-9|5-)/', $model );
```

Every alternative requires a **hyphen after the version number**, so dated IDs like `claude-sonnet-5-20260203` were caught but the bare alias `claude-sonnet-5` (which is what the Anthropic `/v1/models` discovery returns and the user selects) slipped through — the `{` prefill was sent and the whole request 400'd, breaking content generation and AEO proposals on that model.

**Fix:** replaced the denylist with an allowlist of known prefill-capable generations (`claude-2.x`, `claude-3.x`, and the 4.0/4.1/4.5 families, aliases and dated IDs alike) in a new `SWPS_Anthropic_Provider::model_supports_prefill()`. This is future-proof in the right direction: an unknown or future model now simply *skips* the prefill (harmless — the JSON parser already copes without it) instead of sending it and failing the request. Also added Claude Opus 4.8 and Claude Sonnet 5 to the curated fallback model list used when live discovery is unavailable.

## 2. `Apply failed: No proposal cached` right after generating a proposal

`SWPS_AEO_Optimizer::do_propose()` stored the proposal with `update_post_meta()` and reported success without confirming the write persisted. A silent save failure — `wp_json_encode()` returning `false`, the DB rejecting/stripping the value (e.g. non-utf8mb4 tables), an object-cache hiccup — only surfaced later, when the user clicked **Apply** and `do_apply()` found no stored proposal.

**Fix:** `do_propose()` now checks the `wp_json_encode()` result, reads the meta back after saving, and verifies it decodes to the same proposal (matched on `_generated_at`, which also catches a stale previous proposal being returned after a failed write). If verification fails, the user gets an actionable error at generate time instead of a confusing one at apply time.

## Tests

- New `tests/unit/AnthropicPrefillTest.php` — 22 cases covering prefill-capable models (2.x/3.x/4.0/4.1/4.5, aliases + dated IDs) and prefill-rejecting ones (4.6/4.7/4.8, bare `claude-sonnet-5`, `claude-fable-5`, hypothetical dated 5-series and 4.9 IDs).
- Verified locally with a standalone runner (composer's GitHub downloads are blocked in this sandbox); CI's `composer test` will run the suite.
- `php -l` clean on all changed files.

## Release chores

Version bumped to **4.22.1**; changelog entries added to `README.md` and `readme.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMnW7dDLbfu4rKBQeQ8vUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMnW7dDLbfu4rKBQeQ8vUZ)_