### PR TITLE
Fix: "Received empty response from Claude" on Sonnet 5 thinking blocks (4.22.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1711,6 +1711,10 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 
 ## Changelog
 
+### v4.22.2 — July 2026
+- **"Received empty response from Claude" on Sonnet 5+ fixed** — Claude Sonnet 5 and newer models run adaptive thinking by default, so their responses open with a `thinking` content block before the `text` block. The provider read only the first block's text, so every response looked empty. Text is now collected from all text blocks in the response
+- **Clearer truncation error** — when a thinking-enabled model spends the entire `max_tokens` budget on reasoning before emitting any text, the error now says the token budget ran out (actionable) instead of "empty response"
+
 ### v4.22.1 — July 2026
 - **Sonnet 5 and newer Claude models fixed** — selecting Claude Sonnet 5 (or any Claude model newer than the 4.5 generation) no longer fails with `Claude API error (400): This model does not support assistant message prefill`. The prefill check only matched hyphen-suffixed version patterns (`5-…`), so bare model IDs like `claude-sonnet-5` slipped through; the check now allowlists the older prefill-capable generations instead, so future Claude releases work by default
 - **"No proposal cached" apply failures caught earlier** — the AEO optimizer now verifies a generated proposal actually saved (and reads back as valid JSON) before reporting success. Silent save failures — a database rejecting the write, object-cache hiccups — previously surfaced only later as a baffling "Apply failed: No proposal cached" when clicking Apply; they now produce an actionable error at generate time

--- a/includes/providers/ai/class-anthropic-provider.php
+++ b/includes/providers/ai/class-anthropic-provider.php
@@ -60,6 +60,27 @@ class SWPS_Anthropic_Provider extends SWPS_AI_Provider {
 		return (bool) preg_match( '/^claude-(2|3)[.-]|-4-[015](-|$)|-4-\d{8}/', $model );
 	}
 
+	/**
+	 * Concatenate the text content blocks of a Messages API response body.
+	 *
+	 * Newer Claude models (Sonnet 5 and later) run adaptive thinking by
+	 * default, so the `content` array may open with one or more `thinking`
+	 * blocks before the `text` block — `content[0]['text']` is not a safe
+	 * read. Non-text blocks (thinking, tool_use, ...) are skipped.
+	 *
+	 * @param array $content Decoded `content` array from the response body.
+	 * @return string Concatenated text ('' when the response has no text).
+	 */
+	public static function extract_text( array $content ): string {
+		$parts = array();
+		foreach ( $content as $block ) {
+			if ( is_array( $block ) && 'text' === ( $block['type'] ?? '' ) ) {
+				$parts[] = (string) ( $block['text'] ?? '' );
+			}
+		}
+		return implode( '', $parts );
+	}
+
 	public function chat( string $system_prompt, string $user_message, int $max_tokens = 4096 ): string|WP_Error {
 		$api_key = $this->get_api_key();
 
@@ -124,10 +145,6 @@ class SWPS_Anthropic_Provider extends SWPS_AI_Provider {
 			);
 		}
 
-		if ( empty( $body['content'][0]['text'] ) ) {
-			return new WP_Error( 'swps_empty_response', __( 'Received empty response from Claude.', 'stratawp-seo' ) );
-		}
-
 		// Store usage data for cost tracking.
 		if ( ! empty( $body['usage'] ) ) {
 			$this->last_usage = array(
@@ -137,10 +154,32 @@ class SWPS_Anthropic_Provider extends SWPS_AI_Provider {
 		}
 
 		// Store stop reason for truncation detection.
-		// Anthropic: 'end_turn', 'max_tokens', 'stop_sequence'.
+		// Anthropic: 'end_turn', 'max_tokens', 'stop_sequence', 'refusal'.
 		$this->last_stop_reason = $body['stop_reason'] ?? null;
 
-		$text = $body['content'][0]['text'];
+		// Newer Claude models (Sonnet 5 and later) run adaptive thinking by
+		// default, so the response content can start with `thinking` blocks
+		// before the `text` block — reading content[0]['text'] directly made
+		// every such response look empty ("Received empty response from
+		// Claude"). Collect every text block instead.
+		$text = self::extract_text( (array) ( $body['content'] ?? array() ) );
+
+		if ( '' === $text ) {
+			// A thinking-enabled model can burn the whole output budget on
+			// thinking and stop before emitting any text — surface that as
+			// truncation (actionable) rather than a generic empty response.
+			if ( 'max_tokens' === $this->last_stop_reason ) {
+				return new WP_Error(
+					'swps_response_truncated',
+					sprintf(
+						/* translators: %d: max_tokens budget for the request */
+						__( 'Claude used the entire %d-token response budget before producing any text (newer models spend part of the budget on internal reasoning). Try again or increase the token budget.', 'stratawp-seo' ),
+						$max_tokens
+					)
+				);
+			}
+			return new WP_Error( 'swps_empty_response', __( 'Received empty response from Claude.', 'stratawp-seo' ) );
+		}
 
 		// When using JSON prefill, prepend the opening brace we sent as assistant content.
 		if ( $this->requesting_json && $supports_prefill ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.22.1
+Stable tag: 4.22.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,10 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.22.2 =
+* Fixed: "Received empty response from Claude" when generating content with Claude Sonnet 5 or newer models. These models reason ("think") before answering by default, and the reasoning block ahead of the actual text made the response parser think it was empty. The parser now reads the text from anywhere in the response.
+* Improved: when a thinking-enabled model spends the entire response budget before producing text, the error now explains the token budget ran out instead of reporting an empty response.
 
 = 4.22.1 =
 * Fixed: selecting Claude Sonnet 5 (or other newer Claude models) failed with "Claude API error (400): This model does not support assistant message prefill". The prefill compatibility check now allowlists the older prefill-capable models, so new Claude releases work by default.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.22.1
+ * Version: 4.22.2
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.22.1' );
+define( 'SWPS_VERSION', '4.22.2' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/tests/unit/AnthropicExtractTextTest.php
+++ b/tests/unit/AnthropicExtractTextTest.php
@@ -1,0 +1,88 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-ai-provider.php';
+require_once __DIR__ . '/../../includes/providers/ai/class-anthropic-provider.php';
+
+/**
+ * Newer Claude models (Sonnet 5+) run adaptive thinking by default, so the
+ * response `content` array can open with `thinking` blocks before the `text`
+ * block. extract_text() must collect text across all blocks instead of
+ * assuming content[0] is the text block (the old read made every thinking
+ * response look like "Received empty response from Claude").
+ */
+final class AnthropicExtractTextTest extends TestCase {
+
+	public function test_classic_text_first_response(): void {
+		$content = array(
+			array(
+				'type' => 'text',
+				'text' => 'Hello world',
+			),
+		);
+		$this->assertSame( 'Hello world', SWPS_Anthropic_Provider::extract_text( $content ) );
+	}
+
+	public function test_thinking_block_precedes_text_block(): void {
+		// Sonnet 5 shape: adaptive thinking on by default, display "omitted"
+		// leaves the thinking field an empty string but the block still exists.
+		$content = array(
+			array(
+				'type'      => 'thinking',
+				'thinking'  => '',
+				'signature' => 'sig_abc',
+			),
+			array(
+				'type' => 'text',
+				'text' => '{"edits":[]}',
+			),
+		);
+		$this->assertSame( '{"edits":[]}', SWPS_Anthropic_Provider::extract_text( $content ) );
+	}
+
+	public function test_multiple_text_blocks_are_concatenated_in_order(): void {
+		$content = array(
+			array(
+				'type' => 'text',
+				'text' => 'part one, ',
+			),
+			array(
+				'type'     => 'thinking',
+				'thinking' => 'interleaved reasoning',
+			),
+			array(
+				'type' => 'text',
+				'text' => 'part two',
+			),
+		);
+		$this->assertSame( 'part one, part two', SWPS_Anthropic_Provider::extract_text( $content ) );
+	}
+
+	public function test_thinking_only_response_yields_empty_string(): void {
+		// Model spent the whole output budget thinking (stop_reason max_tokens).
+		$content = array(
+			array(
+				'type'     => 'thinking',
+				'thinking' => '',
+			),
+		);
+		$this->assertSame( '', SWPS_Anthropic_Provider::extract_text( $content ) );
+	}
+
+	public function test_empty_and_malformed_content_is_tolerated(): void {
+		$this->assertSame( '', SWPS_Anthropic_Provider::extract_text( array() ) );
+		$this->assertSame(
+			'ok',
+			SWPS_Anthropic_Provider::extract_text(
+				array(
+					'not-a-block',
+					array( 'type' => 'text' ), // Missing text key.
+					array(
+						'type' => 'text',
+						'text' => 'ok',
+					),
+				)
+			)
+		);
+	}
+}


### PR DESCRIPTION
Follow-up to #83. With the prefill 400 fixed, Sonnet 5 requests now succeed — and hit the next incompatibility: **"Received empty response from Claude"** on content generation.

## Root cause

Claude Sonnet 5 (and newer models) run **adaptive thinking by default** when the request doesn't set a `thinking` parameter. The response's `content` array then opens with a `thinking` block before the `text` block:

```json
"content": [
  { "type": "thinking", "thinking": "", "signature": "..." },
  { "type": "text", "text": "...the actual answer..." }
]
```

`SWPS_Anthropic_Provider::chat()` read only `$body['content'][0]['text']`, so every thinking-enabled response looked empty and errored out. (`search_grounded()` already iterated all blocks correctly — `chat()` was the only offender, and it's the funnel for every AI feature: generation, AEO proposals, meta editor, keywords, digests.)

## Fix

- New `extract_text()` helper concatenates the text from **all** `text`-type content blocks, skipping `thinking`/other block types; `chat()` now uses it.
- `usage` and `stop_reason` are stored **before** the empty-text check, so a thinking-only response that exhausted `max_tokens` now returns an actionable "response budget ran out" error instead of the generic empty-response message.

## Tests

- New `tests/unit/AnthropicExtractTextTest.php`: classic text-first shape, Sonnet 5 thinking-first shape, interleaved text blocks, thinking-only (budget exhausted), and empty/malformed content.
- Verified locally with a standalone runner (composer's GitHub downloads are blocked in this sandbox); CI's `composer test` runs the full suite.
- `php -l` clean on changed files.

## Release chores

Version bumped to **4.22.2**; changelog entries in `README.md` and `readme.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMnW7dDLbfu4rKBQeQ8vUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMnW7dDLbfu4rKBQeQ8vUZ)_