### PR TITLE
Fix regex redirect backslash stripping in programmatic add_redirect (4.26.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1711,6 +1711,9 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 
 ## Changelog
 
+### v4.26.3 — August 2026
+- **Regex redirects no longer lose their backslashes** — a pattern like `^/category/([^/]+)(?:/page/\d+)?$` added via WP-CLI, the add-redirect ability, or a migration import was silently stored as `…(?:/page/d+)?$` and never matched. The redirect manager stripped slashes from its input a second time even though every form/AJAX entry point had already unslashed it; the double-unslash is gone and patterns are stored verbatim
+
 ### v4.26.2 — August 2026
 - **Redirects screen fixed** — the whole page was non-functional: adding a redirect always failed with "Error adding redirect", and the redirect list and 404 log rendered empty even though 404s were being recorded in the database. The page script read its security nonce from a JavaScript global that was never defined (`swps_admin` instead of `swpsAdmin`), so WordPress rejected every AJAX request the page made
 - **Scheme-less URLs handled** — a source entered as `example.com/old-page/` (no `https://`) used to store a redirect that could never match; it's now reduced to its path (`/old-page`). A scheme-less target like `example.com/new-page/` gets `https://` prepended instead of becoming a broken relative path

--- a/includes/class-redirect-manager.php
+++ b/includes/class-redirect-manager.php
@@ -281,9 +281,13 @@ class SWPS_Redirect_Manager {
 
 	/**
 	 * Normalize a source URL to the path format used during request matching.
+	 *
+	 * Input must already be unslashed — callers reading $_POST are responsible
+	 * for wp_unslash() at that boundary. Unslashing here would corrupt regex
+	 * escape sequences (\d, \w) passed in by programmatic callers.
 	 */
 	private function normalize_source_url( string $source, bool $is_regex ): string {
-		$source = trim( wp_unslash( $source ) );
+		$source = trim( $source );
 
 		if ( $is_regex ) {
 			return $source;
@@ -310,7 +314,7 @@ class SWPS_Redirect_Manager {
 			return '';
 		}
 
-		$target = trim( wp_unslash( $target ) );
+		$target = trim( $target );
 		if ( '' === $target ) {
 			return '';
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.26.2
+Stable tag: 4.26.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,9 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.26.3 =
+* Fixed: regex redirects created programmatically (WP-CLI, the add-redirect ability, or a redirect importer) had their backslashes stripped before storage — a pattern like `^/foo/(\d+)$` was silently saved as `^/foo/(d+)$` and never matched a request. The redirect manager unslashed its input a second time even though every admin form and AJAX entry point had already done so; unslashing now happens only at the form boundary, and the programmatic API stores patterns exactly as given.
 
 = 4.26.2 =
 * Fixed: the entire Redirects screen was non-functional — adding a redirect always failed with "Error adding redirect", and the redirect list and 404 log always appeared empty even though 404s were being recorded. The page script read its security nonce from a JavaScript global that was never defined (`swps_admin` instead of `swpsAdmin`), so WordPress rejected every request the page made.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.26.2
+ * Version: 4.26.3
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.26.2' );
+define( 'SWPS_VERSION', '4.26.3' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/tests/unit/RedirectNormalizeTest.php
+++ b/tests/unit/RedirectNormalizeTest.php
@@ -33,6 +33,47 @@ if ( ! function_exists( 'esc_url_raw' ) ) {
 	}
 }
 
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ) {
+		return $thing instanceof WP_Error;
+	}
+}
+
+if ( ! function_exists( 'delete_transient' ) ) {
+	function delete_transient( $transient ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'current_time' ) ) {
+	function current_time( $type ) {
+		return '2026-08-08 00:00:00';
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		return $text;
+	}
+}
+
+if ( ! class_exists( 'SWPS_Test_Redirects_WPDB' ) ) {
+	/**
+	 * Captures insert() payloads so tests can assert on what gets stored.
+	 */
+	class SWPS_Test_Redirects_WPDB {
+		public string $prefix = 'wp_';
+		public int $insert_id = 0;
+		public array $inserts = array();
+
+		public function insert( $table, $data, $format = null ) {
+			$this->inserts[] = $data;
+			$this->insert_id = count( $this->inserts );
+			return 1;
+		}
+	}
+}
+
 require_once __DIR__ . '/../../includes/class-redirect-manager.php';
 
 /**
@@ -79,6 +120,34 @@ class RedirectNormalizeTest extends TestCase {
 
 	public function test_regex_source_is_untouched(): void {
 		$this->assertSame( '^/tag/(.*)$', $this->invoke( 'normalize_source_url', '^/tag/(.*)$', true ) );
+	}
+
+	public function test_regex_source_backslash_sequences_are_preserved(): void {
+		// Regression: wp_unslash() inside normalize_source_url() stripped the
+		// backslash from \d for input not slashed by WP (programmatic callers),
+		// storing a pattern that never matches. Unslashing belongs at the
+		// $_POST boundary, which every AJAX handler already does.
+		$this->assertSame(
+			'^/category/([^/]+)(?:/page/\d+)?$',
+			$this->invoke( 'normalize_source_url', '^/category/([^/]+)(?:/page/\d+)?$', true )
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// add_redirect (storage)
+	// -------------------------------------------------------------------------
+
+	public function test_add_redirect_stores_regex_backslash_verbatim(): void {
+		global $wpdb;
+		$wpdb = new SWPS_Test_Redirects_WPDB();
+
+		$ref      = new ReflectionClass( SWPS_Redirect_Manager::class );
+		$instance = $ref->newInstanceWithoutConstructor();
+
+		$id = $instance->add_redirect( '^/foo/(\d+)$', '/bar/$1', 301, true );
+
+		$this->assertSame( 1, $id );
+		$this->assertSame( '^/foo/(\d+)$', $wpdb->inserts[0]['source_url'] );
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Regex redirects added programmatically — WP-CLI `wp eval`/`eval-file`, the `add-redirect` ability, or a migration import — had their backslashes silently stripped before storage: `^/foo/(\d+)$` was saved as `^/foo/(d+)$` and never matched a request. Observed live on jonimms.com, where a regex row stored `(?:/page/d+)?` instead of `(?:/page/\d+)?`.

## Root cause

`normalize_source_url()` and `normalize_target_url()` called `wp_unslash()` on their input. WordPress only slash-escapes `$_POST`/`$_GET`, and every entry point that reads those (`ajax_add_redirect`, the site-crawl one-click fix, bulk 404 redirect) already unslashes at the boundary — so the internal call was always a second unslash. For programmatic input it destroyed regex escape sequences; for admin-form regex input it was a double-unslash with the same effect.

## Fix

- Removed `wp_unslash()` from both normalize helpers; unslashing stays at the `$_POST` boundaries where it belongs. All six `add_redirect()` call sites were audited — each either unslashes at its own boundary or receives never-slashed data (permalinks, DB rows, ability input).
- Regression tests (written first, watched fail): `normalize_source_url()` must return a `\d` pattern untouched, and `add_redirect()` must hand the verbatim pattern to `$wpdb->insert()` (captured via a stub).

## Release

- Version bumped to 4.26.3 (`stratawp-seo.php` header + `SWPS_VERSION`, `readme.txt` stable tag) with changelog entries in `readme.txt` and `README.md`.

## Testing

- `vendor/bin/phpunit` — 603 tests, 1054 assertions, all passing (2 new)
- `vendor/bin/phpcs` clean on changed files; `vendor/bin/phpstan` clean