### PR TITLE
Fix Yoast-variable leftovers in migrated title templates + paginated duplicate descriptions (4.26.4)

### DIFF
--- a/includes/class-migration.php
+++ b/includes/class-migration.php
@@ -64,29 +64,29 @@ class SWPS_Migration {
 	private const RM_VAR_MAP = array(
 		'%title%'            => '%%title%%',
 		'%sitename%'         => '%%sitename%%',
-		'%sitedesc%'         => '%%sitedesc%%',
+		'%sitedesc%'         => '',
 		'%sep%'              => '%%sep%%',
 		'%excerpt%'          => '%%excerpt%%',
 		'%excerpt_only%'     => '%%excerpt%%',
 		'%page%'             => '%%page%%',
-		'%pagenumber%'       => '%%pagenumber%%',
-		'%pagetotal%'        => '%%pagetotal%%',
+		'%pagenumber%'       => '%%page%%',
+		'%pagetotal%'        => '',
 		'%category%'         => '%%category%%',
 		'%tag%'              => '%%tag%%',
-		'%term%'             => '%%term_title%%',
-		'%term_title%'       => '%%term_title%%',
+		'%term%'             => '%%title%%',
+		'%term_title%'       => '%%title%%',
 		'%date%'             => '%%date%%',
-		'%modified%'         => '%%modified%%',
+		'%modified%'         => '%%date%%',
 		'%search_query%'     => '%%searchphrase%%',
-		'%name%'             => '%%name%%',
-		'%user_description%' => '%%user_description%%',
+		'%name%'             => '%%author%%',
+		'%user_description%' => '',
 		'%pt_plural%'        => '%%pt_plural%%',
 		'%pt_single%'        => '%%pt_single%%',
-		'%currenttime%'      => '%%currenttime%%',
-		'%currentdate%'      => '%%currentdate%%',
-		'%currentyear%'      => '%%currentyear%%',
-		'%currentmonth%'     => '%%currentmonth%%',
-		'%currentday%'       => '%%currentday%%',
+		'%currenttime%'      => '',
+		'%currentdate%'      => '',
+		'%currentyear%'      => '',
+		'%currentmonth%'     => '',
+		'%currentday%'       => '',
 	);
 
 	public function __construct() {
@@ -423,7 +423,7 @@ class SWPS_Migration {
 				if ( ! is_string( $val ) || '' === $val ) {
 					continue;
 				}
-				$rewritten = $this->rewrite_template_vars( $val, 'yoast' );
+				$rewritten = self::rewrite_template_vars( $val, 'yoast' );
 
 				if ( 'title-author-wpseo' === $key ) {
 					$out['swps_title_template_author'] = $rewritten;
@@ -480,7 +480,7 @@ class SWPS_Migration {
 				if ( ! is_string( $val ) || '' === $val ) {
 					continue;
 				}
-				$rewritten = $this->rewrite_template_vars( $val, 'rank_math' );
+				$rewritten = self::rewrite_template_vars( $val, 'rank_math' );
 
 				if ( preg_match( '/^pt_(.+)_title$/', $key, $m ) ) {
 					$out[ "swps_title_template_{$m[1]}" ] = $rewritten;
@@ -512,8 +512,14 @@ class SWPS_Migration {
 
 	/**
 	 * Rewrite source-plugin template variables to StrataWP %%var%% syntax.
+	 *
+	 * Yoast shares the %%var%% delimiters but not the variable names
+	 * (%%term_title%%, %%name%%, ...), so both sources need their names
+	 * mapped onto the supported set. Anything still unsupported afterwards
+	 * is dropped here rather than stored, since the renderer would strip
+	 * it silently at output time (leaving titles like "Archives – Site").
 	 */
-	private function rewrite_template_vars( string $template, string $source ): string {
+	public static function rewrite_template_vars( string $template, string $source ): string {
 		if ( 'rank_math' === $source ) {
 			// Sort keys by length descending so longer matches replace first.
 			$keys = array_keys( self::RM_VAR_MAP );
@@ -522,8 +528,17 @@ class SWPS_Migration {
 				$template = str_replace( $k, self::RM_VAR_MAP[ $k ], $template );
 			}
 		}
-		// Yoast already uses %%var%% so no rewriting needed.
-		return $template;
+
+		$template = SWPS_Search_Appearance::normalize_legacy_vars( $template );
+
+		// Drop any variable the renderer doesn't support.
+		$template = (string) preg_replace_callback(
+			'/%%\w+%%/',
+			static fn( $m ) => in_array( $m[0], SWPS_Search_Appearance::VARIABLES, true ) ? $m[0] : '',
+			$template
+		);
+
+		return trim( (string) preg_replace( '/\s+/', ' ', $template ) );
 	}
 
 	/**

--- a/includes/class-search-appearance.php
+++ b/includes/class-search-appearance.php
@@ -125,6 +125,13 @@ class SWPS_Search_Appearance {
 	 * Singular pages are handled by SWPS_Meta_Editor.
 	 */
 	public function output_meta_description(): void {
+		// Paginated archive views (page 2+) would repeat page 1's description
+		// verbatim — a duplicate-description flag in every crawler. Each page
+		// already carries a self-referencing canonical, so omit it instead.
+		if ( ! is_singular() && (int) get_query_var( 'paged' ) > 1 ) {
+			return;
+		}
+
 		// Singular pages: only output if Meta Editor hasn't set one.
 		if ( is_singular() ) {
 			$post_desc = get_post_meta( get_the_ID(), '_swps_meta_description', true );

--- a/includes/class-search-appearance.php
+++ b/includes/class-search-appearance.php
@@ -19,7 +19,7 @@ class SWPS_Search_Appearance {
 	/**
 	 * Supported template variables.
 	 */
-	private const VARIABLES = array(
+	public const VARIABLES = array(
 		'%%title%%',
 		'%%sitename%%',
 		'%%sep%%',
@@ -33,6 +33,33 @@ class SWPS_Search_Appearance {
 		'%%pt_single%%',
 		'%%pt_plural%%',
 	);
+
+	/**
+	 * Yoast-style variable names mapped to their StrataWP equivalents.
+	 *
+	 * Templates imported from Yoast (and older migrations that stored Yoast
+	 * names verbatim) use these; without aliasing they hit the unknown-variable
+	 * strip in resolve_variables() and vanish from rendered titles — every tag
+	 * archive ends up titled just "Archives – Site".
+	 */
+	private const LEGACY_ALIASES = array(
+		'%%term_title%%'       => '%%title%%',
+		'%%archive_title%%'    => '%%title%%',
+		'%%name%%'             => '%%author%%',
+		'%%primary_category%%' => '%%category%%',
+		'%%pagenumber%%'       => '%%page%%',
+	);
+
+	/**
+	 * Rewrite legacy (Yoast-style) variable names to supported ones.
+	 */
+	public static function normalize_legacy_vars( string $template ): string {
+		return str_replace(
+			array_keys( self::LEGACY_ALIASES ),
+			array_values( self::LEGACY_ALIASES ),
+			$template
+		);
+	}
 
 	public function __construct() {
 		if ( is_admin() ) {
@@ -471,6 +498,8 @@ class SWPS_Search_Appearance {
 	 * Resolve template variables to their current values.
 	 */
 	public function resolve_variables( string $template ): string {
+		$template = self::normalize_legacy_vars( $template );
+
 		$sep      = get_option( 'swps_title_separator', '-' );
 		$sitename = get_bloginfo( 'name' );
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -161,11 +161,6 @@ parameters:
 			path: includes/class-schema.php
 
 		-
-			message: "#^Constant SWPS_Search_Appearance\\:\\:VARIABLES is unused\\.$#"
-			count: 1
-			path: includes/class-search-appearance.php
-
-		-
 			message: "#^Parameter \\#2 \\$user_id of function get_the_author_meta expects int\\|false, string given\\.$#"
 			count: 1
 			path: includes/class-search-appearance.php

--- a/readme.txt
+++ b/readme.txt
@@ -423,6 +423,7 @@ By default, nothing is lost: uninstalling only clears scheduled tasks and caches
 == Changelog ==
 
 = 4.26.4 =
+* Fixed: paginated archive views (`/blog/page/2/` and beyond) repeated page 1's meta description verbatim, tripping duplicate-description flags in site audits. Page 2+ now omits the meta description; each page keeps its self-referencing canonical.
 * Fixed: title templates imported from Yoast SEO kept Yoast's variable names (`%%term_title%%`, `%%name%%`, `%%archive_title%%`), which StrataWP SEO doesn't recognize — the renderer stripped them silently, so every tag, category, and author archive shared a generic title like "Archives – Site". The migration now rewrites Yoast and Rank Math variable names onto the supported set and drops anything unsupported instead of storing it, and the frontend renderer aliases the common legacy names so already-migrated sites get correct archive titles without re-running the migration.
 
 = 4.26.3 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.26.3
+Stable tag: 4.26.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,9 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.26.4 =
+* Fixed: title templates imported from Yoast SEO kept Yoast's variable names (`%%term_title%%`, `%%name%%`, `%%archive_title%%`), which StrataWP SEO doesn't recognize — the renderer stripped them silently, so every tag, category, and author archive shared a generic title like "Archives – Site". The migration now rewrites Yoast and Rank Math variable names onto the supported set and drops anything unsupported instead of storing it, and the frontend renderer aliases the common legacy names so already-migrated sites get correct archive titles without re-running the migration.
 
 = 4.26.3 =
 * Fixed: regex redirects created programmatically (WP-CLI, the add-redirect ability, or a redirect importer) had their backslashes stripped before storage — a pattern like `^/foo/(\d+)$` was silently saved as `^/foo/(d+)$` and never matched a request. The redirect manager unslashed its input a second time even though every admin form and AJAX entry point had already done so; unslashing now happens only at the form boundary, and the programmatic API stores patterns exactly as given.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.26.3
+ * Version: 4.26.4
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.26.3' );
+define( 'SWPS_VERSION', '4.26.4' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/tests/unit/MigrationTemplateVarsTest.php
+++ b/tests/unit/MigrationTemplateVarsTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Tests for template-variable rewriting during Yoast / Rank Math migration.
+ *
+ * Pure-PHP, no WordPress. Covers the static rewrite helpers only; the
+ * migration runner itself (WP options/meta) is smoke-tested via WP-CLI.
+ *
+ * Regression context: Yoast shares the %%var%% delimiters but not the
+ * variable names, so migrated templates stored %%term_title%% / %%name%%
+ * verbatim. The renderer strips unknown variables, which turned every tag
+ * and category archive title into just "Archives – Site".
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-search-appearance.php';
+require_once __DIR__ . '/../../includes/class-migration.php';
+
+/**
+ * @covers SWPS_Migration
+ * @covers SWPS_Search_Appearance
+ */
+final class MigrationTemplateVarsTest extends TestCase {
+
+	public function test_yoast_term_title_is_mapped_to_title(): void {
+		$this->assertSame(
+			'%%title%% Archives %%page%% %%sep%% %%sitename%%',
+			SWPS_Migration::rewrite_template_vars(
+				'%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
+				'yoast'
+			)
+		);
+	}
+
+	public function test_yoast_author_name_is_mapped_to_author(): void {
+		$this->assertSame(
+			'%%author%%, Author at %%sitename%% %%page%%',
+			SWPS_Migration::rewrite_template_vars(
+				'%%name%%, Author at %%sitename%% %%page%%',
+				'yoast'
+			)
+		);
+	}
+
+	public function test_yoast_archive_title_and_pagenumber_aliases(): void {
+		$this->assertSame(
+			'%%title%% %%page%% %%sep%% %%sitename%%',
+			SWPS_Migration::rewrite_template_vars(
+				'%%archive_title%% %%pagenumber%% %%sep%% %%sitename%%',
+				'yoast'
+			)
+		);
+	}
+
+	public function test_unsupported_variables_are_dropped_not_stored(): void {
+		$this->assertSame(
+			'%%sitename%% %%page%% %%sep%%',
+			SWPS_Migration::rewrite_template_vars(
+				'%%sitename%% %%page%% %%sep%% %%sitedesc%%',
+				'yoast'
+			)
+		);
+	}
+
+	public function test_rank_math_term_and_name_map_to_supported_vars(): void {
+		$this->assertSame(
+			'%%title%% Archives %%page%% %%sep%% %%sitename%%',
+			SWPS_Migration::rewrite_template_vars(
+				'%term% Archives %page% %sep% %sitename%',
+				'rank_math'
+			)
+		);
+
+		$this->assertSame(
+			'%%author%% %%sep%% %%sitename%%',
+			SWPS_Migration::rewrite_template_vars(
+				'%name% %sep% %sitename%',
+				'rank_math'
+			)
+		);
+	}
+
+	public function test_rank_math_current_date_vars_are_dropped(): void {
+		$this->assertSame(
+			'%%title%% %%sep%% %%sitename%%',
+			SWPS_Migration::rewrite_template_vars(
+				'%title% %currentyear% %sep% %sitename%',
+				'rank_math'
+			)
+		);
+	}
+
+	public function test_supported_template_passes_through_unchanged(): void {
+		$template = '%%title%% %%page%% %%sep%% %%sitename%%';
+		$this->assertSame( $template, SWPS_Migration::rewrite_template_vars( $template, 'yoast' ) );
+	}
+
+	public function test_normalize_legacy_vars_rewrites_yoast_names(): void {
+		$this->assertSame(
+			'%%title%% Archives %%sep%% %%sitename%%',
+			SWPS_Search_Appearance::normalize_legacy_vars( '%%term_title%% Archives %%sep%% %%sitename%%' )
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Two front-end SEO output fixes surfaced by a Semrush site audit of jonimms.com.

### 1. Yoast variable names survived migration and were stripped at render time

Yoast shares the `%%var%%` template delimiters but not the variable names, and `SWPS_Migration::rewrite_template_vars()` stored Yoast templates verbatim on the assumption no rewriting was needed. The renderer strips variables it doesn't recognize, so `%%term_title%%` and `%%name%%` vanished from output — every tag, category, and post-format archive shared the generic title "Archives – Site", and author archives rendered ", Author at Site".

- Migration now maps Yoast names onto the supported set (`%%term_title%%`/`%%archive_title%%` → `%%title%%`, `%%name%%` → `%%author%%`, `%%pagenumber%%` → `%%page%%`, `%%primary_category%%` → `%%category%%`) and drops still-unsupported variables instead of storing them.
- The Rank Math map no longer targets unsupported names (`%term%`/`%term_title%` → `%%title%%`, `%name%` → `%%author%%`; the `%current*%` family is dropped).
- `SWPS_Search_Appearance` aliases the common legacy names at render time, so sites that already ran the migration get correct archive titles without re-running it.

### 2. Paginated archives repeated page 1's meta description

`/blog/page/2/` and every later page shipped the posts page's meta description verbatim (term and author archives paginate the same way) — a duplicate-description flag in every crawler. Page 2+ now omits the meta description; each paginated page keeps its self-referencing canonical.

## Testing

- 8 new pure-PHP unit tests in `tests/unit/MigrationTemplateVarsTest.php` covering the Yoast and Rank Math rewrite paths, unsupported-variable dropping, and the render-time aliases.
- Full suite: 611 tests / 1063 assertions pass; PHPStan clean (removed the now-stale "VARIABLES is unused" baseline entry).