### PR TITLE
Describe the person on personal-brand sites (4.29.0)

### DIFF
--- a/includes/class-schema-graph.php
+++ b/includes/class-schema-graph.php
@@ -192,6 +192,104 @@ class SWPS_Schema_Graph {
 		return trailingslashit( $author_url ) . '#profilepage';
 	}
 
+	/**
+	 * Build the descriptive properties for a personal-brand Person entity.
+	 *
+	 * Pure helper: takes the raw option values and the Local SEO settings array
+	 * and returns only the properties that have a usable value, so the caller
+	 * can array_merge() the result straight into the #person node. Nothing here
+	 * touches WordPress, which keeps it unit-testable.
+	 *
+	 * @param array  $opts        {
+	 *     Person option values (all optional, all strings).
+	 *
+	 *     @type string $job_title   Role or title, e.g. "Senior WordPress Developer".
+	 *     @type string $description One- or two-sentence bio. Whitespace is collapsed.
+	 *     @type string $image       Absolute URL of a headshot.
+	 *     @type string $knows_about Topics, one per line or comma-separated.
+	 *     @type string $email       Contact email; falls back to the Local SEO email.
+	 * }
+	 * @param array  $local       The swps_local_seo settings array (enabled, email,
+	 *                            locality, region, country). Only locality, region
+	 *                            and country are used for the address — never the
+	 *                            street or postal code, which would publish a home
+	 *                            address for a person.
+	 * @param string $business_id @id of the LocalBusiness node to reference via
+	 *                            worksFor, or '' when no such node is emitted.
+	 * @return array<string,mixed> Schema.org Person properties, possibly empty.
+	 */
+	public static function person_details( array $opts, array $local = array(), string $business_id = '' ): array {
+		$out = array();
+
+		$job_title = trim( (string) ( $opts['job_title'] ?? '' ) );
+		if ( '' !== $job_title ) {
+			$out['jobTitle'] = $job_title;
+		}
+
+		$description = trim( (string) preg_replace( '/\s+/', ' ', (string) ( $opts['description'] ?? '' ) ) );
+		if ( '' !== $description ) {
+			$out['description'] = $description;
+		}
+
+		$image = trim( (string) ( $opts['image'] ?? '' ) );
+		if ( '' !== $image && false !== filter_var( $image, FILTER_VALIDATE_URL ) ) {
+			$out['image'] = array(
+				'@type' => 'ImageObject',
+				'url'   => $image,
+			);
+		}
+
+		$topics = preg_split( '/[\r\n,]+/', (string) ( $opts['knows_about'] ?? '' ) );
+		if ( ! is_array( $topics ) ) {
+			$topics = array();
+		}
+		$topics = array_values(
+			array_unique(
+				array_filter(
+					array_map( 'trim', $topics ),
+					static fn( string $topic ): bool => '' !== $topic
+				)
+			)
+		);
+		if ( ! empty( $topics ) ) {
+			$out['knowsAbout'] = $topics;
+		}
+
+		$local_enabled = ! empty( $local['enabled'] );
+
+		$email = trim( (string) ( $opts['email'] ?? '' ) );
+		if ( '' === $email && $local_enabled ) {
+			$email = trim( (string) ( $local['email'] ?? '' ) );
+		}
+		if ( '' !== $email && false !== filter_var( $email, FILTER_VALIDATE_EMAIL ) ) {
+			$out['email'] = $email;
+		}
+
+		if ( $local_enabled ) {
+			$address     = array();
+			$address_map = array(
+				'locality' => 'addressLocality',
+				'region'   => 'addressRegion',
+				'country'  => 'addressCountry',
+			);
+			foreach ( $address_map as $key => $prop ) {
+				$value = trim( (string) ( $local[ $key ] ?? '' ) );
+				if ( '' !== $value ) {
+					$address[ $prop ] = $value;
+				}
+			}
+			if ( ! empty( $address ) ) {
+				$out['address'] = array_merge( array( '@type' => 'PostalAddress' ), $address );
+			}
+
+			if ( '' !== $business_id ) {
+				$out['worksFor'] = array( '@id' => $business_id );
+			}
+		}
+
+		return $out;
+	}
+
 	// -------------------------------------------------------------------------
 	// FAQ / Takeaways normalization helpers (used by SWPS_Schema)
 	// -------------------------------------------------------------------------

--- a/includes/class-schema.php
+++ b/includes/class-schema.php
@@ -338,6 +338,33 @@ class SWPS_Schema {
 			}
 		}
 
+		// Personal-brand sites: describe the human so the entity is unambiguous.
+		// worksFor only points at #localbusiness when that node will actually be
+		// emitted (same gate as add_local_business_node), so the graph never
+		// carries a dangling reference.
+		if ( 'Person' === $entity_type ) {
+			$local          = (array) get_option( 'swps_local_seo', array() );
+			$emits_business = class_exists( 'SWPS_Local_SEO' )
+				&& ! empty( $local['enabled'] )
+				&& '' !== trim( (string) ( $local['name'] ?? '' ) )
+				&& '' !== trim( (string) ( $local['locality'] ?? '' ) )
+				&& (bool) apply_filters( 'swps_local_seo_emit', true );
+
+			$node = array_merge(
+				$node,
+				SWPS_Schema_Graph::person_details(
+					array(
+						'job_title'   => (string) get_option( 'swps_schema_person_job_title', '' ),
+						'description' => (string) get_option( 'swps_schema_person_description', '' ),
+						'image'       => (string) get_option( 'swps_schema_person_image', '' ),
+						'knows_about' => (string) get_option( 'swps_schema_person_knows_about', '' ),
+					),
+					$local,
+					$emits_business ? SWPS_Schema_Graph::local_business_id() : ''
+				)
+			);
+		}
+
 		// Legacy filter shim — receives standalone-shaped copy with @context; see class-hooks.php.
 		$node = SWPS_Schema_Graph::normalize_node(
 			SWPS_Hooks::filter_schema_organization( $node ),

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -848,6 +848,53 @@ class SWPS_Settings {
 			)
 		);
 
+		// Person-only details. Rendered for every entity type (Settings API has no
+		// conditional fields) but only emitted when "Site Represents" is Person.
+		$this->add_field(
+			'schema_person_job_title',
+			__( 'Job Title (Person)', 'stratawp-seo' ),
+			'text',
+			'swps_schema_section',
+			array(
+				'placeholder' => __( 'Senior WordPress Developer', 'stratawp-seo' ),
+				'description' => __( 'Only used when Site Represents is Person. Populates jobTitle.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'schema_person_description',
+			__( 'Bio (Person)', 'stratawp-seo' ),
+			'textarea',
+			'swps_schema_section',
+			array(
+				'rows'        => 3,
+				'description' => __( 'One or two sentences that identify you unambiguously: what you do, where, and what you are known for. Populates description.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'schema_person_image',
+			__( 'Headshot URL (Person)', 'stratawp-seo' ),
+			'text',
+			'swps_schema_section',
+			array(
+				'placeholder' => 'https://example.com/headshot.jpg',
+				'description' => __( 'Full URL to a photo of the person (square, at least 400x400px). Populates image. The Logo URL above is not used for Person sites.', 'stratawp-seo' ),
+			)
+		);
+
+		$this->add_field(
+			'schema_person_knows_about',
+			__( 'Areas of Expertise (Person)', 'stratawp-seo' ),
+			'textarea',
+			'swps_schema_section',
+			array(
+				'rows'        => 4,
+				'placeholder' => "WordPress\nGutenberg block development\nREST API",
+				'description' => __( 'One topic per line (or comma-separated). Populates knowsAbout, which helps search engines and AI assistants tell you apart from people with the same name.', 'stratawp-seo' ),
+			)
+		);
+
 		// --- SEO Meta Section ---
 		add_settings_section( 'swps_meta_section', __( 'SEO Meta', 'stratawp-seo' ), array( $this, 'render_meta_section' ), 'stratawp-seo' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, ai, content generation, schema, aeo
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 8.0
-Stable tag: 4.28.1
+Stable tag: 4.29.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -421,6 +421,9 @@ No. One AI provider key (Anthropic, OpenAI, Google, or xAI) unlocks everything A
 By default, nothing is lost: uninstalling only clears scheduled tasks and caches, so your settings, analytics, keywords, redirects, backlinks, topics, and voice profiles all survive a delete + reinstall. For a true clean removal, enable Remove Data on Uninstall under Settings → Advanced before deleting — then everything the plugin ever stored is permanently wiped.
 
 == Changelog ==
+
+= 4.29.0 =
+* New: personal-brand sites (Site Represents: Person) can now describe the person. Four new Schema settings — Job Title, Bio, Headshot URL and Areas of Expertise — populate jobTitle, description, image and knowsAbout on the #person entity. When Local SEO is enabled the person also gets email, a city/region/country address (never the street or postal code) and a worksFor link to the LocalBusiness node, so the whole graph resolves to one unambiguous human. Before this the Person entity carried only a name, URL and social links, which is not enough for search engines or AI assistants to tell the site owner apart from other people with the same name.
 
 = 4.28.1 =
 * Fixed: a meta title set on the page assigned to "Posts page" was stored and shown in the editor but never rendered — the blog index kept WordPress's untemplated default. The Meta Editor's title filters gate on is_singular(), which the posts page never satisfies, and Search Appearance had no is_home() branch, so the posts page matched no title template at all. Titles now resolve there the same way descriptions already did, and %%title%% on the posts page resolves to that page's title instead of being stripped as an empty variable.

--- a/stratawp-seo.php
+++ b/stratawp-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name: StrataWP SEO
  * Plugin URI: https://stratawpseo.com
  * Description: AI-powered SEO content generator that knows your WordPress site. Generate optimized blog posts with internal linking, on autopilot.
- * Version: 4.28.1
+ * Version: 4.29.0
  * Author: Jon Imms
  * Author URI: https://jonimms.com
  * License: GPL v2 or later
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SWPS_VERSION', '4.28.1' );
+define( 'SWPS_VERSION', '4.29.0' );
 define( 'SWPS_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'SWPS_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SWPS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
@@ -1403,6 +1403,10 @@ function swps_activate(): void {
 		'schema_name'                 => '',
 		'schema_logo'                 => '',
 		'schema_social_profiles'      => '',
+		'schema_person_job_title'     => '',
+		'schema_person_description'   => '',
+		'schema_person_image'         => '',
+		'schema_person_knows_about'   => '',
 		// Analytics defaults.
 		'analytics_enabled'           => 1,
 		'analytics_retention'         => 90,

--- a/tests/unit/SchemaPersonDetailsTest.php
+++ b/tests/unit/SchemaPersonDetailsTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Tests for SWPS_Schema_Graph::person_details() — the pure builder for the
+ * descriptive properties of a personal-brand Person entity.
+ *
+ * No WordPress dependency — runs in the stub bootstrap environment.
+ *
+ * @package StrataWP_SEO
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../includes/class-schema-graph.php';
+
+final class SchemaPersonDetailsTest extends TestCase {
+
+	private const LOCAL = array(
+		'enabled'     => 1,
+		'email'       => 'hello@example.com',
+		'street'      => '123 Private Lane',
+		'locality'    => 'Omaha',
+		'region'      => 'NE',
+		'postal_code' => '68105',
+		'country'     => 'US',
+	);
+
+	public function test_empty_input_returns_empty_array(): void {
+		$this->assertSame( array(), SWPS_Schema_Graph::person_details( array() ) );
+		$this->assertSame(
+			array(),
+			SWPS_Schema_Graph::person_details( array( 'job_title' => '  ', 'description' => "\n\t", 'image' => '', 'knows_about' => ", ,\n" ) )
+		);
+	}
+
+	public function test_full_input_populates_every_property(): void {
+		$out = SWPS_Schema_Graph::person_details(
+			array(
+				'job_title'   => ' Senior WordPress Developer ',
+				'description' => "Builds custom\n  Gutenberg blocks.\r\n Based in Omaha.",
+				'image'       => 'https://example.com/headshot.jpg',
+				'knows_about' => "WordPress\nGutenberg, REST API\n\nWordPress",
+			),
+			self::LOCAL,
+			'https://example.com/#localbusiness'
+		);
+
+		$this->assertSame( 'Senior WordPress Developer', $out['jobTitle'] );
+		$this->assertSame( 'Builds custom Gutenberg blocks. Based in Omaha.', $out['description'] );
+		$this->assertSame( array( '@type' => 'ImageObject', 'url' => 'https://example.com/headshot.jpg' ), $out['image'] );
+		$this->assertSame( array( 'WordPress', 'Gutenberg', 'REST API' ), $out['knowsAbout'] );
+		$this->assertSame( 'hello@example.com', $out['email'] );
+		$this->assertSame(
+			array( '@type' => 'PostalAddress', 'addressLocality' => 'Omaha', 'addressRegion' => 'NE', 'addressCountry' => 'US' ),
+			$out['address']
+		);
+		$this->assertSame( array( '@id' => 'https://example.com/#localbusiness' ), $out['worksFor'] );
+	}
+
+	public function test_address_never_includes_street_or_postal_code(): void {
+		$out = SWPS_Schema_Graph::person_details( array(), self::LOCAL, '' );
+		$this->assertArrayNotHasKey( 'streetAddress', $out['address'] );
+		$this->assertArrayNotHasKey( 'postalCode', $out['address'] );
+	}
+
+	public function test_local_seo_disabled_skips_address_email_and_works_for(): void {
+		$local = array_merge( self::LOCAL, array( 'enabled' => 0 ) );
+		$out   = SWPS_Schema_Graph::person_details( array( 'job_title' => 'Dev' ), $local, 'https://example.com/#localbusiness' );
+		$this->assertSame( array( 'jobTitle' => 'Dev' ), $out );
+	}
+
+	public function test_works_for_requires_a_business_id(): void {
+		$out = SWPS_Schema_Graph::person_details( array(), self::LOCAL, '' );
+		$this->assertArrayNotHasKey( 'worksFor', $out );
+	}
+
+	public function test_explicit_email_beats_local_seo_email(): void {
+		$out = SWPS_Schema_Graph::person_details( array( 'email' => 'me@example.org' ), self::LOCAL );
+		$this->assertSame( 'me@example.org', $out['email'] );
+	}
+
+	public function test_invalid_image_url_and_email_are_dropped(): void {
+		$out = SWPS_Schema_Graph::person_details(
+			array( 'image' => 'not a url', 'email' => 'not-an-email' ),
+			array( 'enabled' => 1, 'email' => 'also bad' )
+		);
+		$this->assertArrayNotHasKey( 'image', $out );
+		$this->assertArrayNotHasKey( 'email', $out );
+	}
+
+	public function test_partial_address_keeps_only_filled_parts(): void {
+		$out = SWPS_Schema_Graph::person_details( array(), array( 'enabled' => 1, 'locality' => 'Omaha', 'region' => '', 'country' => ' ' ) );
+		$this->assertSame( array( '@type' => 'PostalAddress', 'addressLocality' => 'Omaha' ), $out['address'] );
+	}
+}


### PR DESCRIPTION
## Summary

With **Site Represents: Person**, the `#person` entity only carried `name`, `url` and `sameAs`. Search engines and AI assistants can't disambiguate the site owner from other people with the same name on that alone.

This adds four Schema settings for personal-brand sites and merges them into the `#person` node:

| Setting | Property |
|---|---|
| Job Title | `jobTitle` |
| Bio | `description` (whitespace collapsed) |
| Headshot URL | `image` (ImageObject) |
| Areas of Expertise | `knowsAbout` (one per line or comma-separated, de-duplicated) |

When Local SEO is enabled the person additionally gets `email`, a `PostalAddress` limited to locality/region/country (never street or postal code), and `worksFor` → `#localbusiness`. `worksFor` uses the same gate as `add_local_business_node()` so it is never a dangling reference.

## Implementation

- `SWPS_Schema_Graph::person_details()` is a pure static builder (no WP calls), covered by `tests/unit/SchemaPersonDetailsTest.php`.
- `SWPS_Schema::add_organization_node()` merges the result only when the entity type is Person.
- Settings fields sit under Schema, after Social Profiles, and are labelled "(Person)" since the Settings API can't hide them conditionally.

## Checks

- `composer analyze`: no errors
- `phpunit`: 729 tests, 1334 assertions, OK
- `phpcs` on the new lines: clean