### PR TITLE
Render the meta title on the posts page (4.28.1)

### DIFF
--- a/includes/class-search-appearance.php
+++ b/includes/class-search-appearance.php
@@ -94,9 +94,56 @@ class SWPS_Search_Appearance {
 	}
 
 	/**
+	 * Apply a stored posts-page meta title to core's title parts.
+	 *
+	 * Split out as a pure static so the precedence is unit-testable without
+	 * loading WordPress. An empty or whitespace-only stored title leaves the
+	 * parts untouched so the template path can take over.
+	 *
+	 * @param array  $title_parts Core's title parts.
+	 * @param string $meta_title  Stored _swps_meta_title for the posts page.
+	 * @return array
+	 */
+	public static function apply_posts_page_title( array $title_parts, string $meta_title ): array {
+		$meta_title = trim( $meta_title );
+
+		if ( '' === $meta_title ) {
+			return $title_parts;
+		}
+
+		$title_parts['title'] = $meta_title;
+
+		// The stored title is the complete tag; core would otherwise append
+		// the site name a second time.
+		unset( $title_parts['site'], $title_parts['tagline'] );
+
+		return $title_parts;
+	}
+
+	/**
 	 * Filter the document title parts array.
 	 */
 	public function filter_title_parts( array $title_parts ): array {
+		// Posts page: an explicit per-page meta title wins, mirroring how
+		// resolve_description() sources the posts-page description. The Meta
+		// Editor cannot cover this -- its title filters gate on is_singular(),
+		// which the posts page never satisfies, so a title set on the page
+		// assigned to "Posts page" was stored and shown in the editor but
+		// never rendered.
+		if ( is_home() && ! is_front_page() ) {
+			$posts_page = (int) get_option( 'page_for_posts' );
+
+			if ( $posts_page ) {
+				$meta_title = (string) get_post_meta( $posts_page, '_swps_meta_title', true );
+				$meta_title = (string) SWPS_Hooks::filter_meta_title( $meta_title, $posts_page );
+				$applied    = self::apply_posts_page_title( $title_parts, $meta_title );
+
+				if ( $applied !== $title_parts ) {
+					return $applied;
+				}
+			}
+		}
+
 		$template = $this->get_title_template();
 
 		if ( empty( $template ) ) {
@@ -387,6 +434,13 @@ class SWPS_Search_Appearance {
 			return get_option( 'swps_title_template_homepage', '%%sitename%%' );
 		}
 
+		// Posts page on a site with a static front page. Without this branch
+		// the posts page matched nothing and fell through to the empty return,
+		// leaving WordPress's untemplated default.
+		if ( is_home() ) {
+			return get_option( 'swps_title_template_home', '%%title%% %%sep%% %%sitename%%' );
+		}
+
 		if ( is_singular() ) {
 			$post_type = get_post_type();
 			return get_option( "swps_title_template_{$post_type}", '%%title%% %%sep%% %%sitename%%' );
@@ -530,6 +584,14 @@ class SWPS_Search_Appearance {
 
 				$tags                    = get_the_tags( $post->ID );
 				$replacements['%%tag%%'] = ! empty( $tags ) ? $tags[0]->name : '';
+			}
+		} elseif ( is_home() && ! is_front_page() ) {
+			// %%title%% on the posts page is the title of the page assigned to
+			// it; without this the variable resolved to nothing and was then
+			// stripped, collapsing the template to just the site name.
+			$posts_page = (int) get_option( 'page_for_posts' );
+			if ( $posts_page ) {
+				$replacements['%%title%%'] = get_the_title( $posts_page );
 			}
 		} elseif ( is_category() || is_tag() || is_tax() ) {
 			$term = get_queried_object();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.28.0
+Stable tag: 4.28.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,9 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.28.1 =
+* Fixed: a meta title set on the page assigned to "Posts page" was stored and shown in the editor but never rendered — the blog index kept WordPress's untemplated default. The Meta Editor's title filters gate on is_singular(), which the posts page never satisfies, and Search Appearance had no is_home() branch, so the posts page matched no title template at all. Titles now resolve there the same way descriptions already did, and %%title%% on the posts page resolves to that page's title instead of being stripped as an empty variable.
 
 = 4.28.0 =
 * New: Site Audit Fix-It engine — audit findings are now one-click fixable. Missing, duplicate, too-long and too-short meta titles and descriptions get AI-drafted replacements you review and apply (and can undo) right on the audit dashboard; mixed-content URLs, internal nofollow links, missing image alt text, and noindexed-but-sitemapped pages are fixed mechanically with one click. Every fix snapshots the previous value for undo, fixed issues show a projected health score, and the next crawl verifies the real one.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.28.0
+ * Version: 4.28.1
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.28.0' );
+define( 'SWPS_VERSION', '4.28.1' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/tests/unit/SearchAppearanceTitleTest.php
+++ b/tests/unit/SearchAppearanceTitleTest.php
@@ -1,0 +1,39 @@
+<?php
+// tests/unit/SearchAppearanceTitleTest.php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-search-appearance.php';
+
+final class SearchAppearanceTitleTest extends TestCase {
+
+	public function test_empty_meta_title_leaves_parts_untouched(): void {
+		$parts = array( 'title' => 'Blog', 'site' => 'JonImms' );
+		$this->assertSame( $parts, SWPS_Search_Appearance::apply_posts_page_title( $parts, '' ) );
+	}
+
+	public function test_whitespace_only_meta_title_leaves_parts_untouched(): void {
+		$parts = array( 'title' => 'Blog', 'site' => 'JonImms' );
+		$this->assertSame( $parts, SWPS_Search_Appearance::apply_posts_page_title( $parts, "  \n\t " ) );
+	}
+
+	public function test_meta_title_replaces_title_and_drops_site_suffix(): void {
+		$parts  = array( 'title' => 'Blog', 'site' => 'JonImms', 'tagline' => 'Dev blog' );
+		$result = SWPS_Search_Appearance::apply_posts_page_title( $parts, 'WordPress Development Blog' );
+
+		$this->assertSame( 'WordPress Development Blog', $result['title'] );
+		$this->assertArrayNotHasKey( 'site', $result, 'site suffix must be dropped: the stored title is complete' );
+		$this->assertArrayNotHasKey( 'tagline', $result );
+	}
+
+	public function test_meta_title_is_trimmed(): void {
+		$result = SWPS_Search_Appearance::apply_posts_page_title( array( 'title' => 'Blog' ), '  Padded Title  ' );
+		$this->assertSame( 'Padded Title', $result['title'] );
+	}
+
+	public function test_unrelated_parts_are_preserved(): void {
+		$parts  = array( 'title' => 'Blog', 'page' => 'Page 2', 'site' => 'JonImms' );
+		$result = SWPS_Search_Appearance::apply_posts_page_title( $parts, 'Custom' );
+
+		$this->assertSame( 'Page 2', $result['page'], 'pagination part must survive so page 2+ titles stay distinct' );
+	}
+}


### PR DESCRIPTION
## The bug

A meta title set on the page assigned to **Settings → Reading → "Posts page"** was stored, shown in the editor, and then silently ignored on the front end. The blog index kept WordPress's untemplated default.

On jonimms.com this meant `/blog/` rendered `Blog – JonImms` no matter what was configured.

## Root cause

The posts page is `is_home()` and never `is_singular()`. Three places assumed otherwise:

| Location | Gap |
|---|---|
| `SWPS_Meta_Editor::filter_document_title()` / `filter_title_parts()` | Both open with `if ( ! is_singular() )`, so the stored `_swps_meta_title` was never read for this view. |
| `SWPS_Search_Appearance::get_title_template()` | Branches for front page, singular, category, tag, taxonomy, author, post-type archive, date, search and 404 — but not `is_home()`, so the posts page fell through to the empty return and no template applied. |
| `SWPS_Search_Appearance::resolve_variables()` | No `is_home()` branch, so `%%title%%` resolved to nothing and was stripped, collapsing any template to just the site name. |

Descriptions were already correct — `resolve_description()` has an explicit `is_home()` branch reading the posts-page meta. This asymmetry is why the description could be fixed from the outside and the title could not.

## The fix

Titles now mirror the description path:

1. An explicit `_swps_meta_title` on `page_for_posts` wins.
2. Otherwise the new `swps_title_template_home` option applies, defaulting to `%%title%% %%sep%% %%sitename%%`.
3. `%%title%%` on the posts page resolves to that page's title.

Precedence is split into a pure static, `apply_posts_page_title()`, so it is unit-testable without loading WordPress per the repo's pure-PHP test convention.

## Verification

```
syntax matrix   clean
phpunit         OK (721 tests, 1317 assertions)   [5 new]
phpstan         [OK] No errors
```

End to end against a real site:

- With a stored title, the tag renders it verbatim.
- With none, a distinctive template `PROOF %%title%% :: %%sitename%%` resolved to `PROOF Blog :: JonImms`, confirming both the new template branch and `%%title%%` resolution.

Front page, singular, category, tag and author titles are unchanged.

> **Note for reviewers:** `wp_get_document_title()` runs `wptexturize()`, so the default template's ` - ` separator renders as an en dash. That coincidentally reproduces WordPress's own default title and makes the fix look inert. Verify template changes with a distinctive separator, not a hyphen.

## Release

Version bumped to **4.28.1** across all three synced locations (`Version:` header, `SWPS_VERSION`, `Stable tag:`) with a changelog entry. Merging will trigger the release workflow.