### PR TITLE
Add owned/partner domains for cross-site link suggestions (4.25.0)

### DIFF
--- a/admin/css/admin.css
+++ b/admin/css/admin.css
@@ -1239,6 +1239,18 @@
     font-style: italic;
 }
 
+#swps-internal-links-metabox .swps-cross-site-badge {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: var(--swps-radius-sm);
+    background: var(--swps-secondary-light);
+    color: var(--swps-secondary);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    vertical-align: middle;
+}
+
 #swps-internal-links-metabox .swps-link-actions {
     margin-left: auto;
 }

--- a/admin/js/internal-links.js
+++ b/admin/js/internal-links.js
@@ -43,14 +43,26 @@
             tinymce.activeEditor.execCommand('mceInsertContent', false, ' ' + linkHtml);
         }
 
-        // Mark as inserted via AJAX.
-        $.post(swpsInternalLinks.ajaxUrl, {
-            action:      'swps_link_insert',
-            nonce:       swpsInternalLinks.nonce,
-            post_id:     postId,
-            target_id:   targetId,
-            anchor_text: anchor
-        }).always(function () {
+        // Mark as inserted via AJAX. Cross-site suggestions have no local
+        // post ID and are tracked by URL instead.
+        var insertRequest;
+        if ($li.data('cross-site')) {
+            insertRequest = $.post(swpsInternalLinks.ajaxUrl, {
+                action:  'swps_link_cross_insert',
+                nonce:   swpsInternalLinks.nonce,
+                post_id: postId,
+                url:     targetUrl
+            });
+        } else {
+            insertRequest = $.post(swpsInternalLinks.ajaxUrl, {
+                action:      'swps_link_insert',
+                nonce:       swpsInternalLinks.nonce,
+                post_id:     postId,
+                target_id:   targetId,
+                anchor_text: anchor
+            });
+        }
+        insertRequest.always(function () {
             $li.fadeOut(300, function () { $(this).remove(); });
         });
     });
@@ -63,12 +75,21 @@
         var targetId = $li.data('target-id');
         var postId   = $('#post_ID').val();
 
-        $.post(swpsInternalLinks.ajaxUrl, {
-            action:    'swps_link_dismiss',
-            nonce:     swpsInternalLinks.nonce,
-            post_id:   postId,
-            target_id: targetId
-        });
+        if ($li.data('cross-site')) {
+            $.post(swpsInternalLinks.ajaxUrl, {
+                action:  'swps_link_cross_dismiss',
+                nonce:   swpsInternalLinks.nonce,
+                post_id: postId,
+                url:     $li.data('target-url')
+            });
+        } else {
+            $.post(swpsInternalLinks.ajaxUrl, {
+                action:    'swps_link_dismiss',
+                nonce:     swpsInternalLinks.nonce,
+                post_id:   postId,
+                target_id: targetId
+            });
+        }
 
         $li.fadeOut(300, function () { $(this).remove(); });
     });

--- a/docs/superpowers/specs/2026-07-25-owned-domains-cross-site-links-design.md
+++ b/docs/superpowers/specs/2026-07-25-owned-domains-cross-site-links-design.md
@@ -1,0 +1,111 @@
+# Owned Domains — Cross-Site Link Suggestions
+
+**Date:** 2026-07-25
+**Status:** Approved (design supplied by owner)
+
+## Goal
+
+Let the internal-link engines suggest links between sites the owner controls
+(e.g. `stratawpdev.com` ↔ `jonimms.com`). Today every candidate must be a
+local post: `SWPS_Internal_Links::detect_existing_links()` rejects any href
+not starting with `home_url()` or `/`, and both engines only ever see local
+post IDs.
+
+## Constraints discovered in the codebase
+
+- `swps_link_graph` keys targets by **local post ID** (`target_post_id`
+  BIGINT, unique key on source+target). Cross-site targets have no local ID,
+  so they must NOT be forced into the graph table — no schema migration.
+- Unit tests are pure PHP (no WP bootstrap); WP functions are stubbed per
+  test file. Core matching logic must therefore live in pure static methods.
+- Settings page uses the WP Settings API under the `stratawp-seo` group;
+  complex (array) options are registered directly with a custom render
+  callback (precedent: `swps_aeo_weights`).
+
+## Design
+
+### 1. Setting: `swps_owned_domains`
+
+- Stored as an array of normalized origins (`https://host[:port]`).
+- UI: textarea (one domain per line) in a new **Cross-Site Linking** section
+  on the settings page (SEO tab). Bare hosts get `https://` prepended;
+  paths/queries stripped; invalid entries and the site's own host dropped.
+- Sanitizer is a pure static: `SWPS_Cross_Site_Links::sanitize_owned_domains()`
+  (accepts textarea string or array). `www.` is ignored when comparing hosts.
+- Changing the option flushes cached inventories.
+
+### 2. New class `SWPS_Cross_Site_Links` (includes/class-cross-site-links.php)
+
+- `get_owned_domains(): array` — option, minus own host.
+- `get_inventory(): array` — merged remote post inventory. Per-domain
+  transient `swps_cross_site_inv_<md5(origin)>`, `DAY_IN_SECONDS`; fetches
+  `{origin}/wp-json/wp/v2/posts?per_page=100&_fields=title,link,excerpt`.
+  Fetch failures cache an empty list for `HOUR_IN_SECONDS` so a down site
+  isn't hammered. Items: `['url','title','excerpt','domain']`.
+- `is_owned_url( string $url ): bool` / pure static
+  `url_matches_domains( string $url, array $origins ): bool` — host match,
+  scheme-insensitive, `www.`-insensitive, exact host (no subdomain match).
+- `find_candidates( int $post_id, float $threshold, int $limit ): array` —
+  scores inventory against the source post's indexed terms (from
+  `swps_link_index`) using the keyword engine's tokenizer. Pure static core:
+  `score_candidates( array $term_weights, array $inventory, callable $tokenize, float $threshold, int $limit )`.
+  Title tokens weighted 1.0, excerpt tokens 0.3 (mirrors engine weights),
+  normalized against the best score. Results carry `cross_site => true`.
+- Per-post state in post meta (graph table untouched):
+  - `_swps_cross_site_existing` — `[ ['url','anchor'], … ]`, rebuilt on each
+    `detect_existing_links()` run.
+  - `_swps_cross_site_dismissed` — list of dismissed URLs.
+  - `_swps_cross_site_ai` — AI enrichment keyed by URL
+    (`score`, `anchor_text`, `rationale`).
+  - Suggestions exclude existing + dismissed URLs.
+
+### 3. Relax the same-host filter (`detect_existing_links`)
+
+Owned-domain hrefs are no longer skipped: they're recorded into
+`_swps_cross_site_existing` (they can't resolve via `url_to_postid()`).
+Same-site behavior unchanged; unknown third-party hrefs still skipped.
+
+### 4. Engine merges
+
+- **Keyword path:** metabox render + `ajax_get_suggestions` call
+  `find_candidates()` live (inventory is cached; scoring is in-memory).
+  Cross-site suggestions are NOT persisted to the graph.
+- **AI path:** `SWPS_Link_AI_Engine::analyze()` accepts mixed candidates:
+  local (`post_id`) or cross-site (`url`,`title`,`excerpt`,`cross_site`).
+  Cross-site candidates are sent with `url` as their identifier; the prompt
+  instructs the model to echo whichever identifier a candidate had. Enriched
+  cross-site results are stored in `_swps_cross_site_ai` by
+  `ajax_deep_analysis()` and returned alongside local results.
+
+### 5. UI
+
+- Metabox: cross-site suggestions render in the Suggested list with a
+  `Cross-site` badge showing the host; existing cross-site links appear in
+  the Existing list with the same badge. `<li>` carries
+  `data-cross-site="1"` + `data-target-url`.
+- JS: insert reuses the existing content-insertion path (`data-target-url`);
+  bookkeeping AJAX branches to `swps_link_cross_insert` /
+  `swps_link_cross_dismiss` (URL-based) for cross-site items.
+- Admin CSS: small badge style.
+
+### 6. Out of scope (YAGNI)
+
+- No graph-table schema change, no cross-site rows in link-health stats.
+- No `/pages` inventory, no pagination past 100 posts per domain (v1).
+- No generation-prompt enrichment with cross-site links.
+
+## Testing
+
+Pure-PHP unit tests (existing bootstrap conventions, WP stubs per file):
+
+- `CrossSiteLinksTest` — origin normalization, sanitizer (string + array
+  input, invalid entries, dedupe), `url_matches_domains` (scheme/www/port/
+  subdomain cases), inventory response parsing, candidate scoring
+  (threshold, ordering, limit, exclusions).
+- `InternalLinksDetectTest` — the filter change: same-site absolute and
+  relative hrefs still recorded in the graph (fake `$wpdb`), foreign hrefs
+  still skipped, owned-domain hrefs recorded to cross-site meta and kept out
+  of the graph.
+
+`composer check` (phpcs + PHPStan level 5) must pass; PHPStan baseline not
+extended.

--- a/includes/class-cross-site-links.php
+++ b/includes/class-cross-site-links.php
@@ -1,0 +1,548 @@
+<?php
+/**
+ * Cross-site link candidates from owned/partner domains.
+ *
+ * Maintains the swps_owned_domains setting, fetches each owned domain's
+ * public post inventory over the WP REST API (cached daily), scores that
+ * inventory against a post's indexed terms, and tracks per-post cross-site
+ * link state (existing / dismissed / inserted / AI enrichment) in post meta.
+ *
+ * Cross-site targets have no local post ID, so they deliberately never
+ * enter the swps_link_graph table.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Owned/partner-domain link candidates for the internal-link engines.
+ */
+class SWPS_Cross_Site_Links {
+
+	private const INVENTORY_TRANSIENT_PREFIX = 'swps_cross_site_inv_';
+	private const FETCH_TIMEOUT              = 10;
+
+	// Mirrors SWPS_Link_Keyword_Engine::WEIGHTS for title/body.
+	private const TITLE_WEIGHT   = 1.0;
+	private const EXCERPT_WEIGHT = 0.3;
+
+	private const META_EXISTING  = '_swps_cross_site_existing';
+	private const META_DISMISSED = '_swps_cross_site_dismissed';
+	private const META_INSERTED  = '_swps_cross_site_inserted';
+	private const META_AI        = '_swps_cross_site_ai';
+
+	// -------------------------------------------------------------------------
+	// Pure helpers (unit tested without WordPress)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Normalize a user-entered domain to an origin (scheme://host[:port]).
+	 *
+	 * Bare hosts get https:// prepended; paths, queries, and fragments are
+	 * stripped; only http/https survive.
+	 *
+	 * @param string $input Raw entry, e.g. "jonimms.com" or "https://x.com/p/".
+	 * @return string|null Normalized origin, or null when invalid.
+	 */
+	public static function normalize_origin( string $input ): ?string {
+		$input = trim( $input );
+		if ( '' === $input ) {
+			return null;
+		}
+
+		if ( ! preg_match( '#^[a-z][a-z0-9+.-]*://#i', $input ) ) {
+			$input = 'https://' . $input;
+		}
+
+		$parts = wp_parse_url( $input );
+		if ( ! is_array( $parts ) || empty( $parts['host'] ) || empty( $parts['scheme'] ) ) {
+			return null;
+		}
+
+		$scheme = strtolower( $parts['scheme'] );
+		if ( ! in_array( $scheme, array( 'http', 'https' ), true ) ) {
+			return null;
+		}
+
+		$host = strtolower( $parts['host'] );
+		if ( ! preg_match( '/^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/', $host ) ) {
+			return null;
+		}
+
+		$origin = $scheme . '://' . $host;
+		if ( ! empty( $parts['port'] ) ) {
+			$origin .= ':' . (int) $parts['port'];
+		}
+
+		return $origin;
+	}
+
+	/**
+	 * Sanitize the swps_owned_domains option value.
+	 *
+	 * Accepts the settings textarea (one domain per line) or an array of
+	 * entries; returns a deduped list of normalized origins.
+	 *
+	 * @param mixed $value Raw option value.
+	 * @return array<int, string> Normalized origins.
+	 */
+	public static function sanitize_owned_domains( $value ): array {
+		if ( is_string( $value ) ) {
+			$value = preg_split( '/[\r\n]+/', $value );
+		}
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$origins = array();
+		foreach ( $value as $entry ) {
+			if ( ! is_string( $entry ) ) {
+				continue;
+			}
+			$origin = self::normalize_origin( $entry );
+			if ( null !== $origin && ! in_array( $origin, $origins, true ) ) {
+				$origins[] = $origin;
+			}
+		}
+
+		return $origins;
+	}
+
+	/**
+	 * Whether a URL points at one of the given origins.
+	 *
+	 * Host comparison is scheme-insensitive and ignores a leading "www.",
+	 * but requires an exact host (no subdomain match) and a matching port.
+	 *
+	 * @param string $url     URL to test (absolute or protocol-relative).
+	 * @param array  $origins Normalized origins.
+	 * @return bool True when the URL's host belongs to an origin.
+	 */
+	public static function url_matches_domains( string $url, array $origins ): bool {
+		if ( empty( $origins ) ) {
+			return false;
+		}
+
+		$needle = self::host_key( $url );
+		if ( null === $needle ) {
+			return false;
+		}
+
+		foreach ( $origins as $origin ) {
+			if ( is_string( $origin ) && self::host_key( $origin ) === $needle ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Parse a WP REST /wp/v2/posts response body into inventory items.
+	 *
+	 * @param string $body   Raw JSON response body.
+	 * @param string $origin Origin the response came from.
+	 * @return array<int, array{url: string, title: string, excerpt: string, domain: string}>
+	 */
+	public static function parse_inventory_response( string $body, string $origin ): array {
+		$data = json_decode( $body, true );
+		if ( ! is_array( $data ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $data as $row ) {
+			if ( ! is_array( $row ) || empty( $row['link'] ) || ! is_string( $row['link'] ) ) {
+				continue;
+			}
+			$title   = isset( $row['title']['rendered'] ) ? (string) $row['title']['rendered'] : '';
+			$excerpt = isset( $row['excerpt']['rendered'] ) ? (string) $row['excerpt']['rendered'] : '';
+
+			$items[] = array(
+				'url'     => $row['link'],
+				'title'   => html_entity_decode( wp_strip_all_tags( $title ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ),
+				'excerpt' => html_entity_decode( wp_strip_all_tags( $excerpt ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ),
+				'domain'  => $origin,
+			);
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Score inventory items against a source post's weighted terms.
+	 *
+	 * Mirrors SWPS_Link_Keyword_Engine::find_related(): source term weight
+	 * times target weight (title 1.0, excerpt 0.3), normalized against the
+	 * best raw score, thresholded, ordered by score descending.
+	 *
+	 * @param array    $term_weights Source terms mapped to weights.
+	 * @param array    $inventory    Items from parse_inventory_response().
+	 * @param callable $tokenize     Tokenizer (SWPS_Link_Keyword_Engine::tokenize_public).
+	 * @param float    $threshold    Minimum normalized score.
+	 * @param int      $limit        Maximum results.
+	 * @param array    $exclude_urls URLs to skip (already linked / dismissed).
+	 * @return array<int, array> Scored candidates, each with cross_site => true.
+	 */
+	public static function score_candidates( array $term_weights, array $inventory, callable $tokenize, float $threshold = 0.3, int $limit = 10, array $exclude_urls = array() ): array {
+		if ( empty( $term_weights ) || empty( $inventory ) ) {
+			return array();
+		}
+
+		$scored = array();
+		foreach ( $inventory as $item ) {
+			if ( ! is_array( $item ) || empty( $item['url'] ) || in_array( $item['url'], $exclude_urls, true ) ) {
+				continue;
+			}
+
+			$title_terms   = (array) call_user_func( $tokenize, (string) ( $item['title'] ?? '' ) );
+			$excerpt_terms = (array) call_user_func( $tokenize, (string) ( $item['excerpt'] ?? '' ) );
+
+			$score = 0.0;
+			foreach ( $term_weights as $term => $weight ) {
+				if ( in_array( (string) $term, $title_terms, true ) ) {
+					$score += (float) $weight * self::TITLE_WEIGHT;
+				} elseif ( in_array( (string) $term, $excerpt_terms, true ) ) {
+					$score += (float) $weight * self::EXCERPT_WEIGHT;
+				}
+			}
+
+			if ( $score <= 0 ) {
+				continue;
+			}
+
+			$scored[] = array(
+				'url'        => (string) $item['url'],
+				'title'      => (string) ( $item['title'] ?? '' ),
+				'excerpt'    => (string) ( $item['excerpt'] ?? '' ),
+				'domain'     => (string) ( $item['domain'] ?? '' ),
+				'score'      => $score,
+				'cross_site' => true,
+			);
+		}
+
+		if ( empty( $scored ) ) {
+			return array();
+		}
+
+		$max     = max( array_column( $scored, 'score' ) );
+		$results = array();
+		foreach ( $scored as $item ) {
+			$item['score'] = $max > 0 ? round( $item['score'] / $max, 3 ) : 0.0;
+			if ( $item['score'] >= $threshold ) {
+				$results[] = $item;
+			}
+		}
+
+		usort( $results, fn( $a, $b ) => $b['score'] <=> $a['score'] );
+
+		return array_slice( $results, 0, $limit );
+	}
+
+	/**
+	 * Comparable host key for a URL: lowercased host without a leading
+	 * "www.", plus the explicit port when present.
+	 *
+	 * @param string $url URL or origin.
+	 * @return string|null Host key, or null when the URL has no host.
+	 */
+	private static function host_key( string $url ): ?string {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( empty( $host ) || ! is_string( $host ) ) {
+			return null;
+		}
+
+		$host = strtolower( $host );
+		if ( 0 === strpos( $host, 'www.' ) ) {
+			$host = substr( $host, 4 );
+		}
+
+		$port = wp_parse_url( $url, PHP_URL_PORT );
+
+		return $host . ( $port ? ':' . (int) $port : '' );
+	}
+
+	// -------------------------------------------------------------------------
+	// WordPress-backed API
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Register option-change hooks (inventory cache flush).
+	 */
+	public function register_hooks(): void {
+		add_action( 'update_option_swps_owned_domains', array( $this, 'on_domains_updated' ), 10, 2 );
+	}
+
+	/**
+	 * Configured owned domains, excluding this site's own host.
+	 *
+	 * @return array<int, string> Normalized origins.
+	 */
+	public function get_owned_domains(): array {
+		$origins = self::sanitize_owned_domains( get_option( 'swps_owned_domains', array() ) );
+
+		return array_values(
+			array_filter(
+				$origins,
+				static function ( string $origin ): bool {
+					return ! self::url_matches_domains( $origin, array( home_url() ) );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Whether cross-site linking is active (at least one owned domain).
+	 */
+	public function is_active(): bool {
+		return array() !== $this->get_owned_domains();
+	}
+
+	/**
+	 * Whether a URL belongs to a configured owned domain.
+	 *
+	 * @param string $url URL to test.
+	 */
+	public function is_owned_url( string $url ): bool {
+		return self::url_matches_domains( $url, $this->get_owned_domains() );
+	}
+
+	/**
+	 * Merged post inventory across all owned domains.
+	 *
+	 * @return array<int, array> Inventory items.
+	 */
+	public function get_inventory(): array {
+		$inventory = array();
+		foreach ( $this->get_owned_domains() as $origin ) {
+			$inventory = array_merge( $inventory, $this->get_domain_inventory( $origin ) );
+		}
+
+		return $inventory;
+	}
+
+	/**
+	 * Post inventory for one owned domain, cached in a transient.
+	 *
+	 * Successful fetches cache for a day; failures cache an empty list for
+	 * an hour so an unreachable site isn't hammered on every editor load.
+	 *
+	 * @param string $origin Normalized origin.
+	 * @return array<int, array> Inventory items.
+	 */
+	public function get_domain_inventory( string $origin ): array {
+		$key    = self::INVENTORY_TRANSIENT_PREFIX . md5( $origin );
+		$cached = get_transient( $key );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		$response = wp_remote_get(
+			$origin . '/wp-json/wp/v2/posts?per_page=100&_fields=title,link,excerpt',
+			array( 'timeout' => self::FETCH_TIMEOUT )
+		);
+
+		if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			set_transient( $key, array(), HOUR_IN_SECONDS );
+			return array();
+		}
+
+		$items = self::parse_inventory_response( (string) wp_remote_retrieve_body( $response ), $origin );
+		set_transient( $key, $items, DAY_IN_SECONDS );
+
+		return $items;
+	}
+
+	/**
+	 * Cross-site link suggestions for a post.
+	 *
+	 * Scores the cached inventory against the post's indexed terms and
+	 * overlays any stored AI enrichment. URLs already linked, dismissed,
+	 * or inserted are excluded.
+	 *
+	 * @param int   $post_id   Source post ID.
+	 * @param float $threshold Minimum normalized score.
+	 * @param int   $limit     Maximum suggestions.
+	 * @return array<int, array> Suggestions.
+	 */
+	public function find_candidates( int $post_id, float $threshold = 0.3, int $limit = 5 ): array {
+		$inventory = $this->get_inventory();
+		if ( empty( $inventory ) ) {
+			return array();
+		}
+
+		global $wpdb;
+		$table = $wpdb->prefix . 'swps_link_index';
+
+		$rows = $wpdb->get_results(
+			$wpdb->prepare( "SELECT term, weight FROM {$table} WHERE post_id = %d", $post_id ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			ARRAY_A
+		);
+		if ( empty( $rows ) ) {
+			return array();
+		}
+
+		$term_weights = array();
+		foreach ( $rows as $row ) {
+			$term_weights[ $row['term'] ] = (float) $row['weight'];
+		}
+
+		$exclude = array_merge(
+			array_column( $this->get_existing_links( $post_id ), 'url' ),
+			$this->get_url_list( $post_id, self::META_DISMISSED ),
+			$this->get_url_list( $post_id, self::META_INSERTED )
+		);
+
+		$engine     = new SWPS_Link_Keyword_Engine();
+		$candidates = self::score_candidates(
+			$term_weights,
+			$inventory,
+			array( $engine, 'tokenize_public' ),
+			$threshold,
+			$limit,
+			$exclude
+		);
+
+		$enrichment = $this->get_ai_enrichment( $post_id );
+		foreach ( $candidates as &$candidate ) {
+			if ( isset( $enrichment[ $candidate['url'] ] ) ) {
+				$candidate['score']       = (float) $enrichment[ $candidate['url'] ]['relevance_score'];
+				$candidate['anchor_text'] = (string) $enrichment[ $candidate['url'] ]['anchor_text'];
+				$candidate['rationale']   = (string) $enrichment[ $candidate['url'] ]['rationale'];
+				$candidate['ai_enriched'] = true;
+			}
+		}
+		unset( $candidate );
+
+		return $candidates;
+	}
+
+	// -------------------------------------------------------------------------
+	// Per-post cross-site state (post meta)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Existing cross-site links detected in the post content.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array<int, array{url: string, anchor: string}>
+	 */
+	public function get_existing_links( int $post_id ): array {
+		$value = get_post_meta( $post_id, self::META_EXISTING, true );
+		return is_array( $value ) ? $value : array();
+	}
+
+	/**
+	 * Replace the recorded existing cross-site links for a post.
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param array $links   Array of ['url' => ..., 'anchor' => ...].
+	 */
+	public function set_existing_links( int $post_id, array $links ): void {
+		if ( empty( $links ) ) {
+			delete_post_meta( $post_id, self::META_EXISTING );
+			return;
+		}
+		update_post_meta( $post_id, self::META_EXISTING, array_values( $links ) );
+	}
+
+	/**
+	 * Mark a cross-site suggestion as dismissed for a post.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $url     Suggestion URL.
+	 */
+	public function dismiss_url( int $post_id, string $url ): void {
+		$this->add_url_to_list( $post_id, self::META_DISMISSED, $url );
+	}
+
+	/**
+	 * Mark a cross-site suggestion as inserted for a post.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $url     Suggestion URL.
+	 */
+	public function mark_inserted( int $post_id, string $url ): void {
+		$this->add_url_to_list( $post_id, self::META_INSERTED, $url );
+	}
+
+	/**
+	 * Stored AI enrichment for a post's cross-site suggestions.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array<string, array> Map of URL => enrichment.
+	 */
+	public function get_ai_enrichment( int $post_id ): array {
+		$value = get_post_meta( $post_id, self::META_AI, true );
+		return is_array( $value ) ? $value : array();
+	}
+
+	/**
+	 * Merge AI enrichment results (keyed by URL) into the stored map.
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param array $items   Enriched cross-site items from the AI engine.
+	 */
+	public function store_ai_enrichment( int $post_id, array $items ): void {
+		$map = $this->get_ai_enrichment( $post_id );
+		foreach ( $items as $item ) {
+			if ( empty( $item['url'] ) ) {
+				continue;
+			}
+			$map[ (string) $item['url'] ] = array(
+				'relevance_score' => (float) ( $item['relevance_score'] ?? 0 ),
+				'anchor_text'     => (string) ( $item['anchor_text'] ?? '' ),
+				'rationale'       => (string) ( $item['rationale'] ?? '' ),
+			);
+		}
+		update_post_meta( $post_id, self::META_AI, $map );
+	}
+
+	/**
+	 * Flush cached inventories when the owned-domains option changes.
+	 *
+	 * @param mixed $old_value Previous option value.
+	 * @param mixed $value     New option value.
+	 */
+	public function on_domains_updated( $old_value, $value ): void {
+		$origins = array_unique(
+			array_merge(
+				self::sanitize_owned_domains( $old_value ),
+				self::sanitize_owned_domains( $value )
+			)
+		);
+		foreach ( $origins as $origin ) {
+			delete_transient( self::INVENTORY_TRANSIENT_PREFIX . md5( $origin ) );
+		}
+	}
+
+	/**
+	 * Read a URL-list post meta value.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $meta_key Meta key.
+	 * @return array<int, string>
+	 */
+	private function get_url_list( int $post_id, string $meta_key ): array {
+		$value = get_post_meta( $post_id, $meta_key, true );
+		return is_array( $value ) ? array_values( array_filter( $value, 'is_string' ) ) : array();
+	}
+
+	/**
+	 * Append a URL to a URL-list post meta value (deduped).
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $meta_key Meta key.
+	 * @param string $url     URL to add.
+	 */
+	private function add_url_to_list( int $post_id, string $meta_key, string $url ): void {
+		$list = $this->get_url_list( $post_id, $meta_key );
+		if ( ! in_array( $url, $list, true ) ) {
+			$list[] = $url;
+			update_post_meta( $post_id, $meta_key, $list );
+		}
+	}
+}

--- a/includes/class-internal-links.php
+++ b/includes/class-internal-links.php
@@ -18,12 +18,31 @@ class SWPS_Internal_Links {
 	private const GRAPH_TABLE = 'swps_link_graph';
 	private const CRON_HOOK   = 'swps_link_maintenance';
 
+	/**
+	 * Keyword matching engine.
+	 *
+	 * @var SWPS_Link_Keyword_Engine
+	 */
 	private SWPS_Link_Keyword_Engine $keyword_engine;
+
+	/**
+	 * AI analysis engine.
+	 *
+	 * @var SWPS_Link_AI_Engine
+	 */
 	private SWPS_Link_AI_Engine $ai_engine;
 
-	public function __construct( SWPS_Link_Keyword_Engine $keyword_engine, SWPS_Link_AI_Engine $ai_engine ) {
+	/**
+	 * Cross-site (owned/partner domain) candidate source.
+	 *
+	 * @var SWPS_Cross_Site_Links
+	 */
+	private SWPS_Cross_Site_Links $cross_site;
+
+	public function __construct( SWPS_Link_Keyword_Engine $keyword_engine, SWPS_Link_AI_Engine $ai_engine, ?SWPS_Cross_Site_Links $cross_site = null ) {
 		$this->keyword_engine = $keyword_engine;
 		$this->ai_engine      = $ai_engine;
+		$this->cross_site     = $cross_site ?? new SWPS_Cross_Site_Links();
 
 		if ( ! get_option( 'swps_internal_links_enabled', 1 ) ) {
 			return;
@@ -42,6 +61,8 @@ class SWPS_Internal_Links {
 		add_action( 'wp_ajax_swps_link_dismiss', array( $this, 'ajax_dismiss' ) );
 		add_action( 'wp_ajax_swps_link_insert', array( $this, 'ajax_insert' ) );
 		add_action( 'wp_ajax_swps_link_deep_analysis', array( $this, 'ajax_deep_analysis' ) );
+		add_action( 'wp_ajax_swps_link_cross_dismiss', array( $this, 'ajax_cross_dismiss' ) );
+		add_action( 'wp_ajax_swps_link_cross_insert', array( $this, 'ajax_cross_insert' ) );
 
 		// Admin assets.
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
@@ -236,15 +257,30 @@ class SWPS_Internal_Links {
 	 * @param string $content Post HTML content.
 	 */
 	public function detect_existing_links( int $post_id, string $content ): void {
-		$home_url = home_url();
+		$home_url      = home_url();
+		$owned_domains = $this->cross_site->get_owned_domains();
+		$cross_links   = array();
 
 		if ( ! preg_match_all( '/<a\s[^>]*href=["\']([^"\']+)["\'][^>]*>(.*?)<\/a>/is', $content, $matches, PREG_SET_ORDER ) ) {
+			$this->cross_site->set_existing_links( $post_id, array() );
 			return;
 		}
 
 		foreach ( $matches as $match ) {
 			$href        = $match[1];
 			$anchor_text = wp_strip_all_tags( $match[2] );
+
+			// Links to owned/partner domains have no local post ID, so
+			// they're tracked in post meta rather than the graph table.
+			if ( ! empty( $owned_domains )
+				&& strpos( $href, $home_url ) !== 0
+				&& SWPS_Cross_Site_Links::url_matches_domains( $href, $owned_domains ) ) {
+				$cross_links[] = array(
+					'url'    => $href,
+					'anchor' => sanitize_text_field( mb_substr( $anchor_text, 0, 255 ) ),
+				);
+				continue;
+			}
 
 			// Only internal links.
 			if ( strpos( $href, $home_url ) !== 0 && strpos( $href, '/' ) !== 0 ) {
@@ -267,6 +303,8 @@ class SWPS_Internal_Links {
 				)
 			);
 		}
+
+		$this->cross_site->set_existing_links( $post_id, $cross_links );
 	}
 
 	/**
@@ -484,6 +522,14 @@ class SWPS_Internal_Links {
 
 		$all_existing = array_merge( $existing, $inserted );
 
+		$cross_existing  = $this->cross_site->get_existing_links( $post->ID );
+		$cross_suggested = array();
+		if ( $this->cross_site->is_active() ) {
+			$threshold       = (float) get_option( 'swps_link_relevance_threshold', 0.3 );
+			$max             = (int) get_option( 'swps_link_max_suggestions', 10 );
+			$cross_suggested = $this->cross_site->find_candidates( $post->ID, $threshold, $max );
+		}
+
 		wp_nonce_field( 'swps_internal_links', 'swps_internal_links_nonce' );
 		?>
 		<div id="swps-internal-links-metabox">
@@ -491,13 +537,13 @@ class SWPS_Internal_Links {
 				<?php
 				printf(
 					esc_html__( 'This post has %1$d internal links. %2$d suggestions available.', 'stratawp-seo' ),
-					count( $all_existing ),
-					count( $suggested )
+					count( $all_existing ) + count( $cross_existing ),
+					count( $suggested ) + count( $cross_suggested )
 				);
 				?>
 			</p>
 
-			<?php if ( ! empty( $all_existing ) ) : ?>
+			<?php if ( ! empty( $all_existing ) || ! empty( $cross_existing ) ) : ?>
 				<h4><?php esc_html_e( 'Existing Links', 'stratawp-seo' ); ?></h4>
 				<ul class="swps-existing-links">
 					<?php
@@ -516,10 +562,21 @@ class SWPS_Internal_Links {
 							<?php endif; ?>
 						</li>
 					<?php endforeach; ?>
+					<?php foreach ( $cross_existing as $link ) : ?>
+						<li>
+							<a href="<?php echo esc_url( $link['url'] ); ?>" target="_blank" rel="noopener">
+								<?php echo esc_html( $link['url'] ); ?>
+							</a>
+							<span class="swps-cross-site-badge"><?php echo esc_html( (string) wp_parse_url( $link['url'], PHP_URL_HOST ) ); ?></span>
+							<?php if ( ! empty( $link['anchor'] ) ) : ?>
+								<span class="swps-anchor-text">(<?php echo esc_html( $link['anchor'] ); ?>)</span>
+							<?php endif; ?>
+						</li>
+					<?php endforeach; ?>
 				</ul>
 			<?php endif; ?>
 
-			<?php if ( ! empty( $suggested ) ) : ?>
+			<?php if ( ! empty( $suggested ) || ! empty( $cross_suggested ) ) : ?>
 				<h4><?php esc_html_e( 'Suggested Links', 'stratawp-seo' ); ?></h4>
 				<ul class="swps-suggested-links">
 					<?php
@@ -542,6 +599,30 @@ class SWPS_Internal_Links {
 							<span class="swps-suggested-anchor"><?php echo esc_html( $anchor ); ?></span>
 							<?php if ( ! empty( $link['anchor_context'] ) ) : ?>
 								<span class="swps-rationale"><?php echo esc_html( $link['anchor_context'] ); ?></span>
+							<?php endif; ?>
+							<span class="swps-link-actions">
+								<button type="button" class="button button-small swps-insert-link"><?php esc_html_e( 'Insert', 'stratawp-seo' ); ?></button>
+								<button type="button" class="button button-small swps-dismiss-link"><?php esc_html_e( 'Dismiss', 'stratawp-seo' ); ?></button>
+							</span>
+						</li>
+					<?php endforeach; ?>
+					<?php
+					foreach ( $cross_suggested as $suggestion ) :
+						$score  = (float) $suggestion['score'];
+						$color  = $score >= 0.7 ? 'green' : ( $score >= 0.4 ? 'orange' : 'red' );
+						$anchor = ! empty( $suggestion['anchor_text'] ) ? $suggestion['anchor_text'] : $suggestion['title'];
+						?>
+						<li data-cross-site="1"
+							data-target-url="<?php echo esc_url( $suggestion['url'] ); ?>"
+							data-anchor="<?php echo esc_attr( $anchor ); ?>">
+							<span class="swps-score-dot" style="color:<?php echo esc_attr( $color ); ?>;">&#9679;</span>
+							<a href="<?php echo esc_url( $suggestion['url'] ); ?>" target="_blank" rel="noopener">
+								<?php echo esc_html( $suggestion['title'] ); ?>
+							</a>
+							<span class="swps-cross-site-badge"><?php echo esc_html( (string) wp_parse_url( $suggestion['url'], PHP_URL_HOST ) ); ?></span>
+							<span class="swps-suggested-anchor"><?php echo esc_html( $anchor ); ?></span>
+							<?php if ( ! empty( $suggestion['rationale'] ) ) : ?>
+								<span class="swps-rationale"><?php echo esc_html( $suggestion['rationale'] ); ?></span>
 							<?php endif; ?>
 							<span class="swps-link-actions">
 								<button type="button" class="button button-small swps-insert-link"><?php esc_html_e( 'Insert', 'stratawp-seo' ); ?></button>
@@ -584,12 +665,20 @@ class SWPS_Internal_Links {
 		$suggested = $this->get_links( $post_id, 'suggested' );
 		$existing  = $this->get_links( $post_id, 'existing' );
 
-		wp_send_json_success(
-			array(
-				'suggested' => $suggested,
-				'existing'  => $existing,
-			)
+		$response = array(
+			'suggested' => $suggested,
+			'existing'  => $existing,
 		);
+
+		if ( $this->cross_site->is_active() ) {
+			$threshold = (float) get_option( 'swps_link_relevance_threshold', 0.3 );
+			$max       = (int) get_option( 'swps_link_max_suggestions', 10 );
+
+			$response['cross_site_suggested'] = $this->cross_site->find_candidates( $post_id, $threshold, $max );
+			$response['cross_site_existing']  = $this->cross_site->get_existing_links( $post_id );
+		}
+
+		wp_send_json_success( $response );
 	}
 
 	/**
@@ -644,6 +733,48 @@ class SWPS_Internal_Links {
 	}
 
 	/**
+	 * AJAX: Dismiss a cross-site link suggestion.
+	 */
+	public function ajax_cross_dismiss(): void {
+		check_ajax_referer( 'swps_internal_links', 'nonce' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$post_id = absint( $_POST['post_id'] ?? 0 );
+		$url     = esc_url_raw( wp_unslash( $_POST['url'] ?? '' ) );
+
+		if ( ! $post_id || empty( $url ) || ! $this->cross_site->is_owned_url( $url ) ) {
+			wp_send_json_error( array( 'message' => 'Invalid request.' ) );
+		}
+
+		$this->cross_site->dismiss_url( $post_id, $url );
+		wp_send_json_success();
+	}
+
+	/**
+	 * AJAX: Mark a cross-site link as inserted.
+	 */
+	public function ajax_cross_insert(): void {
+		check_ajax_referer( 'swps_internal_links', 'nonce' );
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			wp_send_json_error( array( 'message' => 'Insufficient permissions.' ) );
+		}
+
+		$post_id = absint( $_POST['post_id'] ?? 0 );
+		$url     = esc_url_raw( wp_unslash( $_POST['url'] ?? '' ) );
+
+		if ( ! $post_id || empty( $url ) || ! $this->cross_site->is_owned_url( $url ) ) {
+			wp_send_json_error( array( 'message' => 'Invalid request.' ) );
+		}
+
+		$this->cross_site->mark_inserted( $post_id, $url );
+		wp_send_json_success();
+	}
+
+	/**
 	 * AJAX: Run AI deep analysis for a post's suggestions.
 	 */
 	public function ajax_deep_analysis(): void {
@@ -660,9 +791,6 @@ class SWPS_Internal_Links {
 
 		// Get current keyword-matched suggestions.
 		$suggested = $this->get_links( $post_id, 'suggested' );
-		if ( empty( $suggested ) ) {
-			wp_send_json_error( array( 'message' => 'No suggestions to analyze.' ) );
-		}
 
 		$candidates = array_map(
 			fn( $link ) => array(
@@ -672,14 +800,32 @@ class SWPS_Internal_Links {
 			$suggested
 		);
 
-		$result = $this->ai_engine->analyze( $post_id, $candidates );
+		// Cross-site candidates from owned/partner domains join the batch.
+		$cross_candidates = array();
+		if ( $this->cross_site->is_active() ) {
+			$threshold        = (float) get_option( 'swps_link_relevance_threshold', 0.3 );
+			$max              = (int) get_option( 'swps_link_max_suggestions', 10 );
+			$cross_candidates = $this->cross_site->find_candidates( $post_id, $threshold, $max );
+		}
+
+		if ( empty( $candidates ) && empty( $cross_candidates ) ) {
+			wp_send_json_error( array( 'message' => 'No suggestions to analyze.' ) );
+		}
+
+		$result = $this->ai_engine->analyze( $post_id, array_merge( $candidates, $cross_candidates ) );
 
 		if ( is_wp_error( $result ) ) {
 			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
 		}
 
-		// Update graph with AI results.
+		// Update graph with AI results; cross-site results go to post meta.
+		$cross_enriched = array();
 		foreach ( $result as $enriched ) {
+			if ( ! empty( $enriched['cross_site'] ) ) {
+				$cross_enriched[] = $enriched;
+				continue;
+			}
+
 			$this->upsert_link(
 				array(
 					'source_post_id'  => $post_id,
@@ -693,9 +839,18 @@ class SWPS_Internal_Links {
 			);
 		}
 
+		if ( ! empty( $cross_enriched ) ) {
+			$this->cross_site->store_ai_enrichment( $post_id, $cross_enriched );
+		}
+
 		// Return updated suggestions.
 		$updated = $this->get_links( $post_id, 'suggested' );
-		wp_send_json_success( array( 'suggestions' => $updated ) );
+		wp_send_json_success(
+			array(
+				'suggestions' => $updated,
+				'cross_site'  => $cross_enriched,
+			)
+		);
 	}
 
 	// -------------------------------------------------------------------------

--- a/includes/class-link-ai-engine.php
+++ b/includes/class-link-ai-engine.php
@@ -40,6 +40,22 @@ class SWPS_Link_AI_Engine {
 
 		$candidate_data = array();
 		foreach ( $candidates as $candidate ) {
+			// Cross-site candidates (owned/partner domains) have no local
+			// post ID — they're identified by URL and carry their own
+			// title/excerpt from the remote inventory.
+			if ( ! empty( $candidate['cross_site'] ) ) {
+				if ( empty( $candidate['url'] ) ) {
+					continue;
+				}
+				$candidate_data[] = array(
+					'url'        => (string) $candidate['url'],
+					'title'      => (string) ( $candidate['title'] ?? '' ),
+					'excerpt'    => (string) ( $candidate['excerpt'] ?? '' ),
+					'cross_site' => true,
+				);
+				continue;
+			}
+
 			$post = get_post( $candidate['post_id'] );
 			if ( ! $post ) {
 				continue;
@@ -66,6 +82,8 @@ You are an SEO internal linking specialist. Analyze the relationship between a s
 2. Suggested anchor text (2-6 words, natural phrasing that would fit in the source post)
 3. A one-line rationale explaining why these posts are related
 
+Candidates are identified by either a numeric "post_id" (same site) or a "url" with "cross_site": true (a partner site run by the same publisher). In each result, echo back exactly the identifier the candidate had: "post_id" for post_id candidates, "url" for url candidates.
+
 Respond with JSON only. No markdown fences.
 
 Required JSON structure:
@@ -75,6 +93,12 @@ Required JSON structure:
     "relevance_score": 0.85,
     "anchor_text": "suggested anchor text",
     "rationale": "Both posts discuss WordPress caching strategies"
+  },
+  {
+    "url": "https://partner-site.com/example-post/",
+    "relevance_score": 0.7,
+    "anchor_text": "suggested anchor text",
+    "rationale": "The partner post expands on this topic"
   }
 ]
 PROMPT;
@@ -114,17 +138,46 @@ PROMPT;
 			$analysis = $result['candidates'];
 		}
 
+		return self::parse_enriched_items( $analysis );
+	}
+
+	/**
+	 * Parse AI response items into enriched results.
+	 *
+	 * Local candidates are identified by post_id, cross-site candidates
+	 * (owned/partner domains) by url. Items missing an identifier or a
+	 * relevance score are skipped; scores are clamped to [0, 1].
+	 *
+	 * @param array $analysis Decoded AI response items.
+	 * @return array<int, array> Enriched results; cross-site entries carry
+	 *                           'url' and 'cross_site' => true.
+	 */
+	public static function parse_enriched_items( array $analysis ): array {
 		$enriched = array();
 		foreach ( $analysis as $item ) {
-			if ( ! isset( $item['post_id'], $item['relevance_score'] ) ) {
+			if ( ! is_array( $item ) || ! isset( $item['relevance_score'] ) ) {
 				continue;
 			}
-			$enriched[] = array(
-				'post_id'         => (int) $item['post_id'],
+
+			$base = array(
 				'relevance_score' => max( 0.0, min( 1.0, (float) $item['relevance_score'] ) ),
 				'anchor_text'     => sanitize_text_field( $item['anchor_text'] ?? '' ),
 				'rationale'       => sanitize_text_field( $item['rationale'] ?? '' ),
 			);
+
+			if ( isset( $item['post_id'] ) ) {
+				$enriched[] = array_merge(
+					array( 'post_id' => (int) $item['post_id'] ),
+					$base,
+					array( 'cross_site' => false )
+				);
+			} elseif ( ! empty( $item['url'] ) && is_string( $item['url'] ) ) {
+				$enriched[] = array_merge(
+					array( 'url' => $item['url'] ),
+					$base,
+					array( 'cross_site' => true )
+				);
+			}
 		}
 
 		return $enriched;

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -1207,6 +1207,30 @@ class SWPS_Settings {
 			)
 		);
 
+		// --- Cross-Site Linking Section ---
+		add_settings_section(
+			'swps_cross_site_section',
+			__( 'Cross-Site Linking', 'stratawp-seo' ),
+			array( $this, 'render_cross_site_section' ),
+			'stratawp-seo'
+		);
+
+		register_setting(
+			'stratawp-seo',
+			'swps_owned_domains',
+			array(
+				'sanitize_callback' => array( 'SWPS_Cross_Site_Links', 'sanitize_owned_domains' ),
+				'default'           => array(),
+			)
+		);
+		add_settings_field(
+			'swps_owned_domains',
+			__( 'Owned domains', 'stratawp-seo' ),
+			array( $this, 'render_owned_domains_field' ),
+			'stratawp-seo',
+			'swps_cross_site_section'
+		);
+
 		// Internal Links settings.
 		register_setting(
 			'swps_settings',
@@ -1525,6 +1549,29 @@ class SWPS_Settings {
 		echo '<p>' . esc_html__( 'Per-post SEO meta fields for titles, descriptions, social previews, and robots directives. Auto-disabled when Yoast, RankMath, or AIOSEO is active.', 'stratawp-seo' ) . '</p>';
 	}
 
+	/**
+	 * Render the Cross-Site Linking section description.
+	 */
+	public function render_cross_site_section(): void {
+		echo '<p>' . esc_html__( 'Suggest links between sites you own. Each domain\'s public posts are fetched over the WordPress REST API (cached daily) and offered as cross-site candidates in the Internal Links metabox.', 'stratawp-seo' ) . '</p>';
+	}
+
+	/**
+	 * Render the owned-domains textarea. The option is stored as an array
+	 * of normalized origins; the textarea shows one per line.
+	 */
+	public function render_owned_domains_field(): void {
+		$domains = get_option( 'swps_owned_domains', array() );
+		$value   = is_array( $domains ) ? implode( "\n", $domains ) : '';
+
+		printf(
+			'<textarea name="swps_owned_domains" class="large-text code" rows="4" placeholder="%s">%s</textarea>',
+			esc_attr( "partner-site.com\nhttps://another-site.com" ),
+			esc_textarea( $value )
+		);
+		echo '<p class="description">' . esc_html__( 'One domain per line. Only add sites you own or partner with — never third-party sites. Your own domain is ignored.', 'stratawp-seo' ) . '</p>';
+	}
+
 	public function render_analytics_section(): void {
 		echo '<p>' . esc_html__( 'On-site analytics tracking and Google Search Console integration.', 'stratawp-seo' ) . '</p>';
 	}
@@ -1684,6 +1731,7 @@ class SWPS_Settings {
 					'swps_audit_section',
 					'swps_schema_section',
 					'swps_meta_section',
+					'swps_cross_site_section',
 					'swps_cleanup_section',
 					'swps_rss_section',
 				),

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.24.2
+Stable tag: 4.25.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,13 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.25.0 =
+* New: Cross-Site Linking — configure owned/partner domains (Settings → SEO → Cross-Site Linking) and the internal-link engines suggest links to those sites' posts. Each domain's public post inventory is fetched over the WordPress REST API and cached daily.
+* New: cross-site suggestions appear in the Internal Links metabox with a domain badge, and Deep Analysis (AI) scores them alongside same-site candidates with suggested anchor text.
+* New: existing links to owned domains in post content are now detected and shown as cross-site links instead of being ignored by the link graph.
+* New: swps_canonical_url filter over the resolved canonical URL, so themes with custom pagination params can self-canonicalize paginated archives.
+* New: swps_meta_description filter over the resolved meta description.
 
 = 4.24.2 =
 * Fixed: on hosts whose firewall blocks URLs containing "shell" (a common webshell-scanner WAF rule), the admin shell stylesheet and script (shell.css / shell.js) were served as 403, collapsing the entire admin panel layout and killing the top-bar controls. The files are renamed to admin-ui.css / admin-ui.js so the URLs no longer trip those rules.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.24.2
+ * Version: 4.25.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.24.2' );
+define( 'SWPS_VERSION', '4.25.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -175,6 +175,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-sitemap-admin.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-post-list-seo.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-link-keyword-engine.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-link-ai-engine.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-cross-site-links.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-internal-links.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-internal-links-admin.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-ai-bots.php';
@@ -405,9 +406,11 @@ final class StrataWP_SEO {
 		if ( is_admin() ) {
 			$this->post_list_seo = new SWPS_Post_List_SEO( $this->content_scorer );
 		}
-		$link_keyword_engine        = new SWPS_Link_Keyword_Engine();
-		$link_ai_engine             = new SWPS_Link_AI_Engine( $this->api, $this->cost_tracker );
-		$this->internal_links       = new SWPS_Internal_Links( $link_keyword_engine, $link_ai_engine );
+		$link_keyword_engine = new SWPS_Link_Keyword_Engine();
+		$link_ai_engine      = new SWPS_Link_AI_Engine( $this->api, $this->cost_tracker );
+		$cross_site_links    = new SWPS_Cross_Site_Links();
+		$cross_site_links->register_hooks();
+		$this->internal_links       = new SWPS_Internal_Links( $link_keyword_engine, $link_ai_engine, $cross_site_links );
 		$this->internal_links_admin = new SWPS_Internal_Links_Admin( $this->internal_links );
 		$this->ai_bots              = new SWPS_AI_Bots();
 		$this->auto_optimize        = new SWPS_Auto_Optimize( $this->content_scorer );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,6 +27,11 @@ if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
     define( 'WEEK_IN_SECONDS', 604800 );
 }
 
+// wpdb result-format constants.
+if ( ! defined( 'ARRAY_A' ) ) {
+    define( 'ARRAY_A', 'ARRAY_A' );
+}
+
 if ( ! function_exists( 'wp_strip_all_tags' ) ) {
     function wp_strip_all_tags( $string, $remove_breaks = false ) {
         $string = preg_replace( '@<(script|style)[^>]*?>.*?</\\1>@si', '', (string) $string );

--- a/tests/unit/CrossSiteLinksTest.php
+++ b/tests/unit/CrossSiteLinksTest.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Unit tests for SWPS_Cross_Site_Links pure helpers.
+ *
+ * Covers origin normalization, the swps_owned_domains sanitizer, owned-URL
+ * matching, REST inventory parsing, and cross-site candidate scoring.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-link-keyword-engine.php';
+require_once __DIR__ . '/../../includes/class-cross-site-links.php';
+
+class CrossSiteLinksTest extends TestCase {
+
+	// ---------------------------------------------------------------------
+	// normalize_origin()
+	// ---------------------------------------------------------------------
+
+	public function test_bare_host_normalizes_to_https_origin(): void {
+		$this->assertSame( 'https://stratawpdev.com', SWPS_Cross_Site_Links::normalize_origin( 'stratawpdev.com' ) );
+	}
+
+	public function test_trailing_slash_and_whitespace_stripped(): void {
+		$this->assertSame( 'https://jonimms.com', SWPS_Cross_Site_Links::normalize_origin( ' https://jonimms.com/ ' ) );
+	}
+
+	public function test_path_and_query_stripped_scheme_preserved(): void {
+		$this->assertSame( 'http://example.org', SWPS_Cross_Site_Links::normalize_origin( 'http://example.org/path/page?x=1' ) );
+	}
+
+	public function test_port_preserved(): void {
+		$this->assertSame( 'https://example.org:8443', SWPS_Cross_Site_Links::normalize_origin( 'https://example.org:8443/x' ) );
+	}
+
+	public function test_host_lowercased(): void {
+		$this->assertSame( 'https://example.org', SWPS_Cross_Site_Links::normalize_origin( 'Example.ORG' ) );
+	}
+
+	public function test_non_http_scheme_rejected(): void {
+		$this->assertNull( SWPS_Cross_Site_Links::normalize_origin( 'ftp://example.org' ) );
+	}
+
+	public function test_empty_and_invalid_input_rejected(): void {
+		$this->assertNull( SWPS_Cross_Site_Links::normalize_origin( '' ) );
+		$this->assertNull( SWPS_Cross_Site_Links::normalize_origin( 'https://' ) );
+		$this->assertNull( SWPS_Cross_Site_Links::normalize_origin( 'not a url' ) );
+	}
+
+	// ---------------------------------------------------------------------
+	// sanitize_owned_domains()
+	// ---------------------------------------------------------------------
+
+	public function test_textarea_string_sanitizes_to_origin_list(): void {
+		$input = "stratawpdev.com\nhttps://jonimms.com/\n\nnot a url\n";
+		$this->assertSame(
+			array( 'https://stratawpdev.com', 'https://jonimms.com' ),
+			SWPS_Cross_Site_Links::sanitize_owned_domains( $input )
+		);
+	}
+
+	public function test_array_input_normalized_and_deduped(): void {
+		$this->assertSame(
+			array( 'https://example.org' ),
+			SWPS_Cross_Site_Links::sanitize_owned_domains( array( 'Example.ORG', 'https://example.org/path' ) )
+		);
+	}
+
+	public function test_non_string_non_array_input_returns_empty(): void {
+		$this->assertSame( array(), SWPS_Cross_Site_Links::sanitize_owned_domains( null ) );
+		$this->assertSame( array(), SWPS_Cross_Site_Links::sanitize_owned_domains( 42 ) );
+	}
+
+	// ---------------------------------------------------------------------
+	// url_matches_domains()
+	// ---------------------------------------------------------------------
+
+	public function test_url_on_owned_host_matches(): void {
+		$this->assertTrue(
+			SWPS_Cross_Site_Links::url_matches_domains( 'https://jonimms.com/post/abc/', array( 'https://jonimms.com' ) )
+		);
+	}
+
+	public function test_scheme_mismatch_still_matches(): void {
+		$this->assertTrue(
+			SWPS_Cross_Site_Links::url_matches_domains( 'http://jonimms.com/post/', array( 'https://jonimms.com' ) )
+		);
+	}
+
+	public function test_www_prefix_ignored_both_directions(): void {
+		$this->assertTrue(
+			SWPS_Cross_Site_Links::url_matches_domains( 'https://www.jonimms.com/x/', array( 'https://jonimms.com' ) )
+		);
+		$this->assertTrue(
+			SWPS_Cross_Site_Links::url_matches_domains( 'https://jonimms.com/x/', array( 'https://www.jonimms.com' ) )
+		);
+	}
+
+	public function test_subdomain_does_not_match(): void {
+		$this->assertFalse(
+			SWPS_Cross_Site_Links::url_matches_domains( 'https://blog.jonimms.com/x/', array( 'https://jonimms.com' ) )
+		);
+	}
+
+	public function test_other_host_does_not_match(): void {
+		$this->assertFalse(
+			SWPS_Cross_Site_Links::url_matches_domains( 'https://google.com/x', array( 'https://jonimms.com' ) )
+		);
+	}
+
+	public function test_port_must_match(): void {
+		$this->assertTrue(
+			SWPS_Cross_Site_Links::url_matches_domains( 'https://example.org:8443/x', array( 'https://example.org:8443' ) )
+		);
+		$this->assertFalse(
+			SWPS_Cross_Site_Links::url_matches_domains( 'https://example.org/x', array( 'https://example.org:8443' ) )
+		);
+	}
+
+	public function test_relative_url_and_empty_list_do_not_match(): void {
+		$this->assertFalse( SWPS_Cross_Site_Links::url_matches_domains( '/about/', array( 'https://jonimms.com' ) ) );
+		$this->assertFalse( SWPS_Cross_Site_Links::url_matches_domains( 'https://jonimms.com/x', array() ) );
+	}
+
+	public function test_protocol_relative_url_matches_by_host(): void {
+		$this->assertTrue(
+			SWPS_Cross_Site_Links::url_matches_domains( '//jonimms.com/post/', array( 'https://jonimms.com' ) )
+		);
+	}
+
+	// ---------------------------------------------------------------------
+	// parse_inventory_response()
+	// ---------------------------------------------------------------------
+
+	public function test_valid_rest_response_parsed_to_inventory_items(): void {
+		$body = wp_json_encode_test_helper(
+			array(
+				array(
+					'title'   => array( 'rendered' => 'Hello &amp; World' ),
+					'link'    => 'https://jonimms.com/hello/',
+					'excerpt' => array( 'rendered' => '<p>Some <b>excerpt</b> &amp; more</p>' ),
+				),
+				array( 'title' => array( 'rendered' => 'No link item' ) ),
+				'garbage',
+			)
+		);
+
+		$items = SWPS_Cross_Site_Links::parse_inventory_response( $body, 'https://jonimms.com' );
+
+		$this->assertCount( 1, $items );
+		$this->assertSame(
+			array(
+				'url'     => 'https://jonimms.com/hello/',
+				'title'   => 'Hello & World',
+				'excerpt' => 'Some excerpt & more',
+				'domain'  => 'https://jonimms.com',
+			),
+			$items[0]
+		);
+	}
+
+	public function test_invalid_json_returns_empty(): void {
+		$this->assertSame( array(), SWPS_Cross_Site_Links::parse_inventory_response( 'not json', 'https://jonimms.com' ) );
+	}
+
+	public function test_rest_error_object_returns_empty(): void {
+		$body = '{"code":"rest_forbidden","message":"nope"}';
+		$this->assertSame( array(), SWPS_Cross_Site_Links::parse_inventory_response( $body, 'https://jonimms.com' ) );
+	}
+
+	// ---------------------------------------------------------------------
+	// score_candidates()
+	// ---------------------------------------------------------------------
+
+	private function tokenizer(): callable {
+		return array( new SWPS_Link_Keyword_Engine(), 'tokenize_public' );
+	}
+
+	private function sample_inventory(): array {
+		return array(
+			array(
+				'url'     => 'https://jonimms.com/caching/',
+				'title'   => 'WordPress caching guide',
+				'excerpt' => 'Speed things up.',
+				'domain'  => 'https://jonimms.com',
+			),
+			array(
+				'url'     => 'https://jonimms.com/garden/',
+				'title'   => 'Gardening tips',
+				'excerpt' => 'A wordpress aside',
+				'domain'  => 'https://jonimms.com',
+			),
+			array(
+				'url'     => 'https://jonimms.com/pasta/',
+				'title'   => 'Cooking pasta',
+				'excerpt' => 'Boil water.',
+				'domain'  => 'https://jonimms.com',
+			),
+		);
+	}
+
+	public function test_scores_normalized_and_thresholded(): void {
+		$terms = array(
+			'wordpress' => 1.0,
+			'caching'   => 0.9,
+		);
+
+		$results = SWPS_Cross_Site_Links::score_candidates( $terms, $this->sample_inventory(), $this->tokenizer(), 0.3, 10 );
+
+		$this->assertCount( 1, $results );
+		$this->assertSame( 'https://jonimms.com/caching/', $results[0]['url'] );
+		$this->assertSame( 1.0, $results[0]['score'] );
+		$this->assertTrue( $results[0]['cross_site'] );
+		$this->assertSame( 'WordPress caching guide', $results[0]['title'] );
+		$this->assertSame( 'https://jonimms.com', $results[0]['domain'] );
+	}
+
+	public function test_excerpt_matches_weighted_lower_and_ordering_desc(): void {
+		$terms = array(
+			'wordpress' => 1.0,
+			'caching'   => 0.9,
+		);
+
+		$results = SWPS_Cross_Site_Links::score_candidates( $terms, $this->sample_inventory(), $this->tokenizer(), 0.1, 10 );
+
+		$this->assertCount( 2, $results );
+		$this->assertSame( 'https://jonimms.com/caching/', $results[0]['url'] );
+		$this->assertSame( 'https://jonimms.com/garden/', $results[1]['url'] );
+		// Raw: caching post = 1.0*1.0 + 0.9*1.0 = 1.9; garden = 1.0*0.3 (excerpt) = 0.3.
+		$this->assertSame( round( 0.3 / 1.9, 3 ), $results[1]['score'] );
+	}
+
+	public function test_limit_applied_after_ordering(): void {
+		$terms = array(
+			'wordpress' => 1.0,
+			'caching'   => 0.9,
+		);
+
+		$results = SWPS_Cross_Site_Links::score_candidates( $terms, $this->sample_inventory(), $this->tokenizer(), 0.1, 1 );
+
+		$this->assertCount( 1, $results );
+		$this->assertSame( 'https://jonimms.com/caching/', $results[0]['url'] );
+	}
+
+	public function test_excluded_urls_skipped_before_normalization(): void {
+		$terms = array(
+			'wordpress' => 1.0,
+			'caching'   => 0.9,
+		);
+
+		$results = SWPS_Cross_Site_Links::score_candidates(
+			$terms,
+			$this->sample_inventory(),
+			$this->tokenizer(),
+			0.3,
+			10,
+			array( 'https://jonimms.com/caching/' )
+		);
+
+		$this->assertCount( 1, $results );
+		$this->assertSame( 'https://jonimms.com/garden/', $results[0]['url'] );
+		$this->assertSame( 1.0, $results[0]['score'] );
+	}
+
+	public function test_empty_terms_or_inventory_return_empty(): void {
+		$this->assertSame( array(), SWPS_Cross_Site_Links::score_candidates( array(), $this->sample_inventory(), $this->tokenizer() ) );
+		$this->assertSame( array(), SWPS_Cross_Site_Links::score_candidates( array( 'x' => 1.0 ), array(), $this->tokenizer() ) );
+	}
+}
+
+/**
+ * json_encode helper so the test reads clearly (wp_json_encode is a WP function).
+ *
+ * @param mixed $data Data to encode.
+ * @return string JSON.
+ */
+function wp_json_encode_test_helper( $data ): string {
+	return (string) json_encode( $data ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+}

--- a/tests/unit/InternalLinksDetectTest.php
+++ b/tests/unit/InternalLinksDetectTest.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Unit tests for SWPS_Internal_Links::detect_existing_links() — the
+ * same-host filter relaxation for owned/partner domains.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( ...$args ) {}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( ...$args ) {}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default_value = false ) {
+		return $GLOBALS['swps_test_options'][ $option ] ?? $default_value;
+	}
+}
+if ( ! function_exists( 'home_url' ) ) {
+	function home_url( $path = '' ) {
+		return 'https://example.com' . $path;
+	}
+}
+if ( ! function_exists( 'url_to_postid' ) ) {
+	function url_to_postid( $url ) {
+		return $GLOBALS['swps_test_url_map'][ $url ] ?? 0;
+	}
+}
+if ( ! function_exists( 'current_time' ) ) {
+	function current_time( $type ) {
+		return '2026-07-25 00:00:00';
+	}
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $str ) {
+		return trim( strip_tags( (string) $str ) );
+	}
+}
+if ( ! function_exists( 'get_post_meta' ) ) {
+	function get_post_meta( $id, $key = '', $single = false ) {
+		return $GLOBALS['swps_test_postmeta'][ $id ][ $key ] ?? '';
+	}
+}
+if ( ! function_exists( 'update_post_meta' ) ) {
+	function update_post_meta( $id, $key, $value ) {
+		$GLOBALS['swps_test_postmeta'][ $id ][ $key ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'delete_post_meta' ) ) {
+	function delete_post_meta( $id, $key ) {
+		unset( $GLOBALS['swps_test_postmeta'][ $id ][ $key ] );
+		return true;
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-link-keyword-engine.php';
+require_once __DIR__ . '/../../includes/class-link-ai-engine.php';
+require_once __DIR__ . '/../../includes/class-cross-site-links.php';
+require_once __DIR__ . '/../../includes/class-internal-links.php';
+
+if ( ! class_exists( 'SWPS_Test_WPDB' ) ) {
+	/**
+	 * Minimal wpdb double: records inserts, returns no existing rows.
+	 */
+	class SWPS_Test_WPDB {
+		public $prefix  = 'wp_';
+		public $inserts = array();
+
+		public function prepare( $query, ...$args ) {
+			return $query;
+		}
+		public function get_row( ...$args ) {
+			return null;
+		}
+		public function get_results( ...$args ) {
+			return array();
+		}
+		public function insert( $table, $data, $format = null ) {
+			$this->inserts[] = array(
+				'table' => $table,
+				'data'  => $data,
+			);
+			return 1;
+		}
+		public function update( ...$args ) {
+			return 1;
+		}
+		public function delete( ...$args ) {
+			return 1;
+		}
+		public function query( ...$args ) {
+			return 1;
+		}
+	}
+}
+
+class InternalLinksDetectTest extends TestCase {
+
+	private SWPS_Test_WPDB $wpdb;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$GLOBALS['swps_test_options']  = array();
+		$GLOBALS['swps_test_postmeta'] = array();
+		$GLOBALS['swps_test_url_map']  = array();
+		$this->wpdb                    = new SWPS_Test_WPDB();
+		$GLOBALS['wpdb']               = $this->wpdb;
+	}
+
+	private function make_engine(): SWPS_Internal_Links {
+		$api  = $this->getMockBuilder( SWPS_AI_Provider::class )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+		$cost = $this->getMockBuilder( SWPS_Cost_Tracker::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		return new SWPS_Internal_Links(
+			new SWPS_Link_Keyword_Engine(),
+			new SWPS_Link_AI_Engine( $api, $cost )
+		);
+	}
+
+	public function test_same_site_absolute_href_recorded_in_graph(): void {
+		$GLOBALS['swps_test_url_map']['https://example.com/about/'] = 42;
+
+		$this->make_engine()->detect_existing_links( 5, '<p>See <a href="https://example.com/about/">About us</a> now.</p>' );
+
+		$this->assertCount( 1, $this->wpdb->inserts );
+		$data = $this->wpdb->inserts[0]['data'];
+		$this->assertSame( 5, $data['source_post_id'] );
+		$this->assertSame( 42, $data['target_post_id'] );
+		$this->assertSame( 'existing', $data['status'] );
+		$this->assertSame( 'About us', $data['anchor_text'] );
+	}
+
+	public function test_relative_href_recorded_in_graph(): void {
+		$GLOBALS['swps_test_url_map']['/services/'] = 7;
+
+		$this->make_engine()->detect_existing_links( 5, "<a href='/services/'>Services</a>" );
+
+		$this->assertCount( 1, $this->wpdb->inserts );
+		$this->assertSame( 7, $this->wpdb->inserts[0]['data']['target_post_id'] );
+	}
+
+	public function test_foreign_href_still_skipped(): void {
+		$this->make_engine()->detect_existing_links( 5, '<a href="https://google.com/search">Google</a>' );
+
+		$this->assertSame( array(), $this->wpdb->inserts );
+		$this->assertArrayNotHasKey( 5, $GLOBALS['swps_test_postmeta'] );
+	}
+
+	public function test_owned_domain_href_recorded_as_cross_site_not_graph(): void {
+		$GLOBALS['swps_test_options']['swps_owned_domains'] = array( 'https://jonimms.com' );
+
+		$this->make_engine()->detect_existing_links( 5, '<a href="https://jonimms.com/post/hello-world/">my post</a>' );
+
+		$this->assertSame( array(), $this->wpdb->inserts );
+		$this->assertSame(
+			array(
+				array(
+					'url'    => 'https://jonimms.com/post/hello-world/',
+					'anchor' => 'my post',
+				),
+			),
+			$GLOBALS['swps_test_postmeta'][5]['_swps_cross_site_existing']
+		);
+	}
+
+	public function test_mixed_content_splits_between_graph_and_cross_site_meta(): void {
+		$GLOBALS['swps_test_options']['swps_owned_domains']         = array( 'https://jonimms.com' );
+		$GLOBALS['swps_test_url_map']['https://example.com/about/'] = 42;
+
+		$content  = '<a href="https://example.com/about/">About</a>';
+		$content .= '<a href="https://jonimms.com/other/">partner</a>';
+		$content .= '<a href="https://google.com/x">skip me</a>';
+
+		$this->make_engine()->detect_existing_links( 5, $content );
+
+		$this->assertCount( 1, $this->wpdb->inserts );
+		$this->assertSame( 42, $this->wpdb->inserts[0]['data']['target_post_id'] );
+		$this->assertCount( 1, $GLOBALS['swps_test_postmeta'][5]['_swps_cross_site_existing'] );
+		$this->assertSame( 'https://jonimms.com/other/', $GLOBALS['swps_test_postmeta'][5]['_swps_cross_site_existing'][0]['url'] );
+	}
+
+	public function test_stale_cross_site_meta_cleared_when_links_removed(): void {
+		$GLOBALS['swps_test_options']['swps_owned_domains'] = array( 'https://jonimms.com' );
+		$GLOBALS['swps_test_postmeta'][5]['_swps_cross_site_existing'] = array(
+			array(
+				'url'    => 'https://jonimms.com/old/',
+				'anchor' => 'old link',
+			),
+		);
+
+		$this->make_engine()->detect_existing_links( 5, '<p>No links here anymore.</p>' );
+
+		$this->assertArrayNotHasKey( '_swps_cross_site_existing', $GLOBALS['swps_test_postmeta'][5] ?? array() );
+	}
+}

--- a/tests/unit/LinkAiEngineParseTest.php
+++ b/tests/unit/LinkAiEngineParseTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Unit tests for SWPS_Link_AI_Engine::parse_enriched_items() — mixed
+ * local (post_id) and cross-site (url) candidate parsing.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $str ) {
+		return trim( strip_tags( (string) $str ) );
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-link-ai-engine.php';
+
+class LinkAiEngineParseTest extends TestCase {
+
+	public function test_local_item_parsed_with_clamped_score(): void {
+		$items = SWPS_Link_AI_Engine::parse_enriched_items(
+			array(
+				array(
+					'post_id'         => 7,
+					'relevance_score' => 1.7,
+					'anchor_text'     => '<b>great anchor</b>',
+					'rationale'       => 'Both cover caching.',
+				),
+			)
+		);
+
+		$this->assertCount( 1, $items );
+		$this->assertSame( 7, $items[0]['post_id'] );
+		$this->assertSame( 1.0, $items[0]['relevance_score'] );
+		$this->assertSame( 'great anchor', $items[0]['anchor_text'] );
+		$this->assertFalse( $items[0]['cross_site'] );
+	}
+
+	public function test_cross_site_item_parsed_by_url(): void {
+		$items = SWPS_Link_AI_Engine::parse_enriched_items(
+			array(
+				array(
+					'url'             => 'https://jonimms.com/a/',
+					'relevance_score' => -0.5,
+					'anchor_text'     => 'partner post',
+					'rationale'       => 'Related topic.',
+				),
+			)
+		);
+
+		$this->assertCount( 1, $items );
+		$this->assertSame( 'https://jonimms.com/a/', $items[0]['url'] );
+		$this->assertSame( 0.0, $items[0]['relevance_score'] );
+		$this->assertTrue( $items[0]['cross_site'] );
+		$this->assertArrayNotHasKey( 'post_id', $items[0] );
+	}
+
+	public function test_items_without_identifier_or_score_skipped(): void {
+		$items = SWPS_Link_AI_Engine::parse_enriched_items(
+			array(
+				array( 'relevance_score' => 0.9 ),
+				array( 'post_id' => 3 ),
+				array( 'url' => 'https://jonimms.com/b/' ),
+				'garbage',
+			)
+		);
+
+		$this->assertSame( array(), $items );
+	}
+
+	public function test_mixed_items_preserve_order(): void {
+		$items = SWPS_Link_AI_Engine::parse_enriched_items(
+			array(
+				array(
+					'post_id'         => 3,
+					'relevance_score' => 0.4,
+				),
+				array(
+					'url'             => 'https://jonimms.com/c/',
+					'relevance_score' => 0.8,
+				),
+			)
+		);
+
+		$this->assertCount( 2, $items );
+		$this->assertSame( 3, $items[0]['post_id'] );
+		$this->assertSame( 'https://jonimms.com/c/', $items[1]['url'] );
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **Cross-Site Linking** setting (Settings → SEO) where owned/partner domains can be configured (e.g. stratawpdev.com ↔ jonimms.com). The internal-link engines then suggest links to those sites' posts alongside same-site suggestions.

- **New `SWPS_Cross_Site_Links`** — `swps_owned_domains` option (textarea, stored as normalized origins; own host excluded; `www.`/scheme-insensitive matching, exact host + port). Each domain's public posts are fetched via `/wp-json/wp/v2/posts?_fields=title,link,excerpt` and cached in a daily transient (hourly backoff on failure, flushed on option change). Inventory is scored against the source post's indexed terms mirroring the keyword engine's weighting (title 1.0 / excerpt 0.3, normalized + thresholded).
- **Graph design** — cross-site targets have no local post ID, so they deliberately never enter `swps_link_graph` (no schema migration). Per-post state (existing / dismissed / inserted / AI enrichment) lives in post meta.
- **Same-host filter relaxed** — `detect_existing_links()` records owned-domain hrefs as cross-site links instead of dropping them; unknown third-party hrefs are still skipped.
- **AI engine** — `analyze()` accepts url-identified cross-site candidates next to `post_id` candidates; the prompt instructs the model to echo back whichever identifier each candidate had, and enrichment is stored per URL.
- **UI** — metabox badges cross-site rows with the domain; insert/dismiss branch to new URL-based AJAX endpoints (`swps_link_cross_insert` / `swps_link_cross_dismiss`, nonce + capability + owned-URL validated).

Also ships the two filters already on main since 4.24.2 (`swps_canonical_url`, `swps_meta_description`) — changelogged under 4.25.0.

## Testing

- 36 new pure-PHP unit tests (origin normalization/sanitizer/URL matching/inventory parsing/scoring, the detect-filter change against a fake `$wpdb`, AI response parsing). Full suite: **549 tests / 997 assertions green**.
- PHPStan level 5 clean, no baseline additions. phpcs: new file 0 errors; touched files at-or-below main's per-file counts.
- Headless smoke on a real WP install: live inventory fetch from jonimms.com (100 posts), owned-domain link detection, and keyword-scored cross-site candidates verified end-to-end.