### PR TITLE
Fix broken admin panel rendering: theme token cascade collision (4.24.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,11 @@ vendor/
 .idea/
 
 # Claude Code / Claude Flow tooling
+# (CLAUDE.md is tracked deliberately — it carries repo conventions,
+#  e.g. commit/PR attribution, that agent sessions must follow.)
 .claude/
 .claude-flow/
 .mcp.json
-CLAUDE.md
 
 # Codex / agent tooling
 .agents/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# CLAUDE.md
+
+Guidance for AI agents working in this repository.
+
+## Attribution — REQUIRED
+
+All commits, pull requests, and issue comments are authored by the repo
+owner, with no AI attribution of any kind:
+
+- Commit author AND committer: `Jon Imms <60996163+JonImmsWordpressDev@users.noreply.github.com>`
+- NEVER add `Co-Authored-By: Claude ...` or any other co-author trailer.
+- NEVER add `Claude-Session: ...` trailers or session links.
+- NEVER add "Generated with Claude Code" (or similar) footers/badges to
+  commit messages, PR titles, PR bodies, or comments.
+
+## Releases
+
+- The version lives in three places and must stay in sync: the
+  `Version:` header and `SWPS_VERSION` define in `stratawp-seo.php`,
+  and `Stable tag:` in `readme.txt` (plus a changelog entry).
+- Merging a version bump to `main` triggers `.github/workflows/release.yml`,
+  which builds the plugin zip and publishes a GitHub release automatically.

--- a/admin/css/components.css
+++ b/admin/css/components.css
@@ -377,17 +377,12 @@ body.swps-has-shell .swps-card-desc {
     color: var(--swps-text-muted);
 }
 
-/* admin.css's legacy :root clobbers the --swps-text alias to dark slate
-   (#1E293B). tokens.css intends --swps-text to alias the primary text colour
-   (var(--swps-text-primary)), but admin.css loads last and wins at :root — so
-   every shell element using `color: var(--swps-text)` (card/section headings,
-   the stat-tile numbers, form labels, keyword table cells, metric values, the
-   content calendar, etc.) renders dark-on-dark and looks blank until selected.
-   Restore the intended aliasing for the shell scope: `body.swps-has-shell`
-   (0,1,1) beats admin.css's `:root` (0,1,0) and stays theme-aware, so the light
-   theme still resolves to its own dark text. --swps-text is used exclusively
-   for `color:` in admin.css/calendar.css, so this only touches text; the light
-   SERP/social preview mocks hardcode their own text colours and are unaffected. */
+/* Safety net for the admin.css legacy-:root collision (issue #88): tokens.css
+   now wins that cascade tie via `:root[data-swps-theme=…]` (0,2,0), but keep
+   this body-scoped re-assert of the most critical alias so text stays readable
+   even if the theme attribute is ever missing from <html>. Body-level custom
+   properties shadow html-level ones for all descendants by inheritance
+   proximity, independent of the :root specificity war. */
 body.swps-has-shell {
     --swps-text: var(--swps-text-primary);
 }

--- a/admin/css/shell.css
+++ b/admin/css/shell.css
@@ -43,6 +43,14 @@ body.swps-has-shell #wpcontent {
 body.folded.swps-has-shell #wpcontent {
     margin-left: 36px; /* WP collapsed sidebar */
 }
+/* WP auto-folds the admin menu to 36px between 783-960px (core's
+   `.auto-fold #wpcontent` rule). Our 160px margin above outranks it,
+   leaving a 124px dead gap in that range — match core's fold here. */
+@media only screen and (min-width: 783px) and (max-width: 960px) {
+    body.auto-fold.swps-has-shell #wpcontent {
+        margin-left: 36px;
+    }
+}
 @media screen and (max-width: 782px) {
     body.swps-has-shell #wpcontent {
         margin-left: 0;

--- a/admin/css/tokens.css
+++ b/admin/css/tokens.css
@@ -16,10 +16,23 @@
  *
  * Dark theme by default. Light theme via [data-swps-theme="light"].
  * Legacy --swps-* names kept as aliases (admin.css continues to work).
+ *
+ * Specificity note: admin.css defines the legacy --swps-* names in a bare
+ * `:root` block (0,1,0) and prints AFTER this file on shell pages, so a
+ * plain attribute selector here would lose the cascade tie and the shell
+ * would render with light-theme text/border/surface values on the dark
+ * theme (issue #88 — "admin panel broken", dark-on-dark text, light-gray
+ * borders). The `:root[data-swps-theme=…]` forms are (0,2,0) and win
+ * regardless of print order. The bare `:root` fallback stays for the
+ * attribute-missing edge case; the light selector is included on this
+ * base block so the non-color tokens and legacy aliases also win in
+ * light mode — the light block below overrides its colors at equal
+ * specificity by source order.
  */
 
 :root,
-[data-swps-theme="dark"] {
+:root[data-swps-theme="dark"],
+:root[data-swps-theme="light"] {
     /* === Surfaces === */
     --swps-bg-app:        linear-gradient(180deg, #0F172A 0%, #1E293B 100%);
     --swps-bg-app-solid:  #0F172A;
@@ -109,7 +122,7 @@
     --swps-border-light:  var(--swps-border);
 }
 
-[data-swps-theme="light"] {
+:root[data-swps-theme="light"] {
     /* === Surfaces === */
     --swps-bg-app:        #FAFAFA;
     --swps-bg-app-solid:  #FAFAFA;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.24.0
+Stable tag: 4.24.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,10 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.24.1 =
+* Fixed: the admin panel rendered with a corrupted mix of light- and dark-theme colors in the default dark theme — invisible white-on-white modal text (Generate preview, Calendar, Keywords research), light-gray borders on every card and input, low-contrast muted text across all pages, and the brand accent turning orange. The legacy stylesheet's :root variables were winning the cascade over the design-token stylesheet; the token theme blocks are now specificity-qualified so they always win on plugin pages.
+* Fixed: a 124px dead gap between the WordPress admin menu and the plugin content on viewports between 783 and 960px (WordPress auto-folds its menu there; the shell kept the full 160px offset).
 
 = 4.24.0 =
 * Fixed: AI telemetry (a _usage key with token counts) leaked into public AEO JSON-LD. Underscore-prefixed keys are now stripped at generation AND at render, so already-stored schema on live posts is cleaned without re-saving.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.24.0
+ * Version: 4.24.1
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.24.0' );
+define( 'SWPS_VERSION', '4.24.1' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );


### PR DESCRIPTION
Fixes #88.

## Root cause

The admin panel rendered with a corrupted mix of light- and dark-theme values in the **default dark theme**. Two stylesheets define the same `--swps-*` CSS custom properties at equal specificity:

- `admin/css/tokens.css` (design system) — `:root, [data-swps-theme="dark"]` → dark values + legacy aliases
- `admin/css/admin.css` (legacy) — bare `:root` → light values

The shell registers its `admin_enqueue_scripts` callback before the main plugin does (`stratawp-seo.php:503` vs `:523`), so tokens.css prints **first** and admin.css prints **last**. At the `(0,1,0)` specificity tie, source order decides — admin.css's light values silently won on every plugin admin page:

| Variable | Intended (dark) | Actually resolved | Impact |
|---|---|---|---|
| `--swps-surface` | `rgba(30,41,59,.55)` | `#FFFFFF` | Modals (Generate preview, Calendar, Keywords) rendered **white-on-white** — the 4.21.0 `--swps-text` band-aid forces text to white, so modal text was invisible |
| `--swps-border` (41 uses) | `rgba(255,255,255,.06)` | `#E2E8F0` | Harsh light-gray outlines on every card, tile, and input |
| `--swps-text-muted` (110 uses) | `#94A3B8` | `#64748B` | Fails WCAG contrast on dark surfaces, panel-wide |
| `--swps-accent` | `#10B981` emerald | `#F97316` orange | Brand color wrong |
| `--swps-warning` | `#F97316` orange | `#14B8A6` teal | Semantic color wrong |

This is the same root cause as the 4.21.0 fix in PR #76, which patched exactly one variable (`--swps-text`) — that band-aid actually completed the white-on-white modal failure by fixing text while surfaces stayed clobbered. Issue #88 is the rest of that iceberg: "UI elements are not rendering correctly, controls are unresponsive, settings cannot be configured" matches invisible modal/settings text and dead-looking controls.

## Fix

**`admin/css/tokens.css`** — qualify the theme blocks as `:root[data-swps-theme="dark"]` / `:root[data-swps-theme="light"]` (`(0,2,0)`), so the design tokens beat the legacy `:root` block regardless of stylesheet print order, in both themes. The bare `:root` fallback stays for the attribute-missing edge case, and non-shell pages (WP core dashboard widget, post editor) are untouched — the theme attribute only exists on plugin pages.

**`admin/css/components.css`** — the 4.21.0 body-scoped band-aid is kept as a safety net; its now-stale comment is rewritten.

**`admin/css/shell.css`** — also fixes a real layout defect found during investigation: WordPress auto-folds its admin menu to 36px on 783–960px viewports, but the shell's higher-specificity `margin-left: 160px` overrode core's `.auto-fold` rule, leaving a 124px dead gap. Added a matching auto-fold rule bounded to that range.

Also adds a tracked `CLAUDE.md` with repo conventions (attribution, release/version-sync notes); the release workflow already excludes it from the plugin zip.

Version bumped to 4.24.1 with changelog so the release workflow publishes on merge.

## Verification

Probed computed custom-property values in headless Chromium using the exact wp-admin stylesheet print order (tokens → shell → components → templates → admin.css), before and after:

**Dark theme (default), before → after:**
- `--swps-surface`: `#FFFFFF` → `rgba(30,41,59,.55)` ✅
- `--swps-border`: `#E2E8F0` → `rgba(255,255,255,.06)` ✅
- `--swps-text-muted`: `#64748B` → `#94A3B8` ✅
- `--swps-accent`: `#F97316` → `#10B981` ✅

**Light theme** now also resolves fully to its intended values (accent `#059669`, warning `#C2410C`, etc. — previously the alias set was clobbered there too).

**Auto-fold**: `#wpcontent` margin-left at a 900px viewport: `160px` → `36px` ✅

Rendered screenshot comparison of a dashboard fragment confirms the visual result (subtle borders, readable muted text, emerald accents, no dead gap).