### PR TITLE
Fix WebP og:image breaking LinkedIn share previews (4.27.1)

### DIFF
--- a/includes/audit/class-opengraph-module.php
+++ b/includes/audit/class-opengraph-module.php
@@ -127,6 +127,7 @@ class SWPS_OpenGraph_Module extends SWPS_Audit_Module {
 		$url         = get_permalink( $post );
 		$site_name   = get_bloginfo( 'name' );
 		$image       = self::get_og_image( $post );
+		$dimensions  = self::get_og_image_dimensions( $post, $image );
 
 		// OG tags. Posts are articles; pages and other singulars are websites.
 		printf( '<meta property="og:type" content="%s" />' . "\n", esc_attr( is_singular( 'post' ) ? 'article' : 'website' ) );
@@ -137,6 +138,10 @@ class SWPS_OpenGraph_Module extends SWPS_Audit_Module {
 
 		if ( $image ) {
 			printf( '<meta property="og:image" content="%s" />' . "\n", esc_url( $image ) );
+			if ( $dimensions ) {
+				printf( '<meta property="og:image:width" content="%d" />' . "\n", $dimensions['width'] );
+				printf( '<meta property="og:image:height" content="%d" />' . "\n", $dimensions['height'] );
+			}
 		}
 
 		// Twitter Card tags.
@@ -190,9 +195,15 @@ class SWPS_OpenGraph_Module extends SWPS_Audit_Module {
 	 * Priority: featured image → first content image → site icon.
 	 */
 	private static function get_og_image( WP_Post $post ): string {
-		// Featured image.
+		// Featured image — resolved via SWPS_Social_Image so WebP/AVIF
+		// uploads fall back to a JPEG copy LinkedIn's crawler can render.
 		$thumb_id = get_post_thumbnail_id( $post->ID );
 		if ( $thumb_id ) {
+			$resolved = SWPS_Social_Image::get( (int) $thumb_id );
+			if ( null !== $resolved ) {
+				return $resolved['url'];
+			}
+
 			$img = wp_get_attachment_image_src( $thumb_id, 'large' );
 			if ( $img ) {
 				return $img[0];
@@ -203,6 +214,45 @@ class SWPS_OpenGraph_Module extends SWPS_Audit_Module {
 		if ( preg_match( '/<img[^>]+src=["\']([^"\']+)/i', $post->post_content, $matches ) ) {
 			return $matches[1];
 		}
+
+		return self::get_site_icon_fallback();
+	}
+
+	/**
+	 * Dimensions for the emitted og:image, when they are knowable.
+	 *
+	 * Only the featured-image path (resolved through SWPS_Social_Image)
+	 * carries dimensions; content-scraped images and icons return null.
+	 *
+	 * @param WP_Post $post  Queried post.
+	 * @param string  $image The URL get_og_image() returned.
+	 * @return array{width: int, height: int}|null
+	 */
+	private static function get_og_image_dimensions( WP_Post $post, string $image ): ?array {
+		if ( '' === $image ) {
+			return null;
+		}
+
+		$thumb_id = get_post_thumbnail_id( $post->ID );
+		if ( ! $thumb_id ) {
+			return null;
+		}
+
+		$resolved = SWPS_Social_Image::get( (int) $thumb_id );
+		if ( null !== $resolved && $resolved['url'] === $image && $resolved['width'] > 0 && $resolved['height'] > 0 ) {
+			return array(
+				'width'  => $resolved['width'],
+				'height' => $resolved['height'],
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Site icon fallback for get_og_image().
+	 */
+	private static function get_site_icon_fallback(): string {
 
 		// Site icon.
 		$icon_id = get_option( 'site_icon' );

--- a/includes/class-meta-editor.php
+++ b/includes/class-meta-editor.php
@@ -614,6 +614,49 @@ class SWPS_Meta_Editor {
 	}
 
 	/**
+	 * Resolve the social image for a post.
+	 *
+	 * A manual Social Image override wins as-is. Featured images go through
+	 * SWPS_Social_Image so WebP/AVIF uploads resolve to a JPEG copy
+	 * (LinkedIn's crawler skips WebP) and dimensions become available.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array{url: string, width: int, height: int} Empty url when no image exists.
+	 */
+	private function get_social_image( int $post_id ): array {
+		$manual = (string) get_post_meta( $post_id, '_swps_social_image', true );
+		if ( '' !== $manual ) {
+			return array(
+				'url'    => $manual,
+				'width'  => 0,
+				'height' => 0,
+			);
+		}
+
+		$thumb_id = get_post_thumbnail_id( $post_id );
+		if ( $thumb_id ) {
+			$resolved = SWPS_Social_Image::get( (int) $thumb_id );
+			if ( null !== $resolved ) {
+				return array(
+					'url'    => $resolved['url'],
+					'width'  => $resolved['width'],
+					'height' => $resolved['height'],
+				);
+			}
+		}
+
+		$fallback = (string) get_the_post_thumbnail_url( $post_id, 'large' )
+				?: (string) get_option( 'swps_schema_logo', '' )
+				?: (string) get_site_icon_url( 512 );
+
+		return array(
+			'url'    => $fallback,
+			'width'  => 0,
+			'height' => 0,
+		);
+	}
+
+	/**
 	 * Output Open Graph tags.
 	 */
 	private function output_og_tags( int $post_id ): void {
@@ -625,18 +668,19 @@ class SWPS_Meta_Editor {
 			?: get_post_meta( $post_id, '_swps_meta_description', true )
 			?: get_the_excerpt( $post_id );
 
-		$image = get_post_meta( $post_id, '_swps_social_image', true )
-				?: get_the_post_thumbnail_url( $post_id, 'large' )
-				?: (string) get_option( 'swps_schema_logo', '' )
-				?: (string) get_site_icon_url( 512 );
+		$image = $this->get_social_image( $post_id );
 
 		// Posts are articles; the front page and other pages are websites.
 		printf( '<meta property="og:type" content="%s" />' . "\n", esc_attr( is_singular( 'post' ) ? 'article' : 'website' ) );
 		printf( '<meta property="og:title" content="%s" />' . "\n", esc_attr( $title ) );
 		printf( '<meta property="og:description" content="%s" />' . "\n", esc_attr( $desc ) );
 		printf( '<meta property="og:url" content="%s" />' . "\n", esc_url( get_permalink( $post_id ) ) );
-		if ( $image ) {
-			printf( '<meta property="og:image" content="%s" />' . "\n", esc_url( $image ) );
+		if ( $image['url'] ) {
+			printf( '<meta property="og:image" content="%s" />' . "\n", esc_url( $image['url'] ) );
+			if ( $image['width'] > 0 && $image['height'] > 0 ) {
+				printf( '<meta property="og:image:width" content="%d" />' . "\n", $image['width'] );
+				printf( '<meta property="og:image:height" content="%d" />' . "\n", $image['height'] );
+			}
 		}
 		printf( '<meta property="og:site_name" content="%s" />' . "\n", esc_attr( get_bloginfo( 'name' ) ) );
 	}
@@ -653,16 +697,13 @@ class SWPS_Meta_Editor {
 			?: get_post_meta( $post_id, '_swps_meta_description', true )
 			?: get_the_excerpt( $post_id );
 
-		$image = get_post_meta( $post_id, '_swps_social_image', true )
-				?: get_the_post_thumbnail_url( $post_id, 'large' )
-				?: (string) get_option( 'swps_schema_logo', '' )
-				?: (string) get_site_icon_url( 512 );
+		$image = $this->get_social_image( $post_id );
 
-		printf( '<meta name="twitter:card" content="%s" />' . "\n", $image ? 'summary_large_image' : 'summary' );
+		printf( '<meta name="twitter:card" content="%s" />' . "\n", $image['url'] ? 'summary_large_image' : 'summary' );
 		printf( '<meta name="twitter:title" content="%s" />' . "\n", esc_attr( $title ) );
 		printf( '<meta name="twitter:description" content="%s" />' . "\n", esc_attr( $desc ) );
-		if ( $image ) {
-			printf( '<meta name="twitter:image" content="%s" />' . "\n", esc_url( $image ) );
+		if ( $image['url'] ) {
+			printf( '<meta name="twitter:image" content="%s" />' . "\n", esc_url( $image['url'] ) );
 		}
 	}
 }

--- a/includes/class-social-image.php
+++ b/includes/class-social-image.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Social image resolution for Open Graph / Twitter Cards.
+ *
+ * LinkedIn's crawler does not render WebP (or AVIF) og:images, so posts
+ * whose featured image was uploaded as WebP shipped share cards with no
+ * preview. This helper picks the best available rendition of an
+ * attachment for social use — preferring JPEG/PNG/GIF — and, when only
+ * WebP/AVIF renditions exist, converts one to a cached JPEG copy.
+ *
+ * @package StrataWP_SEO
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Resolves attachment renditions to a social-safe image with dimensions.
+ */
+class SWPS_Social_Image {
+
+	/**
+	 * Width sweet spot for social cards (LinkedIn/Facebook recommend 1200px).
+	 */
+	private const TARGET_WIDTH = 1200;
+
+	/**
+	 * Meta key caching the converted-JPEG rendition on the attachment.
+	 */
+	private const CONVERTED_META_KEY = '_swps_social_jpeg';
+
+	/**
+	 * Whether a mime type renders in every major share crawler.
+	 *
+	 * WebP and AVIF are excluded: LinkedIn's scraper skips them, leaving
+	 * the share card without an image.
+	 *
+	 * @param string $mime Mime type, e.g. "image/webp".
+	 * @return bool
+	 */
+	public static function is_social_safe( string $mime ): bool {
+		return in_array( $mime, array( 'image/jpeg', 'image/png', 'image/gif' ), true );
+	}
+
+	/**
+	 * Best-effort mime type from a file path or URL extension.
+	 *
+	 * @param string $path File path or URL.
+	 * @return string Mime type, or '' when unrecognized.
+	 */
+	public static function mime_from_path( string $path ): string {
+		$clean = strtolower( (string) preg_replace( '/[?#].*$/', '', $path ) );
+		$ext   = pathinfo( $clean, PATHINFO_EXTENSION );
+
+		$map = array(
+			'jpg'  => 'image/jpeg',
+			'jpeg' => 'image/jpeg',
+			'png'  => 'image/png',
+			'gif'  => 'image/gif',
+			'webp' => 'image/webp',
+			'avif' => 'image/avif',
+		);
+
+		return $map[ $ext ] ?? '';
+	}
+
+	/**
+	 * Choose the best social rendition from a candidate list.
+	 *
+	 * Candidates are arrays with url, width, height, mime keys. Social-safe
+	 * mimes always beat WebP/AVIF regardless of size; within the winning
+	 * pool the width closest to the 1200px target wins, larger on ties.
+	 *
+	 * @param array<int, array{url: string, width: int, height: int, mime: string}> $candidates Renditions.
+	 * @return array{url: string, width: int, height: int, mime: string}|null
+	 */
+	public static function choose_rendition( array $candidates ): ?array {
+		$valid = array_values(
+			array_filter(
+				$candidates,
+				static function ( $c ) {
+					return is_array( $c ) && ! empty( $c['url'] ) && ! empty( $c['width'] );
+				}
+			)
+		);
+
+		if ( ! $valid ) {
+			return null;
+		}
+
+		$safe = array_values(
+			array_filter(
+				$valid,
+				static function ( $c ) {
+					return self::is_social_safe( (string) $c['mime'] );
+				}
+			)
+		);
+
+		$pool = $safe ? $safe : $valid;
+
+		usort(
+			$pool,
+			static function ( $a, $b ) {
+				$dist_a = abs( (int) $a['width'] - self::TARGET_WIDTH );
+				$dist_b = abs( (int) $b['width'] - self::TARGET_WIDTH );
+				if ( $dist_a === $dist_b ) {
+					return (int) $b['width'] <=> (int) $a['width'];
+				}
+				return $dist_a <=> $dist_b;
+			}
+		);
+
+		return $pool[0];
+	}
+
+	/**
+	 * Resolve an attachment to a social-safe image with dimensions.
+	 *
+	 * Picks the best rendition; when only WebP/AVIF exists, converts it to
+	 * a JPEG copy cached beside the original (and in attachment meta) so
+	 * the conversion runs once per attachment.
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 * @return array{url: string, width: int, height: int, mime: string}|null
+	 */
+	public static function get( int $attachment_id ): ?array {
+		$chosen = self::choose_rendition( self::build_candidates( $attachment_id ) );
+		if ( null === $chosen ) {
+			return null;
+		}
+
+		if ( self::is_social_safe( $chosen['mime'] ) ) {
+			return $chosen;
+		}
+
+		return self::ensure_jpeg( $attachment_id, $chosen ) ?? $chosen;
+	}
+
+	/**
+	 * Build rendition candidates (full size + sub-sizes) for an attachment.
+	 *
+	 * @param int $attachment_id Attachment post ID.
+	 * @return array<int, array{url: string, width: int, height: int, mime: string}>
+	 */
+	private static function build_candidates( int $attachment_id ): array {
+		$meta = wp_get_attachment_metadata( $attachment_id );
+		$url  = wp_get_attachment_url( $attachment_id );
+
+		if ( ! is_array( $meta ) || ! $url ) {
+			return array();
+		}
+
+		$candidates = array(
+			array(
+				'url'    => $url,
+				'width'  => (int) $meta['width'],
+				'height' => (int) $meta['height'],
+				'mime'   => self::mime_from_path( $url ),
+			),
+		);
+
+		$base = trailingslashit( dirname( $url ) );
+		foreach ( (array) $meta['sizes'] as $size ) {
+			if ( empty( $size['file'] ) ) {
+				continue;
+			}
+			$candidates[] = array(
+				'url'    => $base . $size['file'],
+				'width'  => (int) ( $size['width'] ?? 0 ),
+				'height' => (int) ( $size['height'] ?? 0 ),
+				'mime'   => (string) ( $size['mime-type'] ?? self::mime_from_path( (string) $size['file'] ) ),
+			);
+		}
+
+		return $candidates;
+	}
+
+	/**
+	 * Return (creating once) a JPEG copy of a WebP/AVIF rendition.
+	 *
+	 * @param int                                                       $attachment_id Attachment post ID.
+	 * @param array{url: string, width: int, height: int, mime: string} $rendition     Chosen unsafe rendition.
+	 * @return array{url: string, width: int, height: int, mime: string}|null Null when conversion is unavailable.
+	 */
+	private static function ensure_jpeg( int $attachment_id, array $rendition ): ?array {
+		$uploads = wp_get_upload_dir();
+
+		// Cached conversion from a previous request.
+		$cached = get_post_meta( $attachment_id, self::CONVERTED_META_KEY, true );
+		if ( is_array( $cached ) && ! empty( $cached['file'] ) ) {
+			$path = trailingslashit( $uploads['basedir'] ) . $cached['file'];
+			if ( file_exists( $path ) ) {
+				return array(
+					'url'    => trailingslashit( $uploads['baseurl'] ) . $cached['file'],
+					'width'  => (int) ( $cached['width'] ?? 0 ),
+					'height' => (int) ( $cached['height'] ?? 0 ),
+					'mime'   => 'image/jpeg',
+				);
+			}
+			delete_post_meta( $attachment_id, self::CONVERTED_META_KEY );
+		}
+
+		// Map the rendition URL back to a local file path.
+		$path = str_replace( trailingslashit( $uploads['baseurl'] ), trailingslashit( $uploads['basedir'] ), $rendition['url'] );
+		if ( $path === $rendition['url'] || ! file_exists( $path ) ) {
+			return null;
+		}
+
+		$editor = wp_get_image_editor( $path );
+		if ( is_wp_error( $editor ) ) {
+			return null;
+		}
+
+		$dest  = preg_replace( '/\.[a-z0-9]+$/i', '', $path ) . '-social.jpg';
+		$saved = $editor->save( $dest, 'image/jpeg' );
+		if ( is_wp_error( $saved ) || empty( $saved['path'] ) ) {
+			return null;
+		}
+
+		$relative = ltrim( str_replace( trailingslashit( $uploads['basedir'] ), '', $saved['path'] ), '/' );
+		update_post_meta(
+			$attachment_id,
+			self::CONVERTED_META_KEY,
+			array(
+				'file'   => $relative,
+				'width'  => (int) $saved['width'],
+				'height' => (int) $saved['height'],
+			)
+		);
+
+		return array(
+			'url'    => trailingslashit( $uploads['baseurl'] ) . $relative,
+			'width'  => (int) $saved['width'],
+			'height' => (int) $saved['height'],
+			'mime'   => 'image/jpeg',
+		);
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.27.0
+Stable tag: 4.27.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,10 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.27.1 =
+* Fixed: posts whose featured image was uploaded as WebP (or AVIF) shipped that file as the og:image, and LinkedIn's crawler does not render WebP — shares showed no preview card image. Open Graph and Twitter Card output now resolves the featured image through a social-safe picker that prefers JPEG/PNG/GIF renditions and, when only WebP/AVIF exists, converts one to a JPEG copy (created once, cached in attachment meta and reused).
+* New: og:image:width and og:image:height are emitted whenever the image dimensions are known, so the first share of a URL renders its preview image immediately instead of waiting for the scraper's second pass.
 
 = 4.27.0 =
 * New: Site Audit dashboard — a crawl-based audit of the rendered site with ~25 checks (missing/duplicate titles and descriptions, viewport/doctype/charset/lang, bot-challenge detection, unminified assets, word count, hreflang, orphan pages, and more), a 0-100 health score, error/warning/notice triage with per-page drill-downs and fix guidance, and crawl-over-crawl trends. The crawler now covers every public URL including term archives and pagination, and noindexed pages are audited for head integrity.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.27.0
+ * Version: 4.27.1
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.27.0' );
+define( 'SWPS_VERSION', '4.27.1' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -107,6 +107,7 @@ require_once SWPS_PLUGIN_DIR . 'includes/class-citation-prompts.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-citation-tracker.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-citation-admin.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-keywords-page.php';
+require_once SWPS_PLUGIN_DIR . 'includes/class-social-image.php';
 require_once SWPS_PLUGIN_DIR . 'includes/class-meta-editor.php';
 
 // Auto-Optimize (v4.1).

--- a/tests/unit/SocialImageTest.php
+++ b/tests/unit/SocialImageTest.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Unit tests for SWPS_Social_Image pure helpers.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-social-image.php';
+
+class SocialImageTest extends TestCase {
+
+	public function test_jpeg_png_gif_are_social_safe(): void {
+		$this->assertTrue( SWPS_Social_Image::is_social_safe( 'image/jpeg' ) );
+		$this->assertTrue( SWPS_Social_Image::is_social_safe( 'image/png' ) );
+		$this->assertTrue( SWPS_Social_Image::is_social_safe( 'image/gif' ) );
+	}
+
+	public function test_webp_and_avif_are_not_social_safe(): void {
+		$this->assertFalse( SWPS_Social_Image::is_social_safe( 'image/webp' ) );
+		$this->assertFalse( SWPS_Social_Image::is_social_safe( 'image/avif' ) );
+	}
+
+	public function test_choose_rendition_returns_null_for_empty_list(): void {
+		$this->assertNull( SWPS_Social_Image::choose_rendition( array() ) );
+	}
+
+	public function test_choose_rendition_prefers_safe_mime_over_webp(): void {
+		$webp = array(
+			'url'    => 'a.webp',
+			'width'  => 1200,
+			'height' => 800,
+			'mime'   => 'image/webp',
+		);
+		$png  = array(
+			'url'    => 'a.png',
+			'width'  => 768,
+			'height' => 512,
+			'mime'   => 'image/png',
+		);
+
+		$chosen = SWPS_Social_Image::choose_rendition( array( $webp, $png ) );
+		$this->assertSame( 'a.png', $chosen['url'] );
+	}
+
+	public function test_choose_rendition_picks_width_closest_to_1200(): void {
+		$small = array(
+			'url'    => 's.png',
+			'width'  => 300,
+			'height' => 200,
+			'mime'   => 'image/png',
+		);
+		$mid   = array(
+			'url'    => 'm.png',
+			'width'  => 1024,
+			'height' => 683,
+			'mime'   => 'image/png',
+		);
+		$huge  = array(
+			'url'    => 'h.png',
+			'width'  => 2560,
+			'height' => 1707,
+			'mime'   => 'image/png',
+		);
+
+		$chosen = SWPS_Social_Image::choose_rendition( array( $small, $huge, $mid ) );
+		$this->assertSame( 'm.png', $chosen['url'] );
+	}
+
+	public function test_choose_rendition_prefers_larger_on_equal_distance(): void {
+		$below = array(
+			'url'    => 'b.png',
+			'width'  => 1100,
+			'height' => 733,
+			'mime'   => 'image/png',
+		);
+		$above = array(
+			'url'    => 'a.png',
+			'width'  => 1300,
+			'height' => 867,
+			'mime'   => 'image/png',
+		);
+
+		$chosen = SWPS_Social_Image::choose_rendition( array( $below, $above ) );
+		$this->assertSame( 'a.png', $chosen['url'] );
+	}
+
+	public function test_choose_rendition_falls_back_to_webp_when_no_safe_candidate(): void {
+		$w1 = array(
+			'url'    => 'w1.webp',
+			'width'  => 300,
+			'height' => 200,
+			'mime'   => 'image/webp',
+		);
+		$w2 = array(
+			'url'    => 'w2.webp',
+			'width'  => 1024,
+			'height' => 683,
+			'mime'   => 'image/webp',
+		);
+
+		$chosen = SWPS_Social_Image::choose_rendition( array( $w1, $w2 ) );
+		$this->assertSame( 'w2.webp', $chosen['url'] );
+	}
+
+	public function test_choose_rendition_ignores_candidates_without_url_or_width(): void {
+		$bad  = array(
+			'url'    => '',
+			'width'  => 1200,
+			'height' => 800,
+			'mime'   => 'image/png',
+		);
+		$bad2 = array(
+			'url'    => 'x.png',
+			'width'  => 0,
+			'height' => 0,
+			'mime'   => 'image/png',
+		);
+		$good = array(
+			'url'    => 'ok.png',
+			'width'  => 640,
+			'height' => 427,
+			'mime'   => 'image/png',
+		);
+
+		$chosen = SWPS_Social_Image::choose_rendition( array( $bad, $bad2, $good ) );
+		$this->assertSame( 'ok.png', $chosen['url'] );
+
+		$this->assertNull( SWPS_Social_Image::choose_rendition( array( $bad, $bad2 ) ) );
+	}
+
+	public function test_mime_from_path_maps_common_extensions(): void {
+		$this->assertSame( 'image/jpeg', SWPS_Social_Image::mime_from_path( '/up/img.jpg' ) );
+		$this->assertSame( 'image/jpeg', SWPS_Social_Image::mime_from_path( 'img.JPEG' ) );
+		$this->assertSame( 'image/png', SWPS_Social_Image::mime_from_path( 'https://x.com/a-1024x683.png?v=2' ) );
+		$this->assertSame( 'image/webp', SWPS_Social_Image::mime_from_path( 'a.webp' ) );
+		$this->assertSame( 'image/avif', SWPS_Social_Image::mime_from_path( 'a.avif' ) );
+		$this->assertSame( 'image/gif', SWPS_Social_Image::mime_from_path( 'a.gif' ) );
+		$this->assertSame( '', SWPS_Social_Image::mime_from_path( 'a.svg' ) );
+		$this->assertSame( '', SWPS_Social_Image::mime_from_path( 'no-extension' ) );
+	}
+}


### PR DESCRIPTION
## Summary

Posts whose featured image was uploaded as WebP (or AVIF) shipped that file as the `og:image`. LinkedIn's crawler does not render WebP, so shares of those posts showed a card with no preview image.

- **New `SWPS_Social_Image` resolver** (`includes/class-social-image.php`): resolves an attachment to its best social-safe rendition — prefers JPEG/PNG/GIF near the 1200px social sweet spot; when only WebP/AVIF renditions exist, converts one to a JPEG copy (created once, cached in `_swps_social_jpeg` attachment meta, reused thereafter).
- **Both OG output paths** — `SWPS_Meta_Editor` and the audit `SWPS_OpenGraph_Module` — now route featured images through the resolver. A manual Social Image override still wins untouched.
- **`og:image:width` / `og:image:height`** are emitted whenever dimensions are known, so the first share of a URL renders its preview immediately instead of waiting for the scraper's second fetch.

## Testing

- `vendor/bin/phpunit`: 664 tests, 1209 assertions, all passing (includes new `tests/unit/SocialImageTest.php`)
- `vendor/bin/phpstan`: no errors
- `phpcs`: new production file clean; no new violations beyond the advisory backlog

## Release

Version bump 4.27.0 → 4.27.1 in `stratawp-seo.php` (header + `SWPS_VERSION`) and `readme.txt` (stable tag + changelog); merging to `main` triggers the release build.