### PR TITLE
Backlinks: Blocked status for bot-walled sources + duplicate-row prevention (4.26.1)

### DIFF
--- a/admin/css/pages/backlinks.css
+++ b/admin/css/pages/backlinks.css
@@ -2,7 +2,7 @@
 
 .swps-bl-stats {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     gap: 12px;
     margin-bottom: 16px;
 }
@@ -92,6 +92,7 @@
 .swps-bl-status.is-live    { background: rgba(16,185,129,.15); color: #059669; }
 .swps-bl-status.is-lost    { background: rgba(245,158,11,.15); color: #b45309; }
 .swps-bl-status.is-broken  { background: rgba(239,68,68,.15);  color: #b91c1c; }
+.swps-bl-status.is-blocked { background: rgba(99,102,241,.15);  color: #4f46e5; }
 .swps-bl-status.is-pending { background: rgba(107,114,128,.15); color: #4b5563; }
 
 .swps-bl-verify, .swps-bl-delete {

--- a/admin/js/backlinks.js
+++ b/admin/js/backlinks.js
@@ -10,12 +10,14 @@
         $('#swps-bl-stat-live').text((stats.live || 0).toLocaleString());
         $('#swps-bl-stat-lost').text((stats.lost || 0).toLocaleString());
         $('#swps-bl-stat-broken').text((stats.broken || 0).toLocaleString());
+        $('#swps-bl-stat-blocked').text((stats.blocked || 0).toLocaleString());
     }
 
     function statusPill(row) {
         var cls = 'is-' + row.status;
         var label = row.status.charAt(0).toUpperCase() + row.status.slice(1);
-        var http = (row.status === 'broken' && row.http_status > 0)
+        var http = ((row.status === 'broken' && row.http_status > 0) ||
+                    (row.status === 'blocked' && row.http_status >= 400))
             ? ' <small>(' + row.http_status + ')</small>'
             : '';
         return '<span class="swps-bl-status ' + cls + '">' + label + http + '</span>';

--- a/includes/class-backlinks.php
+++ b/includes/class-backlinks.php
@@ -27,7 +27,7 @@ class SWPS_Backlinks {
 	public const CRON_HOOK    = 'swps_backlinks_daily_verify';
 	public const HTTP_TIMEOUT = 12;
 	public const VERIFY_BATCH = 25;
-	public const DB_VERSION   = '1';
+	public const DB_VERSION   = '2';
 	public const OPT_DB_VER   = 'swps_backlinks_db_version';
 
 	/**
@@ -55,7 +55,11 @@ class SWPS_Backlinks {
 		// Runtime upgrade: ensure the table exists on existing installs that
 		// didn't run the activation hook (i.e. plugin updated, not reactivated).
 		if ( self::DB_VERSION !== get_option( self::OPT_DB_VER ) ) {
+			// v2 adds a unique index on source_url; exact duplicates must go
+			// first or the ALTER fails and leaves the table unprotected.
+			self::dedupe_existing();
 			self::create_tables();
+			self::ensure_unique_index();
 			update_option( self::OPT_DB_VER, self::DB_VERSION );
 		}
 
@@ -98,6 +102,7 @@ class SWPS_Backlinks {
             notes        TEXT         NULL,
             created_at   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY  (id),
+            UNIQUE KEY source_url (source_url(191)),
             KEY status (status),
             KEY source_host (source_host),
             KEY last_checked (last_checked)
@@ -105,6 +110,40 @@ class SWPS_Backlinks {
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $sql );
+	}
+
+	/**
+	 * Remove exact-duplicate source_url rows, keeping the oldest (lowest id).
+	 * Runs before the v2 unique index is added; near-duplicates (www/scheme/
+	 * slash variants) are left alone — only code-level checks catch those.
+	 */
+	public static function dedupe_existing(): void {
+		global $wpdb;
+		$table = self::table_name();
+        // phpcs:disable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) !== $table ) {
+			return;
+		}
+		$wpdb->query( "DELETE a FROM {$table} a INNER JOIN {$table} b ON a.source_url = b.source_url AND a.id > b.id" );
+        // phpcs:enable
+	}
+
+	/**
+	 * dbDelta silently skips an ALTER that fails (e.g. duplicates present when
+	 * adding the unique key), so verify the index exists and retry if not.
+	 */
+	public static function ensure_unique_index(): void {
+		global $wpdb;
+		$table = self::table_name();
+        // phpcs:disable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) !== $table ) {
+			return;
+		}
+		$exists = $wpdb->get_results( "SHOW INDEX FROM {$table} WHERE Key_name = 'source_url'" );
+		if ( empty( $exists ) ) {
+			$wpdb->query( "ALTER TABLE {$table} ADD UNIQUE KEY source_url (source_url(191))" );
+		}
+        // phpcs:enable
 	}
 
 	public static function schedule_cron(): void {
@@ -198,6 +237,19 @@ class SWPS_Backlinks {
 
 		if ( '' === $source || ! preg_match( '#^https?://#i', $source ) ) {
 			wp_send_json_error( array( 'message' => __( 'Please enter a valid http(s) URL.', 'stratawp-seo' ) ) );
+		}
+
+		$dupe_id = $this->find_duplicate_id( $source, $id );
+		if ( $dupe_id > 0 ) {
+			wp_send_json_error(
+				array(
+					'message' => sprintf(
+						/* translators: %d: id of the existing backlink row */
+						__( 'Already tracking this source URL (entry #%d).', 'stratawp-seo' ),
+						$dupe_id
+					),
+				)
+			);
 		}
 
 		if ( $id > 0 ) {
@@ -344,14 +396,19 @@ class SWPS_Backlinks {
 	 *   - Generic source_url[,target_url[,anchor_text]] CSV
 	 *   - One URL per line
 	 *
-	 * Returns count of newly inserted rows. Existing source_urls are skipped.
+	 * Returns count of newly inserted rows. Existing source_urls are skipped,
+	 * compared in normalized form so www/scheme/trailing-slash variants of an
+	 * already-tracked URL don't create near-duplicate rows.
 	 */
 	public function import_csv( string $raw ): int {
 		$raw   = str_replace( array( "\r\n", "\r" ), "\n", $raw );
 		$lines = array_filter( array_map( 'trim', explode( "\n", $raw ) ) );
 
-		$existing = array_flip( $this->get_all_source_urls() );
-		$count    = 0;
+		$existing = array();
+		foreach ( $this->get_all_source_urls() as $url ) {
+			$existing[ self::normalize_source_url( $url ) ] = true;
+		}
+		$count = 0;
 
 		foreach ( $lines as $i => $line ) {
 			// Skip header rows (first non-URL row).
@@ -374,7 +431,8 @@ class SWPS_Backlinks {
 					continue;
 				}
 			}
-			if ( isset( $existing[ $source ] ) ) {
+			$norm = self::normalize_source_url( $source );
+			if ( isset( $existing[ $norm ] ) ) {
 				continue;
 			}
 			$target = isset( $cols[1] ) ? trim( (string) $cols[1] ) : '';
@@ -391,7 +449,7 @@ class SWPS_Backlinks {
 				)
 			);
 			if ( $id ) {
-				$existing[ $source ] = true;
+				$existing[ $norm ] = true;
 				++$count;
 			}
 		}
@@ -622,6 +680,59 @@ class SWPS_Backlinks {
 		$table = self::table_name();
         // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
 		return array_map( 'strval', (array) $wpdb->get_col( "SELECT source_url FROM {$table}" ) );
+	}
+
+	/**
+	 * Reduce a URL to its dedupe identity: host + path (+ query), with the
+	 * scheme, www. prefix, fragment, and trailing slash stripped, so
+	 * http://www.example.com/page/ and https://example.com/page count as the
+	 * same backlink. Path and query casing are preserved (case-sensitive
+	 * servers exist); hosts are not.
+	 */
+	public static function normalize_source_url( string $url ): string {
+		$url   = trim( $url );
+		$parts = wp_parse_url( $url );
+		if ( empty( $parts['host'] ) ) {
+			return strtolower( rtrim( $url, '/' ) );
+		}
+		$host = strtolower( (string) $parts['host'] );
+		$host = preg_replace( '/^www\./', '', $host ) ?: $host;
+		if ( ! empty( $parts['port'] ) ) {
+			$host .= ':' . (int) $parts['port'];
+		}
+		$norm = $host . rtrim( (string) ( $parts['path'] ?? '' ), '/' );
+		if ( ! empty( $parts['query'] ) ) {
+			$norm .= '?' . $parts['query'];
+		}
+		return $norm;
+	}
+
+	/**
+	 * Id of an existing row tracking the same source URL (in normalized form),
+	 * or 0 if none. $exclude_id skips the row being edited so updating a row
+	 * without changing its URL doesn't match itself.
+	 */
+	public function find_duplicate_id( string $source_url, int $exclude_id = 0 ): int {
+		$norm = self::normalize_source_url( $source_url );
+		if ( '' === $norm ) {
+			return 0;
+		}
+		global $wpdb;
+		$table = self::table_name();
+		// Normalization can't be expressed as an index lookup; the table is a
+		// hand-curated list (tens to hundreds of rows), so scan it.
+        // phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $wpdb->get_results( "SELECT id, source_url FROM {$table}", ARRAY_A );
+		foreach ( (array) $rows as $row ) {
+			$row_id = (int) $row['id'];
+			if ( $row_id === $exclude_id ) {
+				continue;
+			}
+			if ( self::normalize_source_url( (string) $row['source_url'] ) === $norm ) {
+				return $row_id;
+			}
+		}
+		return 0;
 	}
 
 	public function get_ids_for_verify( int $offset, int $limit ): array {

--- a/includes/class-backlinks.php
+++ b/includes/class-backlinks.php
@@ -30,6 +30,27 @@ class SWPS_Backlinks {
 	public const DB_VERSION   = '1';
 	public const OPT_DB_VER   = 'swps_backlinks_db_version';
 
+	/**
+	 * HTTP codes that mean "the site refused the automated request" (bot
+	 * protection, auth, rate limiting), not "the page is gone". 999 is
+	 * LinkedIn's non-standard bot-rejection code.
+	 */
+	private const BLOCKED_HTTP_CODES = array( 401, 403, 429, 999 );
+
+	/**
+	 * Hosts that serve a login wall to anonymous requests: the page returns
+	 * 200 but post content (and any link in it) is never in the HTML, so a
+	 * missing link proves nothing.
+	 */
+	private const AUTHWALLED_HOSTS = array(
+		'linkedin.com',
+		'facebook.com',
+		'instagram.com',
+		'x.com',
+		'twitter.com',
+		'threads.net',
+	);
+
 	public function __construct() {
 		// Runtime upgrade: ensure the table exists on existing installs that
 		// didn't run the activation hook (i.e. plugin updated, not reactivated).
@@ -396,6 +417,46 @@ class SWPS_Backlinks {
 
 	// ---------- Verify ----------
 
+	/**
+	 * Map a verification fetch result to a backlink status.
+	 *
+	 * @param int    $http_code   HTTP response code (0 if the request failed).
+	 * @param bool   $link_found  Whether a link to this site was found in the body.
+	 * @param string $source_host Host of the source page.
+	 * @return string One of 'live', 'lost', 'blocked', 'broken'.
+	 */
+	public static function classify_check( int $http_code, bool $link_found, string $source_host ): string {
+		if ( in_array( $http_code, self::BLOCKED_HTTP_CODES, true ) ) {
+			return 'blocked';
+		}
+		if ( $http_code < 200 || $http_code >= 400 ) {
+			return 'broken';
+		}
+		if ( $link_found ) {
+			return 'live';
+		}
+		if ( self::is_authwalled_host( $source_host ) ) {
+			return 'blocked';
+		}
+		return 'lost';
+	}
+
+	/**
+	 * Whether $host is (a subdomain of) a platform that login-walls
+	 * anonymous requests.
+	 *
+	 * @param string $host Host of the source page.
+	 */
+	private static function is_authwalled_host( string $host ): bool {
+		$host = strtolower( $host );
+		foreach ( self::AUTHWALLED_HOSTS as $walled ) {
+			if ( $host === $walled || str_ends_with( $host, '.' . $walled ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public function verify_one( int $id ): array {
 		$row = $this->get_row( $id );
 		if ( ! $row ) {
@@ -427,24 +488,31 @@ class SWPS_Backlinks {
 		} else {
 			$code                  = (int) wp_remote_retrieve_response_code( $resp );
 			$update['http_status'] = $code;
-			if ( $code < 200 || $code >= 400 ) {
-				$update['notes'] = sprintf( /* translators: %d HTTP status */ __( 'HTTP %d', 'stratawp-seo' ), $code );
-			} else {
-				$body  = (string) wp_remote_retrieve_body( $resp );
-				$found = $this->find_link( $body );
-				if ( $found ) {
-					$update['status']      = 'live';
-					$update['anchor_text'] = '' !== ( $found['anchor'] ?? '' ) ? $found['anchor'] : $row['anchor_text'];
-					$update['target_url']  = '' !== ( $found['href'] ?? '' ) ? $found['href'] : $row['target_url'];
-					$update['notes']       = '';
-					if ( empty( $row['first_seen'] ) ) {
-						$update['first_seen'] = $now;
-					}
-					$update['last_seen'] = $now;
-				} else {
-					$update['status'] = 'lost';
-					$update['notes']  = __( 'Page loaded but contained no link to this site.', 'stratawp-seo' );
+
+			$found = null;
+			if ( $code >= 200 && $code < 400 ) {
+				$found = $this->find_link( (string) wp_remote_retrieve_body( $resp ) );
+			}
+
+			$status           = self::classify_check( $code, null !== $found, $this->host_of( $source ) );
+			$update['status'] = $status;
+
+			if ( 'live' === $status ) {
+				$update['anchor_text'] = '' !== ( $found['anchor'] ?? '' ) ? $found['anchor'] : $row['anchor_text'];
+				$update['target_url']  = '' !== ( $found['href'] ?? '' ) ? $found['href'] : $row['target_url'];
+				$update['notes']       = '';
+				if ( empty( $row['first_seen'] ) ) {
+					$update['first_seen'] = $now;
 				}
+				$update['last_seen'] = $now;
+			} elseif ( 'blocked' === $status ) {
+				$update['notes'] = in_array( $code, self::BLOCKED_HTTP_CODES, true )
+					? sprintf( /* translators: %d HTTP status */ __( 'Site blocks automated link checkers (HTTP %d) — verify manually.', 'stratawp-seo' ), $code )
+					: __( 'Site shows a login wall to automated checkers — verify manually.', 'stratawp-seo' );
+			} elseif ( 'lost' === $status ) {
+				$update['notes'] = __( 'Page loaded but contained no link to this site.', 'stratawp-seo' );
+			} else {
+				$update['notes'] = sprintf( /* translators: %d HTTP status */ __( 'HTTP %d', 'stratawp-seo' ), $code );
 			}
 		}
 
@@ -591,6 +659,7 @@ class SWPS_Backlinks {
 			'live'    => 0,
 			'lost'    => 0,
 			'broken'  => 0,
+			'blocked' => 0,
 			'pending' => 0,
 		);
 		foreach ( $by_status as $r ) {

--- a/includes/class-dashboard.php
+++ b/includes/class-dashboard.php
@@ -431,6 +431,7 @@ class SWPS_Dashboard {
 					'live'           => 0,
 					'lost'           => 0,
 					'broken'         => 0,
+					'blocked'        => 0,
 					'new_30d'        => 0,
 					'lost_30d'       => 0,
 					'unique_domains' => 0,

--- a/includes/class-site-crawler.php
+++ b/includes/class-site-crawler.php
@@ -662,7 +662,7 @@ class SWPS_Site_Crawler {
 			if ( ! empty( $fetch['body'] ) && $fetch['status'] < 400 ) {
 				// Parse against the post-redirect URL so relative hrefs on a
 				// redirect destination resolve against the right base.
-				$page = self::parse_html( $fetch['body'], (string) ( $fetch['final_url'] ?? $url ) );
+				$page = self::parse_html( $fetch['body'], (string) $fetch['final_url'] );
 			}
 
 			// Enrich with WP lookups for the noindex-in-sitemap check

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,16 +41,6 @@ parameters:
 			path: includes/class-background-processor.php
 
 		-
-			message: "#^Offset 'anchor' on array\\{href\\: string, anchor\\: string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: includes/class-backlinks.php
-
-		-
-			message: "#^Offset 'href' on array\\{href\\: string, anchor\\: string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
-			count: 1
-			path: includes/class-backlinks.php
-
-		-
 			message: "#^Ternary operator condition is always true\\.$#"
 			count: 1
 			path: includes/class-backlinks.php

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.26.0
+Stable tag: 4.26.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,9 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.26.1 =
+* Fixed: the Backlinks tracker could store the same source URL twice — saving never checked for an existing row (a double-clicked Save silently created identical entries), and CSV import only skipped exact string matches. Saves now report the already-tracked entry instead of duplicating it, imports skip www/scheme/trailing-slash variants of tracked URLs, and the table gains a unique index on source_url. Existing exact-duplicate rows are removed automatically on upgrade (keeping the oldest).
 
 = 4.26.0 =
 * Fixed: backlinks on bot-protected sites (Medium behind Cloudflare, LinkedIn's login wall, etc.) were falsely reported as Broken or Lost. Verification now distinguishes a refused automated request from a genuinely dead page: HTTP 401/403/429/999 responses and login-walled platforms get a new "Blocked" status with a "verify manually" note instead of inflating the Broken/Lost counts (and the weekly digest's broken-backlink attention item).

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.25.0
+Stable tag: 4.26.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,10 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.26.0 =
+* Fixed: backlinks on bot-protected sites (Medium behind Cloudflare, LinkedIn's login wall, etc.) were falsely reported as Broken or Lost. Verification now distinguishes a refused automated request from a genuinely dead page: HTTP 401/403/429/999 responses and login-walled platforms get a new "Blocked" status with a "verify manually" note instead of inflating the Broken/Lost counts (and the weekly digest's broken-backlink attention item).
+* New: Blocked stat tile and status pill on the Backlinks page.
 
 = 4.25.0 =
 * New: Cross-Site Linking — configure owned/partner domains (Settings → SEO → Cross-Site Linking) and the internal-link engines suggest links to those sites' posts. Each domain's public post inventory is fetched over the WordPress REST API and cached daily.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.26.0
+ * Version: 4.26.1
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.26.0' );
+define( 'SWPS_VERSION', '4.26.1' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.25.0
+ * Version: 4.26.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.25.0' );
+define( 'SWPS_VERSION', '4.26.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/templates/backlinks-page.php
+++ b/templates/backlinks-page.php
@@ -93,6 +93,13 @@ $home_host = wp_parse_url( home_url(), PHP_URL_HOST );
 				<?php esc_html_e( 'Source page returns an error', 'stratawp-seo' ); ?>
 			</div>
 		</div>
+		<div class="swps-tile">
+			<div class="swps-tile-h"><?php esc_html_e( 'Blocked', 'stratawp-seo' ); ?></div>
+			<div class="swps-tile-stat" id="swps-bl-stat-blocked" style="color:#6366f1"><?php echo number_format( (int) ( $stats['blocked'] ?? 0 ) ); ?></div>
+			<div class="swps-tile-trend" style="color:var(--swps-text-faint)">
+				<?php esc_html_e( 'Site blocks automated checkers', 'stratawp-seo' ); ?>
+			</div>
+		</div>
 	</div>
 
 	<!-- Add + import row -->
@@ -168,7 +175,7 @@ $home_host = wp_parse_url( home_url(), PHP_URL_HOST );
 							<td>
 								<span class="swps-bl-status is-<?php echo esc_attr( $status ); ?>">
 									<?php echo esc_html( ucfirst( $status ) ); ?>
-									<?php if ( (int) $row['http_status'] > 0 && in_array( $status, array( 'broken' ), true ) ) : ?>
+									<?php if ( ( 'broken' === $status && (int) $row['http_status'] > 0 ) || ( 'blocked' === $status && (int) $row['http_status'] >= 400 ) ) : ?>
 										<small>(<?php echo (int) $row['http_status']; ?>)</small>
 									<?php endif; ?>
 								</span>

--- a/templates/dashboard-page.php
+++ b/templates/dashboard-page.php
@@ -555,7 +555,7 @@ $welcome_msg = sprintf(
 				<div class="swps-dash-list">
 					<?php
 					foreach ( $bl_recent as $bl ) :
-						$status_color = 'live' === $bl['status'] ? '#10b981' : ( 'lost' === $bl['status'] ? '#f59e0b' : ( 'broken' === $bl['status'] ? '#ef4444' : '#6b7280' ) );
+						$status_color = 'live' === $bl['status'] ? '#10b981' : ( 'lost' === $bl['status'] ? '#f59e0b' : ( 'broken' === $bl['status'] ? '#ef4444' : ( 'blocked' === $bl['status'] ? '#6366f1' : '#6b7280' ) ) );
 						?>
 						<div class="swps-dash-list-row">
 							<div class="swps-dash-list-main">

--- a/tests/unit/BacklinksClassifyTest.php
+++ b/tests/unit/BacklinksClassifyTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * TDD tests for SWPS_Backlinks::classify_check() — pure static helper that
+ * maps a verification fetch result to a backlink status.
+ *
+ * Pure-PHP, no WordPress. The class is required for its static method only;
+ * the constructor (which needs WP) is never called.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-backlinks.php';
+
+/**
+ * @covers SWPS_Backlinks
+ */
+class BacklinksClassifyTest extends TestCase {
+
+	// -------------------------------------------------------------------------
+	// Bot-blocking HTTP codes → blocked (not broken)
+	// -------------------------------------------------------------------------
+
+	public function test_403_is_blocked_not_broken(): void {
+		// Medium behind Cloudflare: 403 to every non-browser client.
+		$this->assertSame( 'blocked', SWPS_Backlinks::classify_check( 403, false, 'medium.com' ) );
+	}
+
+	public function test_401_is_blocked(): void {
+		$this->assertSame( 'blocked', SWPS_Backlinks::classify_check( 401, false, 'example.com' ) );
+	}
+
+	public function test_429_is_blocked(): void {
+		$this->assertSame( 'blocked', SWPS_Backlinks::classify_check( 429, false, 'example.com' ) );
+	}
+
+	public function test_999_is_blocked(): void {
+		// LinkedIn's non-standard bot-rejection code.
+		$this->assertSame( 'blocked', SWPS_Backlinks::classify_check( 999, false, 'www.linkedin.com' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Genuine HTTP errors → broken
+	// -------------------------------------------------------------------------
+
+	public function test_404_is_broken(): void {
+		$this->assertSame( 'broken', SWPS_Backlinks::classify_check( 404, false, 'example.com' ) );
+	}
+
+	public function test_410_is_broken(): void {
+		$this->assertSame( 'broken', SWPS_Backlinks::classify_check( 410, false, 'example.com' ) );
+	}
+
+	public function test_500_is_broken(): void {
+		$this->assertSame( 'broken', SWPS_Backlinks::classify_check( 500, false, 'example.com' ) );
+	}
+
+	public function test_zero_code_is_broken(): void {
+		$this->assertSame( 'broken', SWPS_Backlinks::classify_check( 0, false, 'example.com' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Successful fetch, link present → live
+	// -------------------------------------------------------------------------
+
+	public function test_200_with_link_is_live(): void {
+		$this->assertSame( 'live', SWPS_Backlinks::classify_check( 200, true, 'example.com' ) );
+	}
+
+	public function test_200_with_link_on_authwalled_host_is_live(): void {
+		// Link found wins even on a login-walled platform.
+		$this->assertSame( 'live', SWPS_Backlinks::classify_check( 200, true, 'www.linkedin.com' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Successful fetch, link absent → lost, unless the host is login-walled
+	// -------------------------------------------------------------------------
+
+	public function test_200_without_link_is_lost(): void {
+		$this->assertSame( 'lost', SWPS_Backlinks::classify_check( 200, false, 'example.com' ) );
+	}
+
+	public function test_200_without_link_on_linkedin_is_blocked(): void {
+		// LinkedIn serves its sign-in wall to anonymous fetches: 200 but the
+		// post content (and any link in it) is never in the HTML.
+		$this->assertSame( 'blocked', SWPS_Backlinks::classify_check( 200, false, 'linkedin.com' ) );
+	}
+
+	public function test_200_without_link_on_linkedin_subdomain_is_blocked(): void {
+		$this->assertSame( 'blocked', SWPS_Backlinks::classify_check( 200, false, 'www.linkedin.com' ) );
+	}
+
+	public function test_200_without_link_on_facebook_is_blocked(): void {
+		$this->assertSame( 'blocked', SWPS_Backlinks::classify_check( 200, false, 'facebook.com' ) );
+	}
+
+	public function test_lookalike_host_is_not_treated_as_authwalled(): void {
+		// Suffix matching must not catch unrelated domains.
+		$this->assertSame( 'lost', SWPS_Backlinks::classify_check( 200, false, 'notlinkedin.com' ) );
+	}
+}

--- a/tests/unit/BacklinksNormalizeTest.php
+++ b/tests/unit/BacklinksNormalizeTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tests for SWPS_Backlinks::normalize_source_url() — the pure static helper
+ * that reduces a URL to its duplicate-detection identity.
+ *
+ * Pure-PHP, no WordPress. The class is required for its static method only;
+ * the constructor (which needs WP) is never called.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-backlinks.php';
+
+/**
+ * @covers SWPS_Backlinks
+ */
+class BacklinksNormalizeTest extends TestCase {
+
+	public function test_identical_urls_normalize_identically(): void {
+		$this->assertSame(
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page' ),
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page' )
+		);
+	}
+
+	public function test_scheme_is_ignored(): void {
+		$this->assertSame(
+			SWPS_Backlinks::normalize_source_url( 'http://example.com/page' ),
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page' )
+		);
+	}
+
+	public function test_www_prefix_is_ignored(): void {
+		$this->assertSame(
+			SWPS_Backlinks::normalize_source_url( 'https://www.example.com/page' ),
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page' )
+		);
+	}
+
+	public function test_trailing_slash_is_ignored(): void {
+		$this->assertSame(
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page/' ),
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page' )
+		);
+	}
+
+	public function test_bare_domain_equals_root_path(): void {
+		$this->assertSame(
+			SWPS_Backlinks::normalize_source_url( 'https://example.com' ),
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/' )
+		);
+	}
+
+	public function test_fragment_is_ignored(): void {
+		$this->assertSame(
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page#section' ),
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page' )
+		);
+	}
+
+	public function test_host_case_is_ignored(): void {
+		$this->assertSame(
+			SWPS_Backlinks::normalize_source_url( 'https://EXAMPLE.com/page' ),
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page' )
+		);
+	}
+
+	public function test_path_case_is_preserved(): void {
+		$this->assertNotSame(
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/Page' ),
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page' )
+		);
+	}
+
+	public function test_different_paths_stay_distinct(): void {
+		$this->assertNotSame(
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page-one' ),
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page-two' )
+		);
+	}
+
+	public function test_query_string_stays_distinct(): void {
+		$this->assertNotSame(
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page?p=1' ),
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page?p=2' )
+		);
+	}
+
+	public function test_query_string_is_preserved(): void {
+		$this->assertSame(
+			'example.com/page?p=1',
+			SWPS_Backlinks::normalize_source_url( 'https://www.example.com/page?p=1' )
+		);
+	}
+
+	public function test_non_standard_port_stays_distinct(): void {
+		$this->assertNotSame(
+			SWPS_Backlinks::normalize_source_url( 'https://example.com:8080/page' ),
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page' )
+		);
+	}
+
+	public function test_subdomain_stays_distinct(): void {
+		// Only the www. prefix is collapsed — real subdomains are different hosts.
+		$this->assertNotSame(
+			SWPS_Backlinks::normalize_source_url( 'https://blog.example.com/page' ),
+			SWPS_Backlinks::normalize_source_url( 'https://example.com/page' )
+		);
+	}
+
+	public function test_unparseable_input_falls_back_to_lowercased_string(): void {
+		$this->assertSame( 'not a url', SWPS_Backlinks::normalize_source_url( ' Not a URL ' ) );
+	}
+}


### PR DESCRIPTION
## Problem

Backlinks on bot-protected sites were falsely reported on the Backlinks page:

- **Medium** (behind Cloudflare) 403s every non-browser client at the TLS-fingerprint level, so `wp_remote_get()` can never fetch the page → reported **Broken** even though the link is fine.
- **LinkedIn** serves its sign-in wall to anonymous requests: HTTP 200, but the post content (and the link in it) is never in the HTML → reported **Lost**.

Separately, the tracker stored duplicate rows for the same source URL (saves never checked for an existing row; CSV import only skipped exact string matches).

## Fix 1 — Blocked status (4.26.0)

Verification now distinguishes *the site refused the automated request* from *the page is genuinely dead*:

- New pure static `SWPS_Backlinks::classify_check( $http_code, $link_found, $source_host )` maps each fetch to `live` / `lost` / `blocked` / `broken`.
- HTTP **401 / 403 / 429 / 999** → `blocked` ("Site blocks automated link checkers (HTTP %d) — verify manually.").
- **200 with no link found on a login-walled platform** (linkedin.com, facebook.com, instagram.com, x.com, twitter.com, threads.net — subdomains included) → `blocked` ("Site shows a login wall to automated checkers — verify manually.").
- Genuine 404/410/5xx/timeouts still report `broken`; a found link still wins as `live` regardless of host.
- Backlinks page gains a **Blocked** stat tile and status pill; `get_stats()` reports a `blocked` count so the weekly digest's broken-backlink attention item no longer counts blocked links.

## Fix 2 — Duplicate-row prevention (4.26.1)

- Schema v2: exact-duplicate rows removed on upgrade (keeping the oldest), then `UNIQUE KEY source_url (source_url(191))`; `ensure_unique_index()` retries the ALTER that dbDelta skips silently.
- `ajax_save()` rejects an already-tracked source URL; `normalize_source_url()` collapses scheme/www/trailing-slash/fragment variants for save + CSV-import dedupe.

## Also

- Merged current `main` and resolved the 4.25.1 version-file collision (version is 4.26.1 everywhere, changelog stacked).
- Fixed the PHPStan error in `class-site-crawler.php` (dead `??` on `final_url`) that has kept the Code quality workflow red on `main` since the 4.25.1 merge.

## Testing

- 29 new pure-PHP unit tests (`BacklinksClassifyTest`, `BacklinksNormalizeTest`); full suite green (589 tests), PHPStan clean.
- WP-CLI smoke test through the real `verify_one()` against live URLs: LinkedIn post → `blocked` (login wall), genuine 404 → `broken`, and the Medium article resolves `live` when Cloudflare serves the page and `blocked` when it 403s.
- Production DB already deduped + unique index applied ahead of this code deploy.

Existing rows self-correct on the next daily cron run or a manual **Verify all**.