### PR TITLE
Fix pipeline schema defects, title truncation, archive canonicals (4.24.0)

### DIFF
--- a/includes/class-aeo-schema-generator.php
+++ b/includes/class-aeo-schema-generator.php
@@ -119,6 +119,15 @@ class SWPS_AEO_Schema_Generator {
 
 		$json = $response;
 
+		// The AI provider appends telemetry to its decoded response (e.g. a
+		// _usage key with token counts). Strip underscore-prefixed keys so
+		// they are never validated, stored, or emitted in public JSON-LD.
+		foreach ( array_keys( $json ) as $key ) {
+			if ( is_string( $key ) && str_starts_with( $key, '_' ) ) {
+				unset( $json[ $key ] );
+			}
+		}
+
 		if ( function_exists( 'apply_filters' ) ) {
 			$json = (array) apply_filters( 'swps_aeo_schema_json', $json, $type, null );
 		}

--- a/includes/class-generator.php
+++ b/includes/class-generator.php
@@ -451,9 +451,12 @@ PROMPT;
 		update_post_meta( $post_id, '_swps_focus_keyword', $focus_keyword );
 
 		// Generate meta title (shortened post title if AI didn't provide one).
+		// Shorten at a word boundary — the previous hard mb_substr cut produced
+		// mid-word titles ("…for Wor") in <title> and og:title on every
+		// generated post whose title ran past 60 chars.
 		$meta_title = sanitize_text_field( $ai_result['meta_title'] ?? '' );
 		if ( empty( $meta_title ) ) {
-			$meta_title = mb_substr( $ai_result['title'], 0, 60 );
+			$meta_title = self::shorten_at_word_boundary( (string) $ai_result['title'], 60 );
 		}
 		update_post_meta( $post_id, '_swps_meta_title', $meta_title );
 		$secondary     = $ai_result['secondary_keywords'] ?? array();
@@ -717,5 +720,30 @@ PROMPT;
 	 */
 	private function log( string $message ): void {
 		self::append_log( $message );
+	}
+
+	/**
+	 * Shorten a string to a maximum length, breaking at a word boundary.
+	 *
+	 * @param string $text       Text to shorten.
+	 * @param int    $max_length Maximum length in characters.
+	 * @return string
+	 */
+	public static function shorten_at_word_boundary( string $text, int $max_length ): string {
+		$text = trim( $text );
+		if ( mb_strlen( $text ) <= $max_length ) {
+			return $text;
+		}
+
+		$cut  = mb_substr( $text, 0, $max_length );
+		$last = mb_strrpos( $cut, ' ' );
+
+		// Only back off to the space when it doesn't gut the title; a title
+		// that is one giant unbroken token still gets the hard cut.
+		if ( false !== $last && $last > (int) ( $max_length / 2 ) ) {
+			$cut = mb_substr( $cut, 0, $last );
+		}
+
+		return rtrim( $cut, " \t\n\r\0\x0B,;:—–-" );
 	}
 }

--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -108,8 +108,10 @@ class SWPS_Schema {
 			$this->add_website_node( $graph );
 		}
 
-		// LocalBusiness absorbed into the graph on the homepage when Local SEO is on.
-		if ( is_front_page() || is_home() ) {
+		// LocalBusiness absorbed into the graph on the front page when Local SEO
+		// is on. Front page only — emitting it on the posts page too duplicated
+		// the business entity on /blog/.
+		if ( is_front_page() ) {
 			$this->add_local_business_node( $graph );
 		}
 
@@ -198,6 +200,16 @@ class SWPS_Schema {
 			return;
 		}
 
+		// Sanitization gate — last line of defense for already-stored schema.
+		// Strips non-schema telemetry keys (the AI provider appends _usage
+		// token counts to every response, which leaked into public JSON-LD)
+		// and refuses to emit deprecated types (Google retired HowTo rich
+		// results in 2023).
+		$decoded = self::sanitize_aeo_schema( $decoded );
+		if ( empty( $decoded ) ) {
+			return;
+		}
+
 		/**
 		 * Filter the AEO-generated schema array before output.
 		 *
@@ -207,6 +219,64 @@ class SWPS_Schema {
 		$decoded = (array) apply_filters( "swps_schema_{$type}", $decoded, $post_id );
 
 		$this->output_jsonld( $decoded );
+	}
+
+	/**
+	 * Sanitize a stored AEO schema array before public output.
+	 *
+	 * @param array $schema Decoded schema array.
+	 * @return array Sanitized schema, or empty array when the type is deprecated.
+	 */
+	public static function sanitize_aeo_schema( array $schema ): array {
+		$schema = self::strip_private_keys( $schema );
+
+		/**
+		 * Filter the list of deprecated schema @types that must not be emitted.
+		 *
+		 * @param string[] $types Deprecated type names.
+		 */
+		$deprecated = (array) apply_filters( 'swps_schema_deprecated_types', array( 'HowTo' ) );
+
+		foreach ( (array) ( $schema['@type'] ?? array() ) as $node_type ) {
+			if ( in_array( (string) $node_type, $deprecated, true ) ) {
+				return array();
+			}
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Recursively remove underscore-prefixed keys (non-schema telemetry).
+	 *
+	 * @param array $data Schema data.
+	 * @return array
+	 */
+	private static function strip_private_keys( array $data ): array {
+		$clean = array();
+
+		foreach ( $data as $key => $value ) {
+			if ( is_string( $key ) && str_starts_with( $key, '_' ) ) {
+				continue;
+			}
+			$clean[ $key ] = is_array( $value ) ? self::strip_private_keys( $value ) : $value;
+		}
+
+		return $clean;
+	}
+
+	/**
+	 * Decode HTML entities and strip tags for JSON-LD text fields.
+	 *
+	 * WP display functions (get_the_title, get_the_excerpt, term names)
+	 * return entity-encoded strings (&amp;, &#8217;). JSON-LD strings should
+	 * carry real Unicode, not double-encoded entities.
+	 *
+	 * @param mixed $text Raw text.
+	 * @return string
+	 */
+	private static function plain_text( $text ): string {
+		return trim( html_entity_decode( wp_strip_all_tags( (string) $text ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ) );
 	}
 
 	/**
@@ -291,12 +361,16 @@ class SWPS_Schema {
 			return;
 		}
 
-		$page_title = wp_strip_all_tags( (string) wp_title( '|', false, 'right' ) );
+		// wp_get_document_title() gives the full rendered title (with the site
+		// name interpolated). The previous wp_title( '|', ... ) call returned
+		// only the contextual part with the separator appended, so every
+		// WebPage.name ended in a dangling " |".
+		$page_title = self::plain_text( wp_get_document_title() );
 		$node       = array(
 			'@type' => 'WebPage',
 			'@id'   => SWPS_Schema_Graph::webpage_id( $url ),
 			'url'   => $url,
-			'name'  => '' !== $page_title ? $page_title : get_bloginfo( 'name' ),
+			'name'  => '' !== $page_title ? $page_title : self::plain_text( get_bloginfo( 'name' ) ),
 		);
 
 		$graph->add_node( $node );
@@ -399,22 +473,20 @@ class SWPS_Schema {
 			'@context'         => 'https://schema.org',
 			'@type'            => $article_type,
 			'@id'              => SWPS_Schema_Graph::article_id( $permalink ),
-			'headline'         => get_the_title( $post ),
-			'description'      => $excerpt,
+			'headline'         => self::plain_text( get_the_title( $post ) ),
+			'description'      => self::plain_text( $excerpt ),
 			'datePublished'    => get_the_date( 'c', $post ),
 			'dateModified'     => get_the_modified_date( 'c', $post ),
 			'mainEntityOfPage' => array( '@id' => SWPS_Schema_Graph::webpage_id( $permalink ) ),
 			'wordCount'        => str_word_count( wp_strip_all_tags( $post->post_content ) ),
 		);
 
-		// Publisher — Google requires Organization type for Article.publisher.
-		// On personal-brand sites (swps_schema_entity_type = Person) the site
-		// entity node is Person-typed, so referencing it would emit an invalid
-		// Person publisher. Publisher is a recommended (not required) Article
-		// property, so we omit it entirely in that case.
-		if ( 'Organization' === get_option( 'swps_schema_entity_type', 'Organization' ) ) {
-			$node['publisher'] = array( '@id' => SWPS_Schema_Graph::org_id() );
-		}
+		// Publisher — schema.org (and Google's Article documentation) accept
+		// Organization OR Person for Article.publisher, so reference the site
+		// entity regardless of its type. Previously publisher was omitted
+		// entirely on personal-brand (Person) sites, leaving every Article
+		// without a publisher.
+		$node['publisher'] = array( '@id' => SWPS_Schema_Graph::org_id() );
 
 		// Author node: store inline for the filter shim (back-compat), then
 		// replace with an @id reference after the filter runs. That way
@@ -545,7 +617,7 @@ class SWPS_Schema {
 			$list_items[] = array(
 				'@type'    => 'ListItem',
 				'position' => $position + 1,
-				'name'     => $item['name'],
+				'name'     => self::plain_text( $item['name'] ),
 				'item'     => $item['url'],
 			);
 		}
@@ -579,15 +651,25 @@ class SWPS_Schema {
 			return;
 		}
 
-		$author_url = get_author_posts_url( $author->ID );
-		$person_id  = SWPS_Schema_Graph::person_id( $author->ID );
+		$author_url     = get_author_posts_url( $author->ID );
+		$is_person_site = 'Person' === get_option( 'swps_schema_entity_type', 'Organization' );
 
-		// Full Person node.
-		$person = array_merge(
-			array( '@id' => $person_id ),
-			$this->build_person_node( $author )
-		);
-		$graph->add_node( $person );
+		// On personal-brand (Person) sites the site entity (#person) IS the
+		// author — reference it instead of emitting a second Person node with
+		// a different @id for the same human. This mirrors the reconciliation
+		// add_article_node already does for Article.author. Organization sites
+		// keep a standalone author Person node.
+		$person_id = $is_person_site
+			? SWPS_Schema_Graph::org_id()
+			: SWPS_Schema_Graph::person_id( $author->ID );
+
+		if ( ! $is_person_site ) {
+			$person = array_merge(
+				array( '@id' => $person_id ),
+				$this->build_person_node( $author )
+			);
+			$graph->add_node( $person );
+		}
 
 		// ProfilePage referencing Person.
 		$profile_node = array(
@@ -596,7 +678,7 @@ class SWPS_Schema {
 			'name'       => sprintf(
 				/* translators: %s: author display name */
 				__( 'Author: %s', 'stratawp-seo' ),
-				$author->display_name
+				self::plain_text( $author->display_name )
 			),
 			'url'        => $author_url,
 			'mainEntity' => array( '@id' => $person_id ),

--- a/includes/class-search-appearance.php
+++ b/includes/class-search-appearance.php
@@ -51,6 +51,10 @@ class SWPS_Search_Appearance {
 		// Meta description for non-singular pages — priority 2 (same as Meta Editor).
 		add_action( 'wp_head', array( $this, 'output_meta_description' ), 2 );
 
+		// Self-referencing canonicals for non-singular views — neither core
+		// nor the Canonical module covers the posts page or archives.
+		add_action( 'wp_head', array( $this, 'output_canonical' ), 1 );
+
 		// Open Graph / Twitter for non-singular pages — priority 5 (Meta Editor
 		// covers singular views at priority 2; the audit OG module covers
 		// singular views at priority 5 when the Meta Editor is disabled).
@@ -183,6 +187,40 @@ class SWPS_Search_Appearance {
 		if ( ! empty( $image ) ) {
 			printf( '<meta name="twitter:image" content="%s" />' . "\n", esc_url( $image ) );
 		}
+	}
+
+	/**
+	 * Output a self-referencing canonical on non-singular views.
+	 *
+	 * WordPress core's rel_canonical and the Canonical audit module are both
+	 * singular-only, so the posts page, term archives, author archives, and
+	 * post type archives shipped with no canonical at all. Paginated archives
+	 * canonicalize to their own page URL.
+	 */
+	public function output_canonical(): void {
+		if ( is_singular() || is_404() || is_search() ) {
+			return;
+		}
+
+		// A manual term-level canonical override is emitted by Taxonomy Meta.
+		if ( is_category() || is_tag() || is_tax() ) {
+			$term = get_queried_object();
+			if ( $term instanceof WP_Term && get_term_meta( $term->term_id, '_swps_canonical_url', true ) ) {
+				return;
+			}
+		}
+
+		$url = $this->get_context_url();
+		if ( '' === $url ) {
+			return;
+		}
+
+		$paged = max( 1, (int) get_query_var( 'paged' ) );
+		if ( $paged > 1 ) {
+			$url = trailingslashit( $url ) . user_trailingslashit( 'page/' . $paged, 'paged' );
+		}
+
+		printf( '<link rel="canonical" href="%s" />' . "\n", esc_url( $url ) );
 	}
 
 	/**

--- a/includes/class-sitemap-manager.php
+++ b/includes/class-sitemap-manager.php
@@ -522,6 +522,17 @@ class SWPS_Sitemap_Manager {
 		if ( $post && preg_match_all( '/<img[^>]+src=["\']([^"\']+)["\'][^>]*>/i', $post->post_content, $matches ) ) {
 			$seen = array( $thumb_id ? wp_get_attachment_url( $thumb_id ) : '' );
 			foreach ( $matches[1] as $img_url ) {
+				// The regex captures whatever literal sits in src="…" — including
+				// relative paths, lazy-load placeholders, and non-URL strings from
+				// code samples. Only absolute http(s) URLs belong in the image
+				// sitemap, and they must match the site's scheme (a stray http://
+				// theme-asset URL on an https site is a mixed-scheme signal).
+				if ( ! preg_match( '#^https?://#i', $img_url ) ) {
+					continue;
+				}
+				if ( is_ssl() ) {
+					$img_url = set_url_scheme( $img_url, 'https' );
+				}
 				if ( in_array( $img_url, $seen, true ) ) {
 					continue;
 				}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.23.0
+Stable tag: 4.24.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,18 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.24.0 =
+* Fixed: AI telemetry (a _usage key with token counts) leaked into public AEO JSON-LD. Underscore-prefixed keys are now stripped at generation AND at render, so already-stored schema on live posts is cleaned without re-saving.
+* Fixed: deprecated schema types are no longer emitted from stored AEO data — Google retired HowTo rich results in 2023. Filterable via swps_schema_deprecated_types.
+* Fixed: every WebPage schema node's name ended in a dangling " |" — the builder used wp_title() (contextual part + separator) instead of the full document title.
+* Fixed: JSON-LD strings (Article headline/description, WebPage name, breadcrumb names) carried double-encoded HTML entities (&amp;, &#8217;); they now decode to real Unicode.
+* Fixed: Article.publisher was omitted entirely on personal-brand (Person) sites; it now references the site entity (schema.org and Google accept Person publishers).
+* Fixed: author archives emitted two Person nodes with different @ids for the same person on Person-entity sites; the ProfilePage now references the single site entity.
+* Fixed: generated meta titles were hard-cut at 60 characters mid-word; they now shorten at a word boundary.
+* New: self-referencing canonicals on the posts page, term/author/post-type archives (pagination-aware) — previously no canonical was emitted on any non-singular view.
+* Fixed: LocalBusiness schema no longer duplicates onto the posts page; it emits on the front page only.
+* Fixed: the image sitemap accepted any string found in an img src — including non-URL strings and http:// URLs on https sites. Entries are now validated as absolute URLs and scheme-normalized.
 
 = 4.23.0 =
 * New: the blog-index homepage and posts page now emit a meta description (posts-page SEO description, the new Homepage Meta Description setting, or the site tagline) and full Open Graph/Twitter Card tags — previously these pages shipped with no description and no social preview at all.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.23.0
+ * Version: 4.24.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.23.0' );
+define( 'SWPS_VERSION', '4.24.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Plugin-side fixes from the uploaded 8 July SEO audit PDF (final post-flush pass). Companion site PR: JonImmsWordpressDev/jonimms.com#29. Version bumped to **4.24.0** with changelog, so merging publishes the release automatically.

## C1 · Pipeline schema defects
- **`_usage` token telemetry leaked into public JSON-LD**: `SWPS_AI_Provider::chat_json()` appends `_usage` to every decoded response; the AEO schema generator stored it wholesale. Underscore-prefixed keys are now stripped at **generation** (`class-aeo-schema-generator.php`) and again at **render** (`SWPS_Schema::sanitize_aeo_schema()`), so the 3 affected live posts are cleaned at output without touching the DB.
- **Deprecated HowTo blocked at render**: Google retired HowTo rich results in 2023; stored HowTo blocks (2 live posts) no longer emit. Filterable via `swps_schema_deprecated_types`.
- The fabricated "Anthropic" Product/Offer block is content-level — the render gate strips its `_usage`, but **you should still delete that block** from the AI-code-review post's AEO panel (manual-action risk cited by the audit).
- **Both breadcrumb-rollout encoding bugs fixed**: double-encoded entities (`&amp;`, `&#8217;`) in JSON-LD strings (Article headline/description, WebPage.name, breadcrumb names now decode to real Unicode), and the dangling `" |"` in every `WebPage.name` (was `wp_title('|',false,'right')` — contextual title + separator, never the site name; now the full document title).

## H2 · Title truncation
`class-generator.php` fell back to `mb_substr($title, 0, 60)` — the AI response contract has no `meta_title` key, so the hard cut ran on **every** generated post and was stored into `_swps_meta_title` (hence `<title>`/`og:title` cut mid-word while the schema headline stayed complete). Now shortens at a word boundary.

## H3/Medium · Archive canonicals
No canonical existed on any non-singular view (core's `rel_canonical` and the Canonical module are singular-only). Search Appearance now emits self-referencing, pagination-aware canonicals for the posts page (`/blog/` — the audit's "canonical still missing"), term archives (deferring to term-level `_swps_canonical_url` overrides), author archives, and post type archives.

## H6 · Template schema gaps
- `Article.publisher` was omitted on Person-entity sites (all 20 posts) — now references the site entity (schema.org + Google accept Person publishers).
- Author archives emitted two Person nodes with mismatched `@id`s (`#person` vs `#/schema/person/N`) for the same human — `add_author_nodes` now reuses the single site entity, mirroring `add_article_node`.
- LocalBusiness duplicated onto `/blog/` (`is_front_page() || is_home()`) — now front page only.

## Medium · Sitemap image bugs
The in-content image regex emitted whatever string sat in `src="…"` — non-URL strings (the stray "GraphQL") and `http://` theme assets on the https site. Entries are now validated as absolute http(s) URLs and scheme-normalized via `set_url_scheme()`.

## Verified
`php -l` clean on all changed files; unit tests don't cover the changed emitters (checked), and the `quality.yml` CI gate (phpcs/phpstan/phpunit) validates on this PR.

## Not in this PR (audit items that are ops/content, not plugin code)
Enable IndexNow (settings) + verify the key file passes the 20i WAF · GSC Request Indexing + Live Test on `/` and robots.txt · `/blog/` description copy rewrite · deleting the fabricated Product block · FAQ Microdata/JSON-LD disjoint + SoftwareApplication on /stratawp-seo/ (page content) · entity/authority work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERG32yq8jfNSNTrkKYwi7K

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERG32yq8jfNSNTrkKYwi7K)_