### PR TITLE
Fix front-end SEO output gaps found by site audit

### DIFF
--- a/includes/audit/class-opengraph-module.php
+++ b/includes/audit/class-opengraph-module.php
@@ -128,8 +128,8 @@ class SWPS_OpenGraph_Module extends SWPS_Audit_Module {
 		$site_name   = get_bloginfo( 'name' );
 		$image       = self::get_og_image( $post );
 
-		// OG tags.
-		printf( '<meta property="og:type" content="article" />' . "\n" );
+		// OG tags. Posts are articles; pages and other singulars are websites.
+		printf( '<meta property="og:type" content="%s" />' . "\n", esc_attr( is_singular( 'post' ) ? 'article' : 'website' ) );
 		printf( '<meta property="og:title" content="%s" />' . "\n", esc_attr( $title ) );
 		printf( '<meta property="og:description" content="%s" />' . "\n", esc_attr( $description ) );
 		printf( '<meta property="og:url" content="%s" />' . "\n", esc_url( $url ) );
@@ -151,9 +151,23 @@ class SWPS_OpenGraph_Module extends SWPS_Audit_Module {
 
 	/**
 	 * Get OG description from post.
-	 * Priority: Yoast meta desc → RankMath desc → excerpt → first 160 chars.
+	 * Priority: SWPS social desc → SWPS meta desc → Yoast → RankMath →
+	 * excerpt → first 160 chars.
 	 */
 	private static function get_description( WP_Post $post ): string {
+		// The plugin's own per-post fields win — previously only rival
+		// plugins' keys were read, so an SWPS description was silently
+		// ignored in this fallback path.
+		$desc = get_post_meta( $post->ID, '_swps_social_description', true );
+		if ( ! empty( $desc ) ) {
+			return $desc;
+		}
+
+		$desc = get_post_meta( $post->ID, '_swps_meta_description', true );
+		if ( ! empty( $desc ) ) {
+			return $desc;
+		}
+
 		$desc = get_post_meta( $post->ID, '_yoast_wpseo_metadesc', true );
 		if ( ! empty( $desc ) ) {
 			return $desc;

--- a/includes/class-breadcrumbs.php
+++ b/includes/class-breadcrumbs.php
@@ -114,8 +114,17 @@ class SWPS_Breadcrumbs {
 			if ( 'post' === $post->post_type ) {
 				$categories = get_the_category( $post->ID );
 				if ( ! empty( $categories ) ) {
-					// Use Yoast primary category if set, otherwise first.
-					$primary  = $categories[0];
+					// Use Yoast primary category if set, otherwise first — same
+					// resolution as the JSON-LD breadcrumb path in SWPS_Schema,
+					// so both trails show the same category.
+					$primary    = $categories[0];
+					$primary_id = (int) get_post_meta( $post->ID, '_yoast_wpseo_primary_category', true );
+					if ( $primary_id ) {
+						$term = get_term( $primary_id, 'category' );
+						if ( $term instanceof WP_Term ) {
+							$primary = $term;
+						}
+					}
 					$crumbs[] = array(
 						'label' => $primary->name,
 						'url'   => get_category_link( $primary->term_id ),

--- a/includes/class-meta-editor.php
+++ b/includes/class-meta-editor.php
@@ -36,6 +36,7 @@ class SWPS_Meta_Editor {
 			add_action( 'wp_head', array( $this, 'output_meta_tags' ), 2 );
 			add_filter( 'pre_get_document_title', array( $this, 'filter_document_title' ), 20 );
 			add_filter( 'document_title_parts', array( $this, 'filter_title_parts' ), 20 );
+			add_filter( 'wp_robots', array( $this, 'filter_robots' ) );
 		}
 
 		// Auto-generate meta on publish if setting is enabled.
@@ -171,7 +172,6 @@ class SWPS_Meta_Editor {
 
 		$meta_desc = get_post_meta( $post_id, '_swps_meta_description', true );
 		$canonical = get_post_meta( $post_id, '_swps_canonical_url', true );
-		$robots    = get_post_meta( $post_id, '_swps_robots', true );
 
 		// Meta description.
 		$meta_desc = SWPS_Hooks::filter_meta_description( $meta_desc, $post_id );
@@ -186,17 +186,51 @@ class SWPS_Meta_Editor {
 			remove_action( 'wp_head', 'rel_canonical' );
 		}
 
-		// Robots.
-		$robots = SWPS_Hooks::filter_meta_robots( $robots, $post_id );
-		if ( ! empty( $robots ) && 'index, follow' !== $robots ) {
-			printf( '<meta name="robots" content="%s" />' . "\n", esc_attr( $robots ) );
-		}
+		// Robots are merged into core's single tag via the wp_robots filter
+		// (see filter_robots) so the page never carries two robots meta tags.
 
 		// Open Graph.
 		$this->output_og_tags( $post_id );
 
 		// Twitter Card.
 		$this->output_twitter_tags( $post_id );
+	}
+
+	/**
+	 * Merge the per-post robots setting into core's robots meta tag.
+	 *
+	 * Previously this printed its own <meta name="robots"> next to core's
+	 * default (max-image-preview:large), leaving two robots tags on
+	 * noindexed pages. Directives are parsed from the stored
+	 * comma-separated string (e.g. "noindex, follow").
+	 *
+	 * @param array $robots Core robots directives.
+	 * @return array
+	 */
+	public function filter_robots( array $robots ): array {
+		if ( ! is_singular() ) {
+			return $robots;
+		}
+
+		$post_id = get_the_ID();
+		if ( ! $post_id ) {
+			return $robots;
+		}
+
+		$setting = get_post_meta( $post_id, '_swps_robots', true );
+		$setting = SWPS_Hooks::filter_meta_robots( $setting, $post_id );
+
+		if ( empty( $setting ) || 'index, follow' === $setting ) {
+			return $robots;
+		}
+
+		foreach ( array_map( 'trim', explode( ',', $setting ) ) as $directive ) {
+			if ( '' !== $directive && 'index' !== $directive ) {
+				$robots[ $directive ] = true;
+			}
+		}
+
+		return $robots;
 	}
 
 	/**

--- a/includes/class-redirect-manager.php
+++ b/includes/class-redirect-manager.php
@@ -73,8 +73,9 @@ class SWPS_Redirect_Manager {
 				$pattern = '#' . str_replace( '#', '\#', $redirect->source_url ) . '#';
 				if ( preg_match( $pattern, $request_path, $matches ) ) {
 					$target = $redirect->target_url;
-					// Replace capture groups.
-					for ( $i = 1; $i < count( $matches ); $i++ ) {
+					// Replace capture groups, highest index first so $1 does
+					// not corrupt $10, $11, etc.
+					for ( $i = count( $matches ) - 1; $i >= 1; $i-- ) {
 						$target = str_replace( '$' . $i, $matches[ $i ], $target );
 					}
 					$redirect->target_url = $target;

--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -122,8 +122,13 @@ class SWPS_Schema {
 			$this->add_article_node( $graph );
 		}
 
-		// JSON-LD breadcrumbs only when HTML breadcrumbs feature is disabled.
-		if ( ! is_front_page() && ! get_option( 'swps_breadcrumbs_enabled', 1 ) ) {
+		// JSON-LD breadcrumbs — Google's preferred breadcrumb format. Previously
+		// gated on the HTML breadcrumbs toggle being OFF, which meant a default
+		// install (toggle on, but theme never calling swps_breadcrumbs()) shipped
+		// no BreadcrumbList markup at all. Now emitted by default; sites whose
+		// theme renders the microdata trail can turn this off to avoid the
+		// harmless duplicate.
+		if ( ! is_front_page() && get_option( 'swps_breadcrumbs_jsonld', 1 ) ) {
 			$this->add_breadcrumb_node( $graph );
 		}
 
@@ -344,6 +349,13 @@ class SWPS_Schema {
 
 		$opts = get_option( 'swps_local_seo', array() );
 		if ( empty( $opts['enabled'] ) ) {
+			return;
+		}
+
+		// Same "meaningful data" threshold as SWPS_Local_SEO::is_enabled() —
+		// without it, enabled + name but no locality emitted a thin,
+		// address-less LocalBusiness node.
+		if ( '' === trim( (string) ( $opts['name'] ?? '' ) ) || '' === trim( (string) ( $opts['locality'] ?? '' ) ) ) {
 			return;
 		}
 

--- a/includes/class-search-appearance.php
+++ b/includes/class-search-appearance.php
@@ -51,8 +51,15 @@ class SWPS_Search_Appearance {
 		// Meta description for non-singular pages — priority 2 (same as Meta Editor).
 		add_action( 'wp_head', array( $this, 'output_meta_description' ), 2 );
 
-		// Robots directives from Search Appearance noindex controls.
-		add_action( 'wp_head', array( $this, 'output_robots_directives' ), 2 );
+		// Open Graph / Twitter for non-singular pages — priority 5 (Meta Editor
+		// covers singular views at priority 2; the audit OG module covers
+		// singular views at priority 5 when the Meta Editor is disabled).
+		add_action( 'wp_head', array( $this, 'output_og_tags' ), 5 );
+
+		// Robots directives from Search Appearance noindex controls — merged
+		// into WordPress core's single robots meta tag instead of printing a
+		// second <meta name="robots"> alongside core's.
+		add_filter( 'wp_robots', array( $this, 'filter_robots' ) );
 	}
 
 	/**
@@ -106,19 +113,113 @@ class SWPS_Search_Appearance {
 	}
 
 	/**
-	 * Output robots meta tags for Search Appearance visibility settings.
+	 * Merge Search Appearance visibility settings into core's robots meta tag.
+	 *
+	 * Using the wp_robots filter keeps the page on a single
+	 * <meta name="robots"> tag (core's), so directives like
+	 * max-image-preview:large are preserved alongside noindex.
+	 *
+	 * @param array $robots Core robots directives.
+	 * @return array
 	 */
-	public function output_robots_directives(): void {
-		$robots = $this->get_robots_directives();
+	public function filter_robots( array $robots ): array {
+		foreach ( $this->get_robots_directives() as $directive ) {
+			$robots[ $directive ] = true;
+		}
 
-		if ( empty( $robots ) ) {
+		return $robots;
+	}
+
+	/**
+	 * Output Open Graph and Twitter Card tags for non-singular pages.
+	 *
+	 * Singular views are handled by SWPS_Meta_Editor (or the audit OG module
+	 * when the Meta Editor is disabled). Without this, the blog index,
+	 * category/tag/taxonomy archives, author archives, and post type archives
+	 * shipped no social preview card at all.
+	 */
+	public function output_og_tags(): void {
+		if ( is_singular() || is_search() || is_404() || is_admin() || is_feed() ) {
 			return;
 		}
 
-		printf(
-			'<meta name="robots" content="%s" />' . "\n",
-			esc_attr( implode( ', ', $robots ) )
-		);
+		$title = wp_get_document_title();
+		$desc  = $this->get_description();
+		$url   = $this->get_context_url();
+		$image = (string) get_option( 'swps_schema_logo', '' )
+				?: (string) get_site_icon_url( 512 );
+
+		// Term-level social overrides from Taxonomy Meta.
+		if ( is_category() || is_tag() || is_tax() ) {
+			$term = get_queried_object();
+			if ( $term instanceof WP_Term ) {
+				$og_title = get_term_meta( $term->term_id, '_swps_og_title', true );
+				$og_desc  = get_term_meta( $term->term_id, '_swps_og_description', true );
+				$og_image = get_term_meta( $term->term_id, '_swps_og_image', true );
+				$title    = ! empty( $og_title ) ? $og_title : $title;
+				$desc     = ! empty( $og_desc ) ? $og_desc : $desc;
+				$image    = ! empty( $og_image ) ? $og_image : $image;
+			}
+		}
+
+		printf( '<meta property="og:type" content="website" />' . "\n" );
+		printf( '<meta property="og:title" content="%s" />' . "\n", esc_attr( $title ) );
+		if ( ! empty( $desc ) ) {
+			printf( '<meta property="og:description" content="%s" />' . "\n", esc_attr( wp_strip_all_tags( $desc ) ) );
+		}
+		if ( ! empty( $url ) ) {
+			printf( '<meta property="og:url" content="%s" />' . "\n", esc_url( $url ) );
+		}
+		if ( ! empty( $image ) ) {
+			printf( '<meta property="og:image" content="%s" />' . "\n", esc_url( $image ) );
+		}
+		printf( '<meta property="og:site_name" content="%s" />' . "\n", esc_attr( get_bloginfo( 'name' ) ) );
+
+		printf( '<meta name="twitter:card" content="%s" />' . "\n", $image ? 'summary_large_image' : 'summary' );
+		printf( '<meta name="twitter:title" content="%s" />' . "\n", esc_attr( $title ) );
+		if ( ! empty( $desc ) ) {
+			printf( '<meta name="twitter:description" content="%s" />' . "\n", esc_attr( wp_strip_all_tags( $desc ) ) );
+		}
+		if ( ! empty( $image ) ) {
+			printf( '<meta name="twitter:image" content="%s" />' . "\n", esc_url( $image ) );
+		}
+	}
+
+	/**
+	 * Canonical URL for the current non-singular context.
+	 */
+	private function get_context_url(): string {
+		if ( is_front_page() ) {
+			return home_url( '/' );
+		}
+
+		if ( is_home() ) {
+			$posts_page = (int) get_option( 'page_for_posts' );
+			return $posts_page ? (string) get_permalink( $posts_page ) : home_url( '/' );
+		}
+
+		if ( is_category() || is_tag() || is_tax() ) {
+			$term = get_queried_object();
+			if ( $term instanceof WP_Term ) {
+				$link = get_term_link( $term );
+				return is_wp_error( $link ) ? '' : $link;
+			}
+		}
+
+		if ( is_author() ) {
+			$author = get_queried_object();
+			return $author ? get_author_posts_url( $author->ID ) : '';
+		}
+
+		if ( is_post_type_archive() ) {
+			$post_type = get_query_var( 'post_type' );
+			if ( is_array( $post_type ) ) {
+				$post_type = reset( $post_type );
+			}
+			return is_string( $post_type ) ? (string) get_post_type_archive_link( $post_type ) : '';
+		}
+
+		return '';
 	}
 
 	/**
@@ -177,6 +278,14 @@ class SWPS_Search_Appearance {
 			}
 		}
 
+		if ( is_author() && get_option( 'swps_noindex_author', 0 ) ) {
+			return array( 'noindex', 'follow' );
+		}
+
+		if ( is_date() && get_option( 'swps_noindex_date', 0 ) ) {
+			return array( 'noindex', 'follow' );
+		}
+
 		return array();
 	}
 
@@ -184,7 +293,10 @@ class SWPS_Search_Appearance {
 	 * Get the title template for the current page context.
 	 */
 	private function get_title_template(): string {
-		if ( is_front_page() && is_home() ) {
+		// Both homepage setups — "your latest posts" AND a static front page —
+		// use the homepage template. The old is_front_page() && is_home() check
+		// silently ignored the configured template on static front pages.
+		if ( is_front_page() ) {
 			return get_option( 'swps_title_template_homepage', '%%sitename%%' );
 		}
 
@@ -237,6 +349,25 @@ class SWPS_Search_Appearance {
 	 * Get the meta description for the current page context.
 	 */
 	private function get_description(): string {
+		// Blog-index homepage / posts page: previously returned nothing, so the
+		// most-shared URL on a blog-style site had no meta description at all.
+		if ( is_home() || ( is_front_page() && ! is_singular() ) ) {
+			$posts_page = (int) get_option( 'page_for_posts' );
+			if ( $posts_page ) {
+				$meta_desc = get_post_meta( $posts_page, '_swps_meta_description', true );
+				if ( ! empty( $meta_desc ) ) {
+					return $meta_desc;
+				}
+			}
+
+			$template = get_option( 'swps_desc_template_homepage', '' );
+			if ( ! empty( $template ) ) {
+				return $this->resolve_variables( $template );
+			}
+
+			return (string) get_bloginfo( 'description' );
+		}
+
 		if ( is_singular() ) {
 			$post_type = get_post_type();
 			$template  = get_option( "swps_desc_template_{$post_type}", '%%excerpt%%' );

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1165,9 +1165,13 @@ class SWPS_Settings {
 		register_setting( 'swps_search_appearance', 'swps_title_template_404', array( 'sanitize_callback' => 'sanitize_text_field' ) );
 		register_setting( 'swps_search_appearance', 'swps_title_template_author', array( 'sanitize_callback' => 'sanitize_text_field' ) );
 		register_setting( 'swps_search_appearance', 'swps_title_template_date', array( 'sanitize_callback' => 'sanitize_text_field' ) );
+		register_setting( 'swps_search_appearance', 'swps_desc_template_homepage', array( 'sanitize_callback' => 'sanitize_textarea_field' ) );
+		register_setting( 'swps_search_appearance', 'swps_noindex_author', array( 'sanitize_callback' => 'absint' ) );
+		register_setting( 'swps_search_appearance', 'swps_noindex_date', array( 'sanitize_callback' => 'absint' ) );
 
 		// Breadcrumb settings.
 		register_setting( 'swps_search_appearance', 'swps_breadcrumbs_enabled', array( 'sanitize_callback' => 'absint' ) );
+		register_setting( 'swps_search_appearance', 'swps_breadcrumbs_jsonld', array( 'sanitize_callback' => 'absint' ) );
 		register_setting( 'swps_search_appearance', 'swps_breadcrumbs_separator', array( 'sanitize_callback' => 'sanitize_text_field' ) );
 		register_setting( 'swps_search_appearance', 'swps_breadcrumbs_home_label', array( 'sanitize_callback' => 'sanitize_text_field' ) );
 

--- a/includes/class-sitemap-manager.php
+++ b/includes/class-sitemap-manager.php
@@ -329,7 +329,7 @@ class SWPS_Sitemap_Manager {
 			printf(
 				"<sitemap>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n</sitemap>\n",
 				esc_url( home_url( "/{$tax}-sitemap.xml" ) ),
-				gmdate( 'Y-m-d\TH:i:s+00:00' )
+				$this->get_site_lastmod()
 			);
 		}
 
@@ -338,7 +338,7 @@ class SWPS_Sitemap_Manager {
 			printf(
 				"<sitemap>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n</sitemap>\n",
 				esc_url( home_url( '/author-sitemap.xml' ) ),
-				gmdate( 'Y-m-d\TH:i:s+00:00' )
+				$this->get_site_lastmod()
 			);
 		}
 
@@ -377,7 +377,7 @@ class SWPS_Sitemap_Manager {
 			printf(
 				"<url>\n  <loc>%s</loc>\n  <lastmod>%s</lastmod>\n  <priority>1.0</priority>\n</url>\n",
 				esc_url( home_url( '/' ) ),
-				gmdate( 'Y-m-d\TH:i:s+00:00' )
+				$this->get_site_lastmod()
 			);
 
 			// When a static front page is set, it is emitted above as the
@@ -558,5 +558,19 @@ class SWPS_Sitemap_Manager {
 			)
 		);
 		return $date ? gmdate( 'Y-m-d\TH:i:s+00:00', strtotime( $date ) ) : gmdate( 'Y-m-d\TH:i:s+00:00' );
+	}
+
+	/**
+	 * Site-wide last modification timestamp for sitemap entries that
+	 * aggregate many objects (taxonomy/author sub-sitemaps, homepage URL).
+	 *
+	 * Previously these were stamped gmdate(now), which changed on every
+	 * request — a volatile lastmod is an unreliable crawl-scheduling signal.
+	 */
+	private function get_site_lastmod(): string {
+		$modified = get_lastpostmodified( 'gmt' );
+		return $modified
+			? gmdate( 'Y-m-d\TH:i:s+00:00', strtotime( $modified ) )
+			: gmdate( 'Y-m-d\TH:i:s+00:00' );
 	}
 }

--- a/includes/class-taxonomy-meta.php
+++ b/includes/class-taxonomy-meta.php
@@ -36,7 +36,41 @@ class SWPS_Taxonomy_Meta {
 		// Frontend meta output for archive pages (only when no conflict).
 		if ( ! is_admin() && ! defined( 'WPSEO_VERSION' ) && ! defined( 'RANK_MATH_VERSION' ) && ! defined( 'AIOSEO_VERSION' ) ) {
 			add_action( 'wp_head', array( $this, 'output_archive_meta' ), 3 );
+			add_filter( 'wp_robots', array( $this, 'filter_robots' ) );
 		}
+	}
+
+	/**
+	 * Merge per-term robots settings into core's robots meta tag.
+	 *
+	 * Previously printed as a second <meta name="robots"> tag alongside
+	 * WordPress core's default tag.
+	 *
+	 * @param array $robots Core robots directives.
+	 * @return array
+	 */
+	public function filter_robots( array $robots ): array {
+		if ( ! is_category() && ! is_tag() && ! is_tax() ) {
+			return $robots;
+		}
+
+		$term = get_queried_object();
+		if ( ! $term instanceof \WP_Term ) {
+			return $robots;
+		}
+
+		$setting = get_term_meta( $term->term_id, '_swps_robots', true );
+		if ( empty( $setting ) ) {
+			return $robots;
+		}
+
+		foreach ( array_map( 'trim', explode( ',', $setting ) ) as $directive ) {
+			if ( '' !== $directive ) {
+				$robots[ $directive ] = true;
+			}
+		}
+
+		return $robots;
 	}
 
 	/**
@@ -168,21 +202,12 @@ class SWPS_Taxonomy_Meta {
 			printf( '<link rel="canonical" href="%s" />' . "\n", esc_url( $canonical ) );
 		}
 
-		// Robots.
-		$robots = get_term_meta( $term->term_id, '_swps_robots', true );
-		if ( ! empty( $robots ) ) {
-			printf( '<meta name="robots" content="%s" />' . "\n", esc_attr( $robots ) );
-		}
-
-		// OG tags.
-		$og_title = get_term_meta( $term->term_id, '_swps_og_title', true );
-		$og_desc  = get_term_meta( $term->term_id, '_swps_og_description', true );
-
-		if ( ! empty( $og_title ) ) {
-			printf( '<meta property="og:title" content="%s" />' . "\n", esc_attr( $og_title ) );
-		}
-		if ( ! empty( $og_desc ) ) {
-			printf( '<meta property="og:description" content="%s" />' . "\n", esc_attr( $og_desc ) );
-		}
+		// Robots are merged into core's tag via the wp_robots filter (see
+		// filter_robots). Open Graph output moved to
+		// SWPS_Search_Appearance::output_og_tags(), which emits the complete
+		// tag set (type/url/site_name/image) with the term-level
+		// _swps_og_title / _swps_og_description / _swps_og_image overrides —
+		// the partial og:title/og:description pair emitted here produced a
+		// malformed card on the platforms that read it.
 	}
 }

--- a/templates/search-appearance-page.php
+++ b/templates/search-appearance-page.php
@@ -133,6 +133,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<input type="text" class="large-text swps-title-template"
 						name="swps_title_template_author"
 						value="<?php echo esc_attr( get_option( 'swps_title_template_author', '%%author%% %%sep%% %%sitename%%' ) ); ?>">
+					<label style="display:block;margin-top:6px;">
+						<input type="hidden" name="swps_noindex_author" value="0">
+						<input type="checkbox" name="swps_noindex_author" value="1"
+							<?php checked( get_option( 'swps_noindex_author', 0 ) ); ?>>
+						<?php esc_html_e( 'Noindex author archives (recommended for single-author sites — the author archive duplicates the blog index)', 'stratawp-seo' ); ?>
+					</label>
 				</td>
 			</tr>
 			<tr>
@@ -141,6 +147,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<input type="text" class="large-text swps-title-template"
 						name="swps_title_template_date"
 						value="<?php echo esc_attr( get_option( 'swps_title_template_date', '%%title%% %%sep%% %%sitename%%' ) ); ?>">
+					<label style="display:block;margin-top:6px;">
+						<input type="hidden" name="swps_noindex_date" value="0">
+						<input type="checkbox" name="swps_noindex_date" value="1"
+							<?php checked( get_option( 'swps_noindex_date', 0 ) ); ?>>
+						<?php esc_html_e( 'Noindex date archives (thin, near-duplicate listings)', 'stratawp-seo' ); ?>
+					</label>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Homepage Meta Description', 'stratawp-seo' ); ?></th>
+				<td>
+					<textarea class="large-text" rows="2"
+						name="swps_desc_template_homepage"><?php echo esc_textarea( get_option( 'swps_desc_template_homepage', '' ) ); ?></textarea>
+					<p class="description"><?php esc_html_e( 'Used on a "latest posts" homepage and the posts page. Leave blank to fall back to the site tagline. Template variables supported.', 'stratawp-seo' ); ?></p>
 				</td>
 			</tr>
 		</table>
@@ -154,6 +174,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<input type="checkbox" name="swps_breadcrumbs_enabled" value="1"
 							<?php checked( get_option( 'swps_breadcrumbs_enabled', 1 ) ); ?>>
 						<?php esc_html_e( 'Enable HTML breadcrumb output', 'stratawp-seo' ); ?>
+					</label>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Breadcrumb Structured Data', 'stratawp-seo' ); ?></th>
+				<td>
+					<label>
+						<input type="hidden" name="swps_breadcrumbs_jsonld" value="0">
+						<input type="checkbox" name="swps_breadcrumbs_jsonld" value="1"
+							<?php checked( get_option( 'swps_breadcrumbs_jsonld', 1 ) ); ?>>
+						<?php esc_html_e( 'Emit BreadcrumbList JSON-LD in the schema graph (recommended; disable only if your theme renders the HTML breadcrumb trail, which carries its own microdata)', 'stratawp-seo' ); ?>
 					</label>
 				</td>
 			</tr>

--- a/tests/unit/SitemapHomepageTest.php
+++ b/tests/unit/SitemapHomepageTest.php
@@ -47,6 +47,11 @@ if ( ! function_exists( 'get_post_modified_time' ) ) {
 		return 1700000000;
 	}
 }
+if ( ! function_exists( 'get_lastpostmodified' ) ) {
+	function get_lastpostmodified( $timezone = 'server', $post_type = 'any' ) {
+		return '2023-11-14 22:13:20';
+	}
+}
 if ( ! function_exists( 'esc_url' ) ) {
 	function esc_url( $url ) {
 		return $url;


### PR DESCRIPTION
Companion to the jonimms.com July 2026 `/seo-audit` fixes (JonImmsWordpressDev/jonimms.com#28). These are the plugin-side defects — on a site like jonimms.com (static front page + posts page at /blog/), the blog index and every archive shipped with no meta description and no social card at all.

## Coverage gaps (high impact)
- **Blog-index homepage / posts page had zero `<meta name="description">` and zero OG/Twitter tags.** `SWPS_Meta_Editor::output_meta_tags()` bails on `!is_singular()` and `SWPS_Search_Appearance::get_description()` had no home branch. Now: posts-page `_swps_meta_description` → new `swps_desc_template_homepage` option → site tagline.
- **Archives emitted no social cards** (or a malformed partial `og:title`/`og:description` pair when term fields were set). `SWPS_Search_Appearance::output_og_tags()` now emits the complete OG + Twitter set (`og:type=website`, url, site_name, image) on non-singular views at priority 5, honoring term-level `_swps_og_title` / `_swps_og_description` / `_swps_og_image` overrides. The partial emitter in `SWPS_Taxonomy_Meta` is removed.

## Robots correctness
- **Duplicate robots meta tags**: the plugin printed its own `<meta name="robots">` next to core's default (`max-image-preview:large`). Meta Editor, Taxonomy Meta, and Search Appearance now merge directives into core's single tag via the `wp_robots` filter.
- **Author/date archives couldn't be noindexed**: added `swps_noindex_author` / `swps_noindex_date` options (default off, so no behavior change until enabled) with checkboxes in Search Appearance.

## Structured data
- **BreadcrumbList JSON-LD was absent by default**: it only emitted when HTML breadcrumbs were *disabled*, but the HTML trail only renders if the theme calls `swps_breadcrumbs()` — which most themes don't. JSON-LD now emits by default behind a new `swps_breadcrumbs_jsonld` toggle (disable if your theme renders the microdata trail).
- **LocalBusiness node could emit address-less** (enabled + name, no locality); now applies the same name+locality guard as `is_enabled()`.
- HTML breadcrumb trail now resolves the Yoast primary category like the JSON-LD path, so the two trails can't disagree.

## Smaller fixes
- Static front pages ignored `swps_title_template_homepage` (`is_front_page() && is_home()` only matched latest-posts homepages).
- Audit OG module (Meta-Editor-off fallback): now reads the plugin's own `_swps_social_description`/`_swps_meta_description` before Yoast/RankMath keys, and emits `og:type=website` for pages instead of hardcoded `article`.
- Sitemap `lastmod` for taxonomy/author index entries and the homepage URL was `gmdate(now)` on every request (volatile, unreliable crawl signal); now uses `get_lastpostmodified('gmt')`.
- Redirect regex capture replacement substitutes highest-index groups first so `$1` no longer corrupts `$10+`.
- Added a `get_lastpostmodified` stub to `SitemapHomepageTest` for the new lastmod path.

## Verified
`php -l` passes on all changed files. PHPUnit/PHPCS/PHPStan couldn't run in this sandbox (composer dist downloads blocked) — relying on the `quality.yml` CI gate on this PR.

## Known remaining gaps (not in this PR)
- Sitemap index page-count includes excluded/noindexed posts (can advertise a trailing near-empty sub-sitemap page).
- Taxonomy/author *sub-sitemaps* still emit no per-URL `lastmod`.
- RSS optimizer only hooks `the_content_feed` (summary feeds skipped); before/after content not passed through `wp_kses_post`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERG32yq8jfNSNTrkKYwi7K

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERG32yq8jfNSNTrkKYwi7K)_