### PR TITLE
Fix site-crawl false positives that zeroed the audit score (4.25.1)

### DIFF
--- a/includes/audit/class-site-crawl-module.php
+++ b/includes/audit/class-site-crawl-module.php
@@ -92,6 +92,11 @@ class SWPS_Site_Crawl_Module extends SWPS_Audit_Module {
 		$errors = 0;
 		$issues = array();
 
+		// Prefer the stored severity split (present since 4.25.1): the crawler
+		// already downgrades external bot-walls etc. to warnings, and those
+		// must not cost error-level points.
+		$severity_counts = (array) ( $summary['severity_counts'] ?? array() );
+
 		$labels = array(
 			'broken_link'        => __( 'broken links', 'stratawp-seo' ),
 			'redirect_chain'     => __( 'redirect chains', 'stratawp-seo' ),
@@ -125,8 +130,12 @@ class SWPS_Site_Crawl_Module extends SWPS_Audit_Module {
 			);
 		}
 
-		// Score: start at 100, broken links cost 10 each, other issues 2 each
-		// (capped at 0). Mirrors the severity split used by the crawler.
+		// Score: start at 100, error-severity issues cost 10 each, warnings 2
+		// each (capped at 0). Legacy summaries without a severity split fall
+		// back to counting broken links + redirect loops as errors by type.
+		if ( array() !== $severity_counts ) {
+			$errors = (int) ( $severity_counts['error'] ?? 0 );
+		}
 		$others = max( 0, $total - $errors );
 		$score  = max( 0, 100 - ( $errors * 10 ) - ( $others * 2 ) );
 

--- a/includes/class-crawl-issues.php
+++ b/includes/class-crawl-issues.php
@@ -241,6 +241,41 @@ class SWPS_Crawl_Issues {
 	}
 
 	/**
+	 * Return issue counts grouped by severity for the given run.
+	 *
+	 * @param int $run_id Target run ID.
+	 * @return array{error:int,warning:int}
+	 */
+	public static function severity_counts( int $run_id ): array {
+		global $wpdb;
+
+		$table = $wpdb->prefix . self::TABLE_ISSUES;
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$rows = (array) $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT severity, COUNT(*) AS cnt FROM {$table} WHERE run_id = %d GROUP BY severity",
+				$run_id
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$counts = array(
+			'error'   => 0,
+			'warning' => 0,
+		);
+		foreach ( $rows as $row ) {
+			$severity = (string) ( $row['severity'] ?? '' );
+			if ( isset( $counts[ $severity ] ) ) {
+				$counts[ $severity ] = (int) $row['cnt'];
+			}
+		}
+
+		return $counts;
+	}
+
+	/**
 	 * Return all issue rows for a run, detail JSON decoded, grouped by type.
 	 *
 	 * Each row gains an 'is_new' flag: true when first_seen_run equals the

--- a/includes/class-site-crawler.php
+++ b/includes/class-site-crawler.php
@@ -191,6 +191,71 @@ class SWPS_Site_Crawler {
 	}
 
 	/**
+	 * Resolve a potentially relative href/src/Location value to an absolute URL.
+	 *
+	 * Only http(s) targets are resolvable: any other scheme (mailto:, tel:,
+	 * javascript:, data:, ftp:, …) returns '' — resolving those as relative
+	 * paths would fabricate URLs like /blog/mailto:user@host that 404.
+	 *
+	 * @param string $href     Raw attribute or header value.
+	 * @param string $base_url Absolute URL the value was found on.
+	 * @return string Absolute URL, or '' when non-resolvable.
+	 */
+	public static function resolve_url( string $href, string $base_url ): string {
+		$href = trim( $href );
+		if ( '' === $href || str_starts_with( $href, '#' ) ) {
+			return '';
+		}
+
+		// Already absolute.
+		if ( preg_match( '/^https?:\/\//i', $href ) ) {
+			return $href;
+		}
+
+		$base_parts = wp_parse_url( $base_url );
+		if ( ! is_array( $base_parts ) ) {
+			return '';
+		}
+
+		// Protocol-relative.
+		if ( str_starts_with( $href, '//' ) ) {
+			return ( $base_parts['scheme'] ?? 'https' ) . ':' . $href;
+		}
+
+		// Any other scheme is not crawlable.
+		if ( preg_match( '/^[a-z][a-z0-9+.\-]*:/i', $href ) ) {
+			return '';
+		}
+
+		$scheme = $base_parts['scheme'] ?? 'https';
+		$host   = $base_parts['host'] ?? '';
+
+		// Root-relative.
+		if ( str_starts_with( $href, '/' ) ) {
+			return $scheme . '://' . $host . $href;
+		}
+
+		// Relative: resolve against the base path directory.
+		$base_dir = isset( $base_parts['path'] )
+			? rtrim( dirname( $base_parts['path'] ), '/' )
+			: '';
+
+		// Walk ../ segments.
+		$path     = $base_dir . '/' . $href;
+		$segments = explode( '/', $path );
+		$resolved = array();
+		foreach ( $segments as $seg ) {
+			if ( '..' === $seg ) {
+				array_pop( $resolved );
+			} elseif ( '.' !== $seg ) {
+				$resolved[] = $seg;
+			}
+		}
+
+		return $scheme . '://' . $host . implode( '/', $resolved );
+	}
+
+	/**
 	 * Extract candidate links, assets, and meta signals from an HTML string.
 	 *
 	 * Uses DOMDocument with libxml_use_internal_errors so malformed HTML is
@@ -220,56 +285,8 @@ class SWPS_Site_Crawler {
 		libxml_clear_errors();
 		libxml_use_internal_errors( $prev );
 
-		$base_parts = wp_parse_url( $base_url );
-
-		/**
-		 * Resolve a potentially relative href/src to an absolute URL.
-		 *
-		 * @param string $href Raw value from the attribute.
-		 * @return string Absolute URL, or '' when non-resolvable.
-		 */
-		$resolve = static function ( string $href ) use ( $base_parts ): string {
-			$href = trim( $href );
-			if ( '' === $href || str_starts_with( $href, '#' ) ) {
-				return '';
-			}
-
-			// Already absolute.
-			if ( preg_match( '/^https?:\/\//i', $href ) ) {
-				return $href;
-			}
-
-			// Protocol-relative.
-			if ( str_starts_with( $href, '//' ) ) {
-				return ( $base_parts['scheme'] ?? 'https' ) . ':' . $href;
-			}
-
-			$scheme = $base_parts['scheme'] ?? 'https';
-			$host   = $base_parts['host'] ?? '';
-
-			// Root-relative.
-			if ( str_starts_with( $href, '/' ) ) {
-				return $scheme . '://' . $host . $href;
-			}
-
-			// Relative: resolve against the base path directory.
-			$base_dir = isset( $base_parts['path'] )
-				? rtrim( dirname( $base_parts['path'] ), '/' )
-				: '';
-
-			// Walk ../ segments.
-			$path     = $base_dir . '/' . $href;
-			$segments = explode( '/', $path );
-			$resolved = array();
-			foreach ( $segments as $seg ) {
-				if ( '..' === $seg ) {
-					array_pop( $resolved );
-				} elseif ( '.' !== $seg ) {
-					$resolved[] = $seg;
-				}
-			}
-
-			return $scheme . '://' . $host . implode( '/', $resolved );
+		$resolve = static function ( string $href ) use ( $base_url ): string {
+			return self::resolve_url( $href, $base_url );
 		};
 
 		// <a href>.
@@ -343,7 +360,8 @@ class SWPS_Site_Crawler {
 	 * Classify a fetched URL result into issue rows.
 	 *
 	 * @param array  $fetch     Fetch result: keys url (string), status (int), found_on (string),
-	 *                          hops (array of 3xx responses), loop (bool, MAX_HOPS exceeded).
+	 *                          hops (array of 3xx responses), loop (bool, MAX_HOPS exceeded),
+	 *                          final_url (string, post-redirect URL; falls back to url).
 	 * @param array  $page      Result of parse_html() on the response body. The caller may
 	 *                          enrich it with post_id (int) and sitemap_excluded (bool) for
 	 *                          the noindex-in-sitemap check (pure callers pass fixtures).
@@ -401,10 +419,13 @@ class SWPS_Site_Crawler {
 		}
 
 		// Canonical mismatch: page declares a canonical that differs from the
-		// fetched URL (after normalisation).
+		// URL that actually served the response (after normalisation). Using
+		// the post-redirect URL matters: a link that 301s to a page with a
+		// correct self-canonical is the redirect working, not a mismatch.
 		$canonical = $page['canonical'] ?? null;
 		if ( null !== $canonical ) {
-			$norm_fetched = self::normalize_url( $url, $home_host );
+			$final_url    = (string) ( $fetch['final_url'] ?? $url );
+			$norm_fetched = self::normalize_url( $final_url, $home_host );
 			$norm_canon   = self::normalize_url( $canonical, $home_host );
 			if ( '' !== $norm_fetched && '' !== $norm_canon && $norm_fetched !== $norm_canon ) {
 				$issues[] = array(
@@ -590,8 +611,8 @@ class SWPS_Site_Crawler {
 		 *
 		 * @param int $delay_us Microseconds to sleep between fetches.
 		 */
-		$delay_us = max( 0, (int) apply_filters( 'swps_crawl_delay_us', (int) ( $state['delay_us'] ?? self::DEFAULT_DELAY_US ) ) );
-		$queue_table  = $wpdb->prefix . SWPS_Crawl_Issues::TABLE_QUEUE;
+		$delay_us    = max( 0, (int) apply_filters( 'swps_crawl_delay_us', (int) ( $state['delay_us'] ?? self::DEFAULT_DELAY_US ) ) );
+		$queue_table = $wpdb->prefix . SWPS_Crawl_Issues::TABLE_QUEUE;
 
 		// Fetch next $n pending items.
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -639,7 +660,9 @@ class SWPS_Site_Crawler {
 			);
 
 			if ( ! empty( $fetch['body'] ) && $fetch['status'] < 400 ) {
-				$page = self::parse_html( $fetch['body'], $url );
+				// Parse against the post-redirect URL so relative hrefs on a
+				// redirect destination resolve against the right base.
+				$page = self::parse_html( $fetch['body'], (string) ( $fetch['final_url'] ?? $url ) );
 			}
 
 			// Enrich with WP lookups for the noindex-in-sitemap check
@@ -741,11 +764,13 @@ class SWPS_Site_Crawler {
 	 *
 	 * The returned 'hops' array contains every 3xx response observed (one
 	 * entry per redirect, {url, status}); the final non-3xx response is NOT
-	 * included. 'loop' is true when MAX_HOPS was exceeded without reaching a
-	 * non-3xx response.
+	 * included. 'final_url' is the URL that produced the final response (equal
+	 * to 'url' when no redirect occurred). 'loop' is true only when MAX_HOPS
+	 * was exceeded without reaching a non-3xx response; a 3xx with a missing
+	 * or unresolvable Location header returns status 0 (dead redirect).
 	 *
 	 * @param string $url Starting URL.
-	 * @return array{url:string,status:int,body:string,found_on:string,hops:array,loop:bool}
+	 * @return array{url:string,status:int,body:string,found_on:string,hops:array,loop:bool,final_url:string}
 	 */
 	private function fetch_url( string $url ): array {
 		$hops    = array();
@@ -764,12 +789,13 @@ class SWPS_Site_Crawler {
 
 			if ( is_wp_error( $response ) ) {
 				return array(
-					'url'      => $url,
-					'status'   => 0,
-					'body'     => '',
-					'found_on' => '',
-					'hops'     => $hops,
-					'loop'     => false,
+					'url'       => $url,
+					'status'    => 0,
+					'body'      => '',
+					'found_on'  => '',
+					'hops'      => $hops,
+					'loop'      => false,
+					'final_url' => $current,
 				);
 			}
 
@@ -777,15 +803,25 @@ class SWPS_Site_Crawler {
 
 			if ( $status >= 300 && $status < 400 ) {
 				$location = wp_remote_retrieve_header( $response, 'location' );
-				if ( empty( $location ) ) {
-					// Redirect with no Location header — dead end.
-					break;
+				// RFC 7231 allows relative Location values; resolve against
+				// the URL that answered. Missing/unresolvable = dead redirect.
+				$next = is_string( $location ) ? self::resolve_url( $location, $current ) : '';
+				if ( '' === $next ) {
+					return array(
+						'url'       => $url,
+						'status'    => 0,
+						'body'      => '',
+						'found_on'  => '',
+						'hops'      => $hops,
+						'loop'      => false,
+						'final_url' => $current,
+					);
 				}
 				$hops[]  = array(
 					'url'    => $current,
 					'status' => $status,
 				);
-				$current = $location;
+				$current = $next;
 				continue;
 			}
 
@@ -795,23 +831,25 @@ class SWPS_Site_Crawler {
 			}
 
 			return array(
-				'url'      => $url,
-				'status'   => $status,
-				'body'     => $body,
-				'found_on' => '',
-				'hops'     => $hops,
-				'loop'     => false,
+				'url'       => $url,
+				'status'    => $status,
+				'body'      => $body,
+				'found_on'  => '',
+				'hops'      => $hops,
+				'loop'      => false,
+				'final_url' => $current,
 			);
 		}
 
-		// Exceeded MAX_HOPS (or 3xx without Location) — redirect loop.
+		// Exceeded MAX_HOPS — redirect loop.
 		return array(
-			'url'      => $url,
-			'status'   => 0,
-			'body'     => '',
-			'found_on' => '',
-			'hops'     => $hops,
-			'loop'     => true,
+			'url'       => $url,
+			'status'    => 0,
+			'body'      => '',
+			'found_on'  => '',
+			'hops'      => $hops,
+			'loop'      => true,
+			'final_url' => $current,
 		);
 	}
 
@@ -923,6 +961,7 @@ class SWPS_Site_Crawler {
 			'completed_at'     => gmdate( 'Y-m-d H:i:s' ),
 			'crawled'          => SWPS_Crawl_Issues::crawled_count( $run_id ),
 			'issue_counts'     => SWPS_Crawl_Issues::issue_counts( $run_id ),
+			'severity_counts'  => SWPS_Crawl_Issues::severity_counts( $run_id ),
 			'external_checked' => (int) ( $state['external_checked'] ?? 0 ),
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.25.0
+Stable tag: 4.25.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,13 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.25.1 =
+* Fixed: the site crawler resolved mailto:/tel:/javascript: hrefs as relative paths, fabricating internal URLs (e.g. /blog/mailto:user@host) that were then reported as broken links. Non-http(s) schemes are now skipped.
+* Fixed: redirects answering with a relative Location header (allowed by RFC 7231) failed the follow-up fetch and were reported as broken links with no status. Relative Location values are now resolved against the redirecting URL.
+* Fixed: canonical mismatches were evaluated against the pre-redirect URL, so every internal link that 301s to a correctly self-canonicalized page was flagged. The canonical is now compared against the URL that actually served the response.
+* Fixed: a 3xx response with no Location header was misreported as a redirect loop; it is now reported as a broken (dead) redirect. Redirect-destination HTML is also parsed against the post-redirect URL so its relative links resolve correctly.
+* Fixed: the Site Crawl audit score charged error-level points (10) for warning-severity issues, including external links behind bot-walls (e.g. LinkedIn's HTTP 999). The score now follows the crawler's own severity split: errors cost 10, warnings 2.
 
 = 4.25.0 =
 * New: Cross-Site Linking — configure owned/partner domains (Settings → SEO → Cross-Site Linking) and the internal-link engines suggest links to those sites' posts. Each domain's public post inventory is fetched over the WordPress REST API and cached daily.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.25.0
+ * Version: 4.25.1
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.25.0' );
+define( 'SWPS_VERSION', '4.25.1' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/tests/unit/SiteCrawlerTest.php
+++ b/tests/unit/SiteCrawlerTest.php
@@ -338,4 +338,105 @@ class SiteCrawlerTest extends TestCase {
 		$types = array_column( $rows, 'type' );
 		$this->assertNotContains( 'noindex_in_sitemap', $types );
 	}
+
+	// -------------------------------------------------------------------------
+	// resolve_url — scheme handling and relative resolution
+	// -------------------------------------------------------------------------
+
+	public function test_resolve_url_passes_through_absolute(): void {
+		$result = SWPS_Site_Crawler::resolve_url( 'https://other.com/page', 'https://example.com/' );
+		$this->assertSame( 'https://other.com/page', $result );
+	}
+
+	public function test_resolve_url_skips_mailto(): void {
+		$result = SWPS_Site_Crawler::resolve_url( 'mailto:someone@example.com', 'https://example.com/blog/' );
+		$this->assertSame( '', $result );
+	}
+
+	public function test_resolve_url_skips_tel(): void {
+		$result = SWPS_Site_Crawler::resolve_url( 'tel:+15551234567', 'https://example.com/contact/' );
+		$this->assertSame( '', $result );
+	}
+
+	public function test_resolve_url_skips_javascript(): void {
+		$result = SWPS_Site_Crawler::resolve_url( 'javascript:void(0)', 'https://example.com/' );
+		$this->assertSame( '', $result );
+	}
+
+	public function test_resolve_url_root_relative(): void {
+		$result = SWPS_Site_Crawler::resolve_url( '/blog/post/', 'https://example.com/old-slug/' );
+		$this->assertSame( 'https://example.com/blog/post/', $result );
+	}
+
+	public function test_resolve_url_protocol_relative(): void {
+		$result = SWPS_Site_Crawler::resolve_url( '//cdn.example.com/a.js', 'https://example.com/' );
+		$this->assertSame( 'https://cdn.example.com/a.js', $result );
+	}
+
+	public function test_resolve_url_walks_parent_segments(): void {
+		$result = SWPS_Site_Crawler::resolve_url( '../other', 'https://example.com/section/page' );
+		$this->assertSame( 'https://example.com/other', $result );
+	}
+
+	public function test_parse_html_does_not_fabricate_links_from_mailto(): void {
+		$html   = '<html><body>'
+			. '<a href="mailto:someone@example.com">mail</a>'
+			. '<a href="tel:+15551234567">call</a>'
+			. '<a href="/real-page/">real</a>'
+			. '</body></html>';
+		$result = SWPS_Site_Crawler::parse_html( $html, 'https://example.com/blog/' );
+		$this->assertContains( 'https://example.com/real-page/', $result['links'] );
+		$this->assertNotContains( 'https://example.com/blog/mailto:someone@example.com', $result['links'] );
+		$this->assertCount( 1, $result['links'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// classify — canonical compared against the post-redirect URL
+	// -------------------------------------------------------------------------
+
+	public function test_classify_no_canonical_mismatch_when_redirect_target_self_canonicalizes(): void {
+		// /old 301s to /new; /new declares itself canonical. That is the
+		// redirect working, not a mismatch.
+		$fetch = array(
+			'url'       => 'https://example.com/old',
+			'status'    => 200,
+			'found_on'  => 'https://example.com/',
+			'hops'      => array(
+				array( 'url' => 'https://example.com/old', 'status' => 301 ),
+			),
+			'loop'      => false,
+			'final_url' => 'https://example.com/new/',
+		);
+		$page  = array( 'links' => array(), 'images' => array(), 'canonical' => 'https://example.com/new/', 'h1_count' => 1, 'has_noindex' => false, 'mixed' => array() );
+		$rows  = SWPS_Site_Crawler::classify( $fetch, $page, 'example.com' );
+		$types = array_column( $rows, 'type' );
+		$this->assertNotContains( 'canonical_mismatch', $types );
+	}
+
+	public function test_classify_canonical_mismatch_against_final_url(): void {
+		// The redirect target itself declares a DIFFERENT canonical — real issue.
+		$fetch = array(
+			'url'       => 'https://example.com/old',
+			'status'    => 200,
+			'found_on'  => 'https://example.com/',
+			'hops'      => array(
+				array( 'url' => 'https://example.com/old', 'status' => 301 ),
+			),
+			'loop'      => false,
+			'final_url' => 'https://example.com/new/',
+		);
+		$page  = array( 'links' => array(), 'images' => array(), 'canonical' => 'https://example.com/elsewhere/', 'h1_count' => 1, 'has_noindex' => false, 'mixed' => array() );
+		$rows  = SWPS_Site_Crawler::classify( $fetch, $page, 'example.com' );
+		$types = array_column( $rows, 'type' );
+		$this->assertContains( 'canonical_mismatch', $types );
+	}
+
+	public function test_classify_canonical_falls_back_to_url_without_final_url(): void {
+		// Legacy fetch arrays without final_url keep the old comparison.
+		$fetch = array( 'url' => 'https://example.com/page?utm_source=x', 'status' => 200, 'found_on' => 'https://example.com/', 'hops' => array() );
+		$page  = array( 'links' => array(), 'images' => array(), 'canonical' => 'https://example.com/page', 'h1_count' => 1, 'has_noindex' => false, 'mixed' => array() );
+		$rows  = SWPS_Site_Crawler::classify( $fetch, $page, 'example.com' );
+		$types = array_column( $rows, 'type' );
+		$this->assertContains( 'canonical_mismatch', $types );
+	}
 }


### PR DESCRIPTION
## Problem

The SEO Audit page reports **Site Crawl 0/100** on sites where most reported issues are crawler artifacts, not real problems. On a live production site the latest run reported 120 issues, of which ~105 were false positives:

- **~22 fake broken links** — `mailto:` hrefs in the shared footer were resolved as *relative paths*, fabricating URLs like `/blog/tag/wordpress/page/mailto:user@host`, which the crawler then fetched and reported as 404s.
- **75 fake canonical mismatches** — every internal link that 301s to a correctly self-canonicalized page was flagged, because `classify()` compared the canonical against the *pre-redirect* URL. Working redirects were reported as issues.
- **Several status-0 broken links** — redirects answering with a relative `Location:` header (allowed by RFC 7231) failed the follow-up `wp_remote_get()` (invalid URL) and surfaced as broken links with no HTTP status.

With broken links costing 10 points each, the fabricated mailto 404s alone guarantee a 0/100 regardless of actual site health.

## Fix

- New pure static `SWPS_Site_Crawler::resolve_url()` (extracted from the `parse_html()` closure) that skips every non-http(s) scheme — `mailto:`, `tel:`, `javascript:`, `data:`, etc.
- `fetch_url()` resolves relative `Location` values against the redirecting URL, returns the post-redirect `final_url`, and reports a 3xx-without-Location as a dead redirect instead of a redirect loop (`loop` stays reserved for MAX_HOPS exhaustion).
- `classify()` compares the canonical tag against `final_url` (falls back to the requested URL for legacy fetch arrays).
- `process_chunk()` parses redirect-destination HTML against `final_url` so relative hrefs on the destination resolve against the right base.
- The audit score now follows the crawler's own severity split (errors 10 points, warnings 2) via a `severity_counts` field stored in the run summary. External bot-walls (e.g. LinkedIn's HTTP 999, already downgraded to warning severity by the crawler) no longer cost error-level points. Legacy summaries without the field keep the old type-based scoring.

## Testing

- 13 new unit tests: `resolve_url()` scheme handling and relative resolution, `parse_html()` no longer fabricating links from `mailto:`/`tel:` hrefs, and canonical classification against `final_url` (match, mismatch, and legacy fallback).
- Full suite: 560 tests, 1010 assertions, green. PHPCS clean on touched files.
