### PR TITLE
Fix dead Redirects screen: undefined nonce global + scheme-less URL input (4.26.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1711,6 +1711,10 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 
 ## Changelog
 
+### v4.26.2 — August 2026
+- **Redirects screen fixed** — the whole page was non-functional: adding a redirect always failed with "Error adding redirect", and the redirect list and 404 log rendered empty even though 404s were being recorded in the database. The page script read its security nonce from a JavaScript global that was never defined (`swps_admin` instead of `swpsAdmin`), so WordPress rejected every AJAX request the page made
+- **Scheme-less URLs handled** — a source entered as `example.com/old-page/` (no `https://`) used to store a redirect that could never match; it's now reduced to its path (`/old-page`). A scheme-less target like `example.com/new-page/` gets `https://` prepended instead of becoming a broken relative path
+
 ### v4.22.2 — July 2026
 - **"Received empty response from Claude" on Sonnet 5+ fixed** — Claude Sonnet 5 and newer models run adaptive thinking by default, so their responses open with a `thinking` content block before the `text` block. The provider read only the first block's text, so every response looked empty. Text is now collected from all text blocks in the response
 - **Clearer truncation error** — when a thinking-enabled model spends the entire `max_tokens` budget on reasoning before emitting any text, the error now says the token budget ran out (actionable) instead of "empty response"

--- a/admin/js/redirects.js
+++ b/admin/js/redirects.js
@@ -4,7 +4,7 @@
 (function () {
     'use strict';
 
-    const nonce = typeof swps_admin !== 'undefined' ? swps_admin.nonce : '';
+    const nonce = typeof swpsAdmin !== 'undefined' ? swpsAdmin.nonce : '';
     const ajaxUrl = typeof ajaxurl !== 'undefined' ? ajaxurl : '/wp-admin/admin-ajax.php';
 
     // -------------------------------------------------------------------------

--- a/includes/class-redirect-manager.php
+++ b/includes/class-redirect-manager.php
@@ -262,6 +262,24 @@ class SWPS_Redirect_Manager {
 	}
 
 	/**
+	 * Prepend https:// to scheme-less input whose first segment looks like a
+	 * hostname ("jonimms.com/tag/foo"), so wp_parse_url() sees a host instead
+	 * of treating the whole string as a path.
+	 */
+	private function maybe_add_scheme( string $url ): string {
+		if ( '' === $url || '/' === $url[0] || wp_parse_url( $url, PHP_URL_SCHEME ) ) {
+			return $url;
+		}
+
+		$first_segment = explode( '/', $url, 2 )[0];
+		if ( preg_match( '/^([a-z0-9-]+\.)+[a-z]{2,}(:\d+)?$/i', $first_segment ) || 'localhost' === strtolower( $first_segment ) ) {
+			return 'https://' . $url;
+		}
+
+		return $url;
+	}
+
+	/**
 	 * Normalize a source URL to the path format used during request matching.
 	 */
 	private function normalize_source_url( string $source, bool $is_regex ): string {
@@ -271,9 +289,11 @@ class SWPS_Redirect_Manager {
 			return $source;
 		}
 
+		$source = $this->maybe_add_scheme( $source );
+
 		$path = wp_parse_url( $source, PHP_URL_PATH );
 		if ( ! is_string( $path ) || '' === $path ) {
-			$path = $source;
+			$path = wp_parse_url( $source, PHP_URL_HOST ) ? '/' : $source;
 		}
 
 		$path = '/' . ltrim( $path, '/' );
@@ -294,6 +314,8 @@ class SWPS_Redirect_Manager {
 		if ( '' === $target ) {
 			return '';
 		}
+
+		$target = $this->maybe_add_scheme( $target );
 
 		$scheme = wp_parse_url( $target, PHP_URL_SCHEME );
 		if ( $scheme && ! in_array( strtolower( $scheme ), array( 'http', 'https' ), true ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.26.1
+Stable tag: 4.26.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,10 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.26.2 =
+* Fixed: the entire Redirects screen was non-functional — adding a redirect always failed with "Error adding redirect", and the redirect list and 404 log always appeared empty even though 404s were being recorded. The page script read its security nonce from a JavaScript global that was never defined (`swps_admin` instead of `swpsAdmin`), so WordPress rejected every request the page made.
+* Fixed: entering a source URL without the https:// prefix (e.g. `example.com/old-page/`) silently stored a redirect that could never match a request. Host-like input is now recognized and reduced to its path, and a scheme-less target like `example.com/new-page/` gets https:// prepended instead of being stored as a broken relative path.
 
 = 4.26.1 =
 * Fixed: the Backlinks tracker could store the same source URL twice — saving never checked for an existing row (a double-clicked Save silently created identical entries), and CSV import only skipped exact string matches. Saves now report the already-tracked entry instead of duplicating it, imports skip www/scheme/trailing-slash variants of tracked URLs, and the table gains a unique index on source_url. Existing exact-duplicate rows are removed automatically on upgrade (keeping the oldest).

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.26.1
+ * Version: 4.26.2
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.26.1' );
+define( 'SWPS_VERSION', '4.26.2' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -732,7 +732,7 @@ final class StrataWP_SEO {
 
 		// Redirects page JS.
 		if ( 'stratawp-seo_page_swps-redirects' === $hook ) {
-			wp_enqueue_script( 'swps-redirects', SWPS_PLUGIN_URL . 'admin/js/redirects.js', array(), SWPS_VERSION, true );
+			wp_enqueue_script( 'swps-redirects', SWPS_PLUGIN_URL . 'admin/js/redirects.js', array( 'swps-admin' ), SWPS_VERSION, true );
 		}
 
 		if ( 'stratawp-seo_page_swps-sitemaps' === $hook ) {

--- a/tests/unit/RedirectNormalizeTest.php
+++ b/tests/unit/RedirectNormalizeTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Tests for SWPS_Redirect_Manager source/target URL normalization.
+ *
+ * Pure-PHP, no WordPress. The class is required for its normalization
+ * helpers only; the constructor (which needs WP hooks) is never called —
+ * instances are created via newInstanceWithoutConstructor() and the
+ * private methods invoked through reflection.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+if ( ! function_exists( 'wp_unslash' ) ) {
+	function wp_unslash( $value ) {
+		return is_string( $value ) ? stripslashes( $value ) : $value;
+	}
+}
+
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $str ) {
+		$str = (string) $str;
+		$str = wp_strip_all_tags( $str );
+		$str = preg_replace( '/[\r\n\t ]+/', ' ', $str );
+		return trim( $str );
+	}
+}
+
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $url ) {
+		return (string) $url;
+	}
+}
+
+require_once __DIR__ . '/../../includes/class-redirect-manager.php';
+
+/**
+ * @covers SWPS_Redirect_Manager
+ */
+class RedirectNormalizeTest extends TestCase {
+
+	private function invoke( string $method, ...$args ) {
+		$ref      = new ReflectionClass( SWPS_Redirect_Manager::class );
+		$instance = $ref->newInstanceWithoutConstructor();
+		$m        = $ref->getMethod( $method );
+		$m->setAccessible( true );
+		return $m->invoke( $instance, ...$args );
+	}
+
+	// -------------------------------------------------------------------------
+	// normalize_source_url
+	// -------------------------------------------------------------------------
+
+	public function test_plain_path_is_kept(): void {
+		$this->assertSame( '/tag/analytics', $this->invoke( 'normalize_source_url', '/tag/analytics/', false ) );
+	}
+
+	public function test_full_url_is_reduced_to_path(): void {
+		$this->assertSame( '/tag/analytics', $this->invoke( 'normalize_source_url', 'https://jonimms.com/tag/analytics/', false ) );
+	}
+
+	public function test_schemeless_host_url_is_reduced_to_path(): void {
+		$this->assertSame( '/tag/analytics', $this->invoke( 'normalize_source_url', 'jonimms.com/tag/analytics/', false ) );
+	}
+
+	public function test_schemeless_www_host_url_is_reduced_to_path(): void {
+		$this->assertSame( '/tag/analytics', $this->invoke( 'normalize_source_url', 'www.jonimms.com/tag/analytics/', false ) );
+	}
+
+	public function test_relative_path_without_leading_slash_gets_one(): void {
+		$this->assertSame( '/tag/analytics', $this->invoke( 'normalize_source_url', 'tag/analytics', false ) );
+	}
+
+	public function test_bare_domain_normalizes_to_root(): void {
+		// Root sources are rejected later by validate_redirect().
+		$this->assertSame( '/', $this->invoke( 'normalize_source_url', 'jonimms.com', false ) );
+	}
+
+	public function test_regex_source_is_untouched(): void {
+		$this->assertSame( '^/tag/(.*)$', $this->invoke( 'normalize_source_url', '^/tag/(.*)$', true ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// normalize_target_url
+	// -------------------------------------------------------------------------
+
+	public function test_target_full_url_is_preserved(): void {
+		$this->assertSame( 'https://jonimms.com/blog/', $this->invoke( 'normalize_target_url', 'https://jonimms.com/blog/', 301 ) );
+	}
+
+	public function test_target_schemeless_host_gets_https_scheme(): void {
+		$this->assertSame( 'https://jonimms.com/blog/', $this->invoke( 'normalize_target_url', 'jonimms.com/blog/', 301 ) );
+	}
+
+	public function test_target_relative_path_gets_leading_slash(): void {
+		$this->assertSame( '/blog/', $this->invoke( 'normalize_target_url', 'blog/', 301 ) );
+	}
+
+	public function test_target_empty_for_410(): void {
+		$this->assertSame( '', $this->invoke( 'normalize_target_url', 'https://jonimms.com/blog/', 410 ) );
+	}
+
+	public function test_target_rejects_unsafe_scheme(): void {
+		$this->assertSame( '', $this->invoke( 'normalize_target_url', 'javascript:alert(1)', 301 ) );
+	}
+}


### PR DESCRIPTION
## Problem

The Redirects screen was entirely non-functional:

1. Adding a redirect always failed with the generic **"Error adding redirect"** alert
2. The 404 log always appeared empty — even though 404 discovery was working fine server-side (the local site's log table had 1,263 rows)
3. The existing-redirects list also always rendered empty

## Root cause

`redirects.js` read its nonce from a `swps_admin` JS global, but the plugin localizes `swpsAdmin` — the snake_case global never existed, so every admin-ajax request went out with an **empty nonce** and `check_ajax_referer()` died with `-1`. Since `-1` parses as valid JSON, `res.success` was falsy and `res.data` undefined → the fallback alert on add, and silent empty tables on every list fetch. (`sitemaps.js` has the same typo but survives via a fallback to `swpsAdmin`.)

A second bug sat in the same repro: a source entered without a scheme (`jonimms.com/tag/analytics/`) was parsed entirely as a path and stored as `/jonimms.com/tag/analytics` — a redirect that could never match. So even with the nonce fixed, the reported flow would have silently created a dead redirect.

## Fix

- `redirects.js`: read the nonce from `swpsAdmin`
- `stratawp-seo.php`: enqueue `redirects.js` with a `swps-admin` dependency so the localized object always precedes it
- `class-redirect-manager.php`: new `maybe_add_scheme()` host detection in both `normalize_source_url()` and `normalize_target_url()` — host-like input (`example.com/old-page/`) reduces to its path `/old-page`; scheme-less targets get `https://` prepended; host-only input normalizes to `/` and is rejected by validation with a clear message

## Testing

- New `RedirectNormalizeTest` (12 tests) covering both normalizers, written failing-first
- Full suite: 601 tests green; PHPStan clean
- Verified live on jonimms.local: add with the exact reported input (`jonimms.com/tag/analytics/` → `https://jonimms.com/blog/`) succeeds and stores `/tag/analytics`, the 301 fires end-to-end (curl confirms `301 → https://jonimms.com/blog/`), the 404 tab lists the logged 404s, and delete works

## Release

- Version bumped to 4.26.2 (header + `SWPS_VERSION` + stable tag), changelog entries in readme.txt and README.md